### PR TITLE
babel-relay-plugin@0.2.6

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-relay-plugin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Babel Relay Plugin for transpiling GraphQL queries for use with Relay.",
   "license": "BSD-3-Clause",
   "repository": "facebook/relay",


### PR DESCRIPTION
Bump version to include the `__typename`-handling logic.