### PR TITLE
Change getQuery to getFragment in RelayRoute test

### DIFF
--- a/src/route/__tests__/RelayRoute-test.js
+++ b/src/route/__tests__/RelayRoute-test.js
@@ -41,14 +41,14 @@ describe('RelayRoute', () => {
         required: (Component, params) => Relay.QL`
           query {
             node(id:$required) {
-              ${Component.getQuery('required')}
+              ${Component.getFragment('required')}
             }
           }
         `,
         optional: (Component, params) => Relay.QL`
           query {
             node(id:$optional) {
-              ${Component.getQuery('optional')}
+              ${Component.getFragment('optional')}
             }
           }
         `


### PR DESCRIPTION
`getQuery` is deprecated and we're trying to get rid of it.