### PR TITLE
babel-relay-plugin: output type name for non-scalar arguments

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-relay-plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Babel Relay Plugin for transpiling GraphQL queries for use with Relay.",
   "license": "BSD-3-Clause",
   "repository": "facebook/relay",

--- a/scripts/babel-relay-plugin/src/GraphQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/GraphQLPrinter.js
@@ -135,7 +135,7 @@ function printQuery(query, options) {
     metadata.rootArg = rootCallDecl.args[0].name;
 
     var rootCallTypeName = getTypeForMetadata(rootCallDecl.args[0].type);
-    if (rootCallTypeName !== 'scalar') {
+    if (rootCallTypeName) {
       metadata.rootCallType = rootCallTypeName;
     }
   }
@@ -474,7 +474,7 @@ function printCalls(field, fieldDecl, options) {
 
     var metadata = {};
     var typeName = getTypeForMetadata(callDecl.type);
-    if (typeName !== 'scalar') {
+    if (typeName) {
       metadata.type = typeName;
     }
     return (
@@ -537,12 +537,13 @@ function getScalarValue(node) {
 
 function getTypeForMetadata(type) {
   type = types.getNamedType(type);
-  if (type instanceof types.GraphQLEnumType) {
-    return 'enum';
-  } else if (type instanceof types.GraphQLInputObjectType) {
-    return 'object';
+  if (
+    type instanceof types.GraphQLEnumType ||
+    type instanceof types.GraphQLInputObjectType
+  ) {
+    return type.name;
   } else if (type instanceof types.GraphQLScalarType) {
-    return 'scalar';
+    return null;
   }
   throw new Error('Unsupported call value type ' + type.name);
 }

--- a/scripts/babel-relay-plugin/src/__fixtures__/callValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/callValues.fixture
@@ -53,7 +53,7 @@ var foo = (function () {
     "generated": true,
     "requisite": true
   })], null, [new GraphQL.Callv("first", 10), new GraphQL.Callv("orderby", "Name"), new GraphQL.Callv("find", "cursor1"), new GraphQL.Callv("isViewerFriend", true), new GraphQL.Callv("gender", "MALE", {
-    "type": "enum"
+    "type": "Gender"
   })], null, null, {
     "parentType": "Node",
     "connection": true

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -46,7 +46,7 @@ var x = (function () {
     'generated': true,
     'requisite': true
   })], null, [new GraphQL.Callv('gender', 'MALE', {
-    'type': 'enum'
+    'type': 'Gender'
   })], null, null, {
     'parentType': 'Node',
     'connection': true

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgument.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgument.fixture
@@ -16,6 +16,6 @@ var q = (function () {
     'parentType': 'SearchResult'
   })], null, {
     'rootArg': 'query',
-    'rootCallType': 'object'
+    'rootCallType': 'SearchInput'
   }, 'QueryWithObjectArgument');
 })();


### PR DESCRIPTION
Changes the babel plugin to output metadata about the name of non-scalar argument types. This is a prerequisite for sending queries with these argument types to the server correctly.

See #100 