### PR TITLE
You can now send someone a permalink to a Relay playground

### DIFF
--- a/website-prototyping-tools/RelayPlayground.css
+++ b/website-prototyping-tools/RelayPlayground.css
@@ -172,6 +172,48 @@ body {
   right: 0;
   top: 52px;
 }
+.rpExecutionGuard {
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.rpExecutionGuardMessage {
+  background-color: hsl(345, 7%, 23%);
+  box-shadow: 1px 1px 3px hsla(0, 0%, 0%, 0.25);
+  color: white;
+  margin: 30px;
+  max-width: 480px;
+  padding: 16px;
+  text-shadow: 0 -1px hsl(345, 7%, 3%);
+}
+.rpExecutionGuardMessage h2 {
+  font-size: 18px;
+  font-weight: 400;
+  margin: 0;
+}
+.rpExecutionGuardMessage p {
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+.rpExecutionGuardMessage button {
+  background-color: hsl(26.5, 100%, 47.5%);
+  border-color:
+    hsl(26.5, 100%, 80%)
+    hsl(26.5, 100%, 30%)
+    hsl(26.5, 100%, 30%)
+    hsl(26.5, 100%, 80%);
+  border-style: solid;
+  border-width: 1px;
+  font-size: 13px;
+  text-transform: uppercase;
+}
+
 .ReactCodeMirror {
   border-right: 1px solid #eee8d5;
   border-top: 1px solid #eee8d5;

--- a/website-prototyping-tools/RelayPlayground.js
+++ b/website-prototyping-tools/RelayPlayground.js
@@ -79,7 +79,11 @@ class PlaygroundRenderer extends React.Component {
 }
 
 export default class RelayPlayground extends React.Component {
+  static defaultProps = {
+    autoExecute: false,
+  };
   static propTypes = {
+    autoExecute: PropTypes.bool.isRequired,
     initialAppSource: PropTypes.string,
     initialSchemaSource: PropTypes.string,
     onAppSourceChange: PropTypes.func,
@@ -92,6 +96,7 @@ export default class RelayPlayground extends React.Component {
     editTarget: 'app',
     error: null,
     schemaSource: this.props.initialSchemaSource,
+    shouldExecuteCode: this.props.autoExecute,
   };
   componentDidMount() {
     // Hijack console.warn to collect GraphQL validation warnings (we hope)
@@ -121,16 +126,25 @@ export default class RelayPlayground extends React.Component {
       collectedWarnings = [];
       return false;
     };
-    this._updateSchema(this.state.schemaSource, this.state.appSource);
+    if (this.state.shouldExecuteCode) {
+      this._updateSchema(this.state.schemaSource, this.state.appSource);
+    }
   }
   componentDidUpdate(prevProps, prevState) {
+    var recentlyEnabledCodeExecution =
+      !prevState.shouldExecuteCode && this.state.shouldExecuteCode;
     var appChanged = this.state.appSource !== prevState.appSource;
     var schemaChanged = this.state.schemaSource !== prevState.schemaSource;
-    if (appChanged || schemaChanged) {
+    if (
+      this.state.shouldExecuteCode &&
+      (recentlyEnabledCodeExecution || appChanged || schemaChanged)
+    ) {
       this.setState({busy: true});
       this._handleSourceCodeChange(
         this.state.appSource,
-        schemaChanged ? this.state.schemaSource : null,
+        recentlyEnabledCodeExecution || schemaChanged
+          ? this.state.schemaSource
+          : null,
       );
     }
   }
@@ -140,6 +154,9 @@ export default class RelayPlayground extends React.Component {
     this._handleSourceCodeChange.cancel();
     console.warn = this._originalConsoleWarn;
     window.onerror = this._originalWindowOnerror;
+  }
+  _handleExecuteClick = () => {
+    this.setState({shouldExecuteCode: true});
   }
   _handleSourceCodeChange = debounce((appSource, schemaSource) => {
     if (schemaSource != null) {
@@ -281,6 +298,32 @@ export default class RelayPlayground extends React.Component {
       this._updateApp(appSource);
     });
   }
+  renderApp() {
+    if (!this.state.shouldExecuteCode) {
+      return (
+        <div className="rpExecutionGuard">
+          <div className="rpExecutionGuardMessage">
+            <h2>For your security, this playground did not auto-execute</h2>
+            <p>
+              Clicking <strong>execute</strong> will run the code in the two
+              tabs to the left.
+            </p>
+            <button onClick={this._handleExecuteClick}>Execute</button>
+          </div>
+        </div>
+      );
+    } else if (this.state.error) {
+      return (
+        <div className="rpError">
+          <h1>{this.state.errorType} Error</h1>
+          <pre className="rpErrorStack">{this.state.error.stack}</pre>
+        </div>
+      );
+    } else if (this.state.appElement) {
+      return <PlaygroundRenderer>{this.state.appElement}</PlaygroundRenderer>;
+    }
+    return null;
+  }
   render() {
     var sourceCode = this.state.editTarget === 'schema'
       ? this.state.schemaSource
@@ -300,9 +343,16 @@ export default class RelayPlayground extends React.Component {
               Schema
             </button>
           </nav>
+          {/* What is going on with the choice of key in Codemirror?
+            * https://github.com/JedWatson/react-codemirror/issues/12
+            */}
           <Codemirror
+            key={`${this.state.editTarget}-${this.state.shouldExecuteCode}`}
             onChange={this._updateCode}
-            options={CODE_EDITOR_OPTIONS}
+            options={{
+              ...CODE_EDITOR_OPTIONS,
+              readOnly: !this.state.shouldExecuteCode,
+            }}
             value={sourceCode}
           />
         </section>
@@ -314,13 +364,7 @@ export default class RelayPlayground extends React.Component {
             } />
           </h1>
           <div className="rpResultOutput">
-            {this.state.error
-              ? <div className="rpError">
-                  <h1>{this.state.errorType} Error</h1>
-                  <pre className="rpErrorStack">{this.state.error.stack}</pre>
-                </div>
-              : <PlaygroundRenderer>{this.state.appElement}</PlaygroundRenderer>
-            }
+            {this.renderApp()}
           </div>
         </section>
       </div>

--- a/website-prototyping-tools/graphiql.js
+++ b/website-prototyping-tools/graphiql.js
@@ -18,10 +18,17 @@ import evalSchema from './evalSchema';
 import queryString from 'querystring';
 import {graphql} from 'graphql';
 
-if (
-  /^https?:\/\/facebook.github.io\//.test(document.referrer) ||
-  /^localhost/.test(document.location.host)
-) {
+const IS_TRUSTED = (
+  (
+    // Running in an iframe on the Relay website
+    window.self !== window.top &&
+    /^https?:\/\/facebook.github.io\//.test(document.referrer)
+  ) ||
+  // Running locally
+  /^(127\.0\.0\.1|localhost)/.test(document.location.host)
+);
+
+if (IS_TRUSTED) {
   // Don't trust location.hash not to have been unencoded by the browser
   var hash = window.location.href.split('#')[1];
   var {

--- a/website-prototyping-tools/playground.js
+++ b/website-prototyping-tools/playground.js
@@ -13,53 +13,110 @@ import React from 'react'; window.React = React;
 import ReactDOM from 'react/lib/ReactDOM';
 import RelayPlayground from './RelayPlayground';
 
+import filterObject from 'fbjs/lib/filterObject';
 import queryString from 'querystring';
+
+const DEFAULT_CACHE_KEY = 'default';
+const IS_TRUSTED = (
+  (
+    // Running in an iframe on the Relay website
+    window.self !== window.top &&
+    /^https?:\/\/facebook.github.io\//.test(document.referrer)
+  ) ||
+  // Running locally
+  /^(127\.0\.0\.1|localhost)/.test(document.location.host)
+);
+
+var sourceWasInjected = false;
 
 // Don't trust location.hash not to have been unencoded by the browser
 var hash = window.location.href.split('#')[1];
 var queryParams = queryString.parse(hash);
 
-if (
-  /^https?:\/\/facebook.github.io\//.test(document.referrer) ||
-  /^localhost/.test(document.location.host)
-) {
-  var {
-    schema: schemaSource,
-    source: appSource,
-  } = queryParams;
-}
-
 var {cacheKey} = queryParams;
-var appSourceCacheKey;
-var schemaSourceCacheKey;
-if (cacheKey) {
-  appSourceCacheKey = `rp-${cacheKey}-source`;
-  if (localStorage.getItem(appSourceCacheKey) != null) {
-    appSource = localStorage.getItem(appSourceCacheKey);
-  }
-  schemaSourceCacheKey = `rp-${cacheKey}-schema`;
-  if (localStorage.getItem(schemaSourceCacheKey) != null) {
-    schemaSource = localStorage.getItem(schemaSourceCacheKey);
-  }
+if (!cacheKey) {
+  cacheKey = DEFAULT_CACHE_KEY;
 }
+var appSourceCacheKey = `rp-${cacheKey}-source`;
+var schemaSourceCacheKey = `rp-${cacheKey}-schema`;
+
+var initialAppSource;
+var initialSchemaSource;
+var storedAppSource = localStorage.getItem(appSourceCacheKey);
+var storedSchemaSource = localStorage.getItem(schemaSourceCacheKey);
+if (cacheKey === DEFAULT_CACHE_KEY) {
+  // Use case #1
+  // The user loaded the playground without a custom cache key.
+  //   Allow code injection via the URL
+  //   OR load code from localStorage
+  //   OR prime the playground with some default 'hello world' code
+  if (queryParams.source != null) {
+    initialAppSource = queryParams.source;
+    sourceWasInjected = queryParams.source !== storedAppSource;
+  } else if (storedAppSource != null) {
+    initialAppSource = storedAppSource;
+  } else {
+    initialAppSource = require('!raw!./HelloApp');
+  }
+  if (queryParams.schema != null) {
+    initialSchemaSource = queryParams.schema;
+    sourceWasInjected = queryParams.schema !== storedSchemaSource;
+  } else if (storedSchemaSource != null) {
+    initialSchemaSource = storedSchemaSource;
+  } else {
+    initialSchemaSource = require('!raw!./HelloSchema');
+  }
+  queryParams = filterObject({
+    source: queryParams.source,
+    schema: queryParams.schema,
+  }, v => v !== undefined);
+} else {
+  // Use case #2
+  // Custom cache keys are useful in cases where you want to embed a playground
+  // that features both custom boilerplate code AND saves the developer's
+  // progress, without overwriting the default code cache. eg. a tutorial.
+  if (storedAppSource != null) {
+    initialAppSource = storedAppSource;
+  } else {
+    initialAppSource = queryParams[`source_${cacheKey}`];
+    if (initialAppSource != null) {
+      sourceWasInjected = true;
+    }
+  }
+  if (storedSchemaSource != null) {
+    initialSchemaSource = storedSchemaSource;
+  } else {
+    initialSchemaSource = queryParams[`schema_${cacheKey}`];
+    if (initialSchemaSource != null) {
+      sourceWasInjected = true;
+    }
+  }
+  queryParams = {};
+}
+window.location.hash = queryString.stringify(queryParams);
 
 var mountPoint = document.createElement('div');
 document.body.appendChild(mountPoint);
 
 ReactDOM.render(
   <RelayPlayground
-    initialAppSource={
-      appSource != null ? appSource : require('!raw!./HelloApp')
-    }
-    initialSchemaSource={
-      schemaSource != null ? schemaSource : require('!raw!./HelloSchema')
-    }
-    onSchemaSourceChange={schemaSourceCacheKey &&
-      function(source) { localStorage.setItem(schemaSourceCacheKey, source); }
-    }
-    onAppSourceChange={appSourceCacheKey &&
-      function(source) { localStorage.setItem(appSourceCacheKey, source); }
-    }
+    autoExecute={IS_TRUSTED || !sourceWasInjected}
+    initialAppSource={initialAppSource}
+    initialSchemaSource={initialSchemaSource}
+    onSchemaSourceChange={function(source) {
+      localStorage.setItem(schemaSourceCacheKey, source);
+      if (cacheKey === DEFAULT_CACHE_KEY) {
+        queryParams.schema = source;
+        window.location.hash = queryString.stringify(queryParams);
+      }
+    }}
+    onAppSourceChange={function(source) {
+      localStorage.setItem(appSourceCacheKey, source);
+      if (cacheKey === DEFAULT_CACHE_KEY) {
+        queryParams.source = source;
+        window.location.hash = queryString.stringify(queryParams);
+      }
+    }}
   />,
   mountPoint
 );


### PR DESCRIPTION
This will enable us to host an instance of the Relay playground on facebook.github.io whose permalinks can be shared. Being able to share playgrounds should make it easy for people to share ideas and bug reports.

This diff enables this while protecting against code injection vulnerabilities. Auto-execution is whitelisted for localhost and wherever a playground is being run in an `<iframe>` on the Relay website (we need this for the tutorial materials). Everywhere else, a mismatch between what you have cached locally and what's in the URL will disable auto-execution and trigger a confirmation dialog. The user will have an opportunity to evaluate the code before choosing to execute it.

![relay](https://cloud.githubusercontent.com/assets/13243/9966456/e9ff9324-5df1-11e5-8810-c5bc2bdd1db1.gif)
