### PR TITLE
Remove reference to text in relay-treasurehunt mutate and get payload

### DIFF
--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -214,7 +214,7 @@ var CheckHidingSpotForTreasureMutation = mutationWithClientMutationId({
       resolve: () => getGame(),
     },
   },
-  mutateAndGetPayload: ({id, text}) => {
+  mutateAndGetPayload: ({id}) => {
     var localHidingSpotId = fromGlobalId(id).id;
     checkHidingSpotForTreasure(localHidingSpotId);
     return {localHidingSpotId};

--- a/examples/relay-treasurehunt/data/schema.js
+++ b/examples/relay-treasurehunt/data/schema.js
@@ -135,7 +135,7 @@ var CheckHidingSpotForTreasureMutation = mutationWithClientMutationId({
       resolve: () => getGame(),
     },
   },
-  mutateAndGetPayload: ({id, text}) => {
+  mutateAndGetPayload: ({id}) => {
     var localHidingSpotId = fromGlobalId(id).id;
     checkHidingSpotForTreasure(localHidingSpotId);
     return {localHidingSpotId};


### PR DESCRIPTION
The `CheckHidingSpotForTreasureMutation` contains a reference to `text` in the `mutateAndGetPayload` method. However this variable is not used and is `undefined`. It looks like it might be a relic from the todo example.