### PR TITLE
Drop "technical preview"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Relay](https://facebook.github.io/relay/) Technical Preview [![Build Status](https://travis-ci.org/facebook/relay.svg)](https://travis-ci.org/facebook/relay) [![npm version](https://badge.fury.io/js/react-relay.svg)](http://badge.fury.io/js/react-relay)
+# [Relay](https://facebook.github.io/relay/) [![Build Status](https://travis-ci.org/facebook/relay.svg)](https://travis-ci.org/facebook/relay) [![npm version](https://badge.fury.io/js/react-relay.svg)](http://badge.fury.io/js/react-relay)
 
 Relay is a JavaScript framework for building data-driven React applications.
 

--- a/website/src/relay/index.js
+++ b/website/src/relay/index.js
@@ -123,7 +123,7 @@ var index = React.createClass({
             <a
               className="button"
               href={'https://github.com/facebook/relay/releases/tag/v' + SiteData.version}>
-              Download the Technical Preview
+              Download
             </a>
           </section>
         </section>


### PR DESCRIPTION
As announced today, we're officially launched now and out of technical
preview:

https://twitter.com/fbOpenSource/status/643522742042628096