### PR TITLE
diffRelayQuery: split plural roots with array calls

### DIFF
--- a/src/traversal/__tests__/diffRelayQuery-test.js
+++ b/src/traversal/__tests__/diffRelayQuery-test.js
@@ -672,11 +672,11 @@ describe('diffRelayQuery', () => {
     expect(diffQueries.length).toBe(2);
     expect(diffQueries[0].getName()).toBe(query.getName());
     expect(diffQueries[0]).toEqualQueryRoot(getNode(
-      Relay.QL`query{nodes(ids:"4") {id, name}}`
+      Relay.QL`query{nodes(ids:["4"]) {id, name}}`
     ));
     expect(diffQueries[1].getName()).toBe(query.getName());
     expect(diffQueries[1]).toEqualQueryRoot(getNode(
-      Relay.QL`query{nodes(ids:"4808495") {id, name}}`
+      Relay.QL`query{nodes(ids:["4808495"]) {id, name}}`
     ));
   });
 
@@ -1147,7 +1147,7 @@ describe('diffRelayQuery', () => {
     `;
     var expected0 = getNode(Relay.QL`
       query {
-        nodes(ids:"4") {
+        nodes(ids:["4"]) {
           id,
           ${firstNameFrag},
           ${expectedFragment},
@@ -1156,7 +1156,7 @@ describe('diffRelayQuery', () => {
     `);
     var expected1 = getNode(Relay.QL`
       query {
-        nodes(ids:"4808495") {
+        nodes(ids:["4808495"]) {
           id,
           name,
           ${defer(firstNameFrag)},

--- a/src/traversal/diffRelayQuery.js
+++ b/src/traversal/diffRelayQuery.js
@@ -81,7 +81,7 @@ function diffRelayQuery(
       );
       nodeRoot = RelayQuery.Root.build(
         rootCallName,
-        rootCallArg,
+        [rootCallArg],
         root.getChildren(),
         {
           rootArg: root.getRootCallArgument(),


### PR DESCRIPTION
Addreses #358 - ensures that when `diffRelayQuery` splits plural root calls into queries per value, that the root call values are arrays of a singular values instead of scalars. This ensures that the check in `RelayOSSNodeInterface` for matching root call / payload plurality passes.