### PR TITLE
Make the babel-relay-plugin browser-safe

### DIFF
--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -15,7 +15,6 @@ var buildClientSchema =
 
 var assert = require('assert');
 var path = require('path');
-var util = require('babel-core').util;
 
 var PROVIDES_MODULE = 'providesModule';
 
@@ -53,7 +52,18 @@ function getBabelRelayPlugin(
 ) /*: Object */ {
   return function(babel) {
     var Plugin = babel.Plugin;
+    var parse = babel.parse;
     var t = babel.types;
+    var traverse = babel.traverse;
+
+    /**
+     * Same as `babel.util.parseTemplate`.
+     */
+    function parseTemplate(loc, code) {
+      var ast = parse(code, {filename: loc, looseModules: true}).program;
+      return traverse.removeProperties(ast);
+    }
+
     return new Plugin('relay-query', {
       visitor: {
         /**
@@ -177,7 +187,7 @@ function getBabelRelayPlugin(
             }
           }
           code = '(' + code + ')';
-          var funcExpr = util.parseTemplate('Relay.QL', code).body[0].expression;
+          var funcExpr = parseTemplate('Relay.QL', code).body[0].expression;
 
           // Immediately invoke the function with substitutions as arguments.
           var substitutions = node.quasi.expressions;


### PR DESCRIPTION
We import `babel-core` here to get the `parseTemplate()` function. `babel-core` doesn't import well in-browser, so I've inlined `parseTemplate()` here.

This will make it possible to run the babel-plugin in-browser.