### PR TITLE
formatRequestError

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -185,20 +185,19 @@ function formatRequestErrors(
     var indent = ' '.repeat(prefix.length);
 
     //custom errors thrown in graphql-server may not have locations
-    var locationMessage = locations
-      ? ('\n' + locations.map(({column, line}) => {
+    var locationMessage = locations ?
+      ('\n' + locations.map(({column, line}) => {
         var queryLine = queryLines[line - 1];
         var offset = Math.min(column - 1, CONTEXT_BEFORE);
         return [
           queryLine.substr(column - 1 - offset, CONTEXT_LENGTH),
           ' '.repeat(offset) + '^^^'
         ].map(messageLine => indent + messageLine).join('\n');
-        }).join('\n'))
-      : '';
+        }).join('\n')) :
+      '';
 
-    return (
-      prefix + message + locationMessage
-    );
+      return prefix + message + locationMessage;
+
   }).join('\n');
 }
 

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -183,16 +183,21 @@ function formatRequestErrors(
   return errors.map(({locations, message}, ii) => {
     var prefix = (ii + 1) + '. ';
     var indent = ' '.repeat(prefix.length);
-    return (
-      prefix + message + '\n' +
-      locations.map(({column, line}) => {
+
+    //custom errors thrown in graphql-server may not have locations
+    var locationMessage = locations
+      ? ('\n' + locations.map(({column, line}) => {
         var queryLine = queryLines[line - 1];
         var offset = Math.min(column - 1, CONTEXT_BEFORE);
         return [
           queryLine.substr(column - 1 - offset, CONTEXT_LENGTH),
           ' '.repeat(offset) + '^^^'
         ].map(messageLine => indent + messageLine).join('\n');
-      }).join('\n')
+        }).join('\n'))
+      : '';
+
+    return (
+      prefix + message + locationMessage
     );
   }).join('\n');
 }

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -167,6 +167,33 @@ describe('RelayDefaultNetworkLayer', () => {
       ].join('\n'));
       expect(error.source).toEqual(response);
     });
+
+    it('handles custom errors', () => {
+      var response = {
+        errors: [{
+          message: 'Something went wrong.'
+        }]
+      };
+
+      expect(fetch).not.toBeCalled();
+      networkLayer.sendMutation(request);
+      expect(fetch).toBeCalled();
+
+      fetch.mock.deferreds[0].resolve(genResponse(response));
+      jest.runAllTimers();
+
+      expect(rejectCallback.mock.calls.length).toBe(1);
+      var error = rejectCallback.mock.calls[0][0];
+      expect(error instanceof Error).toBe(true);
+      expect(error.message).toEqual([
+        'Server request for mutation \`FeedbackLikeMutation\` failed for the ' +
+          'following reasons:',
+        '',
+        '1. Something went wrong.'
+      ].join('\n'));
+      expect(error.source).toEqual(response);
+    })
+
   });
 
   describe('sendQueries', () => {


### PR DESCRIPTION
Modified RelayDefaultNetworkLayer's formatRequestErrors function to check for locations array before attempting to call locations.map.

#325 