### PR TITLE
Mongoose example

### DIFF
--- a/examples/mongoose-example/.gitignore
+++ b/examples/mongoose-example/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+node_modules
+npm-debug.log
+.idea
+data/printedIntrospection.*
+data/printedSchema.*
+data/schema.json

--- a/examples/mongoose-example/LICENSE
+++ b/examples/mongoose-example/LICENSE
@@ -1,0 +1,31 @@
+BSD License
+
+For Relay Starter Kit software
+
+Copyright (c) 2013-2015, Facebook, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/mongoose-example/PATENTS
+++ b/examples/mongoose-example/PATENTS
@@ -1,0 +1,33 @@
+Additional Grant of Patent Rights Version 2
+
+"Software" means the Relay Starter Kit software distributed by Facebook, Inc.
+
+Facebook, Inc. ("Facebook") hereby grants to each recipient of the Software
+("you") a perpetual, worldwide, royalty-free, non-exclusive, irrevocable
+(subject to the termination provision below) license under any Necessary
+Claims, to make, have made, use, sell, offer to sell, import, and otherwise
+transfer the Software. For avoidance of doubt, no license is granted under
+Facebook's rights in any patent claims that are infringed by (i) modifications
+to the Software made by you or any third party or (ii) the Software in
+combination with any software or other technology.
+
+The license granted hereunder will terminate, automatically and without notice,
+if you (or any of your subsidiaries, corporate affiliates or agents) initiate
+directly or indirectly, or take a direct financial interest in, any Patent
+Assertion: (i) against Facebook or any of its subsidiaries or corporate
+affiliates, (ii) against any party if such Patent Assertion arises in whole or
+in part from any software, technology, product or service of Facebook or any of
+its subsidiaries or corporate affiliates, or (iii) against any party relating
+to the Software. Notwithstanding the foregoing, if Facebook or any of its
+subsidiaries or corporate affiliates files a lawsuit alleging patent
+infringement against you in the first instance, and you respond by filing a
+patent infringement counterclaim in that lawsuit against that party that is
+unrelated to the Software, the license granted hereunder will not terminate
+under section (i) of this paragraph due to such counterclaim.
+
+A "Necessary Claim" is a claim of a patent owned by Facebook that is
+necessarily infringed by the Software standing alone.
+
+A "Patent Assertion" is any lawsuit or other action alleging direct, indirect,
+or contributory infringement or inducement to infringe any patent, including a
+cross-claim or counterclaim.

