### PR TITLE
print mutation variables besides $input

### DIFF
--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -101,7 +101,7 @@ type Comment implements Node {
   likeSentence: Text
   message: Text
   name: String
-  profilePicture(size: [String]): Image
+  profilePicture(size: [String], preset: PhotoSize): Image
   segments(first: String): Segments
   screennames: [Screenname]
   subscribeStatus: String
@@ -184,7 +184,7 @@ type Feedback implements Node {
   likeSentence: Text
   message: Text
   name: String
-  profilePicture(size: [String]): Image
+  profilePicture(size: [String], preset: PhotoSize): Image
   segments(first: String): Segments
   screennames: [Screenname]
   subscribeStatus: String
@@ -278,7 +278,7 @@ interface Node {
   likeSentence: Text
   message: Text
   name: String
-  profilePicture(size: [String]): Image
+  profilePicture(size: [String], preset: PhotoSize): Image
   segments(first: String): Segments
   screennames: [Screenname]
   subscribeStatus: String
@@ -302,7 +302,7 @@ interface Actor {
   id: ID!
   lastName: String
   name: String
-  profilePicture(size: [String]): Image
+  profilePicture(size: [String], preset: PhotoSize): Image
   screennames: [Screenname]
   subscribeStatus: String
   subscribers(first: String): SubscribersConnection
@@ -340,7 +340,7 @@ type Page implements Node Actor {
   likeSentence: Text
   message: Text
   name: String
-  profilePicture(size: [String]): Image
+  profilePicture(size: [String], preset: PhotoSize): Image
   segments(first: String): Segments
   screennames: [Screenname]
   subscribeStatus: String
@@ -437,7 +437,7 @@ type Story implements FeedUnit Node {
   likeSentence: Text
   message: Text
   name: String
-  profilePicture(size: [String]): Image
+  profilePicture(size: [String], preset: PhotoSize): Image
   segments(first: String): Segments
   screennames: [Screenname]
   subscribeStatus: String
@@ -515,7 +515,7 @@ type User implements Node Actor {
   likeSentence: Text
   message: Text
   name: String
-  profilePicture(size: [String]): Image
+  profilePicture(size: [String], preset: PhotoSize): Image
   segments(first: String): Segments
   screennames: [Screenname]
   subscribeStatus: String
@@ -547,6 +547,11 @@ type ViewerNotificationsUpdateAllSeenStateResponsePayload {
 enum Environment {
   WEB
   MOBILE
+}
+
+enum PhotoSize {
+  SMALL
+  LARGE
 }
 
 type Settings {

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -845,6 +845,16 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "preset",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "PhotoSize",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -1506,6 +1516,16 @@
                       "name": "String",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "preset",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "PhotoSize",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -2186,6 +2206,16 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "preset",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "PhotoSize",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -2628,6 +2658,16 @@
                       "name": "String",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "preset",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "PhotoSize",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -3221,6 +3261,16 @@
                       "name": "String",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "preset",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "PhotoSize",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -4240,6 +4290,16 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "preset",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "PhotoSize",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -4685,6 +4745,29 @@
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "PhotoSize",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SMALL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LARGE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -5368,6 +5451,16 @@
                       "name": "String",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "preset",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "PhotoSize",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }

--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -22,6 +22,7 @@ var RelayMutationType = require('RelayMutationType');
 var RelayQuery = require('RelayQuery');
 import type RelayQueryTracker from 'RelayQueryTracker';
 var RelayStoreData = require('RelayStoreData');
+import type {Variables} from 'RelayTypes';
 
 var flattenRelayQuery = require('flattenRelayQuery');
 var forEachObject = require('forEachObject');
@@ -295,6 +296,7 @@ var RelayMutationQuery = {
       mutationName,
       mutation,
       tracker,
+      input,
     }: {
       /* Previously each element of configs had the type mixed, which meant
        * that they couldn't be used in configs.forEach without being
@@ -303,6 +305,7 @@ var RelayMutationQuery = {
        */
       configs: Array<{[key: string]: $FlowFixMe}>;
       fatQuery: RelayQuery.Fragment;
+      input: Variables,
       mutationName: string;
       mutation: GraphQL.Mutation;
       tracker?: RelayQueryTracker;
@@ -378,7 +381,7 @@ var RelayMutationQuery = {
       mutationName,
       fatQuery.getType(),
       mutation.calls[0].name,
-      null,
+      input,
       fragmentedFields ? fragmentedFields.getChildren() : null,
       mutation.metadata
     );

--- a/src/mutation/__tests__/RelayMutationTransaction-test.js
+++ b/src/mutation/__tests__/RelayMutationTransaction-test.js
@@ -63,6 +63,8 @@ describe('RelayMutationTransaction', () => {
     });
 
     it('updates store if there is a optimistic response', () => {
+      var input = {foo: 'bar'};
+      mockMutation.getVariables.mockReturnValue(input);
       mockMutation.getOptimisticResponse.mockReturnValue({});
       mockMutation.getOptimisticConfigs.mockReturnValue('optimisticConfigs');
       RelayMutationQuery.buildQuery.mockReturnValue('optimisticQuery');
@@ -75,6 +77,10 @@ describe('RelayMutationTransaction', () => {
       expect(RelayMutationQuery.buildQuery.mock.calls).toEqual([[{
         configs: 'optimisticConfigs',
         fatQuery: 'fatQuery',
+        input: {
+          ...input,
+          [RelayConnectionInterface.CLIENT_MUTATION_ID]: '0',
+        },
         mutation: mutationNode,
         mutationName: 'RelayMutation',
       }]]);

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -75,21 +75,21 @@ describe('RelayDefaultNetworkLayer', () => {
       responseCallback = jest.genMockFunction();
       rejectCallback = jest.genMockFunction();
 
-      var mutation = RelayQuery.Node.buildMutation(
-        'FeedbackLikeMutation',
-        'FeedbackLikeResponsePayload',
-        'feedback_like',
-        null,
-        [RelayQuery.Node.buildField('does_viewer_like')],
-        {inputType: 'FeedbackLikeInput'}
-      );
       variables = {
         input: {
           [RelayConnectionInterface.CLIENT_MUTATION_ID]: 'client:a',
           actor_id: 4,
         },
       };
-      request = new RelayMutationRequest(mutation, variables);
+      var mutation = RelayQuery.Node.buildMutation(
+        'FeedbackLikeMutation',
+        'FeedbackLikeResponsePayload',
+        'feedback_like',
+        variables.input,
+        [RelayQuery.Node.buildField('does_viewer_like')],
+        {inputType: 'FeedbackLikeInput'}
+      );
+      request = new RelayMutationRequest(mutation);
       request.getPromise().then(responseCallback).catch(rejectCallback);
     });
 
@@ -109,7 +109,9 @@ describe('RelayDefaultNetworkLayer', () => {
       });
       expect(body).toEqual(JSON.stringify({
         query: request.getQueryString(),
-        variables: variables,
+        variables: {
+          input_0: variables.input,
+        },
       }));
     });
 


### PR DESCRIPTION
Addresses #307 - We currently assume that mutations have exactly one variable `$input` - however, tracked queries may contain fields with calls that have Enum/InputObject types. These call values must also be printed as variables.

Changes:
- add a `preset` argument to `profilePicture` that accepts an Enum value, as a way of testing call variables in tracked queries
- change `RelayMutationQuery` to accept the value of `$input` as a param and pass it through to `RelayQuery.Node.buildMutation`
- Change the printer to handle variables in mutations the same as they are handled in queries.
- Change `RelayMutationRequest` to return the variables from the printer instead of hard-coding to `$input`