### PR TITLE
babel plugin: refactor printer to use ast nodes not strings

### DIFF
--- a/scripts/babel-relay-plugin/src/__fixtures__/callValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/callValues.fixture
@@ -24,44 +24,44 @@ Output:
 var foo = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query("node", 123, [new GraphQL.Field("friends", [new GraphQL.Field("edges", [new GraphQL.Field("node", [new GraphQL.Field("id", null, null, null, null, null, {
-    "parentType": "User",
-    "requisite": true
+    parentType: "User",
+    requisite: true
   }), new GraphQL.Field("firstName", null, null, [new GraphQL.Callv("if", true), new GraphQL.Callv("unless", false)], null, null, {
-    "parentType": "User"
+    parentType: "User"
   })], null, null, null, null, {
-    "parentType": "UserConnectionEdge",
-    "rootCall": "node",
-    "pk": "id",
-    "requisite": true
+    parentType: "UserConnectionEdge",
+    rootCall: "node",
+    pk: "id",
+    requisite: true
   }), new GraphQL.Field("cursor", null, null, null, null, null, {
-    "parentType": "UserConnectionEdge",
-    "generated": true,
-    "requisite": true
+    parentType: "UserConnectionEdge",
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    "parentType": "UserConnection",
-    "plural": true
+    parentType: "UserConnection",
+    plural: true
   }), new GraphQL.Field("pageInfo", [new GraphQL.Field("hasNextPage", null, null, null, null, null, {
-    "parentType": "PageInfo",
-    "generated": true,
-    "requisite": true
+    parentType: "PageInfo",
+    generated: true,
+    requisite: true
   }), new GraphQL.Field("hasPreviousPage", null, null, null, null, null, {
-    "parentType": "PageInfo",
-    "generated": true,
-    "requisite": true
+    parentType: "PageInfo",
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    "parentType": "UserConnection",
-    "generated": true,
-    "requisite": true
+    parentType: "UserConnection",
+    generated: true,
+    requisite: true
   })], null, [new GraphQL.Callv("first", 10), new GraphQL.Callv("orderby", "Name"), new GraphQL.Callv("find", "cursor1"), new GraphQL.Callv("isViewerFriend", true), new GraphQL.Callv("gender", "MALE", {
-    "type": "Gender"
+    type: "Gender"
   })], null, null, {
-    "parentType": "Node",
-    "connection": true
+    parentType: "Node",
+    connection: true
   }), new GraphQL.Field("id", null, null, null, null, null, {
-    "parentType": "Node",
-    "generated": true,
-    "requisite": true
+    parentType: "Node",
+    generated: true,
+    requisite: true
   })], null, {
-    "rootArg": "id"
+    rootArg: "id"
   }, "CallValues");
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
@@ -22,41 +22,41 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
-    'parentType': 'User'
+    parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'rootCall': 'node',
-    'pk': 'id',
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    rootCall: 'node',
+    pk: 'id',
+    requisite: true
   }), new GraphQL.Field('cursor', null, null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'plural': true
+    parentType: 'UserConnection',
+    plural: true
   }), new GraphQL.Field('pageInfo', [new GraphQL.Field('hasPreviousPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'requisite': true
+    parentType: 'PageInfo',
+    requisite: true
   }), new GraphQL.Field('hasNextPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   })], null, null, 'myPageInfo', null, {
-    'parentType': 'UserConnection',
-    'requisite': true
+    parentType: 'UserConnection',
+    requisite: true
   })], null, [new GraphQL.Callv('first', 3)], null, null, {
-    'parentType': 'Node',
-    'connection': true
+    parentType: 'Node',
+    connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'ConnectionWithPageInfoAlias');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
@@ -20,42 +20,42 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
-    'parentType': 'User'
+    parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'rootCall': 'node',
-    'pk': 'id',
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    rootCall: 'node',
+    pk: 'id',
+    requisite: true
   }), new GraphQL.Field('cursor', null, null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'plural': true
+    parentType: 'UserConnection',
+    plural: true
   }), new GraphQL.Field('pageInfo', [new GraphQL.Field('hasNextPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   }), new GraphQL.Field('hasPreviousPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'requisite': true
+    parentType: 'UserConnection',
+    requisite: true
   })], null, [new GraphQL.Callv('first', 3)], null, null, {
-    'parentType': 'Node',
-    'connection': true
+    parentType: 'Node',
+    connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'ConnectionWithPageInfoSubfields');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
@@ -17,41 +17,41 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('cursor', null, null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    requisite: true
   }), new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'rootCall': 'node',
