### PR TITLE
Throw on webpack compilation error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,7 +100,7 @@ var buildDist = function(opts) {
       throw new gulpUtil.PluginError('webpack', err);
     }
     if (stats.compilation.errors.length) {
-      gulpUtil.log('webpack', '\n' + stats.toString({colors: true}));
+      throw new gulpUtil.PluginError('webpack', stats.toString());
     }
   });
 };


### PR DESCRIPTION
Instead of just logging, actually treat webpack compilation errors as
a failure so that we don't continue.

Test Plan: `gulp dist && echo 'foo'` (with `fbjs@0.2.0`), don't see `foo` echoed.

cc @steveluscher @wincent 

This is the shortest path to prevent the specific issue in #303. Longer term, we might want to something a bit more versatile that also checks at the npm dependency level (might be some packages that do it already, but also pretty easy to do with some `npm outdated --json` and some semver checking or `npm ls --depth=0 | grep 'ERR!'`)