### PR TITLE
Prevent crash on browsers which String.prototype.repeat is not supported yet

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -157,6 +157,16 @@ function throwOnServerError(response: any): any  {
 }
 
 /**
+ * Repeats given string, mostly equivalent of `String.prototype.repeat`
+ */
+function repeat(str: string, times: number): string {
+  for (var result = '', i = 0; i < times; i++) {
+    result += str;
+  };
+  return result;
+}
+
+/**
  * Formats an error response from GraphQL server request.
  */
 function formatRequestErrors(
@@ -169,7 +179,8 @@ function formatRequestErrors(
   var queryLines = request.getQueryString().split('\n');
   return errors.map(({locations, message}, ii) => {
     var prefix = (ii + 1) + '. ';
-    var indent = ' '.repeat(prefix.length);
+
+    var indent = repeat(' ', prefix.length);
     return (
       prefix + message + '\n' +
       locations.map(({column, line}) => {
@@ -177,7 +188,7 @@ function formatRequestErrors(
         var offset = Math.min(column - 1, CONTEXT_BEFORE);
         return [
           queryLine.substr(column - 1 - offset, CONTEXT_LENGTH),
-          ' '.repeat(offset) + '^^^'
+          repeat(' ', offset) + '^^^'
         ].map(messageLine => indent + messageLine).join('\n');
       }).join('\n')
     );

--- a/src/traversal/printRelayQueryCall.js
+++ b/src/traversal/printRelayQueryCall.js
@@ -38,6 +38,13 @@ function printRelayQueryCall(call: Call): string {
   return '.' + call.name + '(' + valueString +')';
 }
 
+function repeat(str: string, times: number): string {
+  for (var result = '', i = 0; i < times; i++) {
+    result += str;
+  };
+  return result;
+}
+
 function sanitizeCallValue(value: CallValue): string {
   if (value == null) {
     return '';
@@ -51,9 +58,9 @@ function sanitizeCallValue(value: CallValue): string {
     value += ' ';
   }
   return value.replace(/^( *)(.*?)( *)$/, (_, prefix, body, suffix) => (
-    '\\ '.repeat(prefix.length) +
+    repeat('\\ ', prefix.length) +
     body +
-    '\\ '.repeat(suffix.length)
+    repeat('\\ ', suffix.length)
   ));
 }
 


### PR DESCRIPTION
There are a few browsers which does not support `String.prototype.repeat`: http://kangax.github.io/compat-table/es6/#String.prototype_methods_String.prototype.repeat

My latest Safari crashes on example. I'm not entirely sure about directly importing babel-runtime in `src`, but at least it is cleaner than using for-loop :) (I hoped fbjs have something like this)

(edit: I think directly requiring `babel-runtime` did not work, so I've just desugared it.)