--- a/examples/mongoose-example/README.md
+++ b/examples/mongoose-example/README.md
@@ -1,0 +1,393 @@
+# Relay Mongoose example
+
+## Folders and files
+
+### js
+React components and entry point to the app.
+
+### data
+Models and schema for graphql
+
+## Scripts
+You can find some scripts in the package.json:
+* `npm start` Is the default that comes with the relay-kit and starts the server
+* `npm run update-schema` generates the associated schema file from the one we will code.
+* `npm run restart` will run `npm run update-schema` and then `npm start`
+* `npm run print-schema` Will print the schema in the console and generate a .graphql file in the data folder called *printedSchema.graphql*
+* `npm run print-instrospection` the same than above but with introspection.
+* `npm run populate` will fill with mock data your MongoDB using mongoose.
+
+> Disclaimer: Info contained in the population script could not be accurate
+
+## The schema
+The schema we will use is the following (you can print it too using `npm run print-schema`):
+
+```graphql
+type Hobby implements Node {
+  id: ID!
+  title: String
+  description: String
+  type: String!
+}
+
+interface Node {
+  id: ID!
+  type: String
+}
+
+type RootMutation {
+  addUser(name: String!, surname: String!, age: Int): User
+  updateUser(id: ID, name: String, surname: String, age: Int): User
+  addHobby(title: String!, description: String!): Hobby
+}
+
+type RootQuery {
+  user(id: ID): User
+  users: [User]
+  hobby(id: ID): Hobby
+  hobbies: [Hobby]
+  node(id: ID!): Node
+}
+
+type User implements Node {
+  id: ID!
+  name: String
+  surname: String
+  age: Int
+  hobbies: [Hobby]
+  type: String!
+}
+```
+As you can see, there is a hobby and user types that implements the node interface. Then you can find 5 queries:
+
+### Queries
+1. **`user(id: ID): User`** that needs the MongoDB *_id* as id parameter to recover that particular user.
+2. **`users: [User]`** that returns the array of users in the ddbb
+3. **`hobby(id: ID): Hobby`** returns a hobby by its ID
+4. **`hobbies: [Hobby]`** returns the list of hobbies
+5. **`node(id: ID!): Node`** returns a node, user or hobby, of the corresponding ID. Node will only return common parameters so
+the following query:
+```graphql
+query query {
+	node(id:"55ddeec2a54c37e61e0a2122") {
+    	id
+        type
+    }
+}
+```
+Will return
+```json
+{
+    "data": {
+        "node": {
+            "id": "55ddeec2a54c37e61e0a2121",
+            "type": "user"
+        }
+    }
+}
+```
+In this case, I'm storing the type in the ddbb too. If you want to query a result via node, you have to use fragments to retrieve the rest of the info:
+
+```graphql
+query query {
+	node(id:"55ddeec2a54c37e61e0a2122") {
+    	id
+      type
+      ...user
+    }
+}
+
+fragment user on User {
+	name
+    surname
+}
+```
+
+Will return
+
+```json
+{
+    "data": {
+        "node": {
+            "id": "55ddeec2a54c37e61e0a2121",
+            "type": "user",
+            "name": "Tim",
+            "surname": "Berners-Lee"
+        }
+    }
+}
+```
+
+### Mutations
+1. **`addUser(name: String!, surname: String!, age: Int): User`** adds a user and accepts the 3 params:
+  * *`name`* as non null(!) string. For example: `"Linus"`
+  * *`surname`*  as non null string. For example: `"Torvalds"`
+  * *`age`* as optional int. For example: `30`
+2. **`updateUser(id: ID, name: String, surname: String, age: Int): User`**
+3. **`addHobby(title: String!, description: String!): Hobby`**
+
+## Writing the schema
+
+### Node interface
+The node interface defines the common parameters for any "node" (user or hobby) of the app: id and type:
+```javascript
+let Node = new GraphQLInterfaceType({
+  name:'Node',
+  description:'An object with an ID',
+  fields: () => ({
+    id: {
+      type:new GraphQLNonNull(GraphQLID),
+      description: 'The global unique ID of an object'
+    },
+    type: {
+      type: GraphQLString,
+      description: "The type of the object"
+    }
+  }),
+  resolveType: (obj) => {
+    if(obj.type === 'user'){
+      return UserType;
+    } else if(obj.type === 'hobby') {
+      return HobbyType;
+    }
+  }
+});
+```
+resolveType must return the type of the corresponding fetched object. So if we fetch an object via "node" and it's type is user, here we must return the instance of "UserType".
+
+### User and Hobby types
+```javascript
+// User
+let UserType = new GraphQLObjectType({
+  name: 'User',
+  description: 'A user',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID)
+    },
+    name: {
+      type: GraphQLString
+    },
+    surname:{
+      type: GraphQLString
+    },
+    age:{
+      type: GraphQLInt
+    },
+    hobbies:{
+      type: new GraphQLList(HobbyType),
+      description: 'The ships used by the faction.'
+    },
+    type:{
+      type: new GraphQLNonNull(GraphQLString)
+    }
+  }),
+
+  interfaces:[Node]
+});
+```
+
+Pretty self-explanatory: it is composed for an id, name, surname and age atomic fields. The it has a one to many relationship with hobbies (a user has 0 or more hobbies).
+
+```javascript
+//Hobby
+let HobbyType = new GraphQLObjectType({
+  name: 'Hobby',
+  description: 'A hobby',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID)
+    },
+    title: {
+      type: GraphQLString
+    },
+    description:{
+      type: GraphQLString
+    },
+    type:{
+      type: new GraphQLNonNull(GraphQLString)
+    }
+  }),
+
+  interfaces:[Node]
+});
+```
+Similar. A hobby is composed by an id, a title, a description and a type (always hobby).
+
+### Queries
+Now let's define the queries for User and Hobby
+```javascript
+//User
+let UserQueries = {
+  users: {
+    type: new GraphQLList(UserType),
+    name: 'users',
+    description: 'A user list',
+    resolve: User.getListOfUsers
+  },
+  user: {
+    type: UserType,
+    args: {
+      id: {
+        type: GraphQLID
+      }
+    },
+    resolve: User.getUserById
+  }
+};
+```
+As we metioned before, we have 2 queries: user and users.
+1. **users** do not accepts arguments and returns a list of users `new GraphQLList(UserType)`. Resolve makes the query on MongoDB using Mongoose and returns the list of users as a Promise.
+2. **user** needs one argument: the mongodb id to query. Returns a UserType and it's resolve method returns a promise with the content of the user
+
+```javascript
+let HobbyQueries = {
+  hobby: {
+    type: HobbyType,
+    args: {
+      id: {
+        type: GraphQLID
+      }
+    },
+    resolve: Hobby.getHobbyById
+  },
+
+  hobbies: {
+    type: new GraphQLList(HobbyType),
+    resolve: Hobby.getListOfHobbies
+  }
+};
+```
+Hobbies queries are pretty similar to user queries:
+1. **hobbies** do not accepts arguments and returns a list of users `new GraphQLList(HobbyType)`. Resolve makes the query on MongoDB using Mongoose and returns the list of hobbies as a Promise.
+2. **hobby** needs one argument: the mongodb id to query. Returns a HobbyType and it's resolve method returns a promise with the content of the hobby
+
+### Declaring RootQuery
+```javascript
+let RootQuery = new GraphQLObjectType({
+  name: 'RootQuery',      //Return this type of object
+
+  fields: () => ({
+    user: UserQueries.user,
+    users: UserQueries.users,
+    hobby: HobbyQueries.hobby,
+    hobbies: HobbyQueries.hobbies,
+    node: nodeField
+  })
+});
+```
+RootQuery just needs a name and to define the fields (queries) that will accept. There is where we passed the previous queries that we have code. As you can see, RootQuery is also a GraphQLObjectType like our UserQueries and HobbyQueries.
+
+### Declaring the schema
+let schema = new GraphQLSchema({
+  query: RootQuery
+});
+
+Finally, we create a GraphQLSchema file to pass our queries object
+
+## Server Ready
+Let's pass to the client
+
+
+## Client side
+On the client, we will declare our React components, our RootContainer and our Route.
+
+### Route (js/routes/AppHomeRoute.js)
+In the route we have to declare 3 things at least:
+1. a `static routeName` to simply give our route a name
+2. a `static path` to access this route
+3. a `static queries` with a Relay.QL query to fetch the object to fill the entire page.
+
+```javascript
+class AppHomeRoute extends Relay.Route {
+  static path = '/';
+
+  static queries = {
+    user: (Component) => Relay.QL `
+      query {
+        user (id: $userId) {
+          ${Component.getFragment('user')}
+        }
+      }
+    `
+  };
+
+  static paramDefinitions = { userId: {required: true} };
+  static routeName = 'AppHomeRoute';
+}
+
+export default AppHomeRoute;
+```
+* `${Component.getFragment('user')}` This could be the most annoying thing. It asks the component that is configured in the container for the fragment it needs. As you have realized, the route does not need to know what exact fields the component needs. This info is contained in the component.
+
+### RootContainer (js/app.js)
+
+In the RootContainer we render a Relay.RootContainer object configuring two objects and the root id on HTML:
+* Component: A component as the parent of every child in the page. In our case, the User component.
+* route: A route to query that has the first query to fetch all data.
+
+```javascript
+import User from './components/User.js';
+import AppHomeRoute from './routes/AppHomeRoute';
+
+React.render(
+  <Relay.RootContainer
+    Component={User}
+    route={new AppHomeRoute({userId: "55ddeec2a54c37e61e0a211c"})}
+  />,
+  document.getElementById('root')
+);
+
+```
+
+### User (js/components/User.js)
+Is the main component. Shows the content of the User and uses a HobbyList component to pass the list of hobbies.
+```javascript
+import HobbyList from './HobbyList.js';
+
+class User extends React.Component {
+  render() {
+    var user = this.props.user;
+
+    return (
+      <div>
+        <h1>Hello {user.name} {user.surname}</h1>
+        <h2>Hobbies</h2>
+        <ul>
+        <HobbyList hobbies={user} />
+        </ul>
+        <h2>Age: {user.age}</h2>
+      </div>
+    );
+  }
+}
+
+export default Relay.createContainer(User, {
+  fragments: {
+    user: () => Relay.QL`
+      fragment on User {
+        id
+        name
+        surname
+        age
+        ${HobbyList.getFragment('hobbies')}
+      }
+    `
+  }
+});
+```
+The most important thing is the declared fragment named `user` that matches the fragment queried by the route previously. This has few implications:
+* Any parent component that wants to use this fragment must call it with this definition `${Component.getFragment('user')}` or `${User.getFragment('user')}`
+* This means that the parent that queries this fragment will pass the fragment fetched information in a prop called `user`
+* At the same time, this component also uses a fragment within its own fragment `${HobbyList.getFragment('hobbies')}`. So now our route, that was only asking for information about the user will also fetch the info needed by this new fragment **without knowing it!!**
+
+## Final thoughts
+You can continue nesting fragments that the parent component will receive via its route in the Root Container. This is the real power of Relay
+
+# Contributions
+Please feel free to help, specially with grammar mistakes as english is not my mother language and I learned it watching "Two and a half men" :)
+
+Any other contribution must be on the road of simplicity to understand and to help others to learn Relay. Contributions must have a README file associated or to update this.
+
+##### Contact
+Mario C. mariocaster@gmail.com

