### PR TITLE
Fix HomeRoute queries for all examples

### DIFF
--- a/examples/relay-treasurehunt/js/routes/AppHomeRoute.js
+++ b/examples/relay-treasurehunt/js/routes/AppHomeRoute.js
@@ -1,6 +1,12 @@
 export default class extends Relay.Route {
   static queries = {
-    game: () => Relay.QL`query { game }`,
+    game: Component => Relay.QL`
+      query {
+        game {
+          ${Component.getFragment('game')},
+        }
+      }
+    `,
   };
   static routeName = 'AppHomeRoute';
 }

--- a/examples/star-wars/js/routes/StarWarsAppHomeRoute.js
+++ b/examples/star-wars/js/routes/StarWarsAppHomeRoute.js
@@ -1,6 +1,12 @@
 export default class extends Relay.Route {
   static queries = {
-    factions: () => Relay.QL`query { factions(names: $factionNames) }`,
+    factions: Component => Relay.QL`
+      query {
+        factions(names: $factionNames) {
+          ${Component.getFragment('factions')},
+        }
+      }
+    `,
   };
   static routeName = 'StarWarsAppHomeRoute';
 }

--- a/examples/todo/js/routes/TodoAppHomeRoute.js
+++ b/examples/todo/js/routes/TodoAppHomeRoute.js
@@ -1,6 +1,12 @@
 export default class extends Relay.Route {
   static queries = {
-    viewer: () => Relay.QL`query RootQuery { viewer }`,
+    viewer: Component => Relay.QL`
+      query RootQuery {
+        viewer {
+          ${Component.getFragment('viewer')},
+        }
+      }
+    `,
   };
   static routeName = 'TodosHomeRoute';
 }


### PR DESCRIPTION
The examples are missing the fragment queries in their home routes