### PR TITLE
Fix mutation spec example to match wording

### DIFF
--- a/website/graphql/Mutations.md
+++ b/website/graphql/Mutations.md
@@ -78,7 +78,7 @@ provided response.
         type {
           kind
           fields {
-            name,
+            name
             type {
               kind
               ofType {
@@ -92,13 +92,16 @@ provided response.
           name
           type {
             kind
-            inputFields {
-              name
-              type {
-                kind
-                ofType {
-                  name
+            ofType {
+              kind
+              inputFields {
+                name
+                type {
                   kind
+                  ofType {
+                    name
+                    kind
+                  }
                 }
               }
             }
@@ -139,20 +142,23 @@ yields
             {
               "name": "input",
               "type": {
-                "kind": "INPUT_OBJECT",
-                "inputFields": [
-                  // May contain more fields here
-                  {
-                    "name": "clientMutationId",
-                    "type": {
-                      "kind": "NON_NULL",
-                      "ofType": {
-                        "name": "String",
-                        "kind": "SCALAR"
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "inputFields": [
+                    // May contain more fields here
+                    {
+                      "name": "clientMutationId",
+                      "type": {
+                        "kind": "NON_NULL",
+                        "ofType": {
+                          "name": "String",
+                          "kind": "SCALAR"
+                        }
                       }
                     }
-                  }
-                ]
+                  ]
+                }
               }
             }
           ]


### PR DESCRIPTION
Spec says that `input` must be "*a NON_NULL wrapper around an INPUT_OBJECT*". This PR fixes the introspection result to correctly have the INPUT_OBJECT wrapped.