### PR TITLE
Support accessing and printing directives

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -15,7 +15,7 @@ var babel = require('babel-core');
 var babelDefaultOptions = require('fbjs-scripts/babel/default-options');
 var createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
 var fs = require('fs');
-var getBabelRelayPlugin = require('babel-relay-plugin');
+var getBabelRelayPlugin = require('../babel-relay-plugin');
 var path = require('path');
 
 var SCHEMA_PATH = path.resolve(__dirname, 'testschema.json');

--- a/src/query/RelayQuery.js
+++ b/src/query/RelayQuery.js
@@ -16,7 +16,7 @@
 var GraphQL = require('GraphQL');
 var RelayConnectionInterface = require('RelayConnectionInterface');
 var RelayFragmentReference = require('RelayFragmentReference');
-import type {Call}  from 'RelayInternalTypes';
+import type {Call, Directive}  from 'RelayInternalTypes';
 var RelayMetaRoute = require('RelayMetaRoute');
 var RelayRouteFragment = require('RelayRouteFragment');
 import type {Variables} from 'RelayTypes';
@@ -366,6 +366,13 @@ class RelayQueryNode {
       children = nextChildren;
     }
     return children;
+  }
+
+  getDirectives(): Array<Directive> {
+    return this.__concreteNode__.directives.map(directive => ({
+      name: directive.name,
+      arguments: callsFromGraphQL(directive.arguments, this.__variables__),
+    }));
   }
 
   getField(field: RelayQueryField): ?RelayQueryField {

--- a/src/query/__tests__/RelayQueryField-test.js
+++ b/src/query/__tests__/RelayQueryField-test.js
@@ -559,4 +559,28 @@ describe('RelayQueryField', () => {
     expect(node.getRoute()).toBe(nodeId.getRoute());
     expect(node.getVariables()).toBe(nodeId.getVariables());
   });
+
+  it('returns directives', () => {
+    var field = getNode(Relay.QL`
+      fragment on Story {
+        feedback @include(if: $cond) @foo(int: 10, bool: true, str: "string")
+      }
+    `, {cond: true}).getChildren()[0];
+    expect(field.getDirectives()).toEqual([
+      {
+        name: 'include',
+        arguments: [
+          {name: 'if', value: true},
+        ],
+      },
+      {
+        name: 'foo',
+        arguments: [
+          {name: 'int', value: 10},
+          {name: 'bool', value: true},
+          {name: 'str', value: 'string'},
+        ],
+      }
+    ]);
+  });
 });

--- a/src/query/__tests__/RelayQueryFragment-test.js
+++ b/src/query/__tests__/RelayQueryFragment-test.js
@@ -224,4 +224,31 @@ describe('RelayQueryFragment', () => {
     expect(node.getRoute()).toBe(fragment.getRoute());
     expect(node.getVariables()).toBe(fragment.getVariables());
   });
+
+  it('returns directives', () => {
+    var fragment = getNode(Relay.QL`
+      fragment on Story
+        @include(if: $cond)
+        @foo(int: 10, bool: true, str: "string")
+      {
+        feedback
+      }
+    `, {cond: true});
+    expect(fragment.getDirectives()).toEqual([
+      {
+        name: 'include',
+        arguments: [
+          {name: 'if', value: true},
+        ],
+      },
+      {
+        name: 'foo',
+        arguments: [
+          {name: 'int', value: 10},
+          {name: 'bool', value: true},
+          {name: 'str', value: 'string'},
+        ],
+      }
+    ]);
+  });
 });

--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -370,4 +370,33 @@ describe('RelayQueryRoot', () => {
     `);
     expect(query.getDeferredFragmentNames()).toEqual({});
   });
+
+  it('returns directives', () => {
+    var query = getNode(Relay.QL`
+      query {
+        me
+          @include(if: $cond)
+          @foo(int: 10, bool: true, str: "string")
+        {
+          id
+        }
+      }
+    `, {cond: true});
+    expect(query.getDirectives()).toEqual([
+      {
+        name: 'include',
+        arguments: [
+          {name: 'if', value: true},
+        ],
+      },
+      {
+        name: 'foo',
+        arguments: [
+          {name: 'int', value: 10},
+          {name: 'bool', value: true},
+          {name: 'str', value: 'string'},
+        ],
+      }
+    ]);
+  });
 });

--- a/src/tools/RelayInternalTypes.js
+++ b/src/tools/RelayInternalTypes.js
@@ -32,6 +32,11 @@ export type ClientMutationID = string;
 
 export type DataID = string;
 
+export type Directive = {
+  name: string;
+  arguments: Array<Call>;
+};
+
 export type FieldValue = mixed;
 
 export type PrintedQuery = {


### PR DESCRIPTION
- Adds `.directives` property to `GraphQL` nodes defaulting to an empty array
- Adds `RelayQueryNode#getDirectives()` for accessing the directives on a node
- `printRelayOSSQuery` now prints directives

Note that directive values are always inlined when printing, because the schema currently does not provide information about the types of arguments for custom directives.