--- a/examples/mongoose-example/build/babelRelayPlugin.js
+++ b/examples/mongoose-example/build/babelRelayPlugin.js
@@ -1,0 +1,4 @@
+var getbabelRelayPlugin = require('babel-relay-plugin');
+var schema = require('../data/schema.json');
+
+module.exports = getbabelRelayPlugin(schema.data);

--- a/examples/mongoose-example/data/Models/HobbySchema.es6
+++ b/examples/mongoose-example/data/Models/HobbySchema.es6
@@ -1,0 +1,63 @@
+import mongoose from 'mongoose';
+
+var HobbySchema = new mongoose.Schema({
+  id: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true,
+    default: mongoose.Types.ObjectId
+  },
+  title: String,
+  description: String,
+  type: String
+});
+
+let Hobby = mongoose.model('Hobby', HobbySchema);
+
+exports.HobbySchema = Hobby;
+
+exports.getHobbyById = (root, {id}) => {
+  return new Promise((resolve, reject) => {
+    Hobby.findById(id).exec((err, res) => {
+      err ? reject(err) : resolve(res);
+    })
+  });
+};
+
+exports.getListOfHobbies = () => {
+  return new Promise((resolve, reject) => {
+    Hobby.find({}).exec((err, res) => {
+      err ? reject(err) : resolve(res);
+    });
+  });
+};
+
+
+exports.addHobby = (obj, {title, description}) => {
+  var newHobby = new Hobby({title: title, description: description});
+
+  return new Promise((resolve, reject) => {
+    newHobby.save((err, res) => {
+      err ? reject(err) : resolve(res);
+    });
+  });
+};
+
+exports.updateHobby = (root, {title, description, id}) => {
+  let modify = {};
+  title ? modify.title = title : null;
+  description ? modify.description = description : null;
+
+  return new Promise((resolve, reject) => {
+    Hobby.update({id: id}, modify, (err, res) => {
+      if (err) {
+        reject(err)
+      } else {
+        Hobby.find({id: id}, (err, res) => {
+          err || res.length != 1 ? reject(err) : resolve(res[0]);
+        });
+      }
+    });
+  });
+};

