### PR TITLE
Re-resolve fragments when their calls change

### DIFF
--- a/src/legacy/store/GraphQLStoreQueryResolver.js
+++ b/src/legacy/store/GraphQLStoreQueryResolver.js
@@ -201,8 +201,13 @@ class GraphQLStoreSingleQueryResolver {
       prevID != null &&
       getCanonicalID(prevID) === getCanonicalID(nextID)
     ) {
-      if (this._hasDataChanged || !nextFragment.isEquivalent(prevFragment)) {
-        // same ID but the data, route and/or variables have changed
+      if (
+        prevID !== nextID ||
+        this._hasDataChanged ||
+        !nextFragment.isEquivalent(prevFragment)
+      ) {
+        // same canonical ID,
+        // but the data, call(s), route, and/or variables have changed
         [nextResult, subscribedIDs] = resolveFragment(nextFragment, nextID);
         nextResult = recycleNodesInto(prevResult, nextResult);
       } else {

--- a/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
@@ -152,6 +152,31 @@ describe('GraphQLStoreQueryResolver', () => {
     expect(resolvedB).toBe(mockResultB);
   });
 
+  it('should re-resolve pointers whose calls differ', () => {
+    var fragmentPointerA = new GraphQLFragmentPointer(
+      'client:123_first(10)',
+      mockQueryFragment
+    );
+    var fragmentPointerB = new GraphQLFragmentPointer(
+      'client:123_first(20)',
+      mockQueryFragment
+    );
+
+    var resolver = new GraphQLStoreQueryResolver(
+      fragmentPointerA,
+      mockCallback
+    );
+
+    require('GraphQLStoreRangeUtils').getCanonicalClientID =
+      // The canonical ID of a range customarily excludes the calls
+      jest.genMockFunction().mockReturnValue('client:123');
+
+    resolver.resolve(fragmentPointerA);
+    resolver.resolve(fragmentPointerB);
+
+    expect(readRelayQueryData.mock.calls.length).toBe(2);
+  });
+
   it('should invoke the callback when change events fire', () => {
     var fragmentPointer = new GraphQLFragmentPointer(
       '1038750002',


### PR DESCRIPTION
Given a fragment with a range whose call is `first(1)` one moment, and `first(2)` the next, make sure that `GraphQLStoreQueryResolver::resolve()` re-resolves it.

Fixes #120.