### PR TITLE
Change from error to warning when a request fails

### DIFF
--- a/src/store/RelayPendingQueryTracker.js
+++ b/src/store/RelayPendingQueryTracker.js
@@ -207,7 +207,7 @@ class PendingFetch {
     var queryID = this.getQuery().getID();
     delete pendingFetchMap[queryID];
 
-    console.error(error.message);
+    console.warn(error.message);
 
     this._errors.push(error);
     this._updateResolvedDeferred();


### PR DESCRIPTION
Since React Native shows a big red box for `console.error` it can get in the way
of development when working on error handling.

Fixes #366.