### PR TITLE
Fix missing container and some missing parens in the docs

### DIFF
--- a/docs/APIReference-Container.md
+++ b/docs/APIReference-Container.md
@@ -136,8 +136,8 @@ module.exports = Relay.createContainer(ProfilePicture, {
       # The variable defined above is available here as `$size`.
       fragment on User { profilePicture(size: $size) { ... } }
     `,
-  };
-}
+  },
+});
 ```
 
 In this example, `profilePicture(size: 50)` will be fetched for the intial render.
@@ -167,7 +167,7 @@ module.exports = Relay.createContainer(ProfilePicture, {
     };
   };
   // ...
-}
+});
 ```
 
 ## Properties and Methods
@@ -222,8 +222,8 @@ module.exports = Relay.createContainer(ProfilePicture, {
     user: () => Relay.QL`
       fragment on User { profilePicture(size: $size) { ... } }
     `,
-  };
-}
+  },
+});
 ```
 In this example, the `width` of the rendered image will always correspond to the `$size` variable used to fetch the current version of `profilePicture.uri`.
 
@@ -278,8 +278,8 @@ module.exports = Relay.createContainer(Feed, {
         },
       }
     `,
-  };
-}
+  },
+});
 ```
 
 > Note
@@ -363,8 +363,8 @@ module.exports = Relay.createContainer(Feed, {
         }
       }
     `,
-  };
-}
+  },
+});
 
 ```
 
@@ -411,8 +411,8 @@ module.exports = Relay.createContainer(ProfilePicture, {
         # ...
       }
     `,
-  };
-}
+  },
+});
 ```
 
 `RelayMutationTransaction.getStatus` can return one of the following strings:

--- a/docs/APIReference-Relay.md
+++ b/docs/APIReference-Relay.md
@@ -122,7 +122,7 @@ var Container = Relay.createContainer(Component, {
   initialVariables?: Object,
   prepareVariables?: (variables: Object, route: string) => Object,
   fragments: {[key: string]: Function}
-})
+});
 ```
 
 Creates a new Relay Container - see the [Container Guide](guides-containers.html) for more details and examples.

--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -92,7 +92,10 @@ class LikeButton extends React.Component {
       </div>
     );
   }
-  static fragments = {
+}
+
+module.exports = Relay.createContainer(LikeButton, {
+  fragments: {
     // You can compose a mutation's query fragments like you would those
     // of any other RelayContainer. This ensures that the data depended
     // upon by the mutation will be fetched and ready for use.
@@ -102,8 +105,8 @@ class LikeButton extends React.Component {
         ${LikeStoryMutation.getFragment('story')},
       }
     `,
-  };
-}
+  },
+});
 ```
 
 In this particular example, the only field that the `LikeButton` cares about is `viewerDoesLike`. That field will form part of the tracked query that Relay will intersect with the fat query of `LikeStoryMutation` to determine what fields to request as part of the server's response payload for the mutation. Another component elsewhere in the application might be interested in the likers count, or the like sentence. Since those fields will automatically be added to Relay's tracked query, the `LikeButton` need not worry about requesting them explicitly.


### PR DESCRIPTION
The LikeButton component in the Mutations guide seemed to be missing
the RelayContainer: the fragments were directly specified on the
component even though this doesn't seem to be supported.
Add the container for LikeButton.

Also add a bunch of missing closing parens for containers in the docs.