### PR TITLE
Fix use of `requireActual` outside of test suite

### DIFF
--- a/src/__forks__/container/RelayContainerProxy.js
+++ b/src/__forks__/container/RelayContainerProxy.js
@@ -11,4 +11,4 @@
 
 'use strict';
 
-module.exports = require.requireActual('RelayOSSContainerProxy');
+module.exports = require('RelayOSSContainerProxy');

--- a/src/__forks__/container/prepareRelayContainerProps.js
+++ b/src/__forks__/container/prepareRelayContainerProps.js
@@ -11,4 +11,4 @@
 
 'use strict';
 
-module.exports = require.requireActual('prepareRelayOSSContainerProps');
+module.exports = require('prepareRelayOSSContainerProps');

--- a/src/__forks__/interface/RelayConnectionInterface.js
+++ b/src/__forks__/interface/RelayConnectionInterface.js
@@ -11,4 +11,4 @@
 
 'use strict';
 
-module.exports = require.requireActual('RelayOSSConnectionInterface');
+module.exports = require('RelayOSSConnectionInterface');

--- a/src/__forks__/interface/RelayNodeInterface.js
+++ b/src/__forks__/interface/RelayNodeInterface.js
@@ -11,4 +11,4 @@
 
 'use strict';
 
-module.exports = require.requireActual('RelayOSSNodeInterface');
+module.exports = require('RelayOSSNodeInterface');

--- a/src/__forks__/traversal/printRelayQuery.js
+++ b/src/__forks__/traversal/printRelayQuery.js
@@ -11,4 +11,4 @@
 
 'use strict';
 
-module.exports = require.requireActual('printRelayOSSQuery');
+module.exports = require('printRelayOSSQuery');


### PR DESCRIPTION
This is a Jest-provided extension, so not suitable for use outside the
test suite.

Test plan: Boot up Relay Starter Kit. See it load, and no errors about
inexistent `requireActual`.

CC: @yungsters 