### PR TITLE
Prevent hash changes from jumping the page to the top

### DIFF
--- a/website-prototyping-tools/playground.js
+++ b/website-prototyping-tools/playground.js
@@ -29,6 +29,11 @@ const IS_TRUSTED = (
 
 var sourceWasInjected = false;
 
+function setHash(object) {
+  // Caution: setting it to nothing causes the page to jump to the top, hence /.
+  window.location.hash = queryString.stringify(object) || '/';
+}
+
 // Don't trust location.hash not to have been unencoded by the browser
 var hash = window.location.href.split('#')[1];
 var queryParams = queryString.parse(hash);
@@ -93,7 +98,7 @@ if (cacheKey === DEFAULT_CACHE_KEY) {
   }
   queryParams = {};
 }
-window.location.hash = queryString.stringify(queryParams);
+setHash(queryParams);
 
 var mountPoint = document.createElement('div');
 document.body.appendChild(mountPoint);
@@ -107,14 +112,14 @@ ReactDOM.render(
       localStorage.setItem(schemaSourceCacheKey, source);
       if (cacheKey === DEFAULT_CACHE_KEY) {
         queryParams.schema = source;
-        window.location.hash = queryString.stringify(queryParams);
+        setHash(queryParams);
       }
     }}
     onAppSourceChange={function(source) {
       localStorage.setItem(appSourceCacheKey, source);
       if (cacheKey === DEFAULT_CACHE_KEY) {
         queryParams.source = source;
-        window.location.hash = queryString.stringify(queryParams);
+        setHash(queryParams);
       }
     }}
   />,


### PR DESCRIPTION
When the playground controller sets the hash to `''`, it caused the browser to scroll the page around. This prevents that.