### PR TITLE
Use HTTPS URL for starter kit

### DIFF
--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -14,7 +14,7 @@ In this tutorial, we will build a game using GraphQL mutations. The goal of the 
 Let's start a project using the Relay Starter Kit as a base.
 
 ```
-git clone git@github.com:relayjs/relay-starter-kit.git relay-treasurehunt
+git clone https://github.com/relayjs/relay-starter-kit.git relay-treasurehunt
 cd relay-treasurehunt
 npm install
 ```


### PR DESCRIPTION
This is lower friction than the SSH URL because it works even without a
GitHub account and a configured SSH key.

Note there is one other SSH URL in the repo that I did not change in
`website/README.md`. That one specifically deals with publishing the
website, for which you need push access, and SSH is going to be more
convenient for that.