### PR TITLE
Bump version number for v0.2.3 release of babel-relay-plugin

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-relay-plugin",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Babel Relay Plugin for transpiling GraphQL queries for use with Relay.",
   "license": "BSD-3-Clause",
   "repository": "facebook/relay",


### PR DESCRIPTION
Publishing this one prior to v0.3.0 of the react-relay package, which
will depend on it.