### PR TITLE
Dont flatten mutation queries

### DIFF
--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -382,9 +382,9 @@ var RelayTestUtils = {
       if (!actualQuery.equals(expectedQuery)) {
         this.message = () => [
           'Expected:',
-          '  ' + printRelayQuery(actualQuery),
+          '  ' + printRelayQuery(actualQuery).text,
           '\ntoMatchPath:',
-          '  ' + printRelayQuery(expectedQuery),
+          '  ' + printRelayQuery(expectedQuery).text,
         ].filter(token => token).join('\n');
 
         return false;
@@ -554,10 +554,10 @@ function printQueryComparison(actual, expected, message) {
 
   return [
     'Expected:',
-    '  ' + printRelayQuery(actual),
+    '  ' + printRelayQuery(actual).text,
     formatRefParam(actual),
     message + ':',
-    '  ' + printRelayQuery(expected),
+    '  ' + printRelayQuery(expected).text,
     formatRefParam(expected),
   ].filter(line => !!line).join('\n');
 }


### PR DESCRIPTION
Mutation queries were being refragmented too early - this removes most calls to `flattenRelayQuery` during mutation query construction and moves the `refragmentRelayQuery` call to the very end.

Addresses #234 