### PR TITLE
Revert "Require matching query/fragment names"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## master
 
 * Upgraded jest to 0.5 and switched Relay to use iojs v2+ only.
-* All fragments in a Relay.Container must now have a query with a matching
-  name in any Relay.Route that uses it and vice versa.
 
 ## 0.1.1 (August 14, 2015)
 

--- a/src/container/__tests__/getRelayQueries-test.js
+++ b/src/container/__tests__/getRelayQueries-test.js
@@ -20,7 +20,6 @@ describe('getRelayQueries', () => {
 
   var getRelayQueries;
 
-  var MockPageComponent;
   var MockPageContainer;
 
   var makeRoute;
@@ -35,7 +34,7 @@ describe('getRelayQueries', () => {
 
     getRelayQueries = require('getRelayQueries');
 
-    MockPageComponent = class MockPageComponent extends React.Component {
+    class MockPageComponent extends React.Component {
       render() {
         return <div/>;
       }
@@ -121,25 +120,6 @@ describe('getRelayQueries', () => {
     }).toFailInvariant(
       'Relay.QL defined on route `BadRoute` named `first` is not a valid ' +
       'query. A typical query is defined using: Relay.QL`query {...}`'
-    );
-  });
-
-  it('throws if there are unmatched query/fragment names', () => {
-    var MockRoute = makeRoute();
-    var route = new MockRoute({id: '123'});
-
-    var AnotherMockContainer = Relay.createContainer(MockPageComponent, {
-      fragments: {
-        middle: () => Relay.QL`fragment on Node{id}`,
-      }
-    });
-
-    expect(() => {
-      getRelayQueries(AnotherMockContainer, route);
-    }).toFailInvariant(
-      'getRelayQueries: Relay(MockPageComponent).fragments and ' +
-      'MockRoute.queries have unmatched fragment names. Make sure that both ' +
-      'define: first, last, middle'
     );
   });
 });

--- a/src/container/getRelayQueries.js
+++ b/src/container/getRelayQueries.js
@@ -46,15 +46,11 @@ function getRelayQueries(
     return cache[cacheKey];
   }
   var querySet = {};
-  var unmatchedNameMap = {};
-  Object.keys(route.queries).forEach(queryName => {
-    unmatchedNameMap[queryName] = true;
-  });
   Component.getFragmentNames().forEach(fragmentName => {
+    // TODO: Fix this. It relies on the query and fragment names matching.
     var queryName = fragmentName;
     var queryBuilder = route.queries[queryName];
     if (queryBuilder) {
-      delete unmatchedNameMap[queryName];
       var concreteQuery = buildRQL.Query(
         queryBuilder,
         Component,
@@ -79,20 +75,9 @@ function getRelayQueries(
           return;
         }
       }
-    } else {
-      unmatchedNameMap[queryName] = true;
     }
     querySet[fragmentName] = null;
   });
-  var unmatchedNames = Object.keys(unmatchedNameMap);
-  invariant(
-    unmatchedNames.length === 0,
-    'getRelayQueries: %s.fragments and %s.queries have unmatched fragment ' +
-    'names. Make sure that both define: %s',
-    Component.displayName,
-    route.name,
-    unmatchedNames.join(', ')
-  );
   cache[cacheKey] = querySet;
   return querySet;
 }


### PR DESCRIPTION
We were a bit too hasty with this change; our bad. It's conceivable that a Relay Container could specify a fragment that contains fields or not, depending on the active route. In fact, this is how some of our internal apps are built; some routes contain a subset of a container's available fragments, with the knowledge that those fragments won't apply when that route is active.

I'll reopen #20 so we can continue talking about this.

Reverts facebook/relay#49