### PR TITLE
printRelayQuery: print non-scalar arguments as query input variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "babel-core": "5.8.21",
     "babel-loader": "5.3.2",
-    "babel-relay-plugin": "^0.1.2",
+    "babel-relay-plugin": "^0.1.3",
     "del": "^1.2.0",
     "envify": "^3.4.0",
     "flow-bin": "0.14.0",

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
@@ -1,9 +1,9 @@
 Input:
 var Relay = require('react-relay');
 var x = Relay.QL`
-  query {
+  query($gender_0:Gender) {
     node(id: 123) {
-      friends(gender: MALE) {
+      friends(gender: $gender_0) {
         edges {
           node {
             id
@@ -45,7 +45,7 @@ var x = (function () {
     'parentType': 'UserConnection',
     'generated': true,
     'requisite': true
-  })], null, [new GraphQL.Callv('gender', 'MALE', {
+  })], null, [new GraphQL.Callv('gender', new GraphQL.CallVariable('gender_0'), {
     'type': 'Gender'
   })], null, null, {
     'parentType': 'Node',
@@ -56,5 +56,5 @@ var x = (function () {
     'requisite': true
   })], null, {
     'rootArg': 'id'
-  }, 'FieldWithEnumArg');
+  }, 'FieldWithEnumQueryArg');
 })();

--- a/src/__forks__/traversal/__tests__/printRelayQuery-test.js
+++ b/src/__forks__/traversal/__tests__/printRelayQuery-test.js
@@ -53,7 +53,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query UnknownFile {
           me {
             firstName,
@@ -62,6 +63,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a query with one root argument', () => {
@@ -72,7 +74,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query UnknownFile {
           node(id:"123") {
             name,
@@ -80,6 +83,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a query with one root numeric argument', () => {
@@ -91,7 +95,8 @@ describe('printRelayQuery', () => {
           },
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query FooQuery {
           node(id:123) {
             name,
@@ -99,6 +104,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a query with multiple root arguments', () => {
@@ -110,7 +116,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query UnknownFile {
           usernames(names:["a","b","c"]) {
             firstName,
@@ -119,6 +126,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a query with multiple numeric arguments', () => {
@@ -130,7 +138,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
         query FooQuery {
           nodes(ids:[123,456]) {
             name,
@@ -138,10 +147,11 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints enum call values', () => {
-      var value = 'WEB';
+      var enumValue = 'WEB';
       var query = getNode(Relay.QL`
         query FooQuery {
           settings(environment: $env) {
@@ -149,19 +159,23 @@ describe('printRelayQuery', () => {
           },
         }
       `, {
-        env: value
+        env: enumValue
       });
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
-        query FooQuery {
-          settings(environment:WEB) {
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
+        query FooQuery($environment_0:Environment) {
+          settings(environment:$environment_0) {
             notificationSounds
           }
         }
       `));
