### PR TITLE
babel plugin: print list/non-null annotations on variable types

### DIFF
--- a/scripts/babel-relay-plugin/src/GraphQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/GraphQLPrinter.js
@@ -2,6 +2,7 @@
 "use strict";
 
 var kinds = require('graphql/language/kinds');
+var printer = require('graphql/language/printer');
 var types = require('graphql/type');
 var typeIntrospection = require('graphql/type/introspection');
 
@@ -577,16 +578,16 @@ function getScalarValue(node) {
 }
 
 function getTypeForMetadata(type) {
-  type = types.getNamedType(type);
+  var namedType = types.getNamedType(type);
   if (
-    type instanceof types.GraphQLEnumType ||
-    type instanceof types.GraphQLInputObjectType
+    namedType instanceof types.GraphQLEnumType ||
+    namedType instanceof types.GraphQLInputObjectType
   ) {
-    return type.name;
-  } else if (type instanceof types.GraphQLScalarType) {
+    return String(type);
+  } else if (namedType instanceof types.GraphQLScalarType) {
     return null;
   }
-  throw new Error('Unsupported call value type ' + type.name);
+  throw new Error('Unsupported call value type ' + namedType.name);
 }
 
 function isEnum(type) {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgument.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgument.fixture
@@ -16,6 +16,6 @@ var q = (function () {
     'parentType': 'SearchResult'
   })], null, {
     'rootArg': 'query',
-    'rootCallType': 'SearchInput'
+    'rootCallType': '[SearchInput!]'
   }, 'QueryWithObjectArgument');
 })();

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -3,7 +3,7 @@ type Root {
   nodes(ids: [Int]): [Node]
   media(id: Int): Media
   viewer: Viewer
-  search(query: SearchInput): [SearchResult]
+  search(query: [SearchInput!]): [SearchResult]
 }
 
 type SearchResult {

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -110,9 +110,17 @@
                   "name": "query",
                   "description": null,
                   "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "SearchInput",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "SearchInput",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null
                 }


### PR DESCRIPTION
Addresses #203 - `printRelayQuery` does not inline complex argument values, instead it synthesizes new query arguments and sends the data as variables. This was failing for non-null or list types - fixed!