### PR TITLE
Remove `engines` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "prepublish": "npm run build",
     "test": "NODE_ENV=test jest"
   },
-  "engines": {
-    "node": ">=2"
-  },
   "dependencies": {
     "babel-runtime": "5.8.20",
     "crc32": "^0.2.2",


### PR DESCRIPTION
Per @zao in facebook/fbjs#38:

> We really shouldn't be doing - this flag is only consumed in downstream installs. Saying that fbjs is only compatible with node > 2 is a lie. It might be all we test with but that doesn't make it true.

> It would be good to have some prevention mechanism to make sure the right versions of tools are being used for development (Eg, check node and npm versions)

> Actually 1 place that might use this info is TravisCI. Just confirm in relay what version gets run both before and with a PR to remove this line.