### PR TITLE
Update jest’s preprocessor with inline-requires and a cache key.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "babel-runtime": "5.8.20",
-    "fbjs": "0.1.0-alpha.10",
+    "fbjs": "0.1.0-alpha.12",
     "react-static-container": "^1.0.0-alpha.1"
   },
   "peerDependencies": {

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -1,11 +1,21 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 // TODO: sync babel config with gulpfile. There are differences (eg, we don't
 // want to use the DEV plugin).
 
+var assign = require('object-assign');
 var babel = require('babel-core');
-var babelPluginModules = require('fbjs/scripts/babel/rewrite-modules');
+var babelDefaultOptions = require('fbjs/scripts/babel/default-options');
+var createCacheKeyFunction = require('fbjs/scripts/jest/createCacheKeyFunction');
 var fs = require('fs');
 var getBabelRelayPlugin = require('babel-relay-plugin');
-var objectAssign = require('object-assign');
 var path = require('path');
 
 var SCHEMA_PATH = path.resolve(__dirname, 'testschema.json');
@@ -14,27 +24,48 @@ var graphQLPlugin = getBabelRelayPlugin(
   JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8')).data
 );
 
-var babelOpts = {
-  nonStandard: true,
-  loose: [
-    'es6.classes'
-  ],
-  stage: 1,
-  plugins: [babelPluginModules, graphQLPlugin],
-  retainLines: true,
-  _moduleMap: objectAssign({}, require('fbjs/module-map'), {
-    'React': 'react',
-    'ReactUpdates': 'react/lib/ReactUpdates',
-    'StaticContainer.react': 'react-static-container'
-  }),
-  extra: {
-    debug: false, // enable to debug the relay babel transform
-    documentName: 'UnknownFile'
-  },
-};
+// Fix the path to node_modules because jest is slooow with
+// node_modules paths (facebook/jest#465)
+function fixModules(list) {
+  Object.keys(list).forEach(function(moduleName) {
+    list[moduleName] = __dirname + '/../../node_modules/' + list[moduleName];
+  });
+  return list;
+}
+
+var babelOptions = assign(
+  {},
+  babelDefaultOptions,
+  {
+    plugins: babelDefaultOptions.plugins.concat([graphQLPlugin]),
+    retainLines: true,
+    _moduleMap: fixModules(assign({}, require('fbjs/module-map'), {
+      'React': 'react',
+      'ReactUpdates': 'react/lib/ReactUpdates',
+      'StaticContainer.react': 'react-static-container'
+    })),
+    extra: {
+      debug: false, // enable to debug the relay babel transform
+      documentName: 'UnknownFile'
+    },
+  }
+);
 
 module.exports = {
   process: function(src, path) {
-    return babel.transform(src, objectAssign({filename: path}, babelOpts)).code;
-  }
+    return babel.transform(src, assign({filename: path}, babelOptions)).code;
+  },
+
+  getCacheKey: createCacheKeyFunction([
+    __filename,
+    SCHEMA_PATH,
+    path.join(
+      __dirname,
+      '..',
+      '..',
+      'node_modules',
+      'babel-relay-plugin',
+      'package.json'
+    )
+  ])
 };


### PR DESCRIPTION
See https://github.com/facebook/fbjs/pull/45
