### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+## 0.3.1 (September 11, 2015)
+
+* Rebuild to replace faulty NPM package (no code changes).
+
 ## 0.3.0 (September 11, 2015)
 
 * Fix query variable printing for non-null and list types (#203).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-relay",
   "description": "A framework for building data-driven React applications.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "keywords": [
     "graphql",
     "react",

--- a/website/core/SiteData.js
+++ b/website/core/SiteData.js
@@ -3,5 +3,5 @@
  */
 
 module.exports = {
-  version: '0.3.0'
+  version: '0.3.1'
 };


### PR DESCRIPTION
We need to rebuild the just-released (as v0.3.0) NPM package, which had
faulty `dist/` contents.

Fixes https://github.com/facebook/relay/issues/301