### PR TITLE
simplify tests with transformRelayClientPayload()

### DIFF
--- a/src/store/__tests__/RelayStoreData_cacheManager-test.js
+++ b/src/store/__tests__/RelayStoreData_cacheManager-test.js
@@ -25,7 +25,8 @@ var RelayConnectionInterface = require('RelayConnectionInterface');
 var RelayMockCacheManager = require('RelayMockCacheManager');
 var RelayMutationType = require('RelayMutationType');
 var RelayStoreData = require('RelayStoreData');
-var generateRQLFieldAlias = require('generateRQLFieldAlias');
+
+var transformRelayClientPayload = require('transformRelayClientPayload');
 
 describe('RelayStoreData', function() {
   var cacheManager;
@@ -274,10 +275,10 @@ describe('RelayStoreData', function() {
         }
       }
     `);
-    var response = {
+    var response = transformRelayClientPayload(query, {
       node: {
         id: '123',
-        [generateRQLFieldAlias('friends.first(2)')]: {
+        friends: {
           edges: [
             {
               node: {
@@ -298,7 +299,7 @@ describe('RelayStoreData', function() {
           },
         },
       },
-    };
+    });
     storeData.handleQueryPayload(query, response);
 
     expect(cacheManager).toContainCalledMethods({
@@ -362,10 +363,10 @@ describe('RelayStoreData', function() {
         }
       }
     `);
-    var response = {
+    var response = transformRelayClientPayload(query, {
       node: {
         id: '123',
-        [generateRQLFieldAlias('friends.first(2)')]: {
+        friends: {
           edges: [],
           [PAGE_INFO]: {
             [HAS_PREV_PAGE]: false,
@@ -373,7 +374,7 @@ describe('RelayStoreData', function() {
           },
         },
       },
-    };
+    });
     storeData.handleQueryPayload(query, response);
 
     expect(cacheManager).toContainCalledMethods({
@@ -460,10 +461,10 @@ describe('RelayStoreData', function() {
         }
       }
     `);
-    var response = {
+    var response = transformRelayClientPayload(query, {
       node: {
         id: '123',
-        [generateRQLFieldAlias('comments.first(1)')]: {
+        comments: {
           count: 2,
           edges: [
             {
@@ -479,7 +480,7 @@ describe('RelayStoreData', function() {
           },
         },
       }
-    };
+    });
     storeData.handleQueryPayload(query, response);
 
     var configs = [{
@@ -581,10 +582,10 @@ describe('RelayStoreData', function() {
         }
       }
     `);
-    var response = {
+    var response = transformRelayClientPayload(query, {
       node: {
         id: '123',
-        [generateRQLFieldAlias('comments.first(1)')]: {
+        comments: {
           count: 2,
           edges: [
             {
@@ -600,7 +601,7 @@ describe('RelayStoreData', function() {
           },
         },
       }
-    };
+    });
     storeData.handleQueryPayload(query, response);
 
     var configs = [{

--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -480,7 +480,11 @@ var RelayTestUtils = {
     var RelayChangeTracker = require('RelayChangeTracker');
     var RelayQueryTracker = require('RelayQueryTracker');
     var RelayQueryWriter = require('RelayQueryWriter');
+    var transformRelayClientPayload = require('transformRelayClientPayload');
     var writeRelayQueryPayload = require('writeRelayQueryPayload');
+
+    // rewrite any plain name/alias property names into storage keys
+    payload = transformRelayClientPayload(query, payload);
 
     tracker = tracker || new RelayQueryTracker();
     options = options || {};

--- a/src/traversal/__mocks__/transformRelayClientPayload.js
+++ b/src/traversal/__mocks__/transformRelayClientPayload.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = jest.genMockFunction().mockImplementation(
+  require.requireActual('transformRelayClientPayload')
+);

--- a/src/traversal/__tests__/diffRelayQuery_connection-test.js
+++ b/src/traversal/__tests__/diffRelayQuery_connection-test.js
@@ -24,7 +24,6 @@ var RelayConnectionInterface = require('RelayConnectionInterface');
 var RelayNodeInterface = require('RelayNodeInterface');
 var RelayQueryTracker = require('RelayQueryTracker');
 var diffRelayQuery = require('diffRelayQuery');
-var generateRQLFieldAlias = require('generateRQLFieldAlias');
 
 describe('diffRelayQuery', () => {
   var RelayRecordStore;
@@ -76,10 +75,9 @@ describe('diffRelayQuery', () => {
     var store = new RelayRecordStore({records}, {map: rootCallMap});
     var tracker = new RelayQueryTracker();
 
-    var alias = generateRQLFieldAlias('newsFeed.first(3)');
     var payload = {
       viewer: {
-        [alias]: {
+        newsFeed: {
           edges: [
             {cursor: 'c1', node: {id: 's1'}},
             {cursor: 'c2', node: {id: 's2'}},
@@ -119,10 +117,9 @@ describe('diffRelayQuery', () => {
     var tracker = new RelayQueryTracker();
 
     // Write full data for 3 of 5 records, nothing for edges 4-5
-    var alias = generateRQLFieldAlias('newsFeed.first(5)');
     var payload = {
       viewer: {
-        [alias]: {
+        newsFeed: {
           edges: [
             {cursor: 'c1', node: {id: 's1'}},
             {cursor: 'c2', node: {id: 's2'}},
@@ -176,22 +173,6 @@ describe('diffRelayQuery', () => {
     var tracker = new RelayQueryTracker();
 
     // Provide empty IDs to simulate non-refetchable nodes
-    var alias = generateRQLFieldAlias('newsFeed.first(3)');
-    var payload = {
-      viewer: {
-        [alias]: {
-          edges: [
-            {cursor: 'c1', node: {id:'', message:{text:'s1'}}},
-            {cursor: 'c2', node: {id:'', message:{text:'s1'}}},
-            {cursor: 'c3', node: {id:'', message:{text:'s1'}}},
-          ],
-          [PAGE_INFO]: {
-            [HAS_NEXT_PAGE]: true,
-            [HAS_PREV_PAGE]: false,
-          },
-        },
-      },
-    };
     var writeQuery = getNode(Relay.QL`
       query {
         viewer {
@@ -207,6 +188,21 @@ describe('diffRelayQuery', () => {
         }
       }
     `);
+    var payload = {
+      viewer: {
+        newsFeed: {
+          edges: [
+            {cursor: 'c1', node: {id:'', message:{text:'s1'}}},
+            {cursor: 'c2', node: {id:'', message:{text:'s1'}}},
+            {cursor: 'c3', node: {id:'', message:{text:'s1'}}},
+          ],
+          [PAGE_INFO]: {
+            [HAS_NEXT_PAGE]: true,
+            [HAS_PREV_PAGE]: false,
+          },
+        },
+      },
+    };
     writePayload(store, writeQuery, payload, tracker);
 
     // `feedback{id}` is missing but there is no way to refetch it
@@ -241,10 +237,9 @@ describe('diffRelayQuery', () => {
     var store = new RelayRecordStore({records}, {map: rootCallMap});
     var tracker = new RelayQueryTracker();
 
-    var alias = generateRQLFieldAlias('newsFeed.first(3)');
     var payload = {
       viewer: {
-        [alias]: {
+        newsFeed: {
           edges: [
             {cursor: 'c1', node: {id:'s1', message:{text:'s1'}}},
             {cursor: 'c2', node: {id:'s2', message:{text:'s1'}}},
@@ -339,10 +334,9 @@ describe('diffRelayQuery', () => {
     var store = new RelayRecordStore({records}, {map: rootCallMap});
     var tracker = new RelayQueryTracker();
 
-    var alias = generateRQLFieldAlias('newsFeed.first(3)');
     var payload = {
       viewer: {
-        [alias]: {
+        newsFeed: {
           edges: [
             {cursor: 'c1', node: {id:'s1', message:{text:'s1'}}},
             {cursor: 'c2', node: {id:'s2', message:{text:'s1'}}},
@@ -492,10 +486,9 @@ describe('diffRelayQuery', () => {
     var store = new RelayRecordStore({records}, {map: rootCallMap});
     var tracker = new RelayQueryTracker();
 
-    var alias = generateRQLFieldAlias('notificationStories.first(3)');
     var payload = {
       viewer: {
-        [alias]: {
+        notificationStories: {
           edges: [
             {cursor: 'c1', node: {id:'s1', message:{text:'s1'}}},
             {cursor: 'c2', node: {id:'s2', message:{text:'s1'}}},
@@ -598,10 +591,9 @@ describe('diffRelayQuery', () => {
     var store = new RelayRecordStore({records}, {map: rootCallMap});
     var tracker = new RelayQueryTracker();
 
-    var alias = generateRQLFieldAlias('newsFeed.first(1)');
     var payload = {
       viewer: {
-        [alias]: {
+        newsFeed: {
           edges: [
             {cursor: 'c1', node: {id:'s1', message:{text:'s1'}}},
           ],

--- a/src/traversal/__tests__/transformRelayClientPayload-test.js
+++ b/src/traversal/__tests__/transformRelayClientPayload-test.js
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+var RelayTestUtils = require('RelayTestUtils');
+RelayTestUtils.unmockRelay();
+
+var Relay = require('Relay');
+var generateRQLFieldAlias = require('generateRQLFieldAlias');
+var transformRelayClientPayload = require('transformRelayClientPayload');
+
+describe('transformClientPayload()', () => {
+  var {getNode} = RelayTestUtils;
+
+  it('transforms singular root payloads', () => {
+    var query = getNode(Relay.QL`
+      query {
+        node(id: "123") {
+          friends(first:"1") {
+            count,
+            edges {
+              node {
+                id,
+                ... on User {
+                  profilePicture(size: "32") {
+                    uri,
+                  },
+                },
+              },
+            },
+          },
+        }
+      }
+    `);
+    var payload = {
+      node: {
+        id: '123',
+        friends: {
+          count: 1,
+          edges: [
+            {
+              cursor: 'friend:cursor',
+              node: {
+                id: 'client:friend',
+                profilePicture: {
+                  uri: 'friend.jpg',
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+    expect(transformRelayClientPayload(query, payload)).toEqual({
+      node: {
+        id: '123',
+        [generateRQLFieldAlias('friends.first(1)')]: {
+          count: 1,
+          edges: [
+            {
+              cursor: 'friend:cursor',
+              node: {
+                id: 'client:friend',
+                [generateRQLFieldAlias('profilePicture.size(32)')]: {
+                  uri: 'friend.jpg',
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('transforms plural root payloads of arrays', () => {
+    var query = getNode(Relay.QL`
+      query {
+        nodes(ids: ["123", "456"]) {
+          ... on User {
+            profilePicture(size: "32") {
+              uri,
+            },
+          },
+        },
+      }
+    `);
+    var payload = {
+      123: {
+        id: '123',
+        profilePicture: {
+          uri: '123.jpg',
+        },
+      },
+      456: {
+        id: '456',
+        profilePicture: {
+          uri: '456.jpg',
+        },
+      },
+    };
+    expect(transformRelayClientPayload(query, payload)).toEqual({
+      123: {
+        id: '123',
+        [generateRQLFieldAlias('profilePicture.size(32)')]: {
+          uri: '123.jpg',
+        },
+      },
+      456: {
+        id: '456',
+        [generateRQLFieldAlias('profilePicture.size(32)')]: {
+          uri: '456.jpg',
+        },
+      },
+    });
+  });
+
+  it('transforms plural root payloads of objects', () => {
+    var query = getNode(Relay.QL`
+      query {
+        nodes(ids: ["123", "456"]) {
+          ... on User {
+            profilePicture(size: "32") {
+              uri,
+            },
+          },
+        },
+      }
+    `);
+    var payload = [
+      {
+        id: '123',
+        profilePicture: {
+          uri: '123.jpg',
+        },
+      },
+      {
+        id: '456',
+        profilePicture: {
+          uri: '456.jpg',
+        },
+      },
+    ];
+    expect(transformRelayClientPayload(query, payload)).toEqual([
+      {
+        id: '123',
+        [generateRQLFieldAlias('profilePicture.size(32)')]: {
+          uri: '123.jpg',
+        },
+      },
+      {
+        id: '456',
+        [generateRQLFieldAlias('profilePicture.size(32)')]: {
+          uri: '456.jpg',
+        },
+      },
+    ]);
+  });
+});

--- a/src/traversal/__tests__/writeRelayQueryPayload_connectionField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_connectionField-test.js
@@ -20,7 +20,6 @@ jest
 
 var Relay = require('Relay');
 var RelayConnectionInterface = require('RelayConnectionInterface');
-var generateRQLFieldAlias = require('generateRQLFieldAlias');
 var RelayMetaRoute = require('RelayMetaRoute');
 var RelayQuery = require('RelayQuery');
 
@@ -71,11 +70,10 @@ describe('writeRelayQueryPayload()', () => {
       }
     `);
 
-    var alias = generateRQLFieldAlias('friends.first(3)');
     var payload = {
       node: {
         id: '123',
-        [alias]: {
+        friends: {
           edges: [],
           [PAGE_INFO]: {
             [HAS_NEXT_PAGE]: false,
@@ -134,43 +132,42 @@ describe('writeRelayQueryPayload()', () => {
     `);
     var payload = {
       node: {
-        id: '123'
-      }
-    };
-    var alias = generateRQLFieldAlias('friends.first(3)');
-    payload.node[alias] = {
-      edges: [
-        {
-          cursor: 'friend1',
-          node: {
-            id: 'friend1ID'
+        id: '123',
+        friends: {
+          edges: [
+            {
+              cursor: 'friend1',
+              node: {
+                id: 'friend1ID'
+              },
+              source: {
+                id: '123'
+              }
+            },
+            {
+              cursor: 'friend2',
+              node: {
+                id: 'friend2ID'
+              },
+              source: {
+                id: '123'
+              }
+            },
+            {
+              cursor: 'friend3',
+              node: {
+                id: 'friend3ID'
+              },
+              source: {
+                id: '123'
+              }
+            }
+          ],
+          [PAGE_INFO]: {
+            [HAS_NEXT_PAGE]: true,
+            [HAS_PREV_PAGE]: false,
           },
-          source: {
-            id: '123'
-          }
         },
-        {
-          cursor: 'friend2',
-          node: {
-            id: 'friend2ID'
-          },
-          source: {
-            id: '123'
-          }
-        },
-        {
-          cursor: 'friend3',
-          node: {
-            id: 'friend3ID'
-          },
-          source: {
-            id: '123'
-          }
-        }
-      ],
-      [PAGE_INFO]: {
-        [HAS_NEXT_PAGE]: true,
-        [HAS_PREV_PAGE]: false,
       },
     };
     var results = writePayload(store, query, payload);
@@ -232,27 +229,26 @@ describe('writeRelayQueryPayload()', () => {
     `);
     var payload = {
       node: {
-        id: '123'
-      }
-    };
-    var alias = generateRQLFieldAlias('friends.first(3)');
-    payload.node[alias] = {
-      edges: [
-        null,
-        {
-          cursor: 'friend2',
-          node: null,
-        },
-        {
-          cursor: 'friend3',
-          node: {
-            id: 'friend3ID'
+        id: '123',
+        friends: {
+          edges: [
+            null,
+            {
+              cursor: 'friend2',
+              node: null,
+            },
+            {
+              cursor: 'friend3',
+              node: {
+                id: 'friend3ID'
+              },
+            }
+          ],
+          [PAGE_INFO]: {
+            [HAS_NEXT_PAGE]: true,
+            [HAS_PREV_PAGE]: false,
           },
-        }
-      ],
-      [PAGE_INFO]: {
-        [HAS_NEXT_PAGE]: true,
-        [HAS_PREV_PAGE]: false,
+        },
       },
     };
     var results = writePayload(store, query, payload);
@@ -324,25 +320,24 @@ describe('writeRelayQueryPayload()', () => {
     `);
     payload = {
       node: {
-        id: '123'
-      }
-    };
-    var alias = generateRQLFieldAlias('friends.first(1)');
-    payload.node[alias] = {
-      edges: [
-        {
-          cursor: 'friend1',
-          node: {
-            id: 'friend1ID'
+        id: '123',
+        friends: {
+          edges: [
+            {
+              cursor: 'friend1',
+              node: {
+                id: 'friend1ID'
+              },
+              source: {
+                id: '123'
+              }
+            },
+          ],
+          [PAGE_INFO]: {
+            [HAS_NEXT_PAGE]: true,
+            [HAS_PREV_PAGE]: false,
           },
-          source: {
-            id: '123'
-          }
         },
-      ],
-      [PAGE_INFO]: {
-        [HAS_NEXT_PAGE]: true,
-        [HAS_PREV_PAGE]: false,
       },
     };
     var results = writePayload(store, query, payload);
@@ -397,11 +392,10 @@ describe('writeRelayQueryPayload()', () => {
         }
       }
     `);
-    var alias = generateRQLFieldAlias('friends.isViewerFriend(true)');
     var payload = {
       node: {
         id: '123',
-        [alias]: {
+        friends: {
           edges: [
             {
               cursor: 'friend1',
@@ -446,20 +440,19 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
-          id: '123'
-        }
-      };
-      var alias = generateRQLFieldAlias('friends.first(1)');
-      payload.node[alias] = {
-        edges: [{
-          node: {
-            id: 'node1'
+          id: '123',
+          friends: {
+            edges: [{
+              node: {
+                id: 'node1'
+              },
+              cursor: 'cursor1'
+            }],
+            [PAGE_INFO]: {
+              [HAS_NEXT_PAGE]: true,
+              [HAS_PREV_PAGE]: false,
+            },
           },
-          cursor: 'cursor1'
-        }],
-        [PAGE_INFO]: {
-          [HAS_NEXT_PAGE]: true,
-          [HAS_PREV_PAGE]: false,
         },
       };
       var records = {};
@@ -483,20 +476,19 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
-          id: '123'
-        }
-      };
-      var alias = generateRQLFieldAlias('friends.first(1).after(cursor1)');
-      payload.node[alias] = {
-        edges: [{
-          node: {
-            id: 'node2'
+          id: '123',
+          friends: {
+            edges: [{
+              node: {
+                id: 'node2'
+              },
+              cursor: 'cursor2'
+            }],
+            [PAGE_INFO]: {
+              [HAS_NEXT_PAGE]: true,
+              [HAS_PREV_PAGE]: true,
+            },
           },
-          cursor: 'cursor2'
-        }],
-        [PAGE_INFO]: {
-          [HAS_NEXT_PAGE]: true,
-          [HAS_PREV_PAGE]: true,
         },
       };
       var results = writePayload(store, query, payload);
@@ -544,21 +536,20 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
-          id: '123'
-        }
-      };
-      var alias = generateRQLFieldAlias('friends.find(node1)');
-      payload.node[alias] = {
-        edges: [{
-          node: {
-            id: 'node1',
-            name: 'Tim' // added field
+          id: '123',
+          friends: {
+            edges: [{
+              node: {
+                id: 'node1',
+                name: 'Tim' // added field
+              },
+              cursor: 'cursor1'
+            }],
+            [PAGE_INFO]: {
+              [HAS_NEXT_PAGE]: true,
+              [HAS_PREV_PAGE]: true,
+            },
           },
-          cursor: 'cursor1'
-        }],
-        [PAGE_INFO]: {
-          [HAS_NEXT_PAGE]: true,
-          [HAS_PREV_PAGE]: true,
         },
       };
       var results = writePayload(store, query, payload);
@@ -607,23 +598,22 @@ describe('writeRelayQueryPayload()', () => {
       `, RelayMetaRoute.get('$RelayTest'), {});
       var payload = {
         node: {
-          id: '123'
-        }
-      };
-      var alias = generateRQLFieldAlias('friends.find(node1)');
-      payload.node[alias] = {
-        edges: [{
-          node: {
-            id: 'node1',
+          id: '123',
+          friends: {
+            edges: [{
+              node: {
+                id: 'node1',
+              },
+              source: { // new edge field
+                id: '456'
+              },
+              cursor: 'cursor1'
+            }],
+            [PAGE_INFO]: {
+              [HAS_NEXT_PAGE]: true,
+              [HAS_PREV_PAGE]: true,
+            },
           },
-          source: { // new edge field
-            id: '456'
-          },
-          cursor: 'cursor1'
-        }],
-        [PAGE_INFO]: {
-          [HAS_NEXT_PAGE]: true,
-          [HAS_PREV_PAGE]: true,
         },
       };
       var results = writePayload(store, query, payload);
@@ -672,20 +662,19 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
-          id: '123'
-        }
-      };
-      var alias = generateRQLFieldAlias('friends.first(1)');
-      payload.node[alias] = {
-        edges: [{
-          node: {
-            id: 'node1b'
+          id: '123',
+          friends: {
+            edges: [{
+              node: {
+                id: 'node1b'
+              },
+              cursor: 'cursor1b'
+            }],
+            [PAGE_INFO]: {
+              [HAS_NEXT_PAGE]: true,
+              [HAS_PREV_PAGE]: false,
+            },
           },
-          cursor: 'cursor1b'
-        }],
-        [PAGE_INFO]: {
-          [HAS_NEXT_PAGE]: true,
-          [HAS_PREV_PAGE]: false,
         },
       };
       var results = writePayload(store, query, payload);
@@ -732,20 +721,19 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
-          id: '123'
-        }
-      };
-      var alias = generateRQLFieldAlias('friends.first(1)');
-      payload.node[alias] = {
-        edges: [{
-          node: {
-            id: 'node1b'
+          id: '123',
+          friends: {
+            edges: [{
+              node: {
+                id: 'node1b'
+              },
+              cursor: 'cursor1b'
+            }],
+            [PAGE_INFO]: {
+              [HAS_NEXT_PAGE]: true,
+              [HAS_PREV_PAGE]: false,
+            },
           },
-          cursor: 'cursor1b'
-        }],
-        [PAGE_INFO]: {
-          [HAS_NEXT_PAGE]: true,
-          [HAS_PREV_PAGE]: false,
         },
       };
       var results = writePayload(store, query, payload, null, {forceIndex: 1});

--- a/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
@@ -22,7 +22,6 @@ var Relay = require('Relay');
 var RelayQueryPath = require('RelayQueryPath');
 var RelayQueryTracker = require('RelayQueryTracker');
 var invariant = require('invariant');
-var generateRQLFieldAlias = require('generateRQLFieldAlias');
 
 describe('writePayload()', () => {
   var RelayRecordStore;
@@ -223,11 +222,10 @@ describe('writePayload()', () => {
           }
         }
       `);
-      var alias = generateRQLFieldAlias('friends.first(1)');
       var payload = {
         node: {
           id: '123',
-          [alias]: {
+          friends: {
             edges: [
               {
                 cursor: 'cursor1',
@@ -427,11 +425,10 @@ describe('writePayload()', () => {
           }
         }
       `);
-      var alias = generateRQLFieldAlias('friends.first(1)');
       var payload = {
         node: {
           id: '123',
-          [alias]: {
+          friends: {
             edges: [
               {
                 cursor: 'c1',
@@ -487,11 +484,10 @@ describe('writePayload()', () => {
           }
         }
       `);
-      var alias = generateRQLFieldAlias('friends.first(1)');
       var payload = {
         node: {
           id: '123',
-          [alias]: {
+          friends: {
             edges: [
               {
                 cursor: 'c1',
@@ -523,11 +519,10 @@ describe('writePayload()', () => {
           }
         }
       `);
-      alias = generateRQLFieldAlias('friends.after(c1).first(1)');
       payload = {
         node: {
           id: '123',
-          [alias]: {
+          friends: {
             edges: [
               {
                 cursor: 'c2',
@@ -579,7 +574,6 @@ describe('writePayload()', () => {
           }
         }
       `);
-      var alias = generateRQLFieldAlias('friends.first(1)');
       var payload = {
         node: {
           id: '123',
@@ -591,7 +585,7 @@ describe('writePayload()', () => {
               },
             },
           ],
-          [alias]: {
+          friends: {
             edges: [
               {
                 cursor: 'c1',

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -28,7 +28,6 @@ var RelayMutationType = require('RelayMutationType');
 var RelayQueryWriter = require('RelayQueryWriter');
 var GraphQLMutatorConstants = require('GraphQLMutatorConstants');
 var generateClientEdgeID = require('generateClientEdgeID');
-var generateRQLFieldAlias = require('generateRQLFieldAlias');
 var writeRelayUpdatePayload = require('writeRelayUpdatePayload');
 
 describe('writePayload()', () => {
@@ -85,7 +84,7 @@ describe('writePayload()', () => {
       var payload = {
         node: {
           id: 'feedback_id',
-          [generateRQLFieldAlias('topLevelComments.first(1)')]: {
+          topLevelComments: {
             count: 1,
             edges: [
               {
@@ -303,11 +302,10 @@ describe('writePayload()', () => {
           }
         }
       `);
-      var alias = generateRQLFieldAlias('topLevelComments.first(1)');
       var payload = {
         node: {
           id: feedbackID,
-          [alias]: {
+          topLevelComments: {
             count: 1,
             edges: [
               {
@@ -715,11 +713,10 @@ describe('writePayload()', () => {
           }
         }
       `);
-      var alias = generateRQLFieldAlias('topLevelComments.first(1)');
       var payload = {
         node: {
           id: feedbackID,
-          [alias]: {
+          topLevelComments: {
             count: 1,
             edges: [
               {

--- a/src/traversal/transformRelayClientPayload.js
+++ b/src/traversal/transformRelayClientPayload.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule transformRelayClientPayload
+ * @flow
+ * @typechecks
+ */
+
+'use strict';
+
+var RelayQuery = require('RelayQuery');
+
+var invariant = require('invariant');
+var mapObject = require('mapObject');
+
+type Payload = mixed;
+
+/**
+ * Transforms payloads with property keys that match the "application" names
+ * (schema names or aliases) into a payload that the server would return for
+ * the given query (i.e. using serialization keys instead).
+ */
+function transformRelayClientPayload(
+  node: RelayQuery.Node,
+  data: Payload
+): Payload {
+  if (data == null) {
+    return data;
+  }
+  if (node instanceof RelayQuery.Root) {
+    // Handle both FB & OSS formats for root payloads on plural calls: FB
+    // returns objects, OSS returns arrays.
+    if (Array.isArray(data)) {
+      return data.map(item => transform(node, item));
+    } else {
+      invariant(
+        typeof data === 'object',
+        'transformClientPayload(): Expected the root payload for query `%s` ' +
+        'to be an array or object, got `%s`.',
+        node.getName(),
+        data
+      );
+      return mapObject(data, item => transform(node, item));
+    }
+  }
+  return transform(node, data);
+}
+
+function transform(
+  node: RelayQuery.Node,
+  data: Payload
+): Payload {
+  if (data == null || node.isScalar()) {
+    return data;
+  }
+  if (Array.isArray(data)) {
+    return data.map(item => transform(node, item));
+  }
+  invariant(
+    typeof data === 'object' && data !== null,
+    'transformClientPayload(): Expected data for a non-scalar query node to ' +
+    'be null, undefined, an array, or an object. Got `%s`.',
+    data
+  );
+  var payload = data;
+  var response = {};
+  node.getChildren().forEach(child => {
+    if (child instanceof RelayQuery.Field) {
+      // Read first from the application name, otherwise from the serialization
+      // key, in order to make the function idempotent.
+      var serializationKey = child.getSerializationKey();
+      response[serializationKey] = transform(
+        child,
+        payload[child.getApplicationName()] || payload[serializationKey]
+      );
+    } else {
+      invariant(
+        child instanceof RelayQuery.Fragment,
+        'transformClientPayload(): Unexpected node type.'
+      );
+      response = {
+        ...response,
+        ...transform(child, payload),
+      };
+    }
+  });
+  return response;
+}
+
+module.exports = transformRelayClientPayload;


### PR DESCRIPTION
A lot of our tests have to write data into the store before testing some other logic. However, the payloads must be manually constructed using `generateRQLFieldAlias()`. It's not a big deal, but it's annoying. 

So this PR adds a new module `transformClientPayload(query: RelayQuery.Node, payload: Payload): Payload` - it accepts payloads where the keys correspond to field names/aliases (which cannot be written into the store as-is), and returns an equivalent payload where keys are renamed to the serialization key of the corresponding field (which *can* be written to the store). See the unit test for this module for an example, and how it (slightly) simplifies tests that write to the store.

I didn't convert all tests - I wanted to get feedback first.