### PR TITLE
Improve invariants on invalid fragments

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -987,6 +987,14 @@ function create(
         fragmentNames.map(name => '`' + name + '`').join(', ')
       );
     }
+    invariant(
+      typeof fragmentBuilder === 'function',
+      'RelayContainer: Expected `%s.fragments.%s` to be a function returning '+
+      'a fragment. Example: `%s: () => Relay.QL`fragment on ...`',
+      containerName,
+      fragmentName,
+      fragmentName
+    );
     return new RelayFragmentReference(
       () => buildContainerFragment(
         containerName,

--- a/src/container/__tests__/RelayContainer-test.js
+++ b/src/container/__tests__/RelayContainer-test.js
@@ -116,6 +116,25 @@ describe('RelayContainer', function() {
       );
     });
 
+    it('throws if container defines a fragment without function', () => {
+      var BadContainer = Relay.createContainer(MockComponent, {
+        fragments: {
+          viewer: Relay.QL`
+            fragment on Viewer {
+              newsFeed,
+            }
+          `
+        }
+      });
+      expect(() => {
+        BadContainer.getFragment('viewer');
+      }).toFailInvariant(
+        'RelayContainer: Expected `Relay(MockComponent).fragments.viewer` to ' +
+        'be a function returning a fragment. Example: ' +
+        '`viewer: () => Relay.QL`fragment on ...`'
+      );
+    });
+
     it('creates query for a container without fragments', () => {
       // Test that scalar constants are substituted, not only query fragments.
       var TEST_PHOTO_SIZE = 100;


### PR DESCRIPTION
If you accidentally leave off the little fat arrow (`() =>`) when defining a fragment like:
```js
Relay.createContainer(MyComponent, {
  fragments: {
    viewer: Relay.QL`
      fragment on Viewer {
        newsFeed,
      }
    `
  }
});
```
you will receive a very cryptic:  `fragmentBuilder is not a function`. This PR improves it to instead say:

> Relay(MyComponent): Expected query fragment named \`viewer\` to be a function returning a fragment. A typical fragment is defined using: viewer: () => Relay.QL\`fragment on Type {...}\`