--- a/examples/mongoose-example/data/Models/UserSchema.es6
+++ b/examples/mongoose-example/data/Models/UserSchema.es6
@@ -1,0 +1,83 @@
+import mongoose from 'mongoose';
+
+import Hobby from './HobbySchema.es6';
+
+let UserSchema = new mongoose.Schema({
+  id: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true,
+    default: mongoose.Types.ObjectId
+  },
+  name: String,
+  surname: String,
+  age: Number,
+  hobbies: [{type: mongoose.Schema.Types.ObjectId, ref: 'Hobby'}],
+  friends: [{type: mongoose.Schema.Types.ObjectId, ref: 'User'}],
+  type: String
+});
+
+UserSchema.set('toJSON', {getters: true});
+
+let User = mongoose.model('User', UserSchema);
+
+exports.UserSchema = User;
+
+exports.getUserById = (root, {id}) => {
+  return new Promise((resolve, reject) => {
+    User.findById(id).populate('hobbies friends').exec((err, res) => {
+      err ? reject(err) : resolve(res);
+    })
+  });
+};
+
+exports.updateUser = (user) => {
+  return new Promise((resolve, reject) => {
+    user.save((err, res) => {
+      err ? reject(err) : resolve(res);
+    });
+  });
+};
+
+exports.getListOfUsers = () => {
+  return new Promise((resolve, reject) => {
+    User.find({}).populate('hobbies friends').exec((err, res) => {
+      err ? reject(err) : resolve(res);
+    });
+  });
+};
+
+exports.addUser = (root, {name, surname, age, hobbies, friends}) => {
+  var newUser = new User({
+    name: name,
+    surname: surname,
+    age: age,
+    hobbies: hobbies,
+    friends: friends
+  });
+
+  return new Promise((resolve, reject) => {
+    newUser.save((err, res) => {
+      err ? reject(err) : resolve(res);
+    });
+  });
+};
+
+exports.updateUser = (root, {name, surname, age ,hobbies, friends, id}) => {
+  let modify = {};
+
+  name ? modify.name = name : null;
+  surname ? modify.surname = surname : null;
+  age ? modify.age = age : null;
+  hobbies ? modify.hobbies = hobbies : null;
+  friends ? modify.friends = friends : null;
+
+  return new Promise((resolve, reject) => {
+    User.update({id: id}, modify, (err, res) => {
+      User.find({id: id}, (err, res) => {
+        err || res.length != 1 ? reject(err) : resolve(res[0]);
+      });
+    });
+  });
+};

