### PR TITLE
Docs improvements

### DIFF
--- a/docs/GraphQL-RelaySpecification.md
+++ b/docs/GraphQL-RelaySpecification.md
@@ -40,7 +40,7 @@ The schema described below will be used to demonstrate the functionality
 that a GraphQL server used by Relay should implement. The two core types
 are a faction and a ship in the Star Wars universe, where a faction
 has many ships associated with it. The schema below is the output of the
-GraphQL.js `schemaPrinter`.
+GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
 
 ```
 interface Node {

--- a/docs/Guides-BabelPlugin.md
+++ b/docs/Guides-BabelPlugin.md
@@ -31,7 +31,7 @@ This gets converted into an immediately-invoked function:
 
 ## Usage
 
-The easiest way to get started for now is with the [Relay Starter Kit](https://github.com/facebook/relay-starter-kit) - this includes an example schema file and configures the `babel-relay-plugin` npm module to transpile queries.
+The easiest way to get started for now is with the [Relay Starter Kit](https://github.com/facebook/relay-starter-kit) - this includes an example schema file and configures the [`babel-relay-plugin`](https://www.npmjs.com/package/babel-relay-plugin) npm module to transpile queries.
 
 ## Advanced Usage
 

--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -138,7 +138,7 @@ class LikeStoryMutation extends Relay.Mutation {
 
 ## Fragment variables
 
-Like can be done with [Relay containers](guides-containers.html), we can prepare variables for use by our mutation's fragment builders, based on the previous variables and the runtime environment.
+Like it can be done with [Relay containers](guides-containers.html), we can prepare variables for use by our mutation's fragment builders, based on the previous variables and the runtime environment.
 
 ```
 class RentMovieMutation extends Relay.Mutation {

--- a/docs/Guides-RootContainer.md
+++ b/docs/Guides-RootContainer.md
@@ -142,4 +142,4 @@ When `forceFetch` is true and `renderFetched` is called as a result of available
 
 **Relay.RootContainer** also supports the `onReadyStateChange` prop which lets us receive fine-grained events as they occur while fulfilling the data requirements.
 
-Learn how to use `onReadyStateChange` in our next guide, Ready State.
+Learn how to use `onReadyStateChange` in our next guide, [Ready State](guides-ready-state.html).

--- a/docs/Guides-RootContainer.md
+++ b/docs/Guides-RootContainer.md
@@ -78,7 +78,7 @@ When all data necessary to render becomes available, **Relay.RootContainer** wil
 
 This snippet configures **Relay.RootContainer** to render `ProfilePicture` within a `ScrollView` component as soon as data is ready.
 
-The `renderFetched` callback is always called with a `data` argument, which is an object mapping from `propName` to query data. It is expected that the `renderFetched` callback renders the supplied `Component` with them (e.g. using the JSX spread attributes feature).
+The `renderFetched` callback is always called with a `data` argument, which is an object mapping from `propName` to query data. It is expected that the `renderFetched` callback renders the supplied `Component` with them (e.g. using the [JSX spread attributes feature](https://facebook.github.io/react/docs/jsx-spread.html)).
 
 > Note
 >

--- a/docs/Guides-RootContainer.md
+++ b/docs/Guides-RootContainer.md
@@ -142,4 +142,4 @@ When `forceFetch` is true and `renderFetched` is called as a result of available
 
 **Relay.RootContainer** also supports the `onReadyStateChange` prop which lets us receive fine-grained events as they occur while fulfilling the data requirements.
 
-Learn how to use this prop in the [Ready State guide](guides-ready-state.html).
+Learn how to use `onReadyStateChange` in our next guide, Ready State.

--- a/docs/Guides-Routes.md
+++ b/docs/Guides-Routes.md
@@ -11,7 +11,7 @@ Routes are responsible for defining the entry points into a Relay application. B
 
 > Note
 >
-> Relay routes don't really implement any URL routing specific logic or work with History API. In the future we will maybe rename RelayRoute to be something more like RelayQueryRoots or RelayQueryConfig.
+> Relay routes don't really implement any URL routing specific logic or work with History API. In the future we will maybe rename RelayRoute to be something more like RelayQueryRoots or RelayQueryConfig. For more information around why Relay doesn't have any routing features and suggestions for routing solutions you should read [this post](https://medium.com/@cpojer/relay-and-routing-36b5439bad9).
 
 ## Queries vs. Fragments
 

--- a/docs/Guides-Routes.md
+++ b/docs/Guides-Routes.md
@@ -11,7 +11,7 @@ Routes are responsible for defining the entry points into a Relay application. B
 
 > Note
 >
-> Relay routes don't really implement any URL routing specific logic or work with History API. In the future we will maybe rename RelayRoute to be something more like RelayQueryRoots or RelayQueryConfig. For more information around why Relay doesn't have any routing features and suggestions for routing solutions you should read [this post](https://medium.com/@cpojer/relay-and-routing-36b5439bad9).
+> Relay routes don't really implement any URL routing specific logic or work with History API. In the future we will maybe rename RelayRoute to be something more like RelayQueryRoots or RelayQueryConfig. For more information around why Relay doesn't provide URL-routing features, and suggestions for such solutions, see [this post](https://medium.com/@cpojer/relay-and-routing-36b5439bad9).
 
 ## Queries vs. Fragments
 

--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -11,7 +11,7 @@ In this tutorial, we will build a game using GraphQL mutations. The goal of the 
 
 ## Warm up
 
-Let's start a project using the Relay Starter Kit as a base.
+Let's start a project using the [Relay Starter Kit](https://github.com/relayjs/relay-starter-kit) as a base.
 
 ```
 git clone https://github.com/relayjs/relay-starter-kit.git relay-treasurehunt

--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -431,4 +431,4 @@ export default Relay.createContainer(App, {
 
 A working copy of the treasure hunt can be found in the `./examples/` directory.
 
-Now that we've gone end-to-end with Relay, let's dive into more detail in the guides section.
+Now that we've gone through this tutorial, let's dive into some videos from conferences where GraphQL and Relay were introduced and explained.

--- a/docs/QuickStart-Videos.md
+++ b/docs/QuickStart-Videos.md
@@ -7,16 +7,16 @@ permalink: docs/videos.html
 next: guides-containers
 ---
 
-## [React.js Conf January 2015](http://conf.reactjs.com/)
+## [@Scale September 2015](http://www.atscaleconference.com/)
 
-<iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/9sc8Pyc51uU?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+<iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/Pxdgu2XIAAg?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 
 ## [ReactEurope July 2015](https://www.react-europe.org/2015/2015.html)
 
 <iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/IrgHurBjQbg?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 
-## [@Scale September 2015](http://www.atscaleconference.com/)
+## [React.js Conf January 2015](http://conf.reactjs.com/)
 
-<iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/Pxdgu2XIAAg?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+<iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/9sc8Pyc51uU?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 
 Now that we've gone end-to-end with Relay, let's dive into more detail in the guides section.

--- a/docs/QuickStart-Videos.md
+++ b/docs/QuickStart-Videos.md
@@ -18,3 +18,5 @@ next: guides-containers
 ## [@Scale September 2015](http://www.atscaleconference.com/)
 
 <iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/Pxdgu2XIAAg?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
+
+Now that we've gone end-to-end with Relay, let's dive into more detail in the guides section.

--- a/docs/QuickStart-Videos.md
+++ b/docs/QuickStart-Videos.md
@@ -7,14 +7,14 @@ permalink: docs/videos.html
 next: guides-containers
 ---
 
-## React.js Conf
+## [React.js Conf January 2015](http://conf.reactjs.com/)
 
 <iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/9sc8Pyc51uU?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 
-## React Europe
+## [ReactEurope July 2015](https://www.react-europe.org/2015/2015.html)
 
 <iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/IrgHurBjQbg?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 
-## @Scale
+## [@Scale September 2015](http://www.atscaleconference.com/)
 
 <iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/Pxdgu2XIAAg?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
I just went through the docs and tutorials as I was introducing GraphQL & Relay to a project and found a few places that the docs could be improved on - let me know what you think, feedback is obviously welcome :)

In summary:
- Linked to Conference pages where videos came through & added dates so that people have a little more context on a video's recency
- Added reference to [Relay and Routing medium post](https://medium.com/@cpojer/relay-and-routing-36b5439bad9)
- Changed a couple of sentences at the end of some guides referencing what's coming up next; for example, at the end of the Tutorial section it says you'll be taken to the Guides, but actually you get to the Videos section first
- Added links to external dependencies / plugins / functions that are mentioned and I had to look for rather than click on and be taken there