### PR TITLE
babel plugin - support introspection fields

### DIFF
--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
@@ -1,0 +1,21 @@
+Input:
+var foo = Relay.QL`
+  query IntrospectionQueryFroSchema {
+    __schema {
+      types {
+        name
+      }
+    }
+  }
+`;
+
+Output:
+var foo = (function () {
+  var GraphQL = Relay.QL.__GraphQL;
+  return new GraphQL.Query("__schema", null, [new GraphQL.Field("types", [new GraphQL.Field("name", null, null, null, null, null, {
+    "parentType": "__Type"
+  })], null, null, null, null, {
+    "parentType": "__Schema",
+    "plural": true
+  })], null, null, "IntrospectionQueryFroSchema");
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
@@ -1,0 +1,18 @@
+Input:
+var foo = Relay.QL`
+  query IntrospectionQueryForType {
+    __type(name: "Root") {
+      name
+    }
+  }
+`;
+
+Output:
+var foo = (function () {
+  var GraphQL = Relay.QL.__GraphQL;
+  return new GraphQL.Query("__type", "Root", [new GraphQL.Field("name", null, null, null, null, null, {
+    "parentType": "__Type"
+  })], null, {
+    "rootArg": "name"
+  }, "IntrospectionQueryForType");
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
@@ -1,0 +1,18 @@
+Input:
+var foo = Relay.QL`
+  query UnionWithTypename {
+    media(id: 123) {
+      __typename
+    },
+  }
+`;
+
+Output:
+var foo = (function () {
+  var GraphQL = Relay.QL.__GraphQL;
+  return new GraphQL.Query("media", 123, [new GraphQL.Field("__typename", null, null, null, null, null, {
+    "parentType": "Media"
+  })], null, {
+    "rootArg": "id"
+  }, "UnionWithTypename");
+})();

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -1,6 +1,7 @@
 type Root {
   node(id: Int): Node
   nodes(ids: [Int]): [Node]
+  media(id: Int): Media
   viewer: Viewer
   search(query: SearchInput): [SearchResult]
 }
@@ -154,3 +155,5 @@ enum Gender {
   FEMALE,
   UNKNOWN
 }
+
+union Media = Story | ProfilePicture

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -68,6 +68,29 @@
               "deprecationReason": null
             },
             {
+              "name": "media",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "UNION",
+                "name": "Media",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "viewer",
               "description": null,
               "args": [],
@@ -1239,6 +1262,27 @@
           "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
+        },
+        {
+          "kind": "UNION",
+          "name": "Media",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Story",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ProfilePicture",
+              "ofType": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",


### PR DESCRIPTION
Supports compiling introspection queries/fields:
- `query { __schema }` 
- `query { __type(name: "Name") }` 
- `__typename` on any field.