### PR TITLE
More Flexible Default Network Layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Upgraded jest to 0.5 and switched Relay to use iojs v2+ only.
 * All fragments in a Relay.Container must now have a query with a matching
   name in any Relay.Route that uses it and vice versa.
+* Changed `Relay.DefaultNetworkLayer` constructor to take an `init` object
+  instead of `fetchTimeout` and `retryDelays`.
 
 ## 0.1.1 (August 14, 2015)
 

--- a/docs/Guides-NetworkLayer.md
+++ b/docs/Guides-NetworkLayer.md
@@ -21,7 +21,7 @@ Relay.injectNetworkLayer(
 );
 ```
 
-The constructor for `Relay.DefaultNetworkLayer` also accepts an optional second argument that accepts any valid initialization property that `fetch` accepts.
+Underneath the hood, the default network layer uses `fetch` ([Living Standard](https://fetch.spec.whatwg.org)). The constructor for `Relay.DefaultNetworkLayer` takes an optional second argument that accepts any valid initialization property that `fetch` accepts.
 
 ```{3}
 Relay.injectNetworkLayer(
@@ -31,7 +31,7 @@ Relay.injectNetworkLayer(
 );
 ```
 
-Underneath the hood, the default network layer uses `fetch`. When it sends queries, it will automatically fail requests after a 15 second timeout. Also, failed requests are automatically retried twice, with a 1 second delay and a 3 second delay, respectively.
+When it sends queries, it will automatically fail requests after a 15 second timeout. Also, failed requests are automatically retried twice, with a 1 second delay and a 3 second delay, respectively.
 
 Like the GraphQL URI, the timeout and retry behavior can be configured:
 

--- a/docs/Guides-NetworkLayer.md
+++ b/docs/Guides-NetworkLayer.md
@@ -21,15 +21,26 @@ Relay.injectNetworkLayer(
 );
 ```
 
+The constructor for `Relay.DefaultNetworkLayer` also accepts an optional second argument that accepts any valid initialization property that `fetch` accepts.
+
+```{3}
+Relay.injectNetworkLayer(
+  new Relay.DefaultNetworkLayer('http://example.com/graphql', {
+    credentials: 'same-origin',
+  })
+);
+```
+
 Underneath the hood, the default network layer uses `fetch`. When it sends queries, it will automatically fail requests after a 15 second timeout. Also, failed requests are automatically retried twice, with a 1 second delay and a 3 second delay, respectively.
 
 Like the GraphQL URI, the timeout and retry behavior can be configured:
 
 ```{3-4}
 Relay.injectNetworkLayer(
-  new Relay.DefaultNetworkLayer('http://example.com/graphql'),
-  30000,    // Timeout after 30s.
-  [5000]    // Only retry once after a 5s delay.
+  new Relay.DefaultNetworkLayer('http://example.com/graphql', {
+    fetchTimeout: 30000,   // Timeout after 30s.
+    retryDelays: [5000],   // Only retry once after a 5s delay.
+  })
 );
 ```
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "babel-runtime": "5.8.20",
     "crc32": "^0.2.2",
-    "fbjs": "0.1.0-alpha.7",
+    "fbjs": "0.1.0-alpha.9",
     "react-static-container": "^1.0.0-alpha.1"
   },
   "peerDependencies": {

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -32,7 +32,7 @@ type GraphQLErrorLocation = {
 
 class RelayDefaultNetworkLayer {
   _uri: string;
-  _init: InitWithRetries;
+  _init: $FlowIssue; // InitWithRetries
 
   constructor(uri: string, init?: ?InitWithRetries) {
     this._uri = uri;

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -19,6 +19,7 @@ import type RelayQueryRequest from 'RelayQueryRequest';
 
 var fetch = require('fetch');
 var fetchWithRetries = require('fetchWithRetries');
+import type {InitWithRetries} from 'fetchWithRetries';
 
 type GraphQLError = {
   message: string;
@@ -29,18 +30,13 @@ type GraphQLErrorLocation = {
   line: number;
 };
 
-var DEFAULT_FETCH_TIMEOUT = 15000;
-var DEFAULT_RETRY_DELAYS = [1000, 3000];
-
 class RelayDefaultNetworkLayer {
   _uri: string;
-  _timeout: number;
-  _retryDelays: Array<number>;
+  _init: InitWithRetries;
 
-  constructor(uri: string, timeout?: number, retryDelays?: Array<number>) {
+  constructor(uri: string, init?: ?InitWithRetries) {
     this._uri = uri;
-    this._timeout = typeof timeout === 'number' ? timeout : DEFAULT_FETCH_TIMEOUT;
-    this._retryDelays = retryDelays || DEFAULT_RETRY_DELAYS;
+    this._init = {...init};
 
     // Bind instance methods to facilitate reuse when creating custom network
     // layers.
@@ -121,17 +117,21 @@ class RelayDefaultNetworkLayer {
         }
       }
       init = {
+        ...this._init,
         body: formData,
         method: 'POST',
       };
     } else {
       init = {
+        ...this._init,
         body: JSON.stringify({
           query: request.getQueryString(),
           variables: request.getVariables(),
         }),
-        credentials: 'same-origin',
-        headers: {'Content-Type': 'application/json'},
+        headers: {
+          ...this._init.headers,
+          'Content-Type': 'application/json',
+        },
         method: 'POST',
       };
     }
@@ -143,15 +143,16 @@ class RelayDefaultNetworkLayer {
    */
   _sendQuery(request: RelayQueryRequest): Promise {
     return fetchWithRetries(this._uri, {
+      ...this._init,
       body: JSON.stringify({
         query: request.getQueryString(),
         variables: request.getVariables(),
       }),
-      credentials: 'same-origin',
-      fetchTimeout: this._timeout,
-      headers: {'Content-Type': 'application/json'},
+      headers: {
+        ...this._init.headers,
+        'Content-Type': 'application/json',
+      },
       method: 'POST',
-      retryDelays: this._retryDelays,
     });
   }
 }


### PR DESCRIPTION
Per discussion in #48, replaces the second and third arguments to `DefaultNetworkLayer` with a `fetch`-like `init` object. This will allow a higher degree of configuration (e.g. it allows setting custom headers).