### PR TITLE
remove path from example routes

### DIFF
--- a/examples/relay-treasurehunt/js/routes/AppHomeRoute.js
+++ b/examples/relay-treasurehunt/js/routes/AppHomeRoute.js
@@ -1,5 +1,4 @@
 export default class extends Relay.Route {
-  static path = '/';
   static queries = {
     game: (Component) => Relay.QL`
       query {

--- a/examples/star-wars/js/routes/StarWarsAppHomeRoute.js
+++ b/examples/star-wars/js/routes/StarWarsAppHomeRoute.js
@@ -1,5 +1,4 @@
 export default class extends Relay.Route {
-  static path = '/';
   static queries = {
     factions: (Component) => Relay.QL`
       query {

--- a/examples/todo/js/routes/TodoAppHomeRoute.js
+++ b/examples/todo/js/routes/TodoAppHomeRoute.js
@@ -1,5 +1,4 @@
 export default class extends Relay.Route {
-  static path = '/';
   static queries = {
     viewer: (Component) => Relay.QL`
       query RootQuery {


### PR DESCRIPTION
I found this `path` variable on the example routes confusing - I couldn't find any documentation on it, and changing or removing it seems to have no effect on the examples.  Is it safe to remove?