### PR TITLE
printRelayQuery returns {text,variables} - (OSS version)

### DIFF
--- a/scripts/babel-relay-plugin/src/GraphQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/GraphQLPrinter.js
@@ -135,7 +135,7 @@ function printQuery(query, options) {
     metadata.rootArg = rootCallDecl.args[0].name;
 
     var rootCallTypeName = getTypeForMetadata(rootCallDecl.args[0].type);
-    if (rootCallTypeName !== 'scalar') {
+    if (rootCallTypeName) {
       metadata.rootCallType = rootCallTypeName;
     }
   }
@@ -474,7 +474,7 @@ function printCalls(field, fieldDecl, options) {
 
     var metadata = {};
     var typeName = getTypeForMetadata(callDecl.type);
-    if (typeName !== 'scalar') {
+    if (typeName) {
       metadata.type = typeName;
     }
     return (
@@ -538,11 +538,11 @@ function getScalarValue(node) {
 function getTypeForMetadata(type) {
   type = types.getNamedType(type);
   if (type instanceof types.GraphQLEnumType) {
-    return 'enum';
+    return type.name;
   } else if (type instanceof types.GraphQLInputObjectType) {
-    return 'object';
+    return type.name;
   } else if (type instanceof types.GraphQLScalarType) {
-    return 'scalar';
+    return null;
   }
   throw new Error('Unsupported call value type ' + type.name);
 }

--- a/scripts/babel-relay-plugin/src/GraphQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/GraphQLPrinter.js
@@ -537,9 +537,10 @@ function getScalarValue(node) {
 
 function getTypeForMetadata(type) {
   type = types.getNamedType(type);
-  if (type instanceof types.GraphQLEnumType) {
-    return type.name;
-  } else if (type instanceof types.GraphQLInputObjectType) {
+  if (
+    type instanceof types.GraphQLEnumType ||
+    type instanceof types.GraphQLInputObjectType
+  ) {
     return type.name;
   } else if (type instanceof types.GraphQLScalarType) {
     return null;

--- a/scripts/babel-relay-plugin/src/__fixtures__/callValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/callValues.fixture
@@ -53,7 +53,7 @@ var foo = (function () {
     "generated": true,
     "requisite": true
   })], null, [new GraphQL.Callv("first", 10), new GraphQL.Callv("orderby", "Name"), new GraphQL.Callv("find", "cursor1"), new GraphQL.Callv("isViewerFriend", true), new GraphQL.Callv("gender", "MALE", {
-    "type": "enum"
+    "type": "Gender"
   })], null, null, {
     "parentType": "Node",
     "connection": true

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -46,7 +46,7 @@ var x = (function () {
     'generated': true,
     'requisite': true
   })], null, [new GraphQL.Callv('gender', 'MALE', {
-    'type': 'enum'
+    'type': 'Gender'
   })], null, null, {
     'parentType': 'Node',
     'connection': true

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgument.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgument.fixture
@@ -16,6 +16,6 @@ var q = (function () {
     'parentType': 'SearchResult'
   })], null, {
     'rootArg': 'query',
-    'rootCallType': 'object'
+    'rootCallType': 'SearchInput'
   }, 'QueryWithObjectArgument');
 })();

--- a/src/__forks__/traversal/__tests__/printRelayQuery-test.js
+++ b/src/__forks__/traversal/__tests__/printRelayQuery-test.js
@@ -151,7 +151,7 @@ describe('printRelayQuery', () => {
     });
 
     it('prints enum call values', () => {
-      var value = 'WEB';
+      var enumValue = 'WEB';
       var query = getNode(Relay.QL`
         query FooQuery {
           settings(environment: $env) {
@@ -159,7 +159,7 @@ describe('printRelayQuery', () => {
           },
         }
       `, {
-        env: value
+        env: enumValue
       });
       var {text, variables} = printRelayQuery(query);
       expect(text).toEqual(trimQuery(`
@@ -169,11 +169,13 @@ describe('printRelayQuery', () => {
           }
         }
       `));
-      expect(variables).toEqual({});
+      expect(variables).toEqual({
+        0: enumValue,
+      });
     });
 
     it('prints object call values', () => {
-      var value = {query: 'Menlo Park'};
+      var objectValue = {query: 'Menlo Park'};
       var query = getNode(Relay.QL`
         query {
           checkinSearchQuery(query: $q) {
@@ -181,7 +183,7 @@ describe('printRelayQuery', () => {
           }
         }
       `, {
-        q: value,
+        q: objectValue,
       });
 
       var {text, variables} = printRelayQuery(query);
@@ -192,7 +194,9 @@ describe('printRelayQuery', () => {
           }
         }
       `));
-      expect(variables).toEqual({});
+      expect(variables).toEqual({
+        0: objectValue,
+      });
     });
 
     it('throws for ref queries', () => {
@@ -210,8 +214,7 @@ describe('printRelayQuery', () => {
         },
         'RefQueryName'
       );
-      var {text, variables} = printRelayQuery(query);
-      expect(() => text).toFailInvariant(
+      expect(() => printRelayQuery(query)).toFailInvariant(
         'printRelayQuery(): Deferred queries are not supported.'
       );
     });
@@ -307,7 +310,7 @@ describe('printRelayQuery', () => {
           }
         }
       `, {first: 10});
-      var {text, variables} = printRelayQuery(query);
+      var {text, variables} = printRelayQuery(fragment);
       expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Viewer {
           ${alias}:newsFeed(first:10) {
@@ -336,7 +339,7 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      var {text, variables} = printRelayQuery(query);
+      var {text, variables} = printRelayQuery(fragment);
       expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Actor {
           ${alias}:profilePicture(size:["32","64"]) {
@@ -361,7 +364,7 @@ describe('printRelayQuery', () => {
           }
         }
       `, variables);
-      var {text, variables} = printRelayQuery(query);
+      var {text, variables} = printRelayQuery(fragment);
       expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Actor {
           ${alias}:profilePicture(size:[32,64]) {
@@ -394,7 +397,7 @@ describe('printRelayQuery', () => {
         isViewerFriend: false,
       });
       var alias = fragment.getChildren()[0].getSerializationKey();
-      var {text, variables} = printRelayQuery(query);
+      var {text, variables} = printRelayQuery(fragment);
       expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Actor {
           ${alias}:friends(first:10,orderby:["name"],isViewerFriend:false) {
@@ -428,7 +431,7 @@ describe('printRelayQuery', () => {
         }
       `);
       var fragmentID = getNode(nestedFragment).getFragmentID();
-      var {text, variables} = printRelayQuery(query);
+      var {text, variables} = printRelayQuery(fragment);
       expect(trimQuery(text)).toEqual(trimQuery(`
         fragment UnknownFile on Viewer {
           actor {
@@ -462,7 +465,7 @@ describe('printRelayQuery', () => {
       {input: ''}
     );
 
-    var {text, variables} = printRelayQuery(query);
+    var {text, variables} = printRelayQuery(mutation);
     expect(text).toEqual(trimQuery(`
       mutation UnknownFile($input:FeedbackLikeInput) {
         feedbackLike(input:$input) {

--- a/src/__forks__/traversal/__tests__/printRelayQuery-test.js
+++ b/src/__forks__/traversal/__tests__/printRelayQuery-test.js
@@ -53,7 +53,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query UnknownFile {
           me {
             firstName,
@@ -62,6 +63,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a query with one root argument', () => {
@@ -72,7 +74,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query UnknownFile {
           node(id:"123") {
             name,
@@ -80,6 +83,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a query with one root numeric argument', () => {
@@ -91,7 +95,8 @@ describe('printRelayQuery', () => {
           },
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query FooQuery {
           node(id:123) {
             name,
@@ -99,6 +104,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a query with multiple root arguments', () => {
@@ -110,7 +116,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query UnknownFile {
           usernames(names:["a","b","c"]) {
             firstName,
@@ -119,6 +126,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a query with multiple numeric arguments', () => {
@@ -130,7 +138,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query FooQuery {
           nodes(ids:[123,456]) {
             name,
@@ -138,6 +147,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints enum call values', () => {
@@ -151,13 +161,15 @@ describe('printRelayQuery', () => {
       `, {
         env: value
       });
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
-        query FooQuery {
-          settings(environment:WEB) {
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
+        query FooQuery($0:Environment) {
+          settings(environment:$0) {
             notificationSounds
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints object call values', () => {
@@ -172,13 +184,15 @@ describe('printRelayQuery', () => {
         q: value,
       });
 
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
-        query UnknownFile {
-          checkinSearchQuery(query: {query:"Menlo Park"}) {
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
+        query UnknownFile($0:CheckinSearchInput) {
+          checkinSearchQuery(query:$0) {
             query
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('throws for ref queries', () => {
@@ -196,7 +210,8 @@ describe('printRelayQuery', () => {
         },
         'RefQueryName'
       );
-      expect(() => printRelayQuery(query)).toFailInvariant(
+      var {text, variables} = printRelayQuery(query);
+      expect(() => text).toFailInvariant(
         'printRelayQuery(): Deferred queries are not supported.'
       );
     });
@@ -214,7 +229,8 @@ describe('printRelayQuery', () => {
         }
       `);
       var fragmentID = getNode(fragment).getFragmentID();
-      expect(trimQuery(printRelayQuery(query))).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(trimQuery(text)).toEqual(trimQuery(`
         query UnknownFile {
           node(id:"123") {
             id,
@@ -227,6 +243,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
   });
 
@@ -239,13 +256,15 @@ describe('printRelayQuery', () => {
           },
         }
       `);
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(fragment);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Viewer {
           actor {
             id
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints inline fragments as references', () => {
@@ -258,7 +277,8 @@ describe('printRelayQuery', () => {
         }
       `);
       var fragmentID = getNode(nestedFragment).getFragmentID();
-      expect(trimQuery(printRelayQuery(fragment))).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(fragment);
+      expect(trimQuery(text)).toEqual(trimQuery(`
         fragment UnknownFile on Node {
           id,
           ...${fragmentID},
@@ -269,6 +289,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
   });
 
@@ -286,7 +307,8 @@ describe('printRelayQuery', () => {
           }
         }
       `, {first: 10});
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Viewer {
           ${alias}:newsFeed(first:10) {
             edges {
@@ -302,6 +324,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a field with multiple arguments', () => {
@@ -313,7 +336,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Actor {
           ${alias}:profilePicture(size:["32","64"]) {
             uri
@@ -321,6 +345,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a field with multiple variable arguments', () => {
@@ -336,7 +361,8 @@ describe('printRelayQuery', () => {
           }
         }
       `, variables);
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Actor {
           ${alias}:profilePicture(size:[32,64]) {
             uri
@@ -344,6 +370,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints scalar arguments', () => {
@@ -367,7 +394,8 @@ describe('printRelayQuery', () => {
         isViewerFriend: false,
       });
       var alias = fragment.getChildren()[0].getSerializationKey();
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Actor {
           ${alias}:friends(first:10,orderby:["name"],isViewerFriend:false) {
             edges {
@@ -384,7 +412,8 @@ describe('printRelayQuery', () => {
           id
         }
       `));
-    })
+      expect(variables).toEqual({});
+    });
 
     it('prints inline fragments as references', () => {
       // these fragments have different types and cannot be flattened
@@ -399,7 +428,8 @@ describe('printRelayQuery', () => {
         }
       `);
       var fragmentID = getNode(nestedFragment).getFragmentID();
-      expect(trimQuery(printRelayQuery(fragment))).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(trimQuery(text)).toEqual(trimQuery(`
         fragment UnknownFile on Viewer {
           actor {
             id,
@@ -412,6 +442,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
   });
 
@@ -431,7 +462,8 @@ describe('printRelayQuery', () => {
       {input: ''}
     );
 
-    expect(printRelayQuery(mutation)).toEqual(trimQuery(`
+    var {text, variables} = printRelayQuery(query);
+    expect(text).toEqual(trimQuery(`
       mutation UnknownFile($input:FeedbackLikeInput) {
         feedbackLike(input:$input) {
           clientMutationId,
@@ -443,5 +475,6 @@ describe('printRelayQuery', () => {
         }
       }
     `));
+    expect(variables).toEqual({});
   });
 });

--- a/src/__forks__/traversal/printRelayQuery.js
+++ b/src/__forks__/traversal/printRelayQuery.js
@@ -13,13 +13,22 @@
 
 'use strict';
 
-import type {Call} from 'RelayInternalTypes';
+import type {Call, PrintedQuery} from 'RelayInternalTypes';
 var RelayProfiler = require('RelayProfiler');
 var RelayQuery = require('RelayQuery');
 
 var invariant = require('invariant');
+var mapObject = require('mapObject');
 
-type FragmentMap = {[key: string]: string};
+type PrinterState = {
+  fragmentMap: {[fragmentID: string]: string};
+  nextVariableID: number;
+  variableMap: {[variableID: string]: Variable};
+};
+type Variable = {
+  type: string;
+  value: mixed;
+};
 
 /**
  * @internal
@@ -27,42 +36,54 @@ type FragmentMap = {[key: string]: string};
  * `printRelayQuery(query)` returns a string representation of the query. The
  * supplied `node` must be flattened (and not contain fragments).
  */
-function printRelayQuery(node: RelayQuery.Node): string {
-  var fragmentMap = {};
+function printRelayQuery(node: RelayQuery.Node): PrintedQuery {
+  var printerState = {
+    fragmentMap: {},
+    nextVariableID: 0,
+    variableMap: {},
+  };
   var queryText = null;
   if (node instanceof RelayQuery.Root) {
-    queryText = printRoot(node, fragmentMap);
+    queryText = printRoot(node, printerState);
   } else if (node instanceof RelayQuery.Fragment) {
-    queryText = printFragment(node, fragmentMap);
+    queryText = printFragment(node, printerState);
   } else if (node instanceof RelayQuery.Field) {
-    queryText = printField(node, fragmentMap);
+    queryText = printField(node, printerState);
   } else if (node instanceof RelayQuery.Mutation) {
-    queryText = printMutation(node, fragmentMap);
+    queryText = printMutation(node, printerState);
   }
   invariant(
     queryText,
     'printRelayQuery(): Unsupported node type.'
   );
   // Reassign to preserve Flow type refinement within closure.
-  var query = queryText;
-  Object.keys(fragmentMap).forEach(fragmentID => {
-    var fragmentText = fragmentMap[fragmentID];
+  var text = queryText;
+  Object.keys(printerState.fragmentMap).forEach(fragmentID => {
+    var fragmentText = printerState.fragmentMap[fragmentID];
     if (fragmentText) {
-      query = query + ' ' + fragmentText;
+      text = text + ' ' + fragmentText;
     }
   });
-  return query;
+  var variables = mapObject(
+    printerState.variableMap,
+    variable => variable.value
+  );
+  return {
+    text,
+    variables,
+  };
 }
 
 function printRoot(
   node: RelayQuery.Root,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   invariant(
     !node.getBatchCall(),
     'printRelayQuery(): Deferred queries are not supported.'
   );
 
+  var queryString = node.getName();
   var rootCall = node.getRootCall();
   var rootArgumentName = node.getRootCallArgument();
   var rootFieldString = rootCall.name;
@@ -72,52 +93,69 @@ function printRoot(
       'printRelayQuery(): Expected an argument name for root field `%s`.',
       rootCall.name
     );
-    var rootArgString =
-      printArgument(rootArgumentName, rootCall.value, node.getCallType());
+    var rootArgString = printArgument(
+      rootArgumentName,
+      rootCall.value,
+      node.getCallType(),
+      printerState
+    );
     if (rootArgString) {
       rootFieldString += '(' + rootArgString + ')';
     }
   }
 
-  return 'query ' + node.getName() + '{' +
-    rootFieldString + printChildren(node, fragmentMap) + '}';
+  var argStrings = null;
+  Object.keys(printerState.variableMap).forEach(variableID => {
+    var variable = printerState.variableMap[variableID];
+    if (variable) {
+      argStrings = argStrings || [];
+      argStrings.push('$' + variableID + ':' + variable.type);
+    }
+  });
+  if (argStrings) {
+    queryString += '(' + argStrings.join(',') + ')';
+  }
+
+  return 'query ' + queryString + '{' +
+    rootFieldString + printChildren(node, printerState) + '}';
 }
 
 function printMutation(
   node: RelayQuery.Mutation,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   var inputName = node.getCallVariableName();
   var call = '(' + inputName + ':$' + inputName + ')';
   return 'mutation ' + node.getName() + '($' + inputName + ':' +
     node.getInputType() + ')' + '{' +
     node.getCall().name + call +
-    printChildren(node, fragmentMap) + '}';
+    printChildren(node, printerState) + '}';
 }
 
 function printFragment(
   node: RelayQuery.Fragment,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   return 'fragment ' + node.getDebugName() + ' on ' +
-    node.getType() + printChildren(node, fragmentMap);
+    node.getType() + printChildren(node, printerState);
 }
 
 function printInlineFragment(
   node: RelayQuery.Fragment,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   var fragmentID = node.getFragmentID();
+  var {fragmentMap} = printerState;
   if (!(fragmentID in fragmentMap)) {
     fragmentMap[fragmentID] = 'fragment ' + fragmentID + ' on ' +
-      node.getType() + printChildren(node, fragmentMap);
+      node.getType() + printChildren(node, printerState);
   }
   return '...' + fragmentID;
 }
 
 function printField(
   node: RelayQuery.Field,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   invariant(
     node instanceof RelayQuery.Field,
@@ -130,7 +168,12 @@ function printField(
   var argStrings = null;
   if (callsWithValues.length) {
     callsWithValues.forEach(({name, value}) => {
-      var argString = printArgument(name, value, node.getCallType(name));
+      var argString = printArgument(
+        name,
+        value,
+        node.getCallType(name),
+        printerState
+      );
       if (argString) {
         argStrings = argStrings || [];
         argStrings.push(argString);
@@ -141,16 +184,16 @@ function printField(
     }
   }
   return (serializationKey !== schemaName ? serializationKey + ':' : '') +
-    fieldString + printChildren(node, fragmentMap);
+    fieldString + printChildren(node, printerState);
 }
 
 function printChildren(
   node: RelayQuery.Node,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   var children = node.getChildren().map(node => {
     if (node instanceof RelayQuery.Field) {
-      return printField(node, fragmentMap);
+      return printField(node, printerState);
     } else {
       invariant(
         node instanceof RelayQuery.Fragment,
@@ -158,7 +201,7 @@ function printChildren(
         '`Fragment`, got `%s`.',
         node.constructor.name
       );
-      return printInlineFragment(node, fragmentMap);
+      return printInlineFragment(node, printerState);
     }
   });
   if (!children.length) {
@@ -167,51 +210,38 @@ function printChildren(
   return '{' + children.join(',') + '}';
 }
 
-function printArgument(name: string, value: mixed, type: ?string): ?string {
+function printArgument(
+  name: string,
+  value: mixed,
+  type: ?string,
+  printerState: PrinterState
+): ?string {
   var stringValue;
   if (value == null) {
     return value;
   }
-  if (type === 'enum') {
-    invariant(
-      typeof value === 'string',
-      'RelayQuery: Expected enum argument `%s` to be a string, got `%s`.',
-      name,
-      value
-    );
-    stringValue = value;
-  } else if (type === 'object') {
-    invariant(
-      typeof value === 'object' && !Array.isArray(value) && value !== null,
-      'RelayQuery: Expected object argument `%s` to be an object, got `%s`.',
-      name,
-      value
-    );
-    stringValue = stringifyInputObject(name, value);
+  if (type != null) {
+    var variableID = createVariable(name, value, type, printerState);
+    stringValue = '$' + variableID;
   } else {
     stringValue = JSON.stringify(value);
   }
   return name + ':' + stringValue;
 }
 
-function stringifyInputObject(name: string, value: mixed): string {
-  invariant(
-    value != null,
-    'RelayQuery: Expected input object `%s` to have non-null values.',
-    name
-  );
-  if (typeof value !== 'object') {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) {
-    return '[' +
-      value.map(stringifyInputObject.bind(null, name)).join(',') + ']';
-  }
-  // Reassign to preserve Flow type refinement within closure.
-  var objectValue: Object = (value: $FlowIssue); // non-null object
-  return '{' + Object.keys(objectValue).map(key => {
-    return key + ':' + stringifyInputObject(name, objectValue[key]);
-  }).join(',') + '}';
+function createVariable(
+  name: string,
+  value: mixed,
+  type: string,
+  printerState: PrinterState
+): string {
+  var variableID = printerState.nextVariableID.toString(36);
+  printerState.nextVariableID++;
+  printerState.variableMap[variableID] = {
+    type,
+    value,
+  };
+  return variableID;
 }
 
 module.exports = RelayProfiler.instrument(

--- a/src/__forks__/traversal/printRelayQuery.js
+++ b/src/__forks__/traversal/printRelayQuery.js
@@ -17,6 +17,7 @@ import type {Call, PrintedQuery} from 'RelayInternalTypes';
 var RelayProfiler = require('RelayProfiler');
 var RelayQuery = require('RelayQuery');
 
+var forEachObject = require('forEachObject');
 var invariant = require('invariant');
 var mapObject = require('mapObject');
 
@@ -58,8 +59,7 @@ function printRelayQuery(node: RelayQuery.Node): PrintedQuery {
   );
   // Reassign to preserve Flow type refinement within closure.
   var text = queryText;
-  Object.keys(printerState.fragmentMap).forEach(fragmentID => {
-    var fragmentText = printerState.fragmentMap[fragmentID];
+  forEachObject(printerState.fragmentMap, (fragmentText, fragmentID) => {
     if (fragmentText) {
       text = text + ' ' + fragmentText;
     }
@@ -105,8 +105,7 @@ function printRoot(
   }
 
   var argStrings = null;
-  Object.keys(printerState.variableMap).forEach(variableID => {
-    var variable = printerState.variableMap[variableID];
+  forEachObject(printerState.variableMap, (variable, variableID) => {
     if (variable) {
       argStrings = argStrings || [];
       argStrings.push('$' + variableID + ':' + variable.type);
@@ -221,7 +220,7 @@ function printArgument(
     return value;
   }
   if (type != null) {
-    var variableID = createVariable(name, value, type, printerState);
+    var variableID = createVariable(value, type, printerState);
     stringValue = '$' + variableID;
   } else {
     stringValue = JSON.stringify(value);
@@ -230,7 +229,6 @@ function printArgument(
 }
 
 function createVariable(
-  name: string,
   value: mixed,
   type: string,
   printerState: PrinterState


### PR DESCRIPTION
Changes `babel-relay-plugin` to output the type names for complex (non-scalar) types, and updates the OSS variant of `printRelayQuery` to return `{text,variables}` instead of only the query text. This corresponds to the change in b5c15125e1f781ef9fb7a6d9fc2cf2b7944a1a24.

An example of the output is as follows:

```javascript:
{
  text: `
    query UnknownFile($0:SearchInput) {
      search(query:$0) {
        ...
      }
    }
  `,
  variables: {
    0: {q: 'foo'},
  },
}
```