### PR TITLE
React components should extend React.Component

### DIFF
--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -34,7 +34,7 @@ var RelayTestUtils = {
     var RelayPropTypes = require('RelayPropTypes');
     var RelayRoute = require('RelayRoute');
 
-    class ContextSetter {
+    class ContextSetter extends React.Component {
       getChildContext() {
         return this.props.context;
       }


### PR DESCRIPTION
This reduces a lot of warning spam in unit tests and makes us more compatible
with the next React upgrade.