### PR TITLE
add babel to devDependencies for examples

### DIFF
--- a/examples/relay-treasurehunt/package.json
+++ b/examples/relay-treasurehunt/package.json
@@ -4,6 +4,7 @@
     "start": "babel-node ./server.js"
   },
   "devDependencies": {
+    "babel": "5.8.21",
     "babel-core": "5.8.22",
     "babel-eslint": "^4.0.5",
     "babel-loader": "5.3.2",

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -4,6 +4,7 @@
     "start": "babel-node ./server.js"
   },
   "devDependencies": {
+    "babel": "5.8.21",
     "babel-core": "5.8.22",
     "babel-eslint": "^4.0.5",
     "babel-loader": "5.3.2",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -4,6 +4,7 @@
     "start": "babel-node ./server.js"
   },
   "devDependencies": {
+    "babel": "5.8.21",
     "babel-core": "5.8.22",
     "babel-eslint": "^4.0.5",
     "babel-loader": "5.3.2",


### PR DESCRIPTION
The examples use `babel-node` which is provided by the `babel` npm package.