--- a/examples/mongoose-example/data/schema.es6
+++ b/examples/mongoose-example/data/schema.es6
@@ -1,0 +1,265 @@
+import User from './Models/UserSchema.es6';
+import Hobby from './Models/HobbySchema.es6';
+
+import {
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLID,
+  GraphQLInterfaceType,
+  GraphQLString,
+  GraphQLInt
+  } from 'graphql';
+
+
+let Node = new GraphQLInterfaceType({
+  name: 'Node',
+  description: 'An object with an ID',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'The global unique ID of an object'
+    },
+    type: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The type of the object"
+    }
+  }),
+  resolveType: (obj) => {
+    if (obj.type === 'user') {
+      return UserType;
+    } else if (obj.type === 'hobby') {
+      return HobbyType;
+    }
+  }
+});
+
+let HobbyType = new GraphQLObjectType({
+  name: 'Hobby',
+  description: 'A hobby',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID)
+    },
+    title: {
+      type: GraphQLString
+    },
+    description: {
+      type: GraphQLString
+    },
+    type: {
+      type: new GraphQLNonNull(GraphQLString)
+    }
+  }),
+
+  interfaces: [Node]
+});
+
+let UserType = new GraphQLObjectType({
+  name: 'User',
+  description: 'A user',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID)
+    },
+    name: {
+      type: GraphQLString
+    },
+    surname: {
+      type: GraphQLString
+    },
+    age: {
+      type: GraphQLInt
+    },
+    hobbies: {
+      type: new GraphQLList(HobbyType),
+      description: 'The ships used by the faction.'
+    },
+    friends: {
+      type: new GraphQLList(UserType)
+    },
+    type: {
+      type: new GraphQLNonNull(GraphQLString)
+    }
+  }),
+
+  interfaces: [Node]
+});
+
+let nodeField = {
+  name: 'Node',
+  type: Node,
+  description: 'A node interface field',
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'Id of node interface'
+    }
+  },
+  resolve: (obj, {id}) => {
+    return User.getUserById(obj, {id: id})
+      .then((user) => {
+        return user ? user : Hobby.getHobbyById(obj, {id: id});
+      }).then((hobby) => {
+        return hobby;
+      });
+  }
+};
+
+let UserQueries = {
+  users: {
+    type: new GraphQLList(UserType),
+    name: 'users',
+    description: 'A user list',
+    resolve: User.getListOfUsers
+  },
+  user: {
+    type: UserType,
+    args: {
+      id: {
+        type: GraphQLID
+      }
+    },
+    resolve: User.getUserById
+  }
+};
+
+let HobbyQueries = {
+  hobby: {
+    type: HobbyType,
+    args: {
+      id: {
+        type: GraphQLID
+      }
+    },
+    resolve: Hobby.getHobbyById
+  },
+
+  hobbies: {
+    type: new GraphQLList(HobbyType),
+    resolve: Hobby.getListOfHobbies
+  }
+};
+
+let UserMutations = {
+  addUser: {
+    type: UserType,
+    args: {
+      name: {
+        name: 'name',
+        type: new GraphQLNonNull(GraphQLString)
+      },
+      surname: {
+        name: 'surname',
+        type: new GraphQLNonNull(GraphQLString)
+      },
+      age: {
+        name: 'age',
+        type: GraphQLInt
+      },
+      hobbies: {
+        name: 'hobbies',
+        type: new GraphQLList(GraphQLID)
+      },
+      friends: {
+        name: 'friends',
+        type: new GraphQLList(GraphQLID)
+      }
+    },
+    resolve: User.addUser,
+    resolveType: UserType
+  },
+  updateUser: {
+    type: UserType,
+    args: {
+      id: {
+        name: 'id',
+        type: GraphQLID
+      },
+      name: {
+        name: 'name',
+        type: GraphQLString
+      },
+      surname: {
+        name: 'surname',
+        type: GraphQLString
+      },
+      age: {
+        name: 'age',
+        type: GraphQLInt
+      }
+    },
+    resolve: User.updateUser,
+    resolveType: UserType
+  }
+};
+
+let HobbyMutations = {
+  addHobby: {
+    type: HobbyType,
+    args: {
+      title: {
+        name: 'title',
+        type: new GraphQLNonNull(GraphQLString)
+      },
+      description: {
+        name: 'description',
+        type: new GraphQLNonNull(GraphQLString)
+      }
+    },
+    resolve: Hobby.addHobby,
+    resolveType: HobbyType
+  },
+  updateHobby: {
+    type: HobbyType,
+    args: {
+      id: {
+        name: 'id',
+        type: new GraphQLNonNull(GraphQLID)
+      },
+      title: {
+        name: 'title',
+        type: GraphQLString
+      },
+      description: {
+        name: 'description',
+        type: GraphQLString
+      }
+    },
+    resolve: Hobby.updateHobby,
+    resolveType: HobbyType
+  }
+};
+
+let RootQuery = new GraphQLObjectType({
+  name: 'RootQuery',      //Return this type of object
+
+  fields: () => ({
+    user: UserQueries.user,
+    users: UserQueries.users,
+    hobby: HobbyQueries.hobby,
+    hobbies: HobbyQueries.hobbies,
+    node: nodeField
+  })
+});
+
+
+let RootMutation = new GraphQLObjectType({
+  name: "RootMutation",
+
+  fields: () => ({
+    addUser: UserMutations.addUser,
+    updateUser: UserMutations.updateUser,
+    addHobby: HobbyMutations.addHobby,
+    updateHobby: HobbyMutations.updateHobby
+  })
+});
+
+
+let schema = new GraphQLSchema({
+  query: RootQuery,
+  mutation: RootMutation
+});
+
+export default schema;

