### PR TITLE
Add missing key attribute in treasure hunt example

### DIFF
--- a/examples/relay-treasurehunt/js/components/App.js
+++ b/examples/relay-treasurehunt/js/components/App.js
@@ -48,6 +48,7 @@ class App extends React.Component {
         <div
           onClick={this._handleHidingSpotClick.bind(this, edge.node)}
           style={this._getHidingSpotStyle(edge.node)}
+          key={edge.node.id}
         />
       );
     });


### PR DESCRIPTION
With react and react-relay bundled into app.js bundle react is complaining about a missing key attribute. For some reason the warning is omitted if react is loaded with a script tag. 