### PR TITLE
Add step to install babel globally to have access to babel-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The repository comes with an implementation of [TodoMVC](http://todomvc.com/). T
 ```
 git clone https://github.com/facebook/relay.git
 cd relay/examples/todo && npm install
+npm install --global babel
 npm start
 ```
 


### PR DESCRIPTION
I didn't have babel installed globally on my machine so `babel-node` couldn't be found when I tried to follow the example instructions, this just adds that step to the README

I used the verbose cli flags for npm so it's more clear to people who aren't so familiar with it what is going on.