--- a/examples/mongoose-example/js/app.js
+++ b/examples/mongoose-example/js/app.js
@@ -1,0 +1,11 @@
+import User from './components/User.js';
+import AppHomeRoute from './routes/AppHomeRoute';
+
+React.render(
+  <Relay.RootContainer
+    Component={User}
+    //TODO Update userId
+    route={new AppHomeRoute({userId: "55df44ba8b56b74b143f5084"})}
+  />,
+  document.getElementById('root')
+);

--- a/examples/mongoose-example/js/components/Friend.js
+++ b/examples/mongoose-example/js/components/Friend.js
@@ -1,0 +1,21 @@
+class Friend extends React.Component {
+  render() {
+    let friend = this.props.friend;
+    return (
+      <li>
+        {friend.name} {friend.surname} ({friend.age})
+      </li>
+    );
+  }
+}
+
+export default Relay.createContainer(Friend, {
+  fragments: {
+    friend: () => Relay.QL`
+      fragment on User {
+        name
+        surname
+        age
+      }`
+  }
+});

--- a/examples/mongoose-example/js/components/FriendsList.js
+++ b/examples/mongoose-example/js/components/FriendsList.js
@@ -1,0 +1,23 @@
+import Friend from './Friend.js';
+
+class FriendList extends React.Component {
+  render() {
+    let user = this.props.user;
+    let friends = user.friends.map((friend) => {
+      return <Friend friend={friend} />;
+    });
+
+    return (<div>{friends}</div>);
+  }
+}
+
+export default Relay.createContainer(FriendList, {
+  fragments: {
+    user: () => Relay.QL`
+      fragment on User {
+        friends {
+          ${Friend.getFragment('friend')}
+        }
+      }`
+  }
+});

--- a/examples/mongoose-example/js/components/Hobby.js
+++ b/examples/mongoose-example/js/components/Hobby.js
@@ -1,0 +1,23 @@
+class Hobby extends React.Component {
+  render() {
+    let hobby = this.props.hobby;
+    return (
+      <li>
+        {hobby.title}
+        <ul>
+          <li>Description: {hobby.description}</li>
+        </ul>
+      </li>
+    );
+  }
+}
+
+export default Relay.createContainer(Hobby, {
+  fragments: {
+    hobby: () => Relay.QL`
+      fragment on Hobby {
+        title
+        description
+      }`
+  }
+});

--- a/examples/mongoose-example/js/components/HobbyList.js
+++ b/examples/mongoose-example/js/components/HobbyList.js
@@ -1,0 +1,23 @@
+import Hobby from './Hobby.js';
+
+class HobbyList extends React.Component {
+  render() {
+    let user = this.props.user;
+    let hobbies = user.hobbies.map((hobby) => {
+      return <Hobby hobby={hobby} />;
+    });
+
+    return (<ul>{hobbies}</ul>);
+  }
+}
+
+export default Relay.createContainer(HobbyList, {
+  fragments: {
+    user: () => Relay.QL`
+      fragment users on User {
+        hobbies {
+          ${Hobby.getFragment('hobby')}
+        }
+      }`
+  }
+});

--- a/examples/mongoose-example/js/components/User.js
+++ b/examples/mongoose-example/js/components/User.js
@@ -1,0 +1,34 @@
+import HobbyList from './HobbyList.js';
+import FriendsList from './FriendsList.js';
+
+class User extends React.Component {
+  render() {
+    var user = this.props.user;
+
+    return (
+      <div>
+        <h1>Hello {user.name} {user.surname}</h1>
+        <h2>Hobbies</h2>
+        <HobbyList user={user} />
+        <h2>Friends</h2>
+        <FriendsList user={user} />
+        <h2>Age: {user.age}</h2>
+      </div>
+    );
+  }
+}
+
+export default Relay.createContainer(User, {
+  fragments: {
+    user: () => Relay.QL`
+      fragment on User {
+        id
+        name
+        surname
+        age
+        ${HobbyList.getFragment('user')}
+        ${FriendsList.getFragment('user')}
+      }
+    `
+  }
+});

--- a/examples/mongoose-example/js/routes/AppHomeRoute.js
+++ b/examples/mongoose-example/js/routes/AppHomeRoute.js
@@ -1,0 +1,16 @@
+class AppHomeRoute extends Relay.Route {
+  static queries = {
+    user: (Component) => Relay.QL `
+      query {
+        user (id: $userId) {
+          ${Component.getFragment('user')}
+        }
+      }
+    `
+  };
+
+  static paramDefinitions = {userId: {required: true}};
+  static routeName = 'AppHomeRoute';
+}
+
+export default AppHomeRoute;

