### PR TITLE
Fix website/publish.sh for iojs

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,6 @@
     "compression": "1.2.2",
     "connect": "3.3.3",
     "errorhandler": "1.3.0",
-    "execSync": "^1.0.2",
     "fs-extra": "0.23.1",
     "glob": "*",
     "mkdirp": "*",

--- a/website/server/buildGraphQLSpec.js
+++ b/website/server/buildGraphQLSpec.js
@@ -1,16 +1,16 @@
-var exec = require('execSync').exec
+var exec = require('child_process').execFileSync;
 var fs = require('fs-extra');
 var glob = require('glob');
 
 module.exports = function(targetDir) {
   fs.copySync('node_modules/spec-md/css', targetDir + '/relay/graphql');
   glob.sync('graphql/*.md').forEach(function(file) {
-    var html = exec('./node_modules/.bin/spec-md ' + file).stdout;
+    var html = exec('./node_modules/.bin/spec-md', [file]);
     var outFilename = (
       targetDir + '/relay/graphql/' +
       path.basename(file, '.md').toLowerCase() +
       '.htm'
     );
-    fs.writeFileSync(outFilename, html);
+    fs.writeFileSync(outFilename, html.toString());
   });
 }

--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -1,5 +1,4 @@
 var buildGraphQLSpec = require('./buildGraphQLSpec');
-var exec = require('execSync').exec
 var fs = require('fs-extra');
 var glob = require('glob');
 var mkdirp = require('mkdirp');

--- a/website/server/server.js
+++ b/website/server/server.js
@@ -17,7 +17,7 @@ var PROJECT_ROOT = path.resolve(__dirname, '..');
 var FILE_SERVE_ROOT = path.join(PROJECT_ROOT, 'src');
 
 var port = argv.port;
-if (argv.$0 === 'node ./server/generate.js') {
+if (argv.$0.indexOf('./server/generate.js') !== -1) {
   // Using a different port so that you can publish the website
   // and keeping the server up at the same time.
   port = 8079;


### PR DESCRIPTION
The check for argv.$0 failed since it hardcoded `node`. This is not a lot
prettier, but at least doesn't depend on the binary name.