### PR TITLE
Ignore node_modules/graphql in `.flowconfig`

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/__tests__/.*
+.*/node_modules/graphql/.*
 .*/react/node_modules/.*
 .*/react-static-container/node_modules/.*
 


### PR DESCRIPTION
Renaming `GraphQL_EXPERIMENTAL` to `GraphQL` in 1cfd48d1df9ea726d6775931fea05bf2420c4cff appears to have confused Flow.