### PR TITLE
Remove double JSON.stringify calls around variables

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -125,7 +125,7 @@ class RelayDefaultNetworkLayer {
       init = {
         body: JSON.stringify({
           query: request.getQueryString(),
-          variables: JSON.stringify(request.getVariables()),
+          variables: request.getVariables(),
         }),
         headers: {'Content-Type': 'application/json'},
         method: 'POST',
@@ -141,7 +141,7 @@ class RelayDefaultNetworkLayer {
     return fetchWithRetries(this._uri, {
       body: JSON.stringify({
         query: request.getQueryString(),
-        variables: JSON.stringify(request.getVariables()),
+        variables: request.getVariables(),
       }),
       fetchTimeout: this._timeout,
       headers: {'Content-Type': 'application/json'},

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -111,7 +111,7 @@ describe('RelayDefaultNetworkLayer', () => {
       });
       expect(body).toEqual(JSON.stringify({
         query: request.getQueryString(),
-        variables: JSON.stringify(variables),
+        variables: variables,
       }));
     });
 
@@ -195,7 +195,7 @@ describe('RelayDefaultNetworkLayer', () => {
       var {body, fetchTimeout, method, retryDelays} = call[1];
       expect(body).toBe(JSON.stringify({
         query: requestA.getQueryString(),
-        variables: JSON.stringify(queryA.getVariables()),
+        variables: queryA.getVariables(),
       }));
       expect(fetchTimeout).toBe(networkConfig.timeout);
       expect(method).toBe('POST');


### PR DESCRIPTION
The POST bodies with these escaped strings are currently overly verbose, harder to debug and require extra parsing on both ends.

These bodies already have Content-Type application/json and express-graphql will only parse the variables param if it needs to (for example in the case of FormData): https://github.com/graphql/express-graphql/blob/9e6765f3c9e9e2f14da3c5fd2616afe73239f62b/src/index.js#L138-L146

I've signed the CLA and all tests pass, thanks!