### PR TITLE
Fixed examples to use local version of babel-relay-plugin, like react-relay

### DIFF
--- a/examples/relay-treasurehunt/package.json
+++ b/examples/relay-treasurehunt/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "babel": "5.8.23",
     "babel-loader": "5.3.2",
-    "babel-relay-plugin": "0.2.1",
+    "babel-relay-plugin": "file:../../scripts/babel-relay-plugin/",
     "classnames": "^2.1.3",
     "express": "^4.13.1",
     "express-graphql": "^0.3.0",

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -8,7 +8,7 @@
     "babel": "5.8.23",
     "babel-eslint": "4.1.0",
     "babel-loader": "5.3.2",
-    "babel-relay-plugin": "0.2.1",
+    "babel-relay-plugin": "file:../../scripts/babel-relay-plugin/",
     "classnames": "^2.1.3",
     "eslint": "^1.0.0",
     "eslint-loader": "^1.0.0",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -8,7 +8,7 @@
     "babel": "5.8.23",
     "babel-eslint": "4.1.0",
     "babel-loader": "5.3.2",
-    "babel-relay-plugin": "0.2.1",
+    "babel-relay-plugin": "file:../../scripts/babel-relay-plugin/",
     "classnames": "^2.1.3",
     "eslint": "^1.0.0",
     "eslint-loader": "^1.0.0",


### PR DESCRIPTION
This is fixing an issue I had which is detailed here: https://github.com/facebook/relay/issues/254.

In examples, `react-relay` is using the local version and `babel-relay-plugin` needs to use the local one as well or the examples won't start.