### PR TITLE
Allow other strings as cursors

### DIFF
--- a/website/graphql/Connections.md
+++ b/website/graphql/Connections.md
@@ -166,7 +166,11 @@ certain optimizations if this field returns an object that implements
 ### Cursor
 
 An "Edge Type" must contain a field called `cursor`. This field must return
-either a String or a Non-Null wrapper around a String.
+either a type that serializes as a String; this may be a String, a Non-Null
+wrapper around a String, or a custom scalar that serializes as a String.
+
+Whatever type this field returns will be referred to as the *cursor type*
+in the rest of this spec.
 
 The result of this field is considered opaque by Relay, but will be passed
 back to the server as described in the "Arguments" section below.
@@ -214,6 +218,7 @@ returns
         {
           "name": "cursor",
           "type": {
+            // This shows the cursor type as String!, other types are possible
             "name": null,
             "kind": "NON_NULL",
             "ofType": {
@@ -239,7 +244,7 @@ allow the client to slice the set of edges before it is returned.
 To enable forward pagination, two arguments are required.
 
  - `first` takes an integer.
- - `after` takes a string.
+ - `after` takes the *cursor type* as described in the `cursor` field section.
 
 The server should use those two arguments to modify the edges returned by
 the connection, returning edges after the `after` cursor, and returning at
@@ -250,7 +255,7 @@ most `first` edges. More formally:
 To enable backward pagination, two arguments are required.
 
  - `last` takes an integer.
- - `before` takes a string.
+ - `before` takes the *cursor type* as described in the `cursor` field section.
 
 The server should use those two arguments to modify the edges returned by
 the connection, returning edges before the `before` cursor, and returning at

--- a/website/graphql/Connections.md
+++ b/website/graphql/Connections.md
@@ -167,7 +167,8 @@ certain optimizations if this field returns an object that implements
 
 An "Edge Type" must contain a field called `cursor`. This field must return
 either a type that serializes as a String; this may be a String, a Non-Null
-wrapper around a String, or a custom scalar that serializes as a String.
+wrapper around a String, a custom scalar that serializes as a String, or a
+Non-Null wrapper around a custom scalar that serializes as a String.
 
 Whatever type this field returns will be referred to as the *cursor type*
 in the rest of this spec.

--- a/website/graphql/Connections.md
+++ b/website/graphql/Connections.md
@@ -166,7 +166,7 @@ certain optimizations if this field returns an object that implements
 ### Cursor
 
 An "Edge Type" must contain a field called `cursor`. This field must return
-either a type that serializes as a String; this may be a String, a Non-Null
+a type that serializes as a String; this may be a String, a Non-Null
 wrapper around a String, a custom scalar that serializes as a String, or a
 Non-Null wrapper around a custom scalar that serializes as a String.
 

--- a/website/src/relay/graphql/connections.htm
+++ b/website/src/relay/graphql/connections.htm
@@ -176,8 +176,8 @@
       </section>
       <section id="sec-Cursor">
         <h4><span class="spec-secnum" title="link to this section"><a href="#sec-Cursor">3.1.2</a></span>Cursor</h4>
-        <p>An &ldquo;Edge Type&rdquo; must contain a field called <code>cursor</code>. This field must return either a type that serializes as a String; this may be a String, a Non&#8208;Null wrapper around a String, a custom scalar that serializes as a
-          String, or a Non&#8208;Null wrapper around a custom scalar that serializes as a String.</p>
+        <p>An &ldquo;Edge Type&rdquo; must contain a field called <code>cursor</code>. This field must return a type that serializes as a String; this may be a String, a Non&#8208;Null wrapper around a String, a custom scalar that serializes as a String,
+          or a Non&#8208;Null wrapper around a custom scalar that serializes as a String.</p>
         <p>Whatever type this field returns will be referred to as the <em>cursor type</em> in the rest of this spec.</p>
         <p>The result of this field is considered opaque by Relay, but will be passed back to the server as described in the &ldquo;Arguments&rdquo; section below.</p>
       </section>

--- a/website/src/relay/graphql/connections.htm
+++ b/website/src/relay/graphql/connections.htm
@@ -176,7 +176,9 @@
       </section>
       <section id="sec-Cursor">
         <h4><span class="spec-secnum" title="link to this section"><a href="#sec-Cursor">3.1.2</a></span>Cursor</h4>
-        <p>An &ldquo;Edge Type&rdquo; must contain a field called <code>cursor</code>. This field must return either a String or a Non&#8208;Null wrapper around a String.</p>
+        <p>An &ldquo;Edge Type&rdquo; must contain a field called <code>cursor</code>. This field must return either a type that serializes as a String; this may be a String, a Non&#8208;Null wrapper around a String, or a custom scalar that serializes as
+          a String.</p>
+        <p>Whatever type this field returns will be referred to as the <em>cursor type</em> in the rest of this spec.</p>
         <p>The result of this field is considered opaque by Relay, but will be passed back to the server as described in the &ldquo;Arguments&rdquo; section below.</p>
       </section>
     </section>
@@ -199,33 +201,34 @@
 }
 </code></pre>
       <p>returns</p><pre><code>{
-  "<span class="hljs-attribute">data</span>": <span class="hljs-value">{
-    "<span class="hljs-attribute">__type</span>": <span class="hljs-value">{
-      "<span class="hljs-attribute">fields</span>": <span class="hljs-value">[
+  "data": {
+    "__type": {
+      "fields": [
         // May contain other items
         {
-          "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"node"</span></span>,
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value">{
-            "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"Example"</span></span>,
-            "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"OBJECT"</span></span>,
-            "<span class="hljs-attribute">ofType</span>": <span class="hljs-value"><span class="hljs-literal">null</span>
-          </span>}
-        </span>},
+          "name": "node",
+          "type": {
+            "name": "Example",
+            "kind": "OBJECT",
+            "ofType": null
+          }
+        },
         {
-          "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"cursor"</span></span>,
-          "<span class="hljs-attribute">type</span>": <span class="hljs-value">{
-            "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-literal">null</span></span>,
-            "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"NON_NULL"</span></span>,
-            "<span class="hljs-attribute">ofType</span>": <span class="hljs-value">{
-              "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"String"</span></span>,
-              "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"SCALAR"</span>
-            </span>}
-          </span>}
-        </span>}
+          "name": "cursor",
+          "type": {
+            // This shows the cursor type as String!, other types are possible
+            "name": null,
+            "kind": "NON_NULL",
+            "ofType": {
+              "name": "String",
+              "kind": "SCALAR"
+            }
+          }
+        }
       ]
-    </span>}
-  </span>}
-</span>}
+    }
+  }
+}
 </code></pre></section>
   </section>
   <section id="sec-Arguments">
