### PR TITLE
babel-relay-plugin: generalize warning about `nodes` fields

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-relay-plugin",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Babel Relay Plugin for transpiling GraphQL queries for use with Relay.",
   "license": "BSD-3-Clause",
   "repository": "facebook/relay",

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
@@ -1,0 +1,19 @@
+Input:
+var Relay = require('react-relay');
+var x = Relay.QL`
+  query {
+    node(id: 123) {
+      friends(first: 3) {
+        nodes {
+          id
+        }
+      }
+    }
+  }
+`;
+
+Output:
+var Relay = require('react-relay');
+var x = (function () {
+  throw new Error('Encountered a GraphQL validation error processing file `connectionWithNodesField.fixture`. Check your terminal for details.');
+})();

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -89,6 +89,7 @@ type PendingPost {
 type UserConnection {
   count: Int
   edges: [UserConnectionEdge]
+  nodes: [User]
   pageInfo: PageInfo
 }
 

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -509,6 +509,22 @@
               "deprecationReason": null
             },
             {
+              "name": "nodes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "pageInfo",
               "description": null,
               "args": [],


### PR DESCRIPTION
GraphQL servers may support various forms of pagination, for example:

```
type UserConnection {
  edges: [UserEdge] # a) access the relationship between the parent record and the User
  users: [User] # b) directly access the linked Users. 
}
type UserEdge {
  node: User
}
```

Relay currently supports only a) - the `edges{node{...}}` variant, and warns about case b) only if the field is called `nodes`. This PR changes the warning by detecting any use of the b) pattern regardless of the field's name.

cc @dschafer @leebyron @schrockn @yuzhi 