### PR TITLE
Fix Flow __REACT_DEVTOOLS_GLOBAL_HOOK__ error

### DIFF
--- a/src/RelayPublic.js
+++ b/src/RelayPublic.js
@@ -26,8 +26,8 @@ var RelayTaskScheduler = require('RelayTaskScheduler');
 var getRelayQueries = require('getRelayQueries');
 var isRelayContainer = require('isRelayContainer');
 
-if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined') {
-  __REACT_DEVTOOLS_GLOBAL_HOOK__._relayInternals = {
+if (typeof global.__REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined') {
+  global.__REACT_DEVTOOLS_GLOBAL_HOOK__._relayInternals = {
     NetworkLayer: require('RelayNetworkLayer'),
     DefaultStoreData: require('RelayStoreData').getDefaultInstance(),
   };


### PR DESCRIPTION
Fixes the only Flow error that currently exists:

```
$ flow check src

/.../relay/src/RelayPublic.js:29:12,41: identifier __REACT_DEVTOOLS_GLOBAL_HOOK__
Could not resolve name

Found 1 error
```