### PR TITLE
Ensure cookies are passed on in fetch

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -129,6 +129,7 @@ class RelayDefaultNetworkLayer {
         }),
         headers: {'Content-Type': 'application/json'},
         method: 'POST',
+        credentials: 'same-origin',
       };
     }
     return fetch(this._uri, init).then(throwOnServerError);
@@ -147,6 +148,7 @@ class RelayDefaultNetworkLayer {
       headers: {'Content-Type': 'application/json'},
       method: 'POST',
       retryDelays: this._retryDelays,
+      credentials: 'same-origin',
     });
   }
 }


### PR DESCRIPTION
By default, no cookies are passed along with `fetch`. It seems unintentional that we would want everyone to implement their own `Relay.NetworkLayer` to support authentication, so I think we should send them by default.