### PR TITLE
Update fbjs to 0.2, use fbjs-scripts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,8 +10,8 @@
 'use strict';
 
 var babel = require('gulp-babel');
-var babelPluginDEV = require('fbjs/scripts/babel/dev-expression');
-var babelPluginModules = require('fbjs/scripts/babel/rewrite-modules');
+var babelPluginDEV = require('fbjs-scripts/babel/dev-expression');
+var babelPluginModules = require('fbjs-scripts/babel/rewrite-modules');
 var del = require('del');
 var derequire = require('gulp-derequire');
 var envify = require('envify/custom');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "babel-runtime": "5.8.20",
-    "fbjs": "0.1.0-alpha.12",
+    "fbjs": "^0.2.0",
     "react-static-container": "^1.0.0-alpha.1"
   },
   "peerDependencies": {
@@ -40,6 +40,7 @@
     "babel-relay-plugin": "^0.1.3",
     "del": "^1.2.0",
     "envify": "^3.4.0",
+    "fbjs-scripts": "^0.2.0",
     "flow-bin": "0.14.0",
     "graphql": "^0.4.2",
     "gulp": "^3.9.0",
@@ -58,7 +59,7 @@
   "jest": {
     "rootDir": "",
     "scriptPreprocessor": "scripts/jest/preprocessor.js",
-    "setupEnvScriptFile": "node_modules/fbjs/scripts/jest/environment.js",
+    "setupEnvScriptFile": "node_modules/fbjs-scripts/jest/environment.js",
     "persistModuleRegistryBetweenSpecs": true,
     "modulePathIgnorePatterns": [
       "<rootDir>/lib/",
@@ -75,6 +76,7 @@
     ],
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/fbjs/node_modules/core-js/",
+      "<rootDir>/node_modules/fbjs-scripts/node_modules/core-js/",
       "<rootDir>/node_modules/fbjs/node_modules/promise/",
       "<rootDir>/node_modules/fbjs/lib/(?!(ErrorUtils.js$|fetch.js$|fetchWithRetries.js$))",
       "<rootDir>/node_modules/react/",

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -12,8 +12,8 @@
 
 var assign = require('object-assign');
 var babel = require('babel-core');
-var babelDefaultOptions = require('fbjs/scripts/babel/default-options');
-var createCacheKeyFunction = require('fbjs/scripts/jest/createCacheKeyFunction');
+var babelDefaultOptions = require('fbjs-scripts/babel/default-options');
+var createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
 var fs = require('fs');
 var getBabelRelayPlugin = require('babel-relay-plugin');
 var path = require('path');


### PR DESCRIPTION
I haven't published these yet but probably will soon. This just ensures we're using the newer versions where we're splitting the scripts part out of `fbjs` into its own package.

Check with me before you merge. I'm planning on getting 1 more thing into fbjs-scripts (and then test in React as well) before publishing.