### PR TITLE
Fix object shorthands in babel-relay-plugin

### DIFF
--- a/scripts/babel-relay-plugin/src/GraphQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/GraphQLPrinter.js
@@ -698,12 +698,12 @@ function getConnectionMetadata(schema, fieldDecl) {
     return null;
   }
   return {
-    cursorType,
-    cursorField,
-    edgesType,
-    edgesField,
-    nodeType,
-    nodeField,
+    cursorType: cursorType,
+    cursorField: cursorField,
+    edgesType: edgesType,
+    edgesField: edgesField,
+    nodeType: nodeType,
+    nodeField: nodeField
   };
 }
 


### PR DESCRIPTION
This ES6 features break the plugin if the code is not transpiled before publishing to NPM.