### PR TITLE
Correct typo in example query for `RANGE_ADD`

### DIFF
--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -346,7 +346,7 @@ class IntroduceShipMutation extends Relay.Mutation {
   // specify the faction's ships connection as part of the fat query.
   getFatQuery() {
     return Relay.QL`
-      fragment on IntroduceShipMutation {
+      fragment on IntroduceShipPayload {
         faction { ships },
         newShipEdge,
       }


### PR DESCRIPTION
Fixes a little typo in an example of a `RANGE_ADD` mutation query.