### PR TITLE
adjust schema to fix splitDeferred test failure

### DIFF
--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -398,6 +398,15 @@ type SegmentsEdge {
   node: String
 }
 
+type NonNodeStory implements FeedUnit {
+  actor: Actor
+  actorCount: Int
+  feedback: Feedback
+  id: ID!
+  message: Text
+  tracking: String
+}
+
 type Story implements FeedUnit Node {
   # FeedUnit
   canViewerDelete: Boolean

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -5657,10 +5657,108 @@
           "possibleTypes": [
             {
               "kind": "OBJECT",
+              "name": "NonNodeStory",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Story",
               "ofType": null
             }
           ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NonNodeStory",
+          "description": null,
+          "fields": [
+            {
+              "name": "actor",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Actor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "actorCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feedback",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Feedback",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Text",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tracking",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "FeedUnit",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
         },
         {
           "kind": "OBJECT",

--- a/src/traversal/__tests__/splitDeferredRelayQueries-test.js
+++ b/src/traversal/__tests__/splitDeferredRelayQueries-test.js
@@ -185,7 +185,7 @@ describe('splitDeferredRelayQueries()', () => {
   });
 
   it('splits nested deferred fragments', () => {
-    var nestedFragment = Relay.QL`fragment on Story{canViewerDelete}`;
+    var nestedFragment = Relay.QL`fragment on NonNodeStory{message}`;
     var fragment = Relay.QL`
       fragment on Viewer {
         newsFeed {


### PR DESCRIPTION
fe8843c089b5d6310e537f0a83444207c2a14c5f changed the schema and make `Story` implement `Node`, but this meant that `splitDeferredRelayQuery()` test cases produced different output (since story can be refetched). The fix is to add a new dummy type `NonNodeStory` that implements `FeedUnit` but not Node and use it in the test.