### PR TITLE
Fix key in rangeBehaviors example

### DIFF
--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -364,7 +364,7 @@ class IntroduceShipMutation extends Relay.Mutation {
         // of any call, append the ship to the end of the connection
         '': 'append',
         // Prepend the ship, wherever the connection is sorted by age
-        'orderby:newest': 'prepend',
+        'orderby(newest)': 'prepend',
       },
     }];
   }


### PR DESCRIPTION
I don't know if you're looking for a PR to further elaborate on the use of `rangeBehaviors`, especially around when the connection is refreshed, but it seems like it'd be an improvement to fix the form of the range behavior key used in the existing example.