### PR TITLE
Typo in snippet?

### DIFF
--- a/docs/Guides-Containers.md
+++ b/docs/Guides-Containers.md
@@ -24,6 +24,7 @@ class ProfilePicture extends React.Component {
     // Expects the `user` prop to have the following shape:
     // {
     //   profilePhoto: {
+    //     uri,
     //     size
     //   }
     // }


### PR DESCRIPTION
The `<Image>` tag seems to use `user.profilePhoto.uri`, which is missing int he schema?