+      expect(variables).toEqual({
+        environment_0: enumValue,
+      });
     });
 
     it('prints object call values', () => {
-      var value = {query: 'Menlo Park'};
+      var objectValue = {query: 'Menlo Park'};
       var query = getNode(Relay.QL`
         query {
           checkinSearchQuery(query: $q) {
@@ -169,16 +183,20 @@ describe('printRelayQuery', () => {
           }
         }
       `, {
-        q: value,
+        q: objectValue,
       });
 
-      expect(printRelayQuery(query)).toEqual(trimQuery(`
-        query UnknownFile {
-          checkinSearchQuery(query: {query:"Menlo Park"}) {
+      var {text, variables} = printRelayQuery(query);
+      expect(text).toEqual(trimQuery(`
+        query UnknownFile($query_0:CheckinSearchInput) {
+          checkinSearchQuery(query:$query_0) {
             query
           }
         }
       `));
+      expect(variables).toEqual({
+        query_0: objectValue,
+      });
     });
 
     it('throws for ref queries', () => {
@@ -214,7 +232,8 @@ describe('printRelayQuery', () => {
         }
       `);
       var fragmentID = getNode(fragment).getFragmentID();
-      expect(trimQuery(printRelayQuery(query))).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(query);
+      expect(trimQuery(text)).toEqual(trimQuery(`
         query UnknownFile {
           node(id:"123") {
             id,
@@ -227,6 +246,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
   });
 
@@ -239,13 +259,15 @@ describe('printRelayQuery', () => {
           },
         }
       `);
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(fragment);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Viewer {
           actor {
             id
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints inline fragments as references', () => {
@@ -258,7 +280,8 @@ describe('printRelayQuery', () => {
         }
       `);
       var fragmentID = getNode(nestedFragment).getFragmentID();
-      expect(trimQuery(printRelayQuery(fragment))).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(fragment);
+      expect(trimQuery(text)).toEqual(trimQuery(`
         fragment UnknownFile on Node {
           id,
           ...${fragmentID},
@@ -269,6 +292,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
   });
 
@@ -286,7 +310,8 @@ describe('printRelayQuery', () => {
           }
         }
       `, {first: 10});
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(fragment);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Viewer {
           ${alias}:newsFeed(first:10) {
             edges {
@@ -302,6 +327,7 @@ describe('printRelayQuery', () => {
           }
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a field with multiple arguments', () => {
@@ -313,7 +339,8 @@ describe('printRelayQuery', () => {
           }
         }
       `);
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(fragment);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Actor {
           ${alias}:profilePicture(size:["32","64"]) {
             uri
@@ -321,6 +348,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints a field with multiple variable arguments', () => {
@@ -336,7 +364,8 @@ describe('printRelayQuery', () => {
           }
         }
       `, variables);
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(fragment);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Actor {
           ${alias}:profilePicture(size:[32,64]) {
             uri
@@ -344,6 +373,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
 
     it('prints scalar arguments', () => {
@@ -367,7 +397,8 @@ describe('printRelayQuery', () => {
         isViewerFriend: false,
       });
       var alias = fragment.getChildren()[0].getSerializationKey();
-      expect(printRelayQuery(fragment)).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(fragment);
+      expect(text).toEqual(trimQuery(`
         fragment UnknownFile on Actor {
           ${alias}:friends(first:10,orderby:["name"],isViewerFriend:false) {
             edges {
@@ -384,7 +415,8 @@ describe('printRelayQuery', () => {
           id
         }
       `));
-    })
+      expect(variables).toEqual({});
+    });
 
     it('prints inline fragments as references', () => {
       // these fragments have different types and cannot be flattened
@@ -399,7 +431,8 @@ describe('printRelayQuery', () => {
         }
       `);
       var fragmentID = getNode(nestedFragment).getFragmentID();
-      expect(trimQuery(printRelayQuery(fragment))).toEqual(trimQuery(`
+      var {text, variables} = printRelayQuery(fragment);
+      expect(trimQuery(text)).toEqual(trimQuery(`
         fragment UnknownFile on Viewer {
           actor {
             id,
@@ -412,6 +445,7 @@ describe('printRelayQuery', () => {
           id
         }
       `));
+      expect(variables).toEqual({});
     });
   });
 
@@ -431,7 +465,8 @@ describe('printRelayQuery', () => {
       {input: ''}
     );
 
-    expect(printRelayQuery(mutation)).toEqual(trimQuery(`
+    var {text, variables} = printRelayQuery(mutation);
+    expect(text).toEqual(trimQuery(`
       mutation UnknownFile($input:FeedbackLikeInput) {
         feedbackLike(input:$input) {
           clientMutationId,
@@ -443,5 +478,6 @@ describe('printRelayQuery', () => {
         }
       }
     `));
+    expect(variables).toEqual({});
   });
 });

--- a/src/__forks__/traversal/printRelayQuery.js
+++ b/src/__forks__/traversal/printRelayQuery.js
@@ -13,13 +13,23 @@
 
 'use strict';
 
-import type {Call} from 'RelayInternalTypes';
+import type {Call, PrintedQuery} from 'RelayInternalTypes';
 var RelayProfiler = require('RelayProfiler');
 var RelayQuery = require('RelayQuery');
 
+var forEachObject = require('forEachObject');
 var invariant = require('invariant');
+var mapObject = require('mapObject');
 
-type FragmentMap = {[key: string]: string};
+type PrinterState = {
+  fragmentMap: {[fragmentID: string]: string};
+  nextVariableID: number;
+  variableMap: {[variableID: string]: Variable};
+};
+type Variable = {
+  type: string;
+  value: mixed;
+};
 
 /**
  * @internal
@@ -27,42 +37,53 @@ type FragmentMap = {[key: string]: string};
  * `printRelayQuery(query)` returns a string representation of the query. The
  * supplied `node` must be flattened (and not contain fragments).
  */
-function printRelayQuery(node: RelayQuery.Node): string {
-  var fragmentMap = {};
+function printRelayQuery(node: RelayQuery.Node): PrintedQuery {
+  var printerState = {
+    fragmentMap: {},
+    nextVariableID: 0,
+    variableMap: {},
+  };
   var queryText = null;
   if (node instanceof RelayQuery.Root) {
-    queryText = printRoot(node, fragmentMap);
+    queryText = printRoot(node, printerState);
   } else if (node instanceof RelayQuery.Fragment) {
-    queryText = printFragment(node, fragmentMap);
+    queryText = printFragment(node, printerState);
   } else if (node instanceof RelayQuery.Field) {
-    queryText = printField(node, fragmentMap);
+    queryText = printField(node, printerState);
   } else if (node instanceof RelayQuery.Mutation) {
-    queryText = printMutation(node, fragmentMap);
+    queryText = printMutation(node, printerState);
   }
   invariant(
     queryText,
     'printRelayQuery(): Unsupported node type.'
   );
   // Reassign to preserve Flow type refinement within closure.
-  var query = queryText;
-  Object.keys(fragmentMap).forEach(fragmentID => {
-    var fragmentText = fragmentMap[fragmentID];
+  var text = queryText;
+  forEachObject(printerState.fragmentMap, (fragmentText, fragmentID) => {
     if (fragmentText) {
-      query = query + ' ' + fragmentText;
+      text = text + ' ' + fragmentText;
     }
   });
-  return query;
+  var variables = mapObject(
+    printerState.variableMap,
+    variable => variable.value
+  );
+  return {
+    text,
+    variables,
+  };
 }
 
 function printRoot(
   node: RelayQuery.Root,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   invariant(
     !node.getBatchCall(),
     'printRelayQuery(): Deferred queries are not supported.'
   );
 
+  var queryString = node.getName();
   var rootCall = node.getRootCall();
   var rootArgumentName = node.getRootCallArgument();
   var rootFieldString = rootCall.name;
@@ -72,52 +93,68 @@ function printRoot(
       'printRelayQuery(): Expected an argument name for root field `%s`.',
       rootCall.name
     );
-    var rootArgString =
-      printArgument(rootArgumentName, rootCall.value, node.getCallType());
+    var rootArgString = printArgument(
+      rootArgumentName,
+      rootCall.value,
+      node.getCallType(),
+      printerState
+    );
     if (rootArgString) {
       rootFieldString += '(' + rootArgString + ')';
     }
   }
 
-  return 'query ' + node.getName() + '{' +
-    rootFieldString + printChildren(node, fragmentMap) + '}';
+  var argStrings = null;
+  forEachObject(printerState.variableMap, (variable, variableID) => {
+    if (variable) {
+      argStrings = argStrings || [];
+      argStrings.push('$' + variableID + ':' + variable.type);
+    }
+  });
+  if (argStrings) {
+    queryString += '(' + argStrings.join(',') + ')';
+  }
+
+  return 'query ' + queryString + '{' +
+    rootFieldString + printChildren(node, printerState) + '}';
 }
 
 function printMutation(
   node: RelayQuery.Mutation,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   var inputName = node.getCallVariableName();
   var call = '(' + inputName + ':$' + inputName + ')';
   return 'mutation ' + node.getName() + '($' + inputName + ':' +
     node.getInputType() + ')' + '{' +
     node.getCall().name + call +
-    printChildren(node, fragmentMap) + '}';
+    printChildren(node, printerState) + '}';
 }
 
 function printFragment(
   node: RelayQuery.Fragment,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   return 'fragment ' + node.getDebugName() + ' on ' +
-    node.getType() + printChildren(node, fragmentMap);
+    node.getType() + printChildren(node, printerState);
 }
 
 function printInlineFragment(
   node: RelayQuery.Fragment,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   var fragmentID = node.getFragmentID();
+  var {fragmentMap} = printerState;
   if (!(fragmentID in fragmentMap)) {
     fragmentMap[fragmentID] = 'fragment ' + fragmentID + ' on ' +
-      node.getType() + printChildren(node, fragmentMap);
+      node.getType() + printChildren(node, printerState);
   }
   return '...' + fragmentID;
 }
 
 function printField(
   node: RelayQuery.Field,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   invariant(
     node instanceof RelayQuery.Field,
@@ -130,7 +167,12 @@ function printField(
   var argStrings = null;
   if (callsWithValues.length) {
     callsWithValues.forEach(({name, value}) => {
-      var argString = printArgument(name, value, node.getCallType(name));
+      var argString = printArgument(
+        name,
+        value,
+        node.getCallType(name),
+        printerState
+      );
       if (argString) {
         argStrings = argStrings || [];
         argStrings.push(argString);
@@ -141,16 +183,16 @@ function printField(
     }
   }
   return (serializationKey !== schemaName ? serializationKey + ':' : '') +
-    fieldString + printChildren(node, fragmentMap);
+    fieldString + printChildren(node, printerState);
 }
 
 function printChildren(
   node: RelayQuery.Node,
-  fragmentMap: FragmentMap
+  printerState: PrinterState
 ): string {
   var children = node.getChildren().map(node => {
     if (node instanceof RelayQuery.Field) {
-      return printField(node, fragmentMap);
+      return printField(node, printerState);
     } else {
       invariant(
         node instanceof RelayQuery.Fragment,
@@ -158,7 +200,7 @@ function printChildren(
         '`Fragment`, got `%s`.',
         node.constructor.name
       );
-      return printInlineFragment(node, fragmentMap);
+      return printInlineFragment(node, printerState);
     }
   });
   if (!children.length) {
@@ -167,51 +209,38 @@ function printChildren(
   return '{' + children.join(',') + '}';
 }
 
-function printArgument(name: string, value: mixed, type: ?string): ?string {
+function printArgument(
+  name: string,
+  value: mixed,
+  type: ?string,
+  printerState: PrinterState
+): ?string {
   var stringValue;
   if (value == null) {
     return value;
   }
-  if (type === 'enum') {
-    invariant(
-      typeof value === 'string',
-      'RelayQuery: Expected enum argument `%s` to be a string, got `%s`.',
-      name,
-      value
-    );
-    stringValue = value;
-  } else if (type === 'object') {
-    invariant(
-      typeof value === 'object' && !Array.isArray(value) && value !== null,
-      'RelayQuery: Expected object argument `%s` to be an object, got `%s`.',
-      name,
-      value
-    );
-    stringValue = stringifyInputObject(name, value);
+  if (type != null) {
+    var variableID = createVariable(name, value, type, printerState);
+    stringValue = '$' + variableID;
   } else {
     stringValue = JSON.stringify(value);
   }
   return name + ':' + stringValue;
 }
 
-function stringifyInputObject(name: string, value: mixed): string {
-  invariant(
-    value != null,
-    'RelayQuery: Expected input object `%s` to have non-null values.',
-    name
-  );
-  if (typeof value !== 'object') {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) {
-    return '[' +
-      value.map(stringifyInputObject.bind(null, name)).join(',') + ']';
-  }
-  // Reassign to preserve Flow type refinement within closure.
-  var objectValue: Object = (value: $FlowIssue); // non-null object
-  return '{' + Object.keys(objectValue).map(key => {
-    return key + ':' + stringifyInputObject(name, objectValue[key]);
-  }).join(',') + '}';
+function createVariable(
+  name: string,
+  value: mixed,
+  type: string,
+  printerState: PrinterState
+): string {
+  var variableID = name + '_' + printerState.nextVariableID.toString(36);
+  printerState.nextVariableID++;
+  printerState.variableMap[variableID] = {
+    type,
+    value,
+  };
+  return variableID;
 }
 
 module.exports = RelayProfiler.instrument(


### PR DESCRIPTION
Updates the OSS `printRelayQuery` to return `{text,variables}` instead of only the query text. This corresponds to the internal printer change from b5c15125e1f781ef9fb7a6d9fc2cf2b7944a1a24.

An example of the output is as follows:

```javascript:
{
  text: `
    query UnknownFile($0:SearchInput) {
      search(query:$0) {
        ...
      }
    }
  `,
  variables: {
    0: {q: 'foo'},
  },
}
```