-    'pk': 'id',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    rootCall: 'node',
+    pk: 'id',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'plural': true
+    parentType: 'UserConnection',
+    plural: true
   }), new GraphQL.Field('pageInfo', [new GraphQL.Field('hasNextPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   }), new GraphQL.Field('hasPreviousPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnection',
+    generated: true,
+    requisite: true
   })], null, [new GraphQL.Callv('first', 3)], null, null, {
-    'parentType': 'Node',
-    'connection': true
+    parentType: 'Node',
+    connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'ConnectionWithoutNodeField');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
@@ -14,12 +14,12 @@ Relay.createContainer(Component, {
       return (function () {
         var GraphQL = Relay.QL.__GraphQL;
         return new GraphQL.QueryFragment('Container', 'Viewer', [new GraphQL.Field('actor', [new GraphQL.Field('id', null, null, null, null, null, {
-          'parentType': 'User',
-          'requisite': true
+          parentType: 'User',
+          requisite: true
         })], null, null, null, null, {
-          'parentType': 'Viewer',
-          'rootCall': 'node',
-          'pk': 'id'
+          parentType: 'Viewer',
+          rootCall: 'node',
+          pk: 'id'
         })]);
       })();
     }

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
@@ -15,16 +15,16 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], [new GraphQL.QueryFragment('User', 'User', [new GraphQL.Field('gender', null, null, null, null, null, {
-    'parentType': 'User'
+    parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })])], {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'FieldForEnum');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
@@ -13,12 +13,12 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('name', null, null, null, 'realname', null, {
-    'parentType': 'Node'
+    parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'FieldWithAlias');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
@@ -15,14 +15,14 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
-    'parentType': 'ProfilePicture'
+    parentType: 'ProfilePicture'
   })], null, [new GraphQL.Callv('size', 100)], 'mugshot', null, {
-    'parentType': 'Node'
+    parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'FieldWithAliasAndArgs');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
@@ -15,14 +15,14 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
-    'parentType': 'ProfilePicture'
+    parentType: 'ProfilePicture'
   })], null, [new GraphQL.Callv('size', 100)], null, null, {
-    'parentType': 'Node'
+    parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'FieldWithArgs');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
@@ -13,13 +13,13 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('FieldWithEmptyArrayArg', 'User', [new GraphQL.Field('friends', [new GraphQL.Field('count', null, null, null, null, null, {
-    'parentType': 'UserConnection'
+    parentType: 'UserConnection'
   })], null, [new GraphQL.Callv('isViewerFriend', false)], null, null, {
-    'parentType': 'User',
-    'connection': true
+    parentType: 'User',
+    connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })]);
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -19,42 +19,42 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'requisite': true
+    parentType: 'User',
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'rootCall': 'node',
-    'pk': 'id',
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    rootCall: 'node',
+    pk: 'id',
+    requisite: true
   }), new GraphQL.Field('cursor', null, null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'plural': true
+    parentType: 'UserConnection',
+    plural: true
   }), new GraphQL.Field('pageInfo', [new GraphQL.Field('hasNextPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   }), new GraphQL.Field('hasPreviousPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnection',
+    generated: true,
+    requisite: true
   })], null, [new GraphQL.Callv('gender', 'MALE', {
-    'type': 'Gender'
+    type: 'Gender'
   })], null, null, {
-    'parentType': 'Node',
-    'connection': true
+    parentType: 'Node',
+    connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'FieldWithEnumArg');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
@@ -19,42 +19,42 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'requisite': true
+    parentType: 'User',
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'rootCall': 'node',
-    'pk': 'id',
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    rootCall: 'node',
+    pk: 'id',
+    requisite: true
   }), new GraphQL.Field('cursor', null, null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'plural': true
+    parentType: 'UserConnection',
+    plural: true
   }), new GraphQL.Field('pageInfo', [new GraphQL.Field('hasNextPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   }), new GraphQL.Field('hasPreviousPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnection',
+    generated: true,
+    requisite: true
   })], null, [new GraphQL.Callv('gender', new GraphQL.CallVariable('gender_0'), {
-    'type': 'Gender'
+    type: 'Gender'
   })], null, null, {
-    'parentType': 'Node',
-    'connection': true
+    parentType: 'Node',
+    connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'FieldWithEnumQueryArg');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
@@ -17,25 +17,25 @@ var Relay = require('Relay');
 var foo = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('FieldWithFakeConnection', 'User', [new GraphQL.Field('fakeConnection', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'FakeNode',
-    'requisite': true
+    parentType: 'FakeNode',
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'FakeEdge',
-    'rootCall': 'node',
-    'pk': 'id',
-    'requisite': true
+    parentType: 'FakeEdge',
+    rootCall: 'node',
+    pk: 'id',
+    requisite: true
   }), new GraphQL.Field('cursor', null, null, null, null, null, {
-    'parentType': 'FakeEdge',
-    'generated': true,
-    'requisite': true
+    parentType: 'FakeEdge',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'FakeConnection',
-    'plural': true
+    parentType: 'FakeConnection',
+    plural: true
   })], null, null, null, null, {
-    'parentType': 'User'
+    parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })]);
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
@@ -15,14 +15,14 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
-    'parentType': 'ProfilePicture'
+    parentType: 'ProfilePicture'
   })], null, [new GraphQL.Callv('size', new GraphQL.CallVariable('size'))], null, null, {
-    'parentType': 'Node'
+    parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'FieldWithParams');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragment.fixture
@@ -7,7 +7,7 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('Fragment', 'Node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'requisite': true
+    parentType: 'Node',
+    requisite: true
   })]);
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentDirectives.fixture
@@ -7,11 +7,11 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('FragmentDirectives', 'Node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'requisite': true
+    parentType: 'Node',
+    requisite: true
   })], null, {
-    'plural': true,
-    'count': 1,
-    'name': 'Foo'
+    plural: true,
+    count: 1,
+    name: 'Foo'
   });
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithModuleName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithModuleName.fixture
@@ -10,14 +10,14 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('Foo', 'Node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'requisite': true
+    parentType: 'Node',
+    requisite: true
   })]);
 })();
 var y = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('Bar', 'Node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'requisite': true
+    parentType: 'Node',
+    requisite: true
   })]);
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithName.fixture
@@ -7,7 +7,7 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('FragmentNameHere', 'Node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'requisite': true
+    parentType: 'Node',
+    requisite: true
   })]);
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithReference.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithReference.fixture
@@ -7,8 +7,8 @@ var Relay = require('react-relay');
 var x = (function (sub_0) {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('FragmentWithReference', 'Node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], [Relay.QL.__frag(sub_0)]);
 })(reference);

--- a/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
@@ -13,14 +13,14 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('InlineFragment', 'Node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], [new GraphQL.QueryFragment('User', 'User', [new GraphQL.Field('userOnlyField', null, null, null, null, null, {
-    'parentType': 'User'
+    parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })])]);
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
@@ -13,9 +13,9 @@ Output:
 var foo = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query("__schema", null, [new GraphQL.Field("types", [new GraphQL.Field("name", null, null, null, null, null, {
-    "parentType": "__Type"
+    parentType: "__Type"
   })], null, null, null, null, {
-    "parentType": "__Schema",
-    "plural": true
+    parentType: "__Schema",
+    plural: true
   })], null, null, "IntrospectionQueryFroSchema");
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
@@ -11,8 +11,8 @@ Output:
 var foo = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query("__type", "Root", [new GraphQL.Field("name", null, null, null, null, null, {
-    "parentType": "__Type"
+    parentType: "__Type"
   })], null, {
-    "rootArg": "name"
+    rootArg: "name"
   }, "IntrospectionQueryForType");
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
@@ -19,43 +19,43 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('friends', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
-    'parentType': 'User'
+    parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'rootCall': 'node',
-    'pk': 'id',
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    rootCall: 'node',
+    pk: 'id',
+    requisite: true
   }), new GraphQL.Field('cursor', null, null, null, null, null, {
-    'parentType': 'UserConnectionEdge',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnectionEdge',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'plural': true
+    parentType: 'UserConnection',
+    plural: true
   }), new GraphQL.Field('pageInfo', [new GraphQL.Field('hasNextPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   }), new GraphQL.Field('hasPreviousPage', null, null, null, null, null, {
-    'parentType': 'PageInfo',
-    'generated': true,
-    'requisite': true
+    parentType: 'PageInfo',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'UserConnection',
-    'generated': true,
-    'requisite': true
+    parentType: 'UserConnection',
+    generated: true,
+    requisite: true
   })], null, [new GraphQL.Callv('first', 3)], null, null, {
-    'parentType': 'Node',
-    'connection': true
+    parentType: 'Node',
+    connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'MetadataConnection');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
@@ -19,18 +19,18 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('viewer', null, [new GraphQL.Field('__configs__', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('name', null, null, null, null, null, {
-    'parentType': 'Config'
+    parentType: 'Config'
   })], null, null, null, null, {
-    'parentType': 'ConfigsConnectionEdge',
-    'requisite': true
+    parentType: 'ConfigsConnectionEdge',
+    requisite: true
   }), new GraphQL.Field('cursor', null, null, null, null, null, {
-    'parentType': 'ConfigsConnectionEdge',
-    'generated': true,
-    'requisite': true
+    parentType: 'ConfigsConnectionEdge',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'ConfigsConnection',
-    'plural': true
+    parentType: 'ConfigsConnection',
+    plural: true
   })], null, null, null, null, {
-    'parentType': 'Viewer'
+    parentType: 'Viewer'
   })], null, null, 'MetadataConnectionLimitable');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
