### PR TITLE
Fix getUser() in todo example

### DIFF
--- a/examples/todo/data/database.js
+++ b/examples/todo/data/database.js
@@ -44,7 +44,7 @@ export function getTodos() {
 }
 
 export function getUser(id) {
-  return usersById[VIEWER_ID];
+  return usersById[id];
 }
 
 export function getViewer() {


### PR DESCRIPTION
This happened to work only because we only ever call it with
`VIEWER_ID`, making it a latent but harmless bug.