### PR TITLE
The build system for the prototype tool can now require(…) JSON files

### DIFF
--- a/website-prototyping-tools/package.json
+++ b/website-prototyping-tools/package.json
@@ -19,6 +19,7 @@
     "graphql": "0.4.2",
     "graphql-relay": "0.3.2",
     "html-webpack-plugin": "1.6.1",
+    "json-loader": "0.5.3",
     "lodash.debounce": "3.1.1",
     "lodash.defer": "3.1.0",
     "lodash.delay": "3.1.0",

--- a/website-prototyping-tools/webpack.config.js
+++ b/website-prototyping-tools/webpack.config.js
@@ -24,6 +24,10 @@ module.exports = {
         loader: 'babel?stage=0',
       },
       {
+        test: /\.json$/,
+        loader: 'json',
+      },
+      {
         test: /\.svg$/,
         loader: 'file-loader',
       },


### PR DESCRIPTION
This is needed to build the new version of the Babel plugin into the prototyping tools, since there's a module in the build tree that's a JSON file.