### PR TITLE
Fix examples by using local Relay package

### DIFF
--- a/examples/relay-treasurehunt/package.json
+++ b/examples/relay-treasurehunt/package.json
@@ -14,7 +14,7 @@
     "graphql": "^0.4.2",
     "graphql-relay": "^0.3.1",
     "react": "^0.14.0-beta3",
-    "react-relay": "0.2.0",
+    "react-relay": "file:../../",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1"
   }

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -18,7 +18,7 @@
     "graphql": "^0.4.2",
     "graphql-relay": "^0.3.1",
     "react": "^0.14.0-beta3",
-    "react-relay": "0.2.0",
+    "react-relay": "file:../../",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1"
   }

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -18,7 +18,7 @@
     "graphql": "^0.4.2",
     "graphql-relay": "^0.3.1",
     "react": "^0.14.0-beta3",
-    "react-relay": "0.2.0",
+    "react-relay": "file:../../",
     "todomvc-app-css": "^2.0.1",
     "todomvc-common": "^1.0.2",
     "webpack": "^1.10.5",


### PR DESCRIPTION
Fixes #199 by using the parent Relay package instead of installing 0.2.0 from npm.