### PR TITLE
Fix LikeStoryMutation example optimistic response

### DIFF
--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -461,7 +461,7 @@ class LikeStoryMutation extends Relay.Mutation {
       story: {
         id: this.props.story.id,
         likers: {
-          count: this.props.story.likers.count + 1,
+          count: this.props.story.likers.count + (this.props.story.viewerDoesLike ? -1 : 1),
         },
         viewerDoesLike: !this.props.story.viewerDoesLike,
       },


### PR DESCRIPTION
Fixes `story.likers.count` of `getOptimisticResponse` in the `LikeStoryMutation` example for the case where the current viewer already likes the story (this should unlike the story, thus decrementing the optimistic `likers.count` by 1).