### PR TITLE
Build index.js into lib

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,8 @@ var paths = {
   src: [
     '*src/**/*.js',
     '!src/**/__tests__/**/*.js',
-    '!src/**/__mocks__/**/*.js'
+    '!src/**/__mocks__/**/*.js',
+    'index.js'
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
     "PATENTS",
     "README.md",
     "dist/",
-    "index.js",
     "lib/"
   ],
-  "main": "index.js",
+  "main": "lib/index.js",
   "repository": "facebook/relay",
   "scripts": {
     "build": "[ $(ulimit -n) -lt 4096 ] && ulimit -n 4096; gulp",

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@
 
 'use strict';
 
-var RelayDefaultNetworkLayer = require('./lib/RelayDefaultNetworkLayer');
-var RelayPublic = require('./lib/RelayPublic');
+var RelayDefaultNetworkLayer = require('./RelayDefaultNetworkLayer');
+var RelayPublic = require('./RelayPublic');
 
 // By default, assume that GraphQL is served at `/graphql` on the same domain.
 RelayPublic.injectNetworkLayer(new RelayDefaultNetworkLayer('/graphql'));


### PR DESCRIPTION
`index.js` needs to be built by gulp because it contains ES6 spreads.

c.c. @yungsters 