### PR TITLE
Hashes with equal signs in them no longer cause the Relay Playground to fail in FF

### DIFF
--- a/website-prototyping-tools/graphiql.js
+++ b/website-prototyping-tools/graphiql.js
@@ -6,7 +6,7 @@ import React from 'react'; window.React = React;
 import ReactDOM from 'react/lib/ReactDOM';
 
 import evalSchema from './evalSchema';
-import queryString from 'query-string';
+import queryString from 'querystring';
 import {graphql} from 'graphql';
 
 if (
@@ -16,7 +16,7 @@ if (
   var {
     query,
     schema: schemaSource,
-  } = queryString.parse(location.hash);
+  } = queryString.parse(location.hash.slice(1));
 }
 
 var Schema;

--- a/website-prototyping-tools/package.json
+++ b/website-prototyping-tools/package.json
@@ -24,7 +24,7 @@
     "lodash.delay": "3.1.0",
     "minimist": "1.2.0",
     "normalize.css": "3.0.3",
-    "query-string": "2.4.0",
+    "querystring": "0.2.0",
     "raw-loader": "0.5.1",
     "react": "^0.14.0-rc",
     "react-codemirror": "0.1.5",

--- a/website-prototyping-tools/playground.js
+++ b/website-prototyping-tools/playground.js
@@ -4,9 +4,9 @@ import React from 'react'; window.React = React;
 import ReactDOM from 'react/lib/ReactDOM';
 import RelayPlayground from './RelayPlayground';
 
-import queryString from 'query-string';
+import queryString from 'querystring';
 
-var queryParams = queryString.parse(location.hash);
+var queryParams = queryString.parse(location.hash.slice(1));
 
 if (
   /^https?:\/\/facebook.github.io\//.test(document.referrer) ||


### PR DESCRIPTION
The old query string parser stopped parsing in Firefox when it encountered an equal sign.