### PR TITLE
Document how to pass custom headers through the DefaultNetworkLayer

### DIFF
--- a/docs/Guides-NetworkLayer.md
+++ b/docs/Guides-NetworkLayer.md
@@ -46,6 +46,18 @@ Relay.injectNetworkLayer(
 
 Unlike queries, failed requests for mutations are not automatically retried.
 
+Custom HTTP headers can be configured by providing a `headers` object:
+
+```{3-5}
+Relay.injectNetworkLayer(
+  new Relay.DefaultNetworkLayer('http://example.com/graphql', {
+    headers: {
+      Authorization: 'Basic SSdsbCBmaW5kIHNvbWV0aGluZyB0byBwdXQgaGVyZQ==',
+    },
+  })
+);
+```
+
 ## Custom Network Layers
 
 Relay also lets us completely replace the default network layer.


### PR DESCRIPTION
This came up as a question on Stack Overflow[0], so I thought we should
document this.

[0]: http://stackoverflow.com/questions/32550061