### PR TITLE
Don't trust browsers not to have unencoded location.hash in the Relay Playground

### DIFF
--- a/website-prototyping-tools/graphiql.js
+++ b/website-prototyping-tools/graphiql.js
@@ -13,10 +13,12 @@ if (
   /^https?:\/\/facebook.github.io\//.test(document.referrer) ||
   /^localhost/.test(document.location.host)
 ) {
+  // Don't trust location.hash not to have been unencoded by the browser
+  var hash = window.location.href.split('#')[1];
   var {
     query,
     schema: schemaSource,
-  } = queryString.parse(location.hash);
+  } = queryString.parse(hash);
 }
 
 var Schema;

--- a/website-prototyping-tools/playground.js
+++ b/website-prototyping-tools/playground.js
@@ -6,7 +6,9 @@ import RelayPlayground from './RelayPlayground';
 
 import queryString from 'query-string';
 
-var queryParams = queryString.parse(location.hash);
+// Don't trust location.hash not to have been unencoded by the browser
+var hash = window.location.href.split('#')[1];
+var queryParams = queryString.parse(hash);
 
 if (
   /^https?:\/\/facebook.github.io\//.test(document.referrer) ||


### PR DESCRIPTION
If you want to be sure to get the raw, unencoded product, use `window.location.href.split('#')[1];`