### PR TITLE
Revert "npm test checks & uses latest babel plugin"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
   "repository": "facebook/relay",
   "scripts": {
     "build": "[ $(ulimit -n) -lt 4096 ] && ulimit -n 4096; gulp",
-    "preinstall": "cd scripts/babel-relay-plugin && npm install",
     "prepublish": "npm run build",
-    "test": "f() { EXIT=0; npm run test-plugin || EXIT=$?; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
-    "test-plugin": "cd scripts/babel-relay-plugin && npm test",
+    "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",
     "update-schema": "babel-node ./scripts/jest/updateSchema.js",
     "lint": "eslint ."


### PR DESCRIPTION
This reverts commit 47f2602c30b4e7940e26b15825cea5e4980af503.

@steveluscher pointed out that travis already tests the plugin, and for
local testing developers can run the extra `npm test` manually.