@@ -15,20 +15,20 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('MetadataDynamic', 'NewsFeedConnection', [new GraphQL.Field('edges', [new GraphQL.Field('node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'requisite': true
+    parentType: 'Node',
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'NewsFeedConnectionEdge',
-    'rootCall': 'node',
-    'pk': 'id',
-    'dynamic': true,
-    'requisite': true
+    parentType: 'NewsFeedConnectionEdge',
+    rootCall: 'node',
+    pk: 'id',
+    dynamic: true,
+    requisite: true
   }), new GraphQL.Field('cursor', null, null, null, null, null, {
-    'parentType': 'NewsFeedConnectionEdge',
-    'generated': true,
-    'requisite': true
+    parentType: 'NewsFeedConnectionEdge',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'NewsFeedConnection',
-    'plural': true
+    parentType: 'NewsFeedConnection',
+    plural: true
   })]);
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
@@ -11,10 +11,10 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'MetadataGenerated');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataNonFindable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataNonFindable.fixture
@@ -15,10 +15,10 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('viewer', null, [new GraphQL.Field('pendingPosts', [new GraphQL.Field('count', null, null, null, null, null, {
-    'parentType': 'PendingPostsConnection'
+    parentType: 'PendingPostsConnection'
   })], null, null, null, null, {
-    'parentType': 'Viewer',
-    'connection': true,
-    'nonFindable': true
+    parentType: 'Viewer',
+    connection: true,
+    nonFindable: true
   })], null, null, 'MetadataNonFindable');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
