### PR TITLE
babel plugin: compiled queries include directive metadata

### DIFF
--- a/scripts/babel-relay-plugin/src/__fixtures__/callValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/callValues.fixture
@@ -23,10 +23,10 @@ var foo = Relay.QL`
 Output:
 var foo = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query("node", 123, [new GraphQL.Field("friends", [new GraphQL.Field("edges", [new GraphQL.Field("node", [new GraphQL.Field("id", null, null, null, null, null, {
+  return new GraphQL.Query("node", new GraphQL.CallValue(123), [new GraphQL.Field("friends", [new GraphQL.Field("edges", [new GraphQL.Field("node", [new GraphQL.Field("id", null, null, null, null, null, {
     parentType: "User",
     requisite: true
-  }), new GraphQL.Field("firstName", null, null, [new GraphQL.Callv("if", true), new GraphQL.Callv("unless", false)], null, null, {
+  }), new GraphQL.Field("firstName", null, null, [new GraphQL.Callv("if", new GraphQL.CallValue(true)), new GraphQL.Callv("unless", new GraphQL.CallValue(false))], null, null, {
     parentType: "User"
   })], null, null, null, null, {
     parentType: "UserConnectionEdge",
@@ -52,7 +52,7 @@ var foo = (function () {
     parentType: "UserConnection",
     generated: true,
     requisite: true
-  })], null, [new GraphQL.Callv("first", 10), new GraphQL.Callv("orderby", "Name"), new GraphQL.Callv("find", "cursor1"), new GraphQL.Callv("isViewerFriend", true), new GraphQL.Callv("gender", "MALE", {
+  })], null, [new GraphQL.Callv("first", new GraphQL.CallValue(10)), new GraphQL.Callv("orderby", new GraphQL.CallValue("Name")), new GraphQL.Callv("find", new GraphQL.CallValue("cursor1")), new GraphQL.Callv("isViewerFriend", new GraphQL.CallValue(true)), new GraphQL.Callv("gender", new GraphQL.CallValue("MALE"), {
     type: "Gender"
   })], null, null, {
     parentType: "Node",

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastCalls.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastCalls.fixture
@@ -17,5 +17,5 @@ var x = Relay.QL`
 Output:
 var Relay = require('react-relay');
 var x = (function () {
-  throw new Error('GraphQL validation/transform error ``Connections arguments `friends(after:<cursor>,last:<count>)` are not supported. Use `(last:<count>)`,`(before:<cursor>,last:<count>)`,or `(after:<cursor>,first:<count>)`.`` in file `connectionWithAfterLastCalls.fixture`.');
+  throw new Error('GraphQL validation/transform error ``Connections arguments `friends(after: <cursor>, last: <count>)` are not supported. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, or `(after: <cursor>, first: <count>)`.`` in file `connectionWithAfterLastCalls.fixture`.');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstCalls.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstCalls.fixture
@@ -17,5 +17,5 @@ var x = Relay.QL`
 Output:
 var Relay = require('react-relay');
 var x = (function () {
-  throw new Error('GraphQL validation/transform error ``Connections arguments `friends(before:<cursor>,first:<count>)` are not supported. Use `(first:<count>)`,`(after:<cursor>,first:<count>)`,or `(before:<cursor>,last:<count>)`.`` in file `connectionWithBeforeFirstCalls.fixture`.');
+  throw new Error('GraphQL validation/transform error ``Connections arguments `friends(before: <cursor>, first: <count>)` are not supported. Use `(first: <count>)`, `(after: <cursor>, first: <count>)`, or `(before: <cursor>, last: <count>)`.`` in file `connectionWithBeforeFirstCalls.fixture`.');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
@@ -21,7 +21,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
     parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'User',
@@ -49,7 +49,7 @@ var x = (function () {
   })], null, null, 'myPageInfo', null, {
     parentType: 'UserConnection',
     requisite: true
-  })], null, [new GraphQL.Callv('first', 3)], null, null, {
+  })], null, [new GraphQL.Callv('first', new GraphQL.CallValue(3))], null, null, {
     parentType: 'Node',
     connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
@@ -19,7 +19,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
     parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'User',
@@ -48,7 +48,7 @@ var x = (function () {
   })], null, null, null, null, {
     parentType: 'UserConnection',
     requisite: true
-  })], null, [new GraphQL.Callv('first', 3)], null, null, {
+  })], null, [new GraphQL.Callv('first', new GraphQL.CallValue(3))], null, null, {
     parentType: 'Node',
     connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
@@ -16,7 +16,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('cursor', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('cursor', null, null, null, null, null, {
     parentType: 'UserConnectionEdge',
     requisite: true
   }), new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
@@ -44,7 +44,7 @@ var x = (function () {
     parentType: 'UserConnection',
     generated: true,
     requisite: true
-  })], null, [new GraphQL.Callv('first', 3)], null, null, {
+  })], null, [new GraphQL.Callv('first', new GraphQL.CallValue(3))], null, null, {
     parentType: 'Node',
     connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
@@ -14,7 +14,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('id', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'Node',
     generated: true,
     requisite: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
@@ -12,7 +12,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('name', null, null, null, 'realname', null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('name', null, null, null, 'realname', null, {
     parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'Node',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
@@ -14,9 +14,9 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
     parentType: 'ProfilePicture'
-  })], null, [new GraphQL.Callv('size', 100)], 'mugshot', null, {
+  })], null, [new GraphQL.Callv('size', new GraphQL.CallValue(100))], 'mugshot', null, {
     parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'Node',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
@@ -14,9 +14,9 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
     parentType: 'ProfilePicture'
-  })], null, [new GraphQL.Callv('size', 100)], null, null, {
+  })], null, [new GraphQL.Callv('size', new GraphQL.CallValue(100))], null, null, {
     parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'Node',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
@@ -14,7 +14,7 @@ var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('FieldWithEmptyArrayArg', 'User', [new GraphQL.Field('friends', [new GraphQL.Field('count', null, null, null, null, null, {
     parentType: 'UserConnection'
-  })], null, [new GraphQL.Callv('isViewerFriend', false)], null, null, {
+  })], null, [new GraphQL.Callv('isViewerFriend', new GraphQL.CallValue(false))], null, null, {
     parentType: 'User',
     connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -18,7 +18,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'User',
     requisite: true
   })], null, null, null, null, {
@@ -45,7 +45,7 @@ var x = (function () {
     parentType: 'UserConnection',
     generated: true,
     requisite: true
-  })], null, [new GraphQL.Callv('gender', 'MALE', {
+  })], null, [new GraphQL.Callv('gender', new GraphQL.CallValue('MALE'), {
     type: 'Gender'
   })], null, null, {
     parentType: 'Node',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
@@ -18,7 +18,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'User',
     requisite: true
   })], null, null, null, null, {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
@@ -14,7 +14,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
     parentType: 'ProfilePicture'
   })], null, [new GraphQL.Callv('size', new GraphQL.CallVariable('size'))], null, null, {
     parentType: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
@@ -10,7 +10,7 @@ var foo = Relay.QL`
 Output:
 var foo = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query("__type", "Root", [new GraphQL.Field("name", null, null, null, null, null, {
+  return new GraphQL.Query("__type", new GraphQL.CallValue("Root"), [new GraphQL.Field("name", null, null, null, null, null, {
     parentType: "__Type"
   })], null, {
     rootArg: "name"

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
@@ -18,7 +18,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
     parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'User',
@@ -48,7 +48,7 @@ var x = (function () {
     parentType: 'UserConnection',
     generated: true,
     requisite: true
-  })], null, [new GraphQL.Callv('first', 3)], null, null, {
+  })], null, [new GraphQL.Callv('first', new GraphQL.CallValue(3))], null, null, {
     parentType: 'Node',
     connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
@@ -10,7 +10,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('id', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'Node',
     generated: true,
     requisite: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
@@ -12,7 +12,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('websites', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('websites', null, null, null, null, null, {
     parentType: 'Node',
     plural: true
   }), new GraphQL.Field('id', null, null, null, null, null, {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
@@ -1,0 +1,57 @@
+Input:
+var Relay = require('react-relay');
+var x = Relay.QL`
+  query {
+    node(id: 123) @source(uri: "facebook.com") {
+      ... on User @include(if: $foo) {
+        name @skip(if: $bar) @meta(data: $data, length: 50)
+      }
+    }
+  }
+`;
+
+Output:
+var Relay = require('react-relay');
+var x = (function () {
+  var GraphQL = Relay.QL.__GraphQL;
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('id', null, null, null, null, null, {
+    parentType: 'Node',
+    generated: true,
+    requisite: true
+  })], [new GraphQL.QueryFragment('User', 'User', [new GraphQL.Field('name', null, null, null, null, null, {
+    parentType: 'User'
+  }, [{
+    name: 'skip',
+    arguments: [{
+      name: 'if',
+      value: new GraphQL.CallVariable('bar')
+    }]
+  }, {
+    name: 'meta',
+    arguments: [{
+      name: 'data',
+      value: new GraphQL.CallVariable('data')
+    }, {
+      name: 'length',
+      value: new GraphQL.CallValue(50)
+    }]
+  }]), new GraphQL.Field('id', null, null, null, null, null, {
+    parentType: 'User',
+    generated: true,
+    requisite: true
+  })], null, null, [{
+    name: 'include',
+    arguments: [{
+      name: 'if',
+      value: new GraphQL.CallVariable('foo')
+    }]
+  }])], {
+    rootArg: 'id'
+  }, 'QueryWithDirectives', [{
+    name: 'source',
+    arguments: [{
+      name: 'uri',
+      value: new GraphQL.CallValue('facebook.com')
+    }]
+  }]);
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
@@ -12,7 +12,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('name', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('name', null, null, null, null, null, {
     parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'Node',

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
@@ -14,7 +14,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
     parentType: 'ProfilePicture'
   })], null, null, null, null, {
     parentType: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
@@ -14,7 +14,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
     parentType: 'ProfilePicture'
   })], null, null, null, null, {
     parentType: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
@@ -26,7 +26,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function (sub_0, sub_1, sub_2, sub_3, sub_4, sub_5, sub_6, sub_7, sub_8, sub_9, sub_10, sub_11) {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
+  return new GraphQL.Query('node', new GraphQL.CallValue(123), [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
     parentType: 'ProfilePicture'
   })], [Relay.QL.__frag(sub_4), Relay.QL.__frag(sub_5), Relay.QL.__frag(sub_6), Relay.QL.__frag(sub_7)], null, null, null, {
     parentType: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
@@ -12,7 +12,7 @@ Output:
 var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query('nodes', [123, 456], [new GraphQL.Field('id', null, null, null, null, null, {
+  return new GraphQL.Query('nodes', [new GraphQL.CallValue(123), new GraphQL.CallValue(456)], [new GraphQL.Field('id', null, null, null, null, null, {
     parentType: 'Node',
     requisite: true
   })], null, {

--- a/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
@@ -10,7 +10,7 @@ var foo = Relay.QL`
 Output:
 var foo = (function () {
   var GraphQL = Relay.QL.__GraphQL;
-  return new GraphQL.Query("media", 123, [new GraphQL.Field("__typename", null, null, null, null, null, {
+  return new GraphQL.Query("media", new GraphQL.CallValue(123), [new GraphQL.Field("__typename", null, null, null, null, null, {
     parentType: "Media"
   })], null, {
     rootArg: "id"


### PR DESCRIPTION
Adds support for directives to `babel-relay-plugin` which were previously ignored. Directives are now passed to `GraphQL.*` nodes as metadata on root fields, fragments, and plain fields.