### PR TITLE
Fixed example projects building Relay twice on npm install

### DIFF
--- a/examples/relay-treasurehunt/package.json
+++ b/examples/relay-treasurehunt/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "babel-node ./server.js",
     "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install"
+    "preinstall": "cd ../.. && npm install --ignore-scripts"
   },
   "dependencies": {
     "babel": "5.8.23",

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "babel-node ./server.js",
     "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install"
+    "preinstall": "cd ../.. && npm install --ignore-scripts"
   },
   "dependencies": {
     "babel": "5.8.23",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "babel-node ./server.js",
     "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install"
+    "preinstall": "cd ../.. && npm install --ignore-scripts"
   },
   "dependencies": {
     "babel": "5.8.23",


### PR DESCRIPTION
Fixes #367 where `npm install` on the projects in `examples/` would build twice. This is due to the nature of `npm install` which recursively executes `npm install --production` on parent directories, including `relay/`. 

Since the `preinstall` script of the projects already executes `npm install` on `relay/`, `npm install` runs twice on `relay/` therefore running the `build` script of `relay/` twice.

Adding `--ignore-scripts` to the `preinstall` script of the projects fixes this by not executing any scripts in the first `npm install` on `relay/`.