### PR TITLE
Verify recordID is a string

### DIFF
--- a/src/store/RelayQueryWriter.js
+++ b/src/store/RelayQueryWriter.js
@@ -84,6 +84,15 @@ class RelayQueryWriter extends RelayQueryVisitor<WriterState> {
     responseData: mixed,
     path: RelayQueryPath
   ): void {
+
+
+    invariant(
+      typeof recordID === 'string',
+      'RelayQueryWriter: Expected id `%s` to be string' +
+      ', instead received a %s',
+      recordID, typeof recordID
+    );
+
     var state = {
       nodeID: null,
       recordID,

--- a/src/store/RelayQueryWriter.js
+++ b/src/store/RelayQueryWriter.js
@@ -84,15 +84,6 @@ class RelayQueryWriter extends RelayQueryVisitor<WriterState> {
     responseData: mixed,
     path: RelayQueryPath
   ): void {
-
-
-    invariant(
-      typeof recordID === 'string',
-      'RelayQueryWriter: Expected id `%s` to be string' +
-      ', instead received a %s',
-      recordID, typeof recordID
-    );
-
     var state = {
       nodeID: null,
       recordID,

--- a/src/traversal/writeRelayQueryPayload.js
+++ b/src/traversal/writeRelayQueryPayload.js
@@ -19,6 +19,8 @@ import type RelayQuery from 'RelayQuery';
 var RelayQueryPath = require('RelayQueryPath');
 import type RelayQueryWriter from 'RelayQueryWriter';
 
+var invariant = require('invariant');
+
 /**
  * @internal
  *
@@ -33,8 +35,17 @@ function writeRelayQueryPayload(
   var store = writer.getRecordStore();
   var path = new RelayQueryPath(query);
 
+
   RelayNodeInterface.getResultsFromPayload(store, query, payload)
     .forEach(({dataID, result}) => {
+      invariant(
+        typeof dataID === 'string',
+        'writeRelayQueryPayload: expected ID on the payload for query `%s` to be string' +
+        ', instead received the `%s` `%s`.',
+        path.getName(),
+        typeof dataID,
+        dataID
+      );
       writer.writePayload(query, dataID, result, path);
     });
 }

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -76,6 +76,15 @@ function writeRelayUpdatePayload(
   payload: {[key: string]: mixed},
   {configs, isOptimisticUpdate}: UpdateOptions
 ): void {
+  invariant(
+    typeof payload[CLIENT_MUTATION_ID] === 'string',
+    'writeRelayUpdatePayload: expected clientMutationID on the payload for mutation `%s` to be string' +
+    ', instead received the `%s` `%s`.',
+    operation.getName(),
+    typeof payload[CLIENT_MUTATION_ID],
+    payload[CLIENT_MUTATION_ID]
+  );
+
   configs.forEach(config => {
     switch (config.type) {
       case RelayMutationType.NODE_DELETE:
@@ -141,6 +150,14 @@ function deleteRecord(
   writer: RelayQueryWriter,
   recordID: DataID
 ): void {
+  invariant(
+    typeof recordID === 'string',
+    'deleteRecord: expected recordID to be string' +
+    ', instead received the `%s` `%s`.',
+    typeof recordID,
+    recordID
+);
+
   var store = writer.getRecordStore();
   // skip if already deleted
   var status = store.getRecordState(recordID);
@@ -237,6 +254,13 @@ function mergeField(
   var path;
 
   if (recordID) {
+    invariant(
+      typeof recordID === 'string',
+      'mergeField: expected recordID to be string' +
+      ', instead received the `%s` `%s`.',
+      typeof recordID,
+      recordID
+    );
     path = new RelayQueryPath(
       RelayQuery.Root.build(
         RelayNodeInterface.NODE,
@@ -302,6 +326,15 @@ function handleRangeAdd(
 ): void {
   var clientMutationID = payload[CLIENT_MUTATION_ID];
   var store = writer.getRecordStore();
+
+  invariant(
+    typeof clientMutationID === 'string',
+    'handleRangeAdd: expected recordID to be string' +
+    ', instead received the `%s` `%s`.',
+    typeof clientMutationID,
+    clientMutationID
+  );
+
 
   // Extracts the new edge from the payload
   var edge = payload[config.edgeName];


### PR DESCRIPTION
Adds a check that `recordID` is a string, fixes https://github.com/facebook/relay/issues/376