### PR TITLE
Warn on non-validation exceptions

### DIFF
--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -148,6 +148,15 @@ function getBabelRelayPlugin(
                   }
                 });
               });
+            } else {
+              console.warn(
+                '\n-- Relay Transform Error -- %s --\n',
+                path.basename(filename)
+              );
+              console.warn(
+                'Error: ' + error.message + '\n' +
+                'File:  ' + filename + '\n'
+              );
             }
 
             var message = (


### PR DESCRIPTION
Errors that are thrown in babel-relay-plugin that aren't validation errors still get a

> Encountered a GraphQL validation error processing file \`...\`. Check your terminal for details.

But nothing is actually ever logged to the terminal.

This PR makes sure that _something_ is shown to help with debugging.