### PR TITLE
publish babel-relay-plugin@0.2.4

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-relay-plugin",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Babel Relay Plugin for transpiling GraphQL queries for use with Relay.",
   "license": "BSD-3-Clause",
   "repository": "facebook/relay",


### PR DESCRIPTION
Bump the version now that the plugin supports printing directive metadata  (from e924c1783681b02cca5a8dfdf981d6b4399e5629)