### PR TITLE
Fix learn.json in TodoMVC example

### DIFF
--- a/examples/todo/public/index.html
+++ b/examples/todo/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-framework="relay">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/examples/todo/public/learn.json
+++ b/examples/todo/public/learn.json
@@ -1,11 +1,13 @@
 {
-	"framework": {
+	"relay": {
 		"name": "Relay",
 		"description": "A JavaScript framework for building data-driven React applications",
 		"homepage": "facebook.github.io/relay/",
-		"source_path": [{
+		"examples": [{
 			"name": "Relay + express-graphql Example",
-			"url": "examples/relay-express-graphql"
+                        "url": "",
+                        "source_url": "https://github.com/facebook/relay/tree/master/examples/todo",
+                        "type": "backend"
 		}],
 		"link_groups": [{
 			"heading": "Official Resources",
@@ -26,5 +28,8 @@
 				"url": "https://stackoverflow.com/questions/tagged/react-relay"
 			}]
 		}]
+	},
+	"templates": {
+		"todomvc": "<header> <h3><%= name %></h3> <span class=\"source-links\"> <% if (typeof examples !== 'undefined') { %> <% examples.forEach(function (example) { %> <h5><%= example.name %></h5> <% if (!location.href.match(example.url + '/')) { %> <a class=\"demo-link\" data-type=\"<%= example.type === 'backend' ? 'external' : 'local' %>\" href=\"<%= example.url %>\">Demo</a>, <% } if (example.type === 'backend') { %><a href=\"<%= example.source_url %>\"><% } else { %><a href=\"https://github.com/tastejs/todomvc/tree/gh-pages/<%= example.source_url ? example.source_url : example.url %>\"><% } %>Source</a> <% }); %> <% } %> </span> </header> <hr> <blockquote class=\"quote speech-bubble\"> <p><%= description %></p> <footer> <a href=\"http://<%= homepage %>\"><%= name %></a> </footer> </blockquote> <% if (typeof link_groups !== 'undefined') { %> <hr> <% link_groups.forEach(function (link_group) { %> <h4><%= link_group.heading %></h4> <ul> <% link_group.links.forEach(function (link) { %> <li> <a href=\"<%= link.url %>\"><%= link.name %></a> </li> <% }); %> </ul> <% }); %> <% } %> <footer> <hr> <em>If you have other helpful links to share, or find any of the links above no longer work, please <a href=\"https://github.com/tastejs/todomvc/issues\">let us know</a>.</em> </footer>"
 	}
 }


### PR DESCRIPTION
I hit this while setting up my own "Relay TodoMVC with routing" example.

You need to set up `data-framework` and the framework key on `learn.json` to get the sidebar to show up (otherwise `learn.json` doesn't do anything). The `source_path` key from the `learn.json` template also doesn't do anything, and you need to drop in the `templates` from their example as well.

The `"url": ""` bit in the example is just to keep the "demo" link from showing up, since as far as I'm aware this isn't running publicly on the internet anywhere.