### PR TITLE
RFC: re-jig node-building API

### DIFF
--- a/src/__forks__/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/__forks__/traversal/__tests__/printRelayOSSQuery-test.js
@@ -191,12 +191,12 @@ describe('printRelayOSSQuery', () => {
     });
 
     it('throws for ref queries', () => {
-      var query = RelayQuery.Node.buildRoot(
+      var query = RelayQuery.Root.build(
         RelayNodeInterface.NODE,
         new GraphQL.BatchCallVariable('q0', '$.*.actor.id'),
         [
-          RelayQuery.Node.buildField('id'),
-          RelayQuery.Node.buildField('name'),
+          RelayQuery.Field.build('id'),
+          RelayQuery.Field.build('name'),
         ],
         {
           isDeferred: true,

--- a/src/container/__tests__/RelayContainer-test.js
+++ b/src/container/__tests__/RelayContainer-test.js
@@ -244,7 +244,7 @@ describe('RelayContainer', function() {
         }),
         {sideshow: true}
       );
-      var expected = RelayQuery.Node.buildFragment(
+      var expected = RelayQuery.Fragment.build(
         'Test',
         'Viewer',
         [getNode(feedFragment)]
@@ -289,7 +289,7 @@ describe('RelayContainer', function() {
         MockSideshow.getQuery('viewer', {hasSideshow: false}),
         {}
       );
-      var expected = RelayQuery.Node.buildFragment(
+      var expected = RelayQuery.Fragment.build(
         'Test',
         'Viewer',
         [getNode(feedFragment)],

--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -272,7 +272,7 @@ var RelayMutationQuery = {
         fatQuery,
       })),
     ];
-    return RelayQuery.Node.buildMutation(
+    return RelayQuery.Mutation.build(
       'OptimisticQuery',
       fatQuery.getType(),
       mutation.calls[0].name,
@@ -311,7 +311,7 @@ var RelayMutationQuery = {
     tracker = tracker || RelayStoreData.getDefaultInstance().getQueryTracker();
 
     var children = [
-      RelayQuery.Node.buildField(
+      RelayQuery.Field.build(
         CLIENT_MUTATION_ID,
         null,
         null,
@@ -352,7 +352,7 @@ var RelayMutationQuery = {
             parentName: config.parentName,
             tracker,
           }));
-          children.push(RelayQuery.Node.buildField(config.deletedIDFieldName));
+          children.push(RelayQuery.Field.build(config.deletedIDFieldName));
           break;
 
         case RelayMutationType.FIELDS_CHANGE:
@@ -367,14 +367,14 @@ var RelayMutationQuery = {
 
     // create a dummy field to re-fragment the input `fields`
     var fragmentedFields = children.length ?
-      refragmentRelayQuery(RelayQuery.Node.buildField(
+      refragmentRelayQuery(RelayQuery.Field.build(
         'build_mutation_field',
         null,
         children
       )) :
       null;
 
-    return RelayQuery.Node.buildMutation(
+    return RelayQuery.Mutation.build(
       mutationName,
       fatQuery.getType(),
       mutation.calls[0].name,
@@ -402,7 +402,7 @@ function buildMutationFragment(
   fatQuery: RelayQuery.Fragment,
   fields: Array<RelayQuery.Node>
 ): ?RelayQuery.Fragment {
-  var fragment = RelayQuery.Node.buildFragment(
+  var fragment = RelayQuery.Fragment.build(
     'MutationQuery',
     fatQuery.getType(),
     fields
@@ -423,20 +423,20 @@ function buildEdgeField(
   edgeFields: Array<RelayQuery.Node>
 ): RelayQuery.Field {
   var fields = [
-    RelayQuery.Node.buildField('cursor'),
+    RelayQuery.Field.build('cursor'),
   ];
   if (RelayConnectionInterface.EDGES_HAVE_SOURCE_FIELD &&
       !GraphQLStoreDataHandler.isClientID(parentID)) {
     fields.push(
-      RelayQuery.Node.buildField(
+      RelayQuery.Field.build(
         'source',
         null,
-        [RelayQuery.Node.buildField('id')]
+        [RelayQuery.Field.build('id')]
       )
     );
   }
   fields.push(...edgeFields);
-  var edgeField = flattenRelayQuery(RelayQuery.Node.buildField(
+  var edgeField = flattenRelayQuery(RelayQuery.Field.build(
     edgeName,
     null,
     fields

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -75,12 +75,12 @@ describe('RelayDefaultNetworkLayer', () => {
       responseCallback = jest.genMockFunction();
       rejectCallback = jest.genMockFunction();
 
-      var mutation = RelayQuery.Node.buildMutation(
+      var mutation = RelayQuery.Mutation.build(
         'FeedbackLikeMutation',
         'FeedbackLikeResponsePayload',
         'feedback_like',
         null,
-        [RelayQuery.Node.buildField('does_viewer_like')],
+        [RelayQuery.Field.build('does_viewer_like')],
         {inputType: 'FeedbackLikeInput'}
       );
       variables = {

--- a/src/query/RelayQuery.js
+++ b/src/query/RelayQuery.js
@@ -116,127 +116,6 @@ class RelayQueryNode {
     return node;
   }
 
-  /**
-   * Helper to construct a new root query with the given attributes and 'empty'
-   * route/variables.
-   */
-  static buildRoot(
-    rootCall: string,
-    rootCallValue?: ?Array<RootCallValue> | ?RootCallValue,
-    children?: ?Array<RelayQueryNode>,
-    metadata?: ?{[key: string]: mixed},
-    name?: ?string
-  ): RelayQueryRoot {
-    var nextChildren = children ? children.filter(child => !!child) : [];
-    var concreteRoot = new GraphQL.Query(
-      rootCall,
-      rootCallValue || null,
-      null,
-      null,
-      metadata,
-      name
-    );
-    var root = new RelayQueryRoot(
-      concreteRoot,
-      RelayMetaRoute.get('$RelayQuery'),
-      {}
-    );
-    root.__children__ = nextChildren;
-    return root;
-  }
-
-  /**
-   * Helper to construct a new fragment with the given attributes and 'empty'
-   * route/variables.
-   */
-  static buildFragment(
-    name: string,
-    type: string,
-    children?: ?Array<RelayQueryNode>,
-    metadata?: ?{[key: string]: mixed}
-  ): RelayQueryFragment {
-    var nextChildren = children ? children.filter(child => !!child) : [];
-    var concreteFragment = new GraphQL.QueryFragment(
-      name,
-      type,
-      null,
-      null,
-      metadata
-    );
-    var fragment = new RelayQueryFragment(
-      concreteFragment,
-      RelayMetaRoute.get('$RelayQuery'),
-      {},
-      {
-        isDeferred: !!(metadata && metadata.isDeferred),
-        isContainerFragment: !!(metadata && metadata.isContainerFragment),
-        isTypeConditional: !!(metadata && metadata.isTypeConditional),
-      }
-    );
-    fragment.__children__ = nextChildren;
-    return fragment;
-  }
-
-  /**
-   * Helper to construct a new field with the given attributes and 'empty'
-   * route/variables.
-   */
-  static buildField(
-    fieldName: string,
-    calls?: ?Array<Call>,
-    children?: ?NextChildren,
-    metadata?: ?{[key: string]: mixed},
-    alias?: ?string
-  ): RelayQueryField {
-    var nextChildren = children ? children.filter(child => !!child) : [];
-    var concreteField = new GraphQL.Field(
-      fieldName,
-      null,
-      null,
-      calls ? callsToGraphQL(calls) : null,
-      alias,
-      null,
-      metadata
-    );
-    var field = new RelayQueryField(
-      concreteField,
-      RelayMetaRoute.get('$RelayQuery'),
-      {}
-    );
-    field.__children__ = nextChildren;
-    return field;
-  }
-
-  /**
-   * Helper to construct a new mutation with the given attributes and 'empty'
-   * route/variables.
-   */
-  static buildMutation(
-    mutationName: string,
-    responseType: string,
-    callName: string,
-    callValue?: ?mixed,
-    children?: ?Array<RelayQueryNode>,
-    metadata?: ?{[key: string]: mixed}
-  ): RelayQueryMutation {
-    var nextChildren = children ? children.filter(child => !!child) : [];
-    var concreteMutation = new GraphQL.Mutation(
-      mutationName,
-      responseType,
-      new GraphQL.Callv(callName, new GraphQL.CallVariable('input')),
-      null,
-      null,
-      metadata
-    );
-    var mutation = new RelayQueryMutation(
-      concreteMutation,
-      RelayMetaRoute.get('$RelayQuery'),
-      {input: callValue || ''}
-    );
-    mutation.__children__ = nextChildren;
-    return mutation;
-  }
-
   static createFragment(
     concreteNode: ConcreteQueryObject,
     route: RelayMetaRoute,
@@ -472,6 +351,35 @@ class RelayQueryRoot extends RelayQueryNode {
   __deferredFragmentNames__: ?FragmentNames;
   __id__: ?string;
 
+  /**
+   * Helper to construct a new root query with the given attributes and 'empty'
+   * route/variables.
+   */
+  static build(
+    rootCall: string,
+    rootCallValue?: ?Array<RootCallValue> | ?RootCallValue,
+    children?: ?Array<RelayQueryNode>,
+    metadata?: ?{[key: string]: mixed},
+    name?: ?string
+  ): RelayQueryRoot {
+    var nextChildren = children ? children.filter(child => !!child) : [];
+    var concreteRoot = new GraphQL.Query(
+      rootCall,
+      rootCallValue || null,
+      null,
+      null,
+      metadata,
+      name
+    );
+    var root = new RelayQueryRoot(
+      concreteRoot,
+      RelayMetaRoute.get('$RelayQuery'),
+      {}
+    );
+    root.__children__ = nextChildren;
+    return root;
+  }
+
   constructor(
     concreteNode: ConcreteQueryObject,
     route: RelayMetaRoute,
@@ -651,6 +559,36 @@ class RelayQueryOperation extends RelayQueryNode {
  * Represents a GraphQL mutation.
  */
 class RelayQueryMutation extends RelayQueryOperation {
+  /**
+   * Helper to construct a new mutation with the given attributes and 'empty'
+   * route/variables.
+   */
+  static build(
+    mutationName: string,
+    responseType: string,
+    callName: string,
+    callValue?: ?mixed,
+    children?: ?Array<RelayQueryNode>,
+    metadata?: ?{[key: string]: mixed}
+  ): RelayQueryMutation {
+    var nextChildren = children ? children.filter(child => !!child) : [];
+    var concreteMutation = new GraphQL.Mutation(
+      mutationName,
+      responseType,
+      new GraphQL.Callv(callName, new GraphQL.CallVariable('input')),
+      null,
+      null,
+      metadata
+    );
+    var mutation = new RelayQueryMutation(
+      concreteMutation,
+      RelayMetaRoute.get('$RelayQuery'),
+      {input: callValue || ''}
+    );
+    mutation.__children__ = nextChildren;
+    return mutation;
+  }
+
   equals(that: RelayQueryNode): boolean {
     if (this === that) {
       return true;
@@ -707,6 +645,38 @@ class RelayQuerySubscription extends RelayQueryOperation {
 class RelayQueryFragment extends RelayQueryNode {
   __fragmentID__: ?string;
   __metadata__: FragmentMetadata;
+
+  /**
+   * Helper to construct a new fragment with the given attributes and 'empty'
+   * route/variables.
+   */
+  static build(
+    name: string,
+    type: string,
+    children?: ?Array<RelayQueryNode>,
+    metadata?: ?{[key: string]: mixed}
+  ): RelayQueryFragment {
+    var nextChildren = children ? children.filter(child => !!child) : [];
+    var concreteFragment = new GraphQL.QueryFragment(
+      name,
+      type,
+      null,
+      null,
+      metadata
+    );
+    var fragment = new RelayQueryFragment(
+      concreteFragment,
+      RelayMetaRoute.get('$RelayQuery'),
+      {},
+      {
+        isDeferred: !!(metadata && metadata.isDeferred),
+        isContainerFragment: !!(metadata && metadata.isContainerFragment),
+        isTypeConditional: !!(metadata && metadata.isTypeConditional),
+      }
+    );
+    fragment.__children__ = nextChildren;
+    return fragment;
+  }
 
   constructor(
     concreteNode: ConcreteQueryObject,
@@ -809,6 +779,36 @@ class RelayQueryFragment extends RelayQueryNode {
  */
 class RelayQueryField extends RelayQueryNode {
   __isRefQueryDependency__: boolean;
+
+  /**
+   * Helper to construct a new field with the given attributes and 'empty'
+   * route/variables.
+   */
+  static build(
+    fieldName: string,
+    calls?: ?Array<Call>,
+    children?: ?NextChildren,
+    metadata?: ?{[key: string]: mixed},
+    alias?: ?string
+  ): RelayQueryField {
+    var nextChildren = children ? children.filter(child => !!child) : [];
+    var concreteField = new GraphQL.Field(
+      fieldName,
+      null,
+      null,
+      calls ? callsToGraphQL(calls) : null,
+      alias,
+      null,
+      metadata
+    );
+    var field = new RelayQueryField(
+      concreteField,
+      RelayMetaRoute.get('$RelayQuery'),
+      {}
+    );
+    field.__children__ = nextChildren;
+    return field;
+  }
 
   constructor(
     concreteNode: ConcreteQueryObject,

--- a/src/query/RelayQueryPath.js
+++ b/src/query/RelayQueryPath.js
@@ -23,7 +23,7 @@ var invariant = require('invariant');
 import type {DataID} from 'RelayInternalTypes';
 
 // Placeholder to mark fields as non-scalar
-var EMPTY_FRAGMENT = RelayQuery.Node.buildFragment(
+var EMPTY_FRAGMENT = RelayQuery.Fragment.build(
   '$RelayQueryPath',
   'Node'
 );
@@ -101,10 +101,10 @@ class RelayQueryPath {
     if (GraphQLStoreDataHandler.isClientID(dataID)) {
       return new RelayQueryPath(node, this);
     } else {
-      var idField = RelayQuery.Node.buildField('id', null, null, {
+      var idField = RelayQuery.Field.build('id', null, null, {
         parentType: RelayNodeInterface.NODE_TYPE,
       });
-      var root = RelayQuery.Node.buildRoot(
+      var root = RelayQuery.Root.build(
         RelayNodeInterface.NODE,
         dataID,
         [idField],
@@ -147,7 +147,7 @@ class RelayQueryPath {
       'RelayQueryPath: Expected a root node.'
     );
     var rootCall = node.getRootCall();
-    return RelayQuery.Node.buildRoot(
+    return RelayQuery.Root.build(
       rootCall.name,
       rootCall.value,
       [child, (node: $FlowIssue).getFieldByStorageKey('id')],

--- a/src/query/RelayQuerySerializer.js
+++ b/src/query/RelayQuerySerializer.js
@@ -84,7 +84,7 @@ var RelayQuerySerializer = {
     children = children.map(RelayQuerySerializer.fromJSON);
 
     if (kind === FIELD) {
-      var field = RelayQuery.Node.buildField(
+      var field = RelayQuery.Field.build(
         name,
         calls,
         children,
@@ -101,7 +101,7 @@ var RelayQuerySerializer = {
         typeof type === 'string',
         'RelayQuerySerializer.fromJSON(): expected `type` to be a string.'
       );
-      var fragment = RelayQuery.Node.buildFragment(
+      var fragment = RelayQuery.Fragment.build(
         name,
         type,
         children,
@@ -114,7 +114,7 @@ var RelayQuerySerializer = {
       return fragment;
     } else if (kind === QUERY) {
       var rootCall = calls[0];
-      var root = RelayQuery.Node.buildRoot(
+      var root = RelayQuery.Root.build(
         rootCall.name,
         rootCall.value,
         children,
@@ -132,7 +132,7 @@ var RelayQuerySerializer = {
         'RelayQuerySerializer.fromJSON(): expected `type` to be a string.'
       );
       var mutationCall = calls[0];
-      var mutation = RelayQuery.Node.buildMutation(
+      var mutation = RelayQuery.Mutation.build(
         name,
         type,
         mutationCall.name,

--- a/src/query/__tests__/RelayQuery-test.js
+++ b/src/query/__tests__/RelayQuery-test.js
@@ -29,121 +29,171 @@ describe('RelayQuery', () => {
     jest.addMatchers(RelayTestUtils.matchers);
   });
 
-  describe('buildRoot()', () => {
-    it('creates roots', () => {
-      var field = RelayQuery.Node.buildField('id');
-      var root = RelayQuery.Node.buildRoot(
-        'node',
-        '4',
-        [field]
-      );
-      expect(root instanceof RelayQuery.Root).toBe(true);
-      expect(root.getRootCall()).toEqual({
-        name: 'node',
-        value: '4'
+  describe('Root', () => {
+    describe('build()', () => {
+      it('creates roots', () => {
+        var field = RelayQuery.Field.build('id');
+        var root = RelayQuery.Root.build(
+          'node',
+          '4',
+          [field]
+        );
+        expect(root instanceof RelayQuery.Root).toBe(true);
+        expect(root.getRootCall()).toEqual({
+          name: 'node',
+          value: '4'
+        });
+        expect(root.getChildren().length).toBe(1);
+        expect(root.getChildren()[0]).toBe(field);
       });
-      expect(root.getChildren().length).toBe(1);
-      expect(root.getChildren()[0]).toBe(field);
-    });
 
-    it('creates deferred roots', () => {
-      var field = RelayQuery.Node.buildField('id');
-      var root = RelayQuery.Node.buildRoot(
-        'node',
-        '4',
-        [field],
-        {isDeferred: true}
-      );
-      expect(root instanceof RelayQuery.Root).toBe(true);
-      expect(root.getRootCall()).toEqual({
-        name: 'node',
-        value: '4'
+      it('creates deferred roots', () => {
+        var field = RelayQuery.Field.build('id');
+        var root = RelayQuery.Root.build(
+          'node',
+          '4',
+          [field],
+          {isDeferred: true}
+        );
+        expect(root instanceof RelayQuery.Root).toBe(true);
+        expect(root.getRootCall()).toEqual({
+          name: 'node',
+          value: '4'
+        });
+        expect(root.getChildren().length).toBe(1);
+        expect(root.getChildren()[0]).toBe(field);
       });
-      expect(root.getChildren().length).toBe(1);
-      expect(root.getChildren()[0]).toBe(field);
-    });
 
-    it('creates roots with batch calls', () => {
-      var root = RelayQuery.Node.buildRoot(
-        'node',
-        new GraphQL.BatchCallVariable('q0', '$.*.id'),
-        []
-      );
-      expect(root instanceof RelayQuery.Root).toBe(true);
-      expect(root.getBatchCall()).toEqual({
-        refParamName: 'ref_q0',
-        sourceQueryID: 'q0',
-        sourceQueryPath: '$.*.id',
+      it('creates roots with batch calls', () => {
+        var root = RelayQuery.Root.build(
+          'node',
+          new GraphQL.BatchCallVariable('q0', '$.*.id'),
+          []
+        );
+        expect(root instanceof RelayQuery.Root).toBe(true);
+        expect(root.getBatchCall()).toEqual({
+          refParamName: 'ref_q0',
+          sourceQueryID: 'q0',
+          sourceQueryPath: '$.*.id',
+        });
       });
     });
   });
 
-  describe('buildFragment()', () => {
-    it('creates empty fragments', () => {
-      var fragment = RelayQuery.Node.buildFragment(
-        'TestFragment',
-        'Node',
-        []
-      );
-      expect(fragment instanceof RelayQuery.Fragment).toBe(true);
-      expect(fragment.getDebugName()).toBe('TestFragment');
-      expect(fragment.getType()).toBe('Node');
-      expect(fragment.getChildren().length).toBe(0);
-      expect(fragment.isPlural()).toBe(false);
-    });
+  describe('Fragment', () => {
+    describe('build()', () => {
+      it('creates empty fragments', () => {
+        var fragment = RelayQuery.Fragment.build(
+          'TestFragment',
+          'Node',
+          []
+        );
+        expect(fragment instanceof RelayQuery.Fragment).toBe(true);
+        expect(fragment.getDebugName()).toBe('TestFragment');
+        expect(fragment.getType()).toBe('Node');
+        expect(fragment.getChildren().length).toBe(0);
+        expect(fragment.isPlural()).toBe(false);
+      });
 
-    it('creates fragments', () => {
-      var field = RelayQuery.Node.buildField('id');
-      var fragment = RelayQuery.Node.buildFragment(
-        'TestFragment',
-        'Node',
-        [field],
-        {isPlural: true, scope: 'RelayQuery_Foo'}
-      );
-      expect(fragment instanceof RelayQuery.Fragment).toBe(true);
-      expect(fragment.getDebugName()).toBe('TestFragment');
-      expect(fragment.getType()).toBe('Node');
-      expect(fragment.getChildren().length).toBe(1);
-      expect(fragment.getChildren()[0]).toBe(field);
-      expect(fragment.isPlural()).toBe(true);
+      it('creates fragments', () => {
+        var field = RelayQuery.Field.build('id');
+        var fragment = RelayQuery.Fragment.build(
+          'TestFragment',
+          'Node',
+          [field],
+          {isPlural: true, scope: 'RelayQuery_Foo'}
+        );
+        expect(fragment instanceof RelayQuery.Fragment).toBe(true);
+        expect(fragment.getDebugName()).toBe('TestFragment');
+        expect(fragment.getType()).toBe('Node');
+        expect(fragment.getChildren().length).toBe(1);
+        expect(fragment.getChildren()[0]).toBe(field);
+        expect(fragment.isPlural()).toBe(true);
+      });
     });
   });
 
-  describe('buildField()', () => {
-    it('builds scalar fields', () => {
-      var field = RelayQuery.Node.buildField('id');
-      expect(field instanceof RelayQuery.Field).toBe(true);
-      expect(field.getSchemaName()).toBe('id');
-      expect(field.getApplicationName()).toBe('id');
-      expect(field.isScalar()).toBe(true);
-      expect(field.getChildren().length).toBe(0);
-      expect(field.getCallsWithValues()).toEqual([]);
-    });
+  describe('Field', () => {
+    describe('build()', () => {
+      it('builds scalar fields', () => {
+        var field = RelayQuery.Field.build('id');
+        expect(field instanceof RelayQuery.Field).toBe(true);
+        expect(field.getSchemaName()).toBe('id');
+        expect(field.getApplicationName()).toBe('id');
+        expect(field.isScalar()).toBe(true);
+        expect(field.getChildren().length).toBe(0);
+        expect(field.getCallsWithValues()).toEqual([]);
+      });
 
-    it('builds fields with children', () => {
-      var child = RelayQuery.Node.buildField('id');
-      var fragment = getNode(Relay.QL`fragment on Node{id}`);
-      var field = RelayQuery.Node.buildField('node', null, [child, fragment]);
-      expect(field.isScalar()).toBe(false);
-      var children = field.getChildren();
-      expect(children.length).toBe(2);
-      expect(children[0]).toBe(child);
-      expect(children[1]).toBe(fragment);
-    });
+      it('builds fields with children', () => {
+        var child = RelayQuery.Field.build('id');
+        var fragment = getNode(Relay.QL`fragment on Node{id}`);
+        var field = RelayQuery.Field.build('node', null, [child, fragment]);
+        expect(field.isScalar()).toBe(false);
+        var children = field.getChildren();
+        expect(children.length).toBe(2);
+        expect(children[0]).toBe(child);
+        expect(children[1]).toBe(fragment);
+      });
 
-    it('builds fields with calls', () => {
-      var field = RelayQuery.Node.buildField('profilePicture', [
-        {name: 'size', value: 32},
-      ]);
-      expect(field.getCallsWithValues()).toEqual([
-        {name: 'size', value: 32},
-      ]);
-      field = RelayQuery.Node.buildField('profilePicture', [
-        {name: 'size', value: ['32']},
-      ]);
-      expect(field.getCallsWithValues()).toEqual([
-        {name: 'size', value: ['32']},
-      ]);
+      it('builds fields with calls', () => {
+        var field = RelayQuery.Field.build('profilePicture', [
+          {name: 'size', value: 32},
+        ]);
+        expect(field.getCallsWithValues()).toEqual([
+          {name: 'size', value: 32},
+        ]);
+        field = RelayQuery.Field.build('profilePicture', [
+          {name: 'size', value: ['32']},
+        ]);
+        expect(field.getCallsWithValues()).toEqual([
+          {name: 'size', value: ['32']},
+        ]);
+      });
+    });
+  });
+
+  describe('Mutation', () => {
+    describe('buildMutation()', () => {
+      it('builds mutation with value', () => {
+        var field = RelayQuery.Field.build('does_viewer_like');
+        var mutation = RelayQuery.Mutation.build(
+          'FeedbackLikeMutation',
+          'FeedbackLikeResponsePayload',
+          'feedback_like',
+          {feedback_id:'123'},
+          [field]
+        );
+
+        expect(mutation instanceof RelayQuery.Mutation).toBe(true);
+        expect(mutation.getName()).toBe('FeedbackLikeMutation');
+        expect(mutation.getResponseType()).toBe('FeedbackLikeResponsePayload');
+        expect(mutation.getChildren().length).toBe(1);
+        expect(mutation.getChildren()[0]).toBe(field);
+        expect(mutation.getCall())
+          .toEqual({name: 'feedback_like', value: {feedback_id:'123'}});
+        expect(mutation.getCallVariableName()).toEqual('input');
+      });
+
+      it('builds mutation with variable', () => {
+        var field = RelayQuery.Field.build('does_viewer_like');
+        var mutation = RelayQuery.Mutation.build(
+          'FeedbackLikeMutation',
+          'FeedbackLikeResponsePayload',
+          'feedback_like',
+          undefined,
+          [field]
+        );
+
+        expect(mutation instanceof RelayQuery.Mutation).toBe(true);
+        expect(mutation.getName()).toBe('FeedbackLikeMutation');
+        expect(mutation.getResponseType()).toBe('FeedbackLikeResponsePayload');
+        expect(mutation.getChildren().length).toBe(1);
+        expect(mutation.getChildren()[0]).toBe(field);
+        expect(mutation.getCall())
+          .toEqual({name: 'feedback_like', value: ''});
+        expect(mutation.getCallVariableName()).toEqual('input');
+      });
     });
   });
 
@@ -225,48 +275,6 @@ describe('RelayQuery', () => {
       expect(grandchildren[1].getCallsWithValues()).toEqual([
         {name: 'size', value: 'override'},
       ]);
-    });
-  });
-
-  describe('buildMutation()', () => {
-    it('builds mutation with value', () => {
-      var field = RelayQuery.Node.buildField('does_viewer_like');
-      var mutation = RelayQuery.Node.buildMutation(
-        'FeedbackLikeMutation',
-        'FeedbackLikeResponsePayload',
-        'feedback_like',
-        {feedback_id:'123'},
-        [field]
-      );
-
-      expect(mutation instanceof RelayQuery.Mutation).toBe(true);
-      expect(mutation.getName()).toBe('FeedbackLikeMutation');
-      expect(mutation.getResponseType()).toBe('FeedbackLikeResponsePayload');
-      expect(mutation.getChildren().length).toBe(1);
-      expect(mutation.getChildren()[0]).toBe(field);
-      expect(mutation.getCall())
-        .toEqual({name: 'feedback_like', value: {feedback_id:'123'}});
-      expect(mutation.getCallVariableName()).toEqual('input');
-    });
-
-    it('builds mutation with variable', () => {
-      var field = RelayQuery.Node.buildField('does_viewer_like');
-      var mutation = RelayQuery.Node.buildMutation(
-        'FeedbackLikeMutation',
-        'FeedbackLikeResponsePayload',
-        'feedback_like',
-        undefined,
-        [field]
-      );
-
-      expect(mutation instanceof RelayQuery.Mutation).toBe(true);
-      expect(mutation.getName()).toBe('FeedbackLikeMutation');
-      expect(mutation.getResponseType()).toBe('FeedbackLikeResponsePayload');
-      expect(mutation.getChildren().length).toBe(1);
-      expect(mutation.getChildren()[0]).toBe(field);
-      expect(mutation.getCall())
-        .toEqual({name: 'feedback_like', value: ''});
-      expect(mutation.getCallVariableName()).toEqual('input');
     });
   });
 });

--- a/src/store/RelayQueryTracker.js
+++ b/src/store/RelayQueryTracker.js
@@ -84,7 +84,7 @@ class RelayQueryTracker {
       });
       trackedNodes.length = 0;
       trackedNodesByID.isFlattened = true;
-      var containerNode = RelayQuery.Node.buildFragment(
+      var containerNode = RelayQuery.Fragment.build(
         'RelayQueryTracker',
         'Node',
         trackedChildren

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -270,7 +270,7 @@ class RelayStoreData {
     }
     // Fragment fields cannot be spread directly into the root because they
     // may not exist on the `Node` type.
-    return RelayQuery.Node.buildRoot(
+    return RelayQuery.Root.build(
       RelayNodeInterface.NODE,
       dataID,
       [fragment],

--- a/src/traversal/__tests__/splitDeferredRelayQueries-test.js
+++ b/src/traversal/__tests__/splitDeferredRelayQueries-test.js
@@ -943,13 +943,13 @@ describe('splitDeferredRelayQueries()', () => {
     // `Relay.QL`, but in order to be future-proof against this possible edge
     // case, we create such a query by hand.
     var fragment = Relay.QL`fragment on Node{name}`;
-    var id = RelayQuery.Node.buildField('id', null, null, {requisite: true});
-    var queryNode = RelayQuery.Node.buildRoot(
+    var id = RelayQuery.Field.build('id', null, null, {requisite: true});
+    var queryNode = RelayQuery.Root.build(
       'node',
       '4',
       [
         id,
-        RelayQuery.Node.buildField(
+        RelayQuery.Field.build(
           'hometown',
           null,
           [id, getNode(defer(fragment))],

--- a/src/traversal/diffRelayQuery.js
+++ b/src/traversal/diffRelayQuery.js
@@ -28,11 +28,11 @@ var invariant = require('invariant');
 var warning = require('warning');
 
 var {EDGES, NODE, PAGE_INFO} = RelayConnectionInterface;
-var idField = RelayQuery.Node.buildField('id', null, null, {
+var idField = RelayQuery.Field.build('id', null, null, {
   parentType: RelayNodeInterface.NODE_TYPE,
   requisite: true,
 });
-var nodeWithID = RelayQuery.Node.buildField(
+var nodeWithID = RelayQuery.Field.build(
   RelayNodeInterface.NODE,
   null,
   [idField],
@@ -79,7 +79,7 @@ function diffRelayQuery(
         'argument array for query, `%s(...).',
         rootCallName
       );
-      nodeRoot = RelayQuery.Node.buildRoot(
+      nodeRoot = RelayQuery.Root.build(
         rootCallName,
         rootCallArg,
         root.getChildren(),
@@ -744,13 +744,13 @@ function buildRoot(
     }
   });
   Object.keys(childTypes).map(type => {
-    fragments.push(RelayQuery.Node.buildFragment(
+    fragments.push(RelayQuery.Fragment.build(
       'diffRelayQuery',
       type,
       childTypes[type]
     ));
   });
-  return RelayQuery.Node.buildRoot(
+  return RelayQuery.Root.build(
     NODE,
     rootID,
     fragments,

--- a/src/traversal/inferRelayFieldsFromData.js
+++ b/src/traversal/inferRelayFieldsFromData.js
@@ -59,9 +59,9 @@ function inferField(value: mixed, key: string): RelayQuery.Field {
     children = [];
   }
   if (key === NODE) {
-    children.push(RelayQuery.Node.buildField('id'));
+    children.push(RelayQuery.Field.build('id'));
   } else if (key === EDGES) {
-    children.push(RelayQuery.Node.buildField('cursor'));
+    children.push(RelayQuery.Field.build('cursor'));
   }
   return buildField(key, children, metadata);
 }
@@ -90,7 +90,7 @@ function buildField(
       };
     });
   }
-  return RelayQuery.Node.buildField(
+  return RelayQuery.Field.build(
     fieldName,
     calls,
     children,

--- a/src/traversal/refragmentRelayQuery.js
+++ b/src/traversal/refragmentRelayQuery.js
@@ -87,7 +87,7 @@ function refragmentRelayQuery<Tn: RelayQuery.Node>(node: Tn): ?Tn {
     }
   });
   Object.keys(fieldsByType).forEach(type => {
-    children.push(RelayQuery.Node.buildFragment(
+    children.push(RelayQuery.Fragment.build(
       'refragmentRelayQuery',
       type,
       fieldsByType[type]

--- a/src/traversal/splitDeferredRelayQueries.js
+++ b/src/traversal/splitDeferredRelayQueries.js
@@ -117,7 +117,7 @@ function wrapNode(
     'splitDeferredRelayQueries(): Cannot build query without a root node.'
   );
   var rootCall = node.getRootCall();
-  return RelayQuery.Node.buildRoot(
+  return RelayQuery.Root.build(
     rootCall.name,
     rootCall.value,
     node.getChildren(),
@@ -217,7 +217,7 @@ function createRefQuery(
   path.push(primaryKey);
 
   // Create the wrapper root query.
-  var root = RelayQuery.Node.buildRoot(
+  var root = RelayQuery.Root.build(
     RelayNodeInterface.NODES,
     new GraphQL.BatchCallVariable(context.getID(), path.join('.')),
     [node],

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -49,7 +49,7 @@ type Payload = Object;
 var {CLIENT_MUTATION_ID, EDGES} = RelayConnectionInterface;
 var {APPEND, PREPEND, REMOVE} = GraphQLMutatorConstants;
 
-var EDGES_FIELD = RelayQuery.Node.buildField(
+var EDGES_FIELD = RelayQuery.Field.build(
   EDGES,
   null,
   null,
@@ -238,7 +238,7 @@ function mergeField(
 
   if (recordID) {
     path = new RelayQueryPath(
-      RelayQuery.Node.buildRoot(
+      RelayQuery.Root.build(
         RelayNodeInterface.NODE,
         recordID,
         null,
@@ -248,7 +248,7 @@ function mergeField(
   } else {
     recordID = store.getRootCallID(fieldName, EMPTY);
     // Root fields that do not accept arguments
-    path = new RelayQueryPath(RelayQuery.Node.buildRoot(fieldName));
+    path = new RelayQueryPath(RelayQuery.Root.build(fieldName));
   }
   invariant(
     recordID,


### PR DESCRIPTION
Just a straight rename and relocating some static methods:

- `RelayQuery.Node.buildField` -> `RelayQuery.Field.build`
- `RelayQuery.Node.buildFragment` -> `RelayQuery.Fragment.build`
- `RelayQuery.Node.buildMutation` -> `RelayQuery.Mutation.build`
- `RelayQuery.Node.buildRoot` -> `RelayQuery.Root.build`

This shaves a few characters off each API, and moves both the code and
the concepts closer to the code for the constituent subclass
implementations, which feels like an improvement to me.

If people agree that this is a good idea, I'll apply the same treatment
to the `RelayQuery.create*` methods as well.