@@ -13,13 +13,13 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('websites', null, null, null, null, null, {
-    'parentType': 'Node',
-    'plural': true
+    parentType: 'Node',
+    plural: true
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'MetadataPlural');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataRequisite.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataRequisite.fixture
@@ -7,7 +7,7 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('MetadataRequisite', 'Node', [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'requisite': true
+    parentType: 'Node',
+    requisite: true
   })]);
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
@@ -13,13 +13,13 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.QueryFragment('MetadataVarArgs', 'User', [new GraphQL.Field('friends', [new GraphQL.Field('count', null, null, null, null, null, {
-    'parentType': 'UserConnection'
+    parentType: 'UserConnection'
   })], null, [new GraphQL.Callv('orderby', new GraphQL.CallVariable('order'))], null, null, {
-    'parentType': 'User',
-    'connection': true
+    parentType: 'User',
+    connection: true
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })]);
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
@@ -15,20 +15,20 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Mutation('Mutation', 'ActorSubscribeResponsePayload', new GraphQL.Callv('actorSubscribe', new GraphQL.CallVariable('input')), [new GraphQL.Field('actor', [new GraphQL.Field('profilePicture', null, null, null, null, null, {
-    'parentType': 'User'
+    parentType: 'User'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'User',
-    'generated': true,
-    'requisite': true
+    parentType: 'User',
+    generated: true,
+    requisite: true
   })], null, null, null, null, {
-    'parentType': 'ActorSubscribeResponsePayload',
-    'rootCall': 'node',
-    'pk': 'id'
+    parentType: 'ActorSubscribeResponsePayload',
+    rootCall: 'node',
+    pk: 'id'
   }), new GraphQL.Field('clientMutationId', null, null, null, null, null, {
-    'parentType': 'ActorSubscribeResponsePayload',
-    'generated': true,
-    'requisite': true
+    parentType: 'ActorSubscribeResponsePayload',
+    generated: true,
+    requisite: true
   })], null, {
-    'inputType': 'ActorSubscribeInput'
+    inputType: 'ActorSubscribeInput'
   });
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
@@ -13,10 +13,10 @@ var Relay = require('react-relay');
 var x = (function (sub_0) {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Mutation('MutationNameHere', 'ActorSubscribeResponsePayload', new GraphQL.Callv('actorSubscribe', new GraphQL.CallVariable('input')), [new GraphQL.Field('clientMutationId', null, null, null, null, null, {
-    'parentType': 'ActorSubscribeResponsePayload',
-    'generated': true,
-    'requisite': true
+    parentType: 'ActorSubscribeResponsePayload',
+    generated: true,
+    requisite: true
   })], [Relay.QL.__frag(sub_0)], {
-    'inputType': 'ActorSubscribeInput'
+    inputType: 'ActorSubscribeInput'
   });
 })(reference);

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
@@ -11,10 +11,10 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Mutation('MutationWithoutArgs', 'ActorSubscribeResponsePayload', new GraphQL.Callv('actorSubscribe', new GraphQL.CallVariable('input')), [new GraphQL.Field('clientMutationId', null, null, null, null, null, {
-    'parentType': 'ActorSubscribeResponsePayload',
-    'generated': true,
-    'requisite': true
+    parentType: 'ActorSubscribeResponsePayload',
+    generated: true,
+    requisite: true
   })], null, {
-    'inputType': 'ActorSubscribeInput'
+    inputType: 'ActorSubscribeInput'
   });
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
@@ -13,12 +13,12 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('name', null, null, null, null, null, {
-    'parentType': 'Node'
+    parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'QueryWithFields');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
@@ -15,14 +15,14 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
-    'parentType': 'ProfilePicture'
+    parentType: 'ProfilePicture'
   })], null, null, null, null, {
-    'parentType': 'Node'
+    parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'QueryNameHere');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
@@ -15,14 +15,14 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
-    'parentType': 'ProfilePicture'
+    parentType: 'ProfilePicture'
   })], null, null, null, null, {
-    'parentType': 'Node'
+    parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], null, {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'QueryWithNestedFields');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
@@ -27,14 +27,14 @@ var Relay = require('react-relay');
 var x = (function (sub_0, sub_1, sub_2, sub_3, sub_4, sub_5, sub_6, sub_7, sub_8, sub_9, sub_10, sub_11) {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('node', 123, [new GraphQL.Field('profilePicture', [new GraphQL.Field('uri', null, null, null, null, null, {
-    'parentType': 'ProfilePicture'
+    parentType: 'ProfilePicture'
   })], [Relay.QL.__frag(sub_4), Relay.QL.__frag(sub_5), Relay.QL.__frag(sub_6), Relay.QL.__frag(sub_7)], null, null, null, {
-    'parentType': 'Node'
+    parentType: 'Node'
   }), new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'generated': true,
-    'requisite': true
+    parentType: 'Node',
+    generated: true,
+    requisite: true
   })], [Relay.QL.__frag(sub_0), Relay.QL.__frag(sub_1), Relay.QL.__frag(sub_2), Relay.QL.__frag(sub_3), Relay.QL.__frag(sub_8), Relay.QL.__frag(sub_9), Relay.QL.__frag(sub_10), Relay.QL.__frag(sub_11)], {
-    'rootArg': 'id'
+    rootArg: 'id'
   }, 'QueryWithNestedFragments');
 })(frag1, frag2, frag3, frag4, frag5, frag6, frag7, frag8, frag9, frag10, frag11, frag12);

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgument.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgument.fixture
@@ -13,9 +13,9 @@ var Relay = require('Relay');
 var q = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('search', new GraphQL.CallVariable('query'), [new GraphQL.Field('title', null, null, null, null, null, {
-    'parentType': 'SearchResult'
+    parentType: 'SearchResult'
   })], null, {
-    'rootArg': 'query',
-    'rootCallType': '[SearchInput!]'
+    rootArg: 'query',
+    rootCallType: '[SearchInput!]'
   }, 'QueryWithObjectArgument');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
