### PR TITLE
Throw if container is missing fragments

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -967,6 +967,7 @@ function create(
     now: componentName + '.getFragmentNames',
     adapter: ContainerConstructor.getFragmentNames,
   });
+  ContainerConstructor.hasFragment = fragmentName => !!fragments[fragmentName];
 
   /**
    * Retrieves a reference to the fragment by name. An optional second argument

--- a/src/container/__tests__/RelayContainer-test.js
+++ b/src/container/__tests__/RelayContainer-test.js
@@ -195,6 +195,12 @@ describe('RelayContainer', function() {
         ])
       ));
     });
+
+    it('returns whether a named fragment is defined', () => {
+      expect(MockContainer.hasFragment('foo')).toBe(true);
+      expect(MockContainer.hasFragment('bar')).toBe(true);
+      expect(MockContainer.hasFragment('baz')).toBe(false);
+    });
   });
 
   describe('conditional fragments', () => {

--- a/src/container/__tests__/getRelayQueries-test.js
+++ b/src/container/__tests__/getRelayQueries-test.js
@@ -20,6 +20,7 @@ var getRelayQueries = require('getRelayQueries');
 
 describe('getRelayQueries', () => {
   var MockPageContainer;
+  var MockPageComponent;
 
   var makeRoute;
 
@@ -28,7 +29,7 @@ describe('getRelayQueries', () => {
   beforeEach(() => {
     jest.resetModuleRegistry();
 
-    class MockPageComponent extends React.Component {
+    MockPageComponent = class MockPageComponent extends React.Component {
       render() {
         return <div/>;
       }
@@ -112,8 +113,26 @@ describe('getRelayQueries', () => {
     expect(() => {
       getRelayQueries(MockPageContainer, badRoute);
     }).toFailInvariant(
-      'Relay.QL defined on route `BadRoute` named `first` is not a valid ' +
-      'query. A typical query is defined using: Relay.QL`query {...}`'
+      'Relay.QL: query `BadRoute.queries.first` is invalid, a typical ' +
+      'query is defined using: () => Relay.QL`query { ... }`.'
+    );
+  });
+
+  it('throws if a container does not include a required fragment', () => {
+    var MockRoute = makeRoute();
+    var route = new MockRoute({id: '123'});
+
+    var AnotherMockContainer = Relay.createContainer(MockPageComponent, {
+      fragments: {
+        first: () => Relay.QL`fragment on Node{id}`,
+      }
+    });
+
+    expect(() => {
+      getRelayQueries(AnotherMockContainer, route);
+    }).toFailInvariant(
+      'Relay.QL: query `MockRoute.queries.last` is invalid, expected ' +
+      'fragment `Relay(MockPageComponent).fragments.last` to be defined.'
     );
   });
 });

--- a/src/container/getRelayQueries.js
+++ b/src/container/getRelayQueries.js
@@ -46,9 +46,16 @@ function getRelayQueries(
     return cache[cacheKey];
   }
   var querySet = {};
-  Component.getFragmentNames().forEach(fragmentName => {
-    // TODO: Fix this. It relies on the query and fragment names matching.
-    var queryName = fragmentName;
+  Object.keys(route.queries).forEach(queryName => {
+    invariant(
+      Component.hasFragment(queryName),
+      'Relay.QL: query `%s.queries.%s` is invalid, expected fragment ' +
+      '`%s.fragments.%s` to be defined.',
+      route.name,
+      queryName,
+      Component.displayName,
+      queryName
+    );
     var queryBuilder = route.queries[queryName];
     if (queryBuilder) {
       var concreteQuery = buildRQL.Query(
@@ -58,8 +65,8 @@ function getRelayQueries(
       );
       invariant(
         concreteQuery !== undefined,
-        'Relay.QL defined on route `%s` named `%s` is not a valid query. ' +
-        'A typical query is defined using: Relay.QL`query {...}`',
+        'Relay.QL: query `%s.queries.%s` is invalid, a typical query is ' +
+        'defined using: () => Relay.QL`query { ... }`.',
         route.name,
         queryName
       );
@@ -71,12 +78,12 @@ function getRelayQueries(
         );
         var rootCall = rootQuery.getRootCall();
         if (rootCall.value !== undefined) {
-          querySet[fragmentName] = rootQuery;
+          querySet[queryName] = rootQuery;
           return;
         }
       }
     }
-    querySet[fragmentName] = null;
+    querySet[queryName] = null;
   });
   cache[cacheKey] = querySet;
   return querySet;

--- a/src/container/isRelayContainer.js
+++ b/src/container/isRelayContainer.js
@@ -14,7 +14,12 @@
 'use strict';
 
 function isRelayContainer(component: any): boolean {
-  return !!(component && component.getFragmentNames && component.getFragment);
+  return !!(
+    component &&
+    component.getFragmentNames &&
+    component.getFragment &&
+    component.hasFragment
+  );
 }
 
 module.exports = isRelayContainer;


### PR DESCRIPTION
Another crack at #20 / #131

Rather than building the query set from the set of all fragments that a component has, it builds them from the set **required** by the route, and throws if the component doesn't provide one.

I'm on the fence about keeping `hasFragment`.

This should be compatible with FB code, but let me know if it's not @steveluscher @josephsavona