### PR TITLE
babel plugin: add option to fail on error & document it

### DIFF
--- a/docs/Guides-BabelPlugin.md
+++ b/docs/Guides-BabelPlugin.md
@@ -31,4 +31,49 @@ This gets converted into an immediately-invoked function:
 
 ## Usage
 
-The easiest way to get started for now is with the [Relay Starter Kit](https://github.com/facebook/relay-starter-kit) - this includes an example schema file and configures the `babel-relay-plugin` npm module to transpile queries. Going forward, we'll provide additional documentation and make it easier to work with this plugin. Expect more information soon.
+The easiest way to get started for now is with the [Relay Starter Kit](https://github.com/facebook/relay-starter-kit) - this includes an example schema file and configures the `babel-relay-plugin` npm module to transpile queries.
+
+## Advanced Usage
+
+If you're not using the starter kit, you'll have to configure `babel` to use the `babel-relay-plugin`. The steps are as follows:
+
+```javascript
+// `babel-relay-plugin` returns a function for creating plugin instances
+var getBabelRelayPlugin = require('babel-relay-plugin');
+
+// load previously saved schema data (see "Schema JSON" below)
+var schemaData = require('schema.json');
+
+// create a plugin instance
+var plugin = getBabelRelayPlugin(schemaData);
+
+// compile code with babel using the plugin
+return babel.transform(source, {
+  plugins: [plugin],
+});
+```
+
+## Schema JSON
+
+The plugin needs to understand your schema - `schemaData` in the above snippet. There are two ways to get this information, depending on the GraphQL implementation.
+
+### Using `graphql`
+
+An example of how to load a `schema.js` file, run the introspection query to get schema information, and save it to a JSON file can be found in the [starter kit](https://github.com/relayjs/relay-starter-kit/blob/master/scripts/updateSchema.js).
+
+### Using Other GraphQL Implementations
+
+If you're using a different GraphQL server implementation, we recommend adapting the above example to load the schema from your GraphQL server (e.g. via an HTTP request) and then save the result as JSON.
+
+
+## Additional Options
+
+By default, `babel-relay-plugin` catches GraphQL validation errors and logs them without exiting. The compiled code will also throw the same errors at runtime, making it obvious that something went wrong whether you're looking at your terminal or browser console.
+
+When compiling code for production deployment, the plugin can be configured to immediately throw upon encountering a validation problem:
+
+```javascript
+var plugin = getBabelRelayPlugin(schemaData, {
+  abortOnError: true,
+});
+```

--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -48,7 +48,8 @@ function extractTemplate(node) {
  * GraphQL queries.
  */
 function getBabelRelayPlugin(
-  schemaProvider /*: Object | Function */
+  schemaProvider, /*: Object | Function */
+  options /*: ?Object */
 ) /*: Object */ {
   return function(babel) {
     var Plugin = babel.Plugin;
@@ -190,6 +191,11 @@ function getBabelRelayPlugin(
             if (state.opts.extra.debug) {
               console.log(error.message);
               console.log(error.stack);
+            }
+            if (options && options.abortOnError) {
+              throw new Error(
+                'Aborting due to GraphQL validation/transform error(s).'
+              );
             }
           }
           code = '(' + code + ')';


### PR DESCRIPTION
As discussed in #265, adds an option to `babel-relay-plugin` to abort on validation errors, instead of logging and carrying on. Also adds some basic documentation about using the plugin including the new option.

The new option can be used as `getBabelRelayPlugin(schema, {abortOnError: true})`