@@ -13,9 +13,9 @@ var Relay = require('react-relay');
 var x = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query('nodes', [123, 456], [new GraphQL.Field('id', null, null, null, null, null, {
-    'parentType': 'Node',
-    'requisite': true
+    parentType: 'Node',
+    requisite: true
   })], null, {
-    'rootArg': 'ids'
+    rootArg: 'ids'
   }, 'QueryWithVarArgs');
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/subscription.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/subscription.fixture
@@ -13,10 +13,10 @@ var Relay = require('react-relay');
 var x = (function (sub_0) {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Mutation('Subscription', 'ActorSubscribeResponsePayload', new GraphQL.Callv('actorSubscribeSubscribe', new GraphQL.CallVariable('input')), [new GraphQL.Field('clientMutationId', null, null, null, null, null, {
-    'parentType': 'ActorSubscribeResponsePayload',
-    'generated': true,
-    'requisite': true
+    parentType: 'ActorSubscribeResponsePayload',
+    generated: true,
+    requisite: true
   })], [Relay.QL.__frag(sub_0)], {
-    'inputType': 'ActorSubscribeInput!'
+    inputType: 'ActorSubscribeInput!'
   });
 })(reference);

--- a/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
@@ -11,8 +11,8 @@ Output:
 var foo = (function () {
   var GraphQL = Relay.QL.__GraphQL;
   return new GraphQL.Query("media", 123, [new GraphQL.Field("__typename", null, null, null, null, null, {
-    "parentType": "Media"
+    parentType: "Media"
   })], null, {
-    "rootArg": "id"
+    rootArg: "id"
   }, "UnionWithTypename");
 })();


### PR DESCRIPTION
`GraphQLPrinter` previously worked by concatenating strings, which makes composition and reusing functions much harder (see #297 for the workarounds that this required - bc a string may represent a literal value *or* some already printed code). This refactors the printer to use babel's builder functions, so that `print*` functions all return JavaScript AST nodes.