--- a/examples/mongoose-example/package.json
+++ b/examples/mongoose-example/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "relay-mongoose-example",
+  "private": true,
+  "description": "An example app of how to use Relay with Mongoose",
+  "repository": "facebook/relay-starter-kit",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "babel-node ./server.js",
+    "update-schema": "babel-node ./scripts/updateSchema.js",
+    "print-schema": "babel-node ./scripts/printSchema.js",
+    "print-introspection": "babel-node ./scripts/printIntrospection.js",
+    "restart": "babel-node ./scripts/updateSchema.js; babel-node ./server.js",
+    "populate": "babel-node ./scripts/populationScript.es6"
+  },
+  "dependencies": {
+    "babel": "5.8.21",
+    "babel-loader": "5.3.2",
+    "babel-relay-plugin": "^0.1.1",
+    "classnames": "^2.1.3",
+    "express": "^4.13.1",
+    "express-graphql": "^0.1.0",
+    "graphql": "^0.2.6",
+    "graphql-relay": "^0.1.0",
+    "mongoose": "^4.1.3",
+    "react": "^0.14.0-beta3",
+    "react-relay": "^0.1.0",
+    "webpack": "^1.10.5",
+    "webpack-dev-server": "^1.10.1"
+  }
+}

--- a/examples/mongoose-example/public/index.html
+++ b/examples/mongoose-example/public/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Relay • Starter Kit</title>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/javascript">
+    // Force `fetch` polyfill to workaround Chrome not displaying request body
+    // in developer tools for the native `fetch`.
+    self.fetch = null;
+    function warnRelayMissing() {
+        document.body.innerHTML = (
+        '<h2>Could not find relay.js</h2>' +
+        '<p>' +
+        'Be sure to run <code>npm run build</code> ' +
+        'in the <code>relay/</code> directory.' +
+        '</p>'
+        );
+    }
+</script>
+<script src="http://localhost:3000/webpack-dev-server.js"></script>
+<script src="node_modules/react/dist/react.min.js"></script>
+<script src="node_modules/react-relay/dist/relay.js"
+        onerror="warnRelayMissing()"></script>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/examples/mongoose-example/scripts/populationScript.es6
+++ b/examples/mongoose-example/scripts/populationScript.es6
@@ -1,0 +1,93 @@
+import mongoose from 'mongoose';
+
+import {UserSchema as User } from '../data/Models/UserSchema.es6';
+import {HobbySchema as Hobby } from '../data/Models/HobbySchema.es6';
+
+mongoose.connect('mongodb://localhost/test');
+
+let hobbyCycling = new Hobby({
+  title: 'cycling',
+  description: 'a painful sport',
+  type: "hobby"
+});
+
+let hobbyHorses = new Hobby({
+  title: 'horses',
+  description: 'to get in one with an animal',
+  type: "hobby"
+});
+
+let hobbyFlying = new Hobby({
+  title: 'flying',
+  description: 'man and machine in one',
+  type: "hobby"
+});
+
+let hobbySleeping = new Hobby({
+  title: 'sleeping',
+  description: 'resting for whole day',
+  type: "hobby"
+});
+
+
+let userRichard = new User({
+  name: "Richard",
+  surname: "Stallman",
+  age: 62,
+  hobbies: [hobbyCycling, hobbyFlying],
+  type: "user"
+});
+
+let userDonald = new User({
+  name: "Donald",
+  surname: "Knuth",
+  age: 77,
+  hobbies: [hobbyHorses, hobbySleeping],
+  type: "user"
+});
+
+let userLinus = new User({
+  name: "Linux",
+  surname: "Torvalds",
+  age: 45,
+  hobbies: [hobbySleeping],
+  type: "user"
+});
+
+let userTim = new User({
+  name: "Tim",
+  surname: "Berners-Lee",
+  age: 60,
+  hobbies: [hobbySleeping, hobbyHorses],
+  friends: [userRichard, userDonald],
+  type: "user"
+});
+
+let userMark = new User({
+  name: "Mark",
+  surname: "Zuckerberg",
+  age: 31,
+  hobbies: [hobbyCycling, hobbyFlying],
+  friends: [userDonald, userLinus]
+});
+
+userDonald.friends = [userRichard, userTim, userLinus];
+userRichard.friends = [userDonald, userTim, userLinus];
+userLinus.friends = [userRichard, userDonald];
+
+hobbyCycling.save();
+hobbyFlying.save();
+hobbyHorses.save();
+hobbySleeping.save();
+
+userRichard.save();
+userDonald.save();
+userLinus.save();
+userTim.save();
+userMark.save();
+
+
+setTimeout(function () {
+  console.log(userRichard._id);
+  mongoose.disconnect();
+}, 1000);