@@ -236,7 +239,7 @@
       <p>To enable forward pagination, two arguments are required.</p>
       <ul>
         <li><code>first</code> takes an integer.</li>
-        <li><code>after</code> takes a string.</li>
+        <li><code>after</code> takes the <em>cursor type</em> as described in the <code>cursor</code> field section.</li>
       </ul>
       <p>The server should use those two arguments to modify the edges returned by the connection, returning edges after the <code>after</code> cursor, and returning at most <code>first</code> edges. More formally:</p>
     </section>
@@ -245,7 +248,7 @@
       <p>To enable backward pagination, two arguments are required.</p>
       <ul>
         <li><code>last</code> takes an integer.</li>
-        <li><code>before</code> takes a string.</li>
+        <li><code>before</code> takes the <em>cursor type</em> as described in the <code>cursor</code> field section.</li>
       </ul>
       <p>The server should use those two arguments to modify the edges returned by the connection, returning edges before the <code>before</code> cursor, and returning at most <code>last</code> edges. More formally:</p>
     </section>

--- a/website/src/relay/graphql/connections.htm
+++ b/website/src/relay/graphql/connections.htm
@@ -176,8 +176,8 @@
       </section>
       <section id="sec-Cursor">
         <h4><span class="spec-secnum" title="link to this section"><a href="#sec-Cursor">3.1.2</a></span>Cursor</h4>
-        <p>An &ldquo;Edge Type&rdquo; must contain a field called <code>cursor</code>. This field must return either a type that serializes as a String; this may be a String, a Non&#8208;Null wrapper around a String, or a custom scalar that serializes as
-          a String.</p>
+        <p>An &ldquo;Edge Type&rdquo; must contain a field called <code>cursor</code>. This field must return either a type that serializes as a String; this may be a String, a Non&#8208;Null wrapper around a String, a custom scalar that serializes as a
+          String, or a Non&#8208;Null wrapper around a custom scalar that serializes as a String.</p>
         <p>Whatever type this field returns will be referred to as the <em>cursor type</em> in the rest of this spec.</p>
         <p>The result of this field is considered opaque by Relay, but will be passed back to the server as described in the &ldquo;Arguments&rdquo; section below.</p>
       </section>

--- a/website/src/relay/graphql/mutations.htm
+++ b/website/src/relay/graphql/mutations.htm
@@ -69,7 +69,7 @@
         type {
           kind
           fields {
-            name,
+            name
             type {
               kind
               ofType {
@@ -83,13 +83,16 @@
           name
           type {
             kind
-            inputFields {
-              name
-              type {
-                kind
-                ofType {
-                  name
+            ofType {
+              kind
+              inputFields {
+                name
+                type {
                   kind
+                  ofType {
+                    name
+                    kind
+                  }
                 }
               }
             }
@@ -126,20 +129,23 @@
             {
               "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"input"</span></span>,
               "<span class="hljs-attribute">type</span>": <span class="hljs-value">{
-                "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"INPUT_OBJECT"</span></span>,
-                "<span class="hljs-attribute">inputFields</span>": <span class="hljs-value">[
-                  // May contain more fields here
-                  {
-                    "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"clientMutationId"</span></span>,
-                    "<span class="hljs-attribute">type</span>": <span class="hljs-value">{
-                      "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"NON_NULL"</span></span>,
-                      "<span class="hljs-attribute">ofType</span>": <span class="hljs-value">{
-                        "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"String"</span></span>,
-                        "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"SCALAR"</span>
+                "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"NON_NULL"</span></span>,
+                "<span class="hljs-attribute">ofType</span>": <span class="hljs-value">{
+                  "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"INPUT_OBJECT"</span></span>,
+                  "<span class="hljs-attribute">inputFields</span>": <span class="hljs-value">[
+                    // May contain more fields here
+                    {
+                      "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"clientMutationId"</span></span>,
+                      "<span class="hljs-attribute">type</span>": <span class="hljs-value">{
+                        "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"NON_NULL"</span></span>,
+                        "<span class="hljs-attribute">ofType</span>": <span class="hljs-value">{
+                          "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"String"</span></span>,
+                          "<span class="hljs-attribute">kind</span>": <span class="hljs-value"><span class="hljs-string">"SCALAR"</span>
+                        </span>}
                       </span>}
                     </span>}
-                  </span>}
-                ]
+                  ]
+                </span>}
               </span>}
             </span>}
           ]


### PR DESCRIPTION
In #89 itwas pointed out that using other scalars as cursors would be useful,
since clients might want to provide a custom scalar the serializes as a String.
Update the spec to ensure that is possible.

This change keeps the requirement that cursors serialize as strings, which
be strongenough to allow clients to handle different servers. It no longer
mandates a type, so servers can just use String if they prefer, or define
a custom scalar if they prefer.

Fixes #89.