### PR TITLE
Upgrade Babel to 5.8.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "babel-runtime": "5.8.20",
+    "babel-runtime": "5.8.24",
     "fbjs": "^0.2.1",
     "react-static-container": "^1.0.0-alpha.1"
   },
@@ -37,7 +37,7 @@
     "react-dom": "^0.14.0-rc"
   },
   "devDependencies": {
-    "babel-core": "^5.8.23",
+    "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.1",
     "babel-loader": "^5.3.2",
     "babel-relay-plugin": "^0.2.4",

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -21,7 +21,7 @@
     "minimist": "^1.1.3"
   },
   "dependencies": {
-    "babel-core": "^5.8.3",
+    "babel-core": "^5.8.25",
     "graphql": "0.4.2"
   }
 }

--- a/website-prototyping-tools/package.json
+++ b/website-prototyping-tools/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "autoprefixer-loader": "2.1.0",
     "babel": "5.8.23",
-    "babel-core": "5.8.23",
+    "babel-core": "5.8.25",
     "babel-loader": "5.3.2",
     "babel-plugin-react-error-catcher": "1.1.9",
     "babel-relay-plugin": "../scripts/babel-relay-plugin",


### PR DESCRIPTION
Contains an update without which we can't publish the website.