### PR TITLE
export Game and HidingSpot class

### DIFF
--- a/examples/relay-treasurehunt/data/database.js
+++ b/examples/relay-treasurehunt/data/database.js
@@ -8,8 +8,8 @@
  */
 
 // Model types
-class Game extends Object {}
-class HidingSpot extends Object {}
+export class Game extends Object {}
+export class HidingSpot extends Object {}
 
 // Mock data
 var game = new Game();


### PR DESCRIPTION
Currently the nodeDefinitions object function checks the object instance against undefined as Game and HidingSpot are not exported.

This doesn't seem to make any difference the example apps functionality -- but should export these anyway to be thorough.