--- a/examples/mongoose-example/scripts/printIntrospection.js
+++ b/examples/mongoose-example/scripts/printIntrospection.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import {
+  printSchema,
+  printIntrospectionSchema
+  } from 'graphql/utilities/schemaPrinter.js';
+
+import graphql from 'graphql';
+
+import Schema from '../data/schema.es6';
+
+async() => {
+  var result = await(printIntrospectionSchema(Schema));
+
+  if (result.errors) {
+    console.error('ERROR: ', JSON.stringify(result.errors, null, 2));
+  } else {
+    console.log(result);
+    fs.writeFileSync('./data/printedIntrospection.graphql', result);
+  }
+}();
+

--- a/examples/mongoose-example/scripts/printSchema.js
+++ b/examples/mongoose-example/scripts/printSchema.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import {
+  printSchema,
+  printInstrospectionSchema
+  } from 'graphql/utilities/schemaPrinter.js';
+
+import graphql from 'graphql';
+
+import Schema from '../data/schema.es6';
+
+async() => {
+  var result = await(printSchema(Schema));
+
+  if (result.errors) {
+    console.error('ERROR: ', JSON.stringify(result.errors, null, 2));
+  } else {
+    console.log(result);
+    fs.writeFileSync('./data/printedSchema.graphql', result);
+  }
+}();
+

--- a/examples/mongoose-example/scripts/updateSchema.js
+++ b/examples/mongoose-example/scripts/updateSchema.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env babel-node --optional es7.asyncFunctions
+
+import fs from 'fs';
+import path from 'path';
+import Schema from '../data/schema.es6';
+import { graphql }  from 'graphql';
+import { introspectionQuery } from 'graphql/utilities';
+
+async() => {
+  var result = await(graphql(Schema, introspectionQuery));
+  if (result.errors) {
+    console.error('ERROR: ', JSON.stringify(result.errors, null, 2));
+  } else {
+    fs.writeFileSync(
+      path.join(__dirname, '../data/schema.json'),
+      JSON.stringify(result, null, 2)
+    );
+  }
+}();

--- a/examples/mongoose-example/server.js
+++ b/examples/mongoose-example/server.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import graphQLHTTP from 'express-graphql';
+import path from 'path';
+import webpack from 'webpack';
+import WebpackDevServer from 'webpack-dev-server';
+import Schema from './data/schema.es6';
+
+import mongoose from 'mongoose';
+
+const APP_PORT = 3000;
+const GRAPHQL_PORT = 8080;
+
+// Expose a GraphQL endpoint
+var graphQLServer = express();
+graphQLServer.use('/', graphQLHTTP({schema: Schema, pretty: true}));
+graphQLServer.listen(GRAPHQL_PORT, () => {
+  console.log(`GraphQL Server is now running on http://localhost:${GRAPHQL_PORT}`);
+  mongoose.connect('mongodb://localhost/test');
+});
+
+// Serve the Relay app
+var compiler = webpack({
+  entry: path.resolve(__dirname, 'js', 'app.js'),
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loader: 'babel',
+        query: {stage: 0, plugins: ['./build/babelRelayPlugin']}
+      }
+    ]
+  },
+  output: {filename: 'app.js', path: '/'}
+});
+var app = new WebpackDevServer(compiler, {
+  contentBase: '/public/',
+  proxy: {'/graphql': `http://localhost:${GRAPHQL_PORT}`},
+  publicPath: '/js/',
+  stats: {colors: true}
+});
+
+// Serve static resources
+app.use('/', express.static('public'));
+app.use('/node_modules/react', express.static('node_modules/react'));
+app.use('/node_modules/react-relay', express.static('node_modules/react-relay'));
+app.listen(APP_PORT, () => {
+  console.log(`App is now running on http://localhost:${APP_PORT}`);
+});


### PR DESCRIPTION
Hi,

I think it is a good idea to have an example of Relay using a real database instead of data stored in an array. This example shows how to use Relay with a MongoDB database, mainly following the principles of the Star Wars example.

Main differences: 
* Does not use graphql-relay. While graphql-relay library empowers productivity, it hides some concepts of graphql and makes it a bit more difficult to understand. Instead, NodeInterface and NodeField are defined in the schema.
* No [name]Database.js. Instead, you can find a Models folder within data folder. There you can find Mongoose schemas and CRUD functions that returns promises.

I have also added some features:
* `npm run restart` script to rebuild schema and start server
* `npm run print-schema` script to print the schema on graphql format on a file within data folder.
* `npm run print-instrospection`. The same than above but with introspection.
* `npm run populate` A script to populate a local MongoDB database with some Mock data. This mock data are some of the most influential programmers in computer science history (including Mark Zuckerberg, of course).
* *Readme* file with an explanation of the example.

Thank you very much

Mario Castro
mariocaster@gmail.com
0034 689 11 10 10