### PR TITLE
diffRelayQuery creates fragmented queries

### DIFF
--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -398,7 +398,7 @@ type SegmentsEdge {
   node: String
 }
 
-type Story implements FeedUnit {
+type Story implements FeedUnit Node {
   actor: Actor
   actors: [Actor]
   actorCount: Int
@@ -411,6 +411,33 @@ type Story implements FeedUnit {
   seenState: String
   tracking: String
   websites: [String]
+
+  # Node minus FeedUnit
+  address: StreetAddress
+  allPhones: [Phone]
+  author: User
+  backgroundImage: Image
+  birthdate: Date
+  body: Text
+  canViewerComment: Boolean
+  canViewerLike: Boolean
+  comments(first: String, last: Int, orderby: String): CommentsConnection
+  doesViewerLike: Boolean
+  emailAddresses: [String]
+  firstName(if: Boolean, unless: Boolean): String
+  friends(after: String, first: String, orderby: [String], find: String, isViewerFriend: Boolean, if: Boolean, unless: Boolean): FriendsConnection
+  hometown: Page
+  lastName: String
+  likers(first: String): LikersOfContentConnection
+  likeSentence: Text
+  segments(first: String): Segments
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: String): SubscribersConnection
+  topLevelComments(first: String): TopLevelCommentsConnection
+  url(site: String): String
+  username: String
+  viewerSavedState: String
 }
 
 type StreetAddress {

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -1712,6 +1712,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "Story",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "User",
               "ofType": null
             }
@@ -5052,6 +5057,500 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "address",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "StreetAddress",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allPhones",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Phone",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "author",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "backgroundImage",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "birthdate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "body",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Text",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canViewerComment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canViewerLike",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comments",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderby",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CommentsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "doesViewerLike",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "emailAddresses",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "firstName",
+              "description": null,
+              "args": [
+                {
+                  "name": "if",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "unless",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "friends",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderby",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "find",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "isViewerFriend",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "if",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "unless",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FriendsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hometown",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Page",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "likers",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LikersOfContentConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "likeSentence",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Text",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "segments",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Segments",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "screennames",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Screenname",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscribeStatus",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscribers",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubscribersConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "topLevelComments",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "TopLevelCommentsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [
+                {
+                  "name": "site",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "username",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "viewerSavedState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -5059,6 +5558,11 @@
             {
               "kind": "INTERFACE",
               "name": "FeedUnit",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
               "ofType": null
             }
           ],

--- a/src/traversal/__tests__/diffRelayQuery-test.js
+++ b/src/traversal/__tests__/diffRelayQuery-test.js
@@ -1007,22 +1007,26 @@ describe('diffRelayQuery', () => {
     var diffQueries = diffRelayQuery(query, store, tracker);
     expect(diffQueries.length).toBe(2);
     expect(diffQueries[0].getName()).toBe(query.getName());
-    expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"4808495") {
-          id,
-          name,
-          lastName,
+          ... on Actor {
+            id,
+            name,
+            lastName,
+          }
         }
       }
     `));
     expect(diffQueries[1].getName()).toBe(query.getName());
-    expect(diffQueries[1]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[1]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"1023896548") {
-          id,
-          firstName,
-          lastName,
+          ... on Actor {
+            id,
+            firstName,
+            lastName,
+          }
         }
       }
     `));
@@ -1366,11 +1370,13 @@ describe('diffRelayQuery', () => {
       }
     `);
 
-    var expected2 = getNode(Relay.QL`
+    var expected2 = getVerbatimNode(Relay.QL`
       query {
         node(id:"4808495") {
-          id,
-          name
+          ... on User {
+            id,
+            name
+          }
         }
       }
     `);
@@ -1480,11 +1486,13 @@ describe('diffRelayQuery', () => {
         }
       }
     `);
-    var expected2 = getNode(Relay.QL`
+    var expected2 = getVerbatimNode(Relay.QL`
       query {
         node(id:"660361306") {
-          id,
-          name
+          ... on User {
+            id,
+            name
+          }
         }
       }
     `);
@@ -1589,9 +1597,16 @@ describe('diffRelayQuery', () => {
     var diffQueries = diffRelayQuery(query, store, tracker);
     expect(diffQueries.length).toBe(1);
     expect(diffQueries[0].getName()).toBe(query.getName());
-    expect(diffQueries[0]).toEqualQueryRoot(getNode(
-      Relay.QL`query{node(id:"4808495"){name}}`
-    ));
+    expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
+      query {
+        node(id:"4808495"){
+          ... on User {
+            name,
+            id
+          }
+        }
+      }
+    `));
 
     var trackedQuery = getNode(Relay.QL`
       query {
@@ -1648,10 +1663,13 @@ describe('diffRelayQuery', () => {
       diffCalls: null
     });
 
-    var expected = getNode(Relay.QL`
+    var expected = getVerbatimNode(Relay.QL`
       query {
         node(id:"4808495") {
-          lastName,
+          ... on User {
+            lastName,
+            id,
+          }
         }
       }
     `);
@@ -1803,11 +1821,13 @@ describe('diffRelayQuery', () => {
       diffCalls: null
     });
 
-    var expected = getNode(Relay.QL`
+    var expected = getVerbatimNode(Relay.QL`
       query {
         node(id:"4808495") {
-          id,
-          lastName
+          ... on User {
+            id,
+            lastName
+          }
         }
       }
     `);

--- a/src/traversal/__tests__/diffRelayQuery_connection-test.js
+++ b/src/traversal/__tests__/diffRelayQuery_connection-test.js
@@ -292,28 +292,37 @@ describe('diffRelayQuery', () => {
     `);
     var diffQueries = diffRelayQuery(fetchQuery, store, tracker);
     expect(diffQueries.length).toBe(3);
-    expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s1") {
-          feedback {
+          ... on FeedUnit {
+            feedback {
+              id
+            },
             id
           }
         }
       }
     `));
-    expect(diffQueries[1]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[1]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s2") {
-          feedback {
+          ... on FeedUnit {
+            feedback {
+              id
+            },
             id
           }
         }
       }
     `));
-    expect(diffQueries[2]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[2]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s3") {
-          feedback {
+          ... on FeedUnit {
+            feedback {
+              id
+            },
             id
           }
         }
@@ -380,10 +389,13 @@ describe('diffRelayQuery', () => {
     `);
     var diffQueries = diffRelayQuery(fetchQuery, store, tracker);
     expect(diffQueries.length).toBe(6);
-    expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s1") {
-          feedback {
+          ... on FeedUnit {
+            feedback {
+              id
+            },
             id
           }
         }
@@ -404,10 +416,13 @@ describe('diffRelayQuery', () => {
         }
       }
     `));
-    expect(diffQueries[2]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[2]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s2") {
-          feedback {
+          ... on FeedUnit {
+            feedback {
+              id
+            },
             id
           }
         }
@@ -428,10 +443,13 @@ describe('diffRelayQuery', () => {
         }
       }
     `));
-    expect(diffQueries[4]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[4]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s3") {
-          feedback {
+          ... on FeedUnit {
+            feedback {
+              id
+            },
             id
           }
         }
@@ -522,28 +540,37 @@ describe('diffRelayQuery', () => {
     `);
     var diffQueries = diffRelayQuery(fetchQuery, store, tracker);
     expect(diffQueries.length).toBe(3);
-    expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s1") {
-          feedback {
+          ... on FeedUnit {
+            feedback {
+              id
+            },
             id
           }
         }
       }
     `));
-    expect(diffQueries[1]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[1]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s2") {
-          feedback {
+          ... on FeedUnit {
+            feedback {
+              id
+            },
             id
           }
         }
       }
     `));
-    expect(diffQueries[2]).toEqualQueryRoot(getNode(Relay.QL`
+    expect(diffQueries[2]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s3") {
-          feedback {
+          ... on FeedUnit {
+            feedback {
+              id
+            },
             id
           }
         }

--- a/src/traversal/diffRelayQuery.js
+++ b/src/traversal/diffRelayQuery.js
@@ -83,7 +83,10 @@ function diffRelayQuery(
         rootCallName,
         rootCallArg,
         root.getChildren(),
-        {rootArg: root.getRootCallArgument()},
+        {
+          rootArg: root.getRootCallArgument(),
+          rootCallType: root.getCallType(),
+        },
         root.getName()
       );
     } else {
@@ -390,11 +393,9 @@ class RelayDiffQueryBuilder {
             hasSplitQueries || !!itemState.trackedNode || !!itemState.diffNode;
           // split diff nodes into root queries
           if (itemState.diffNode) {
-            this.splitQuery(RelayQuery.Node.buildRoot(
-              NODE,
+            this.splitQuery(buildRoot(
               itemID,
               itemState.diffNode.getChildren(),
-              {rootArg: RelayNodeInterface.ID},
               path.getName()
             ));
           }
@@ -572,11 +573,9 @@ class RelayDiffQueryBuilder {
       // split missing `node` fields into a `node(id)` root query
       if (diffNodeField) {
         hasSplitQueries = true;
-        this.splitQuery(RelayQuery.Node.buildRoot(
-          NODE,
+        this.splitQuery(buildRoot(
           nodeID,
           diffNodeField.getChildren(),
-          {rootArg: RelayNodeInterface.ID},
           path.getName()
         ));
       }
@@ -724,6 +723,38 @@ function splitNodeAndEdgesFields(
     edges: hasEdgeChild ? edgeOrFragment.clone(edgeChildren) : null,
     node: hasNodeChild ? edgeOrFragment.clone(nodeChildren) : null,
   };
+}
+
+function buildRoot(
+  rootID: DataID,
+  children: Array<RelayQuery.Node>,
+  name: string
+): RelayQuery.Root {
+  var fragments = [];
+  var childTypes = {};
+  children.forEach(child => {
+    if (child instanceof RelayQuery.Field) {
+      var parentType = child.getParentType();
+      childTypes[parentType] = childTypes[parentType] || [];
+      childTypes[parentType].push(child);
+    } else {
+      fragments.push(child);
+    }
+  });
+  Object.keys(childTypes).map(type => {
+    fragments.push(RelayQuery.Node.buildFragment(
+      'diffRelayQuery',
+      type,
+      childTypes[type]
+    ));
+  });
+  return RelayQuery.Node.buildRoot(
+    NODE,
+    rootID,
+    fragments,
+    {rootArg: RelayNodeInterface.ID},
+    name
+  );
 }
 
 module.exports = RelayProfiler.instrument('diffRelayQuery', diffRelayQuery);


### PR DESCRIPTION
Addresses the issue in #305: `diffRelayQuery` creates top-level queries for missing information but did not wrap the fields in fragments based on type. Rather than use `refragmentRelayQuery` which requires a full traversal of the query, this change relies on the fact that input queries are already correctly fragmented, and only needs to group the top-level fields into fragments by type.

The schema changes are required because otherwise `... on FeedUnit` would not be allowed in a `Node` context.