### PR TITLE
babel-relay-plugin: disallow before/first after/last; inline actual errors

### DIFF
--- a/scripts/babel-relay-plugin/src/GraphQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/GraphQLPrinter.js
@@ -96,7 +96,7 @@ function getFragmentCode(fragment, options) {
 function printQuery(query, options) {
   var selections = getSelections(query);
   if (selections.length !== 1) {
-    throw new Error('expected only single top level query');
+    throw new Error('Expected only single top level query');
   }
 
   // Validate the name of the root call. Throws if it doesn't exist.
@@ -164,7 +164,7 @@ function printQuery(query, options) {
 function printOperation(operation, options) {
   var selections = getSelections(operation);
   if (selections.length !== 1) {
-    throw new Error('expected only single top level field on operation');
+    throw new Error('Expected only single top level field on operation');
   }
   var rootField = selections[0];
 
@@ -382,6 +382,23 @@ function printField(
 
     if (!getArgNamed(fieldDecl, 'find')) {
       metadata.nonFindable = true;
+    }
+
+    if (hasArgument(field, 'first') && hasArgument(field, 'before')) {
+      throw new Error(util.format(
+        'Connections arguments `%s(before: <cursor>, first: <count>)` are ' +
+        'not supported. Use `(first: <count>)` or ' +
+        '`(after: <cursor>, first: <count>)`. ',
+        fieldName
+      ));
+    }
+    if (hasArgument(field, 'last') && hasArgument(field, 'after')) {
+      throw new Error(util.format(
+        'Connections arguments `%s(after: <cursor>, last: <count>)` are ' +
+        'not supported. Use `(last: <count>)` or ' +
+        '`(before: <cursor>, last: <count>)`. ',
+        fieldName
+      ));
     }
 
     var hasEdgesSelection = false;
@@ -741,6 +758,15 @@ function getSelections(node) {
     return node.selectionSet.selections;
   }
   return [];
+}
+
+function hasArgument(field, argumentName) {
+  for (var ix = 0; ix < field.arguments.length; ix++) {
+    if (getName(field.arguments[ix]) === argumentName) {
+      return true;
+    }
+  }
+  return false;
 }
 
 module.exports = GraphQLPrinter;

--- a/scripts/babel-relay-plugin/src/__fixtures__/callInvalidValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/callInvalidValues.fixture
@@ -21,5 +21,5 @@ var foo = Relay.QL`
 
 Output:
 var foo = (function () {
-  throw new Error("Encountered a GraphQL validation error processing file `callInvalidValues.fixture`. Check your terminal for details.");
+  throw new Error("GraphQL validation/transform error ``Argument \"first\" expected type \"Int\" but got: \"10\". Argument \"orderby\" expected type \"[String]\" but got: Name. Argument \"find\" expected type \"String\" but got: cursor1. Argument \"isViewerFriend\" expected type \"Boolean\" but got: \"true\". Argument \"gender\" expected type \"Gender\" but got: \"MALE\".`` in file `callInvalidValues.fixture`.");
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastCalls.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastCalls.fixture
@@ -1,0 +1,21 @@
+Input:
+var Relay = require('react-relay');
+var x = Relay.QL`
+  query {
+    node(id: 123) {
+      friends(last: 3, after: "foo") {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }
+`;
+
+Output:
+var Relay = require('react-relay');
+var x = (function () {
+  throw new Error('GraphQL validation/transform error ``Connections arguments `friends(after: <cursor>, last: <count>)` are not supported. Use `(last: <count>)` or `(before: <cursor>, last: <count>)`. `` in file `connectionWithAfterLastCalls.fixture`.');
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstCalls.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstCalls.fixture
@@ -1,0 +1,21 @@
+Input:
+var Relay = require('react-relay');
+var x = Relay.QL`
+  query {
+    node(id: 123) {
+      friends(first: 3, before: "foo") {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }
+`;
+
+Output:
+var Relay = require('react-relay');
+var x = (function () {
+  throw new Error('GraphQL validation/transform error ``Connections arguments `friends(before: <cursor>, first: <count>)` are not supported. Use `(first: <count>)` or `(after: <cursor>, first: <count>)`. `` in file `connectionWithBeforeFirstCalls.fixture`.');
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
@@ -15,5 +15,5 @@ var x = Relay.QL`
 Output:
 var Relay = require('react-relay');
 var x = (function () {
-  throw new Error('Encountered a GraphQL validation error processing file `connectionWithNodesField.fixture`. Check your terminal for details.');
+  throw new Error('GraphQL validation/transform error ``Unsupported `nodes{...}` field on connection `friends`. Use `edges{node{...}}` instead.`` in file `connectionWithNodesField.fixture`.');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentOnBadType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentOnBadType.fixture
@@ -5,5 +5,5 @@ var x = Relay.QL`fragment on NotAType{id}`;
 Output:
 var Relay = require('react-relay');
 var x = (function () {
-  throw new Error('Encountered a GraphQL validation error processing file `fragmentOnBadType.fixture`. Check your terminal for details.');
+  throw new Error('GraphQL validation/transform error ``Unknown type "NotAType".`` in file `fragmentOnBadType.fixture`.');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/nonExistantMutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/nonExistantMutation.fixture
@@ -13,5 +13,5 @@ var x = Relay.QL`
 Output:
 var Relay = require('react-relay');
 var x = (function () {
-  throw new Error('Encountered a GraphQL validation error processing file `nonExistantMutation.fixture`. Check your terminal for details.');
+  throw new Error('GraphQL validation/transform error ``Cannot query field "fakeMutation" on "Mutation".`` in file `nonExistantMutation.fixture`.');
 })();

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -64,7 +64,7 @@ type NewsFeedConnectionEdge {
 }
 
 type Story implements Node {
-  friends(first: Int, orderby: [String], find: String, isViewerFriend: Boolean, gender: Gender): UserConnection
+  friends(first: Int, last: Int, orderby: [String], find: String, isViewerFriend: Boolean, gender: Gender, before: String, after: String): UserConnection
   id: String
   name: String
   profilePicture(size: Int): ProfilePicture
@@ -100,7 +100,7 @@ type UserConnectionEdge {
 }
 
 interface Node {
-  friends(first: Int, orderby: [String], find: String, isViewerFriend: Boolean, gender: Gender): UserConnection
+  friends(first: Int, last: Int, orderby: [String], find: String, isViewerFriend: Boolean, gender: Gender, before: String, after: String): UserConnection
   id: String
   name: String
   profilePicture(size: Int): ProfilePicture
@@ -108,7 +108,7 @@ interface Node {
 }
 
 type User implements Node {
-  friends(first: Int, orderby: [String], find: String, isViewerFriend: Boolean, gender: Gender): UserConnection
+  friends(first: Int, last: Int, orderby: [String], find: String, isViewerFriend: Boolean, gender: Gender, before: String, after: String): UserConnection
   id: String
   name: String
   profilePicture(size: Int): ProfilePicture
@@ -129,7 +129,7 @@ type FakeEdge {
 }
 
 type FakeNode implements Node {
-  friends(first: Int, orderby: [String], find: String, isViewerFriend: Boolean, gender: Gender): UserConnection
+  friends(first: Int, last: Int, orderby: [String], find: String, isViewerFriend: Boolean, gender: Gender, before: String, after: String): UserConnection
   id: String
   name: String
   profilePicture(size: Int): ProfilePicture

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -142,6 +142,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "orderby",
                   "description": null,
                   "type": {
@@ -181,6 +191,26 @@
                   "type": {
                     "kind": "ENUM",
                     "name": "Gender",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -299,6 +329,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "orderby",
                   "description": null,
                   "type": {
@@ -338,6 +378,26 @@
                   "type": {
                     "kind": "ENUM",
                     "name": "Gender",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -609,6 +669,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "orderby",
                   "description": null,
                   "type": {
@@ -648,6 +718,26 @@
                   "type": {
                     "kind": "ENUM",
                     "name": "Gender",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -934,6 +1024,16 @@
                   "defaultValue": null
                 },
                 {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "orderby",
                   "description": null,
                   "type": {
@@ -973,6 +1073,26 @@
                   "type": {
                     "kind": "ENUM",
                     "name": "Gender",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null

--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -135,9 +135,12 @@ function getBabelRelayPlugin(
             var filename = state.opts.filename || 'UnknownFile';
             var sourceText = error.sourceText;
             var validationErrors = error.validationErrors;
+            var errorMessages;
             if (validationErrors && sourceText) {
               var sourceLines = sourceText.split('\n');
               validationErrors.forEach(function(validationError) {
+                errorMessages = errorMessages || [];
+                errorMessages.push(validationError.message);
                 console.warn(
                   '\n-- GraphQL Validation Error -- %s --\n',
                   path.basename(filename)
@@ -159,6 +162,7 @@ function getBabelRelayPlugin(
                 });
               });
             } else {
+              errorMessages = [error.message];
               console.warn(
                 '\n-- Relay Transform Error -- %s --\n',
                 path.basename(filename)
@@ -170,9 +174,11 @@ function getBabelRelayPlugin(
             }
 
             var message = (
-              'Encountered a GraphQL validation error processing file `' +
+              'GraphQL validation/transform error ``' +
+              errorMessages.join(' ') +
+              '`` in file `' +
               filename +
-              '`. Check your terminal for details.'
+              '`.'
             );
             code = (
               'function() { throw new Error(\'' +


### PR DESCRIPTION
Makes the use of `field(before: .., first: ..)` or after/last an error. This combination is only supported when generated by Relay during the diffing process.

Also, the previous version replaced invalid GraphQL templates with a function that throws - while I was at it, I changed this to include the actual validation error message.

Addresses #247 