### PR TITLE
printRelayQuery - print children before generating variables

### DIFF
--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -1,5 +1,6 @@
 type Root {
   checkinSearchQuery(query: CheckinSearchInput): CheckinSearchResult
+  defaultSettings: Settings,
   settings(environment: Environment): Settings
   me: User
   story: Story
@@ -513,4 +514,5 @@ enum Environment {
 
 type Settings {
   notificationSounds: Boolean
+  notifications(environment: Environment): Boolean
 }

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -37,6 +37,18 @@
               "deprecationReason": null
             },
             {
+              "name": "defaultSettings",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Settings",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "settings",
               "description": null,
               "args": [
@@ -258,6 +270,16 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "CheckinSearchResult",
           "description": null,
@@ -281,8 +303,54 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Settings",
+          "description": null,
+          "fields": [
+            {
+              "name": "notificationSounds",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notifications",
+              "description": null,
+              "args": [
+                {
+                  "name": "environment",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "Environment",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
-          "name": "String",
+          "name": "Boolean",
           "description": null,
           "fields": null,
           "inputFields": null,
@@ -311,39 +379,6 @@
               "deprecationReason": null
             }
           ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Settings",
-          "description": null,
-          "fields": [
-            {
-              "name": "notificationSounds",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Boolean",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {

--- a/src/__forks__/traversal/__tests__/printRelayQuery-test.js
+++ b/src/__forks__/traversal/__tests__/printRelayQuery-test.js
@@ -409,6 +409,40 @@ describe('printRelayQuery', () => {
       expect(variables).toEqual({});
     });
 
+    it('prints object call values', () => {
+      var enumValue = 'WEB';
+      var fragment = Relay.QL`
+        fragment on Settings {
+          notifications(environment: $env)
+        }
+      `;
+      var query = getNode(Relay.QL`
+        query {
+          defaultSettings {
+            ${fragment},
+          }
+        }
+      `, {
+        env: enumValue,
+      });
+      var fragmentID = getNode(fragment, {env: enumValue}).getFragmentID();
+      var alias = generateRQLFieldAlias('notifications.environment(WEB)');
+      var {text, variables} = printRelayQuery(query);
+      expect(trimQuery(text)).toEqual(trimQuery(`
+        query UnknownFile($environment_0:Environment) {
+          defaultSettings {
+            ...${fragmentID}
+          }
+        }
+        fragment ${fragmentID} on Settings {
+          ${alias}:notifications(environment:$environment_0)
+        }
+      `));
+      expect(variables).toEqual({
+        environment_0: enumValue,
+      });
+    });
+
     it('prints inline fragments as references', () => {
       // these fragments have different types and cannot be flattened
       var nestedFragment = Relay.QL`fragment on User{name}`;

--- a/src/__forks__/traversal/printRelayQuery.js
+++ b/src/__forks__/traversal/printRelayQuery.js
@@ -103,20 +103,18 @@ function printRoot(
       rootFieldString += '(' + rootArgString + ')';
     }
   }
+  var children = printChildren(node, printerState);
 
   var argStrings = null;
   forEachObject(printerState.variableMap, (variable, variableID) => {
-    if (variable) {
-      argStrings = argStrings || [];
-      argStrings.push('$' + variableID + ':' + variable.type);
-    }
+    argStrings = argStrings || [];
+    argStrings.push('$' + variableID + ':' + variable.type);
   });
   if (argStrings) {
     queryString += '(' + argStrings.join(',') + ')';
   }
 
-  return 'query ' + queryString + '{' +
-    rootFieldString + printChildren(node, printerState) + '}';
+  return 'query ' + queryString + '{' + rootFieldString + children + '}';
 }
 
 function printMutation(


### PR DESCRIPTION
The previous version of `printRelayQuery` incorrectly generated the `variables` for a query before processing children.

Fixes #203 