### PR TITLE
Clarify description of globally unique IDs

### DIFF
--- a/docs/GraphQL-ObjectIdentification.md
+++ b/docs/GraphQL-ObjectIdentification.md
@@ -111,8 +111,8 @@ yields
 ```
 
 The `Node` interface and `node` field assume globally unique IDs for this
-refetching. A system without globally unique IDs can usually create one
-by combining the type with the type specific ID, which is what was done
+refetching. A system without globally unique IDs can usually synthesize them
+by combining the type with the type-specific ID, which is what was done
 in this example.
 
 The IDs we got back were base64 strings. IDs are designed to be opaque (the


### PR DESCRIPTION
As written, this sentence was a little hard to read:

> A system without globally unique IDs can usually create one

Create one what? An ID, or a system?

I've reworded this to make it clear that the system can create IDs by
switching to the plural, and I've added a missing hyphen in
"type-specific".