### PR TITLE
Streamline route queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Route queries will now automatically compose fragments from containers.
+
 ## 0.2.0 (August 28, 2015)
 
 * Upgraded jest to 0.5 and switched Relay to use iojs v2+ only.

--- a/docs/APIReference-Route.md
+++ b/docs/APIReference-Route.md
@@ -74,27 +74,19 @@ class ProfileRoute extends Relay.Route {
 
 ```
 static queries: {
-  [queryName: string]: (
-    Component: RelayContainer,
-    params: {[name: string]: mixed}
-  ) => Relay.QL`query ...`
+  [queryName: string]: () => Relay.QL`query { ... }`
 }
 ```
 
-Routes must declare a set of query roots using `Relay.QL`. These queries are expected to compose a fragment on the Relay container supplied via the `Component` argument.
+Routes must declare a set of query roots using `Relay.QL`. These queries will automatically compose a matching fragment named `queryName` on
+the Relay container used with this route on a **Relay.RootContainer**.
 
 #### Example
 
 ```
 class ProfileRoute extends Relay.Route {
   static queries = {
-    user: Component => Relay.QL`
-      query {
-        user(id: $userID) {
-          ${Component.getFragment('user')},
-        },
-      }
-    `,
+    user: () => Relay.QL`query { user(id: $userID) }`,
   },
   // ...
 }

--- a/docs/Guides-Routes.md
+++ b/docs/Guides-Routes.md
@@ -65,20 +65,17 @@ Since Relay containers define fragments and not queries, they can be easily embe
 
 ## Routes and Queries
 
-Routes are objects that define a set of root queries and input parameters. Here is a simple route that renders user `123`'s profile photo:
+Routes are objects that define a set of root queries and input parameters. Here is a simple route that might be used to render user `123`'s profile:
 
 ```
 var profileRoute = {
   queries: {
-    // Routes declare queries using functions that receive the top-level Relay
-    // container and return a query root that composes one of its fragments.
-    user: Component => Relay.QL`
+    // Routes declare queries using functions that return a query root. Relay
+    // will automatically compose the `user` fragment from the Relay container
+    // paired with this route on a Relay.RootContainer
+    user: () => Relay.QL`
       # In Relay, the GraphQL query name can be optionally omitted.
-      query {
-        user(id: $userID) {
-          ${Component.getFragment('user')}
-        }
-      }
+      query { user(id: $userID) }
     `,
   },
   params: {
@@ -95,12 +92,8 @@ If we wanted to create an instance of this route for arbitrary users, we can sub
 ```
 class ProfileRoute extends Relay.Route {
   static queries = {
-    user: Component => Relay.QL`
-      query {
-        user(id: $userID) {
-          ${Component.getFragment('user')}
-        }
-      }
+    user: () => Relay.QL`
+      query { user(id: $userID) }
     `,
   };
   static paramDefinitions = {

--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -259,13 +259,7 @@ Let's tweak the file `./routes/AppHomeRoute.js` to anchor our game to the `game`
 export default class extends Relay.Route {
   static path = '/';
   static queries = {
-    game: (Component) => Relay.QL`
-      query {
-        game {
-          ${Component.getFragment('game')},
-        },
-      }
-    `,
+    game: () => Relay.QL`query { game }`,
   };
   static routeName = 'AppHomeRoute';
 }

--- a/examples/relay-treasurehunt/js/routes/AppHomeRoute.js
+++ b/examples/relay-treasurehunt/js/routes/AppHomeRoute.js
@@ -1,12 +1,6 @@
 export default class extends Relay.Route {
   static queries = {
-    game: (Component) => Relay.QL`
-      query {
-        game {
-          ${Component.getFragment('game')},
-        },
-      }
-    `,
+    game: () => Relay.QL`query { game }`,
   };
   static routeName = 'AppHomeRoute';
 }

--- a/examples/star-wars/js/routes/StarWarsAppHomeRoute.js
+++ b/examples/star-wars/js/routes/StarWarsAppHomeRoute.js
@@ -1,12 +1,6 @@
 export default class extends Relay.Route {
   static queries = {
-    factions: (Component) => Relay.QL`
-      query {
-        factions(names: $factionNames) {
-          ${Component.getFragment('factions')},
-        },
-      }
-    `,
+    factions: () => Relay.QL`query { factions(names: $factionNames) }`,
   };
   static routeName = 'StarWarsAppHomeRoute';
 }

--- a/examples/todo/js/routes/TodoAppHomeRoute.js
+++ b/examples/todo/js/routes/TodoAppHomeRoute.js
@@ -1,12 +1,6 @@
 export default class extends Relay.Route {
   static queries = {
-    viewer: (Component) => Relay.QL`
-      query RootQuery {
-        viewer {
-          ${Component.getFragment('viewer')},
-        },
-      }
-    `,
+    viewer: () => Relay.QL`query RootQuery { viewer }`,
   };
   static routeName = 'TodosHomeRoute';
 }

--- a/src/container/__tests__/getRelayQueries-test.js
+++ b/src/container/__tests__/getRelayQueries-test.js
@@ -135,4 +135,16 @@ describe('getRelayQueries', () => {
       'fragment `Relay(MockPageComponent).fragments.last` to be defined.'
     );
   });
+
+  it('includes route parameters when building component fragment', () => {
+    var MockRoute = makeRoute();
+    var params = {id: '123'};
+    var route = new MockRoute(params);
+    MockPageContainer.getFragment = jest.genMockFunction();
+
+    getRelayQueries(MockPageContainer, route);
+
+    expect(MockPageContainer.getFragment.mock.calls.length).toBe(4);
+    expect(MockPageContainer.getFragment.mock.calls[0][1]).toBe(params);
+  });
 });

--- a/src/container/getRelayQueries.js
+++ b/src/container/getRelayQueries.js
@@ -61,7 +61,8 @@ function getRelayQueries(
       var concreteQuery = buildRQL.Query(
         queryBuilder,
         Component,
-        Object.keys(route.params)
+        Object.keys(route.params),
+        Component.getFragment(queryName, route.params)
       );
       invariant(
         concreteQuery !== undefined,


### PR DESCRIPTION
See #104 and #20. This might also conflict a little with #112

Just  wanted to throw this up before I go too far down any rabbit holes. The goal of this PR is to allow route queries to be defined like:
```js
viewer: () => Relay.QL`
  query { viewer }
`,
```
without having to specify `${Component.getFragment('viewer')}` mechanically.

The current change works (for some definition of working) but lacks tests and I'm still wrapping my head around the Relay internals. That being said:
* Does this seem like the correct approach? Any gotchas with variables I'm missing?
* How to we want to handle the two old formats? Should we add some deprecation notices now?
* Any other questions/comments?

.

༼ つ ◕_◕ ༽つ