### PR TITLE
Build 2x faster

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,11 +63,6 @@ var buildDist = function(opts) {
       'react': 'React',
       'react-dom': 'ReactDOM'
     },
-    module: {
-      loaders: [
-        {test: /\.js$/, loader: 'babel'}
-      ],
-    },
     output: {
       filename: opts.output,
       libraryTarget: 'umd',
@@ -127,7 +122,7 @@ gulp.task('modules', function() {
     .pipe(gulp.dest(paths.lib));
 });
 
-gulp.task('dist', ['modules'], function () {
+gulp.task('dist', ['modules'], function() {
   var distOpts = {
     debug: true,
     output: 'relay.js'
@@ -141,7 +136,7 @@ gulp.task('dist', ['modules'], function () {
     .pipe(gulp.dest(paths.dist));
 });
 
-gulp.task('dist:min', ['modules'], function () {
+gulp.task('dist:min', ['modules'], function() {
   var distOpts = {
     debug: false,
     output: 'relay.min.js'
@@ -170,5 +165,5 @@ gulp.task('watch', function() {
 });
 
 gulp.task('default', function(cb) {
-  runSequence('clean', 'website:check-version', 'modules', ['dist', 'dist:min'], cb);
+  runSequence('clean', 'website:check-version', ['dist', 'dist:min'], cb);
 });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.1",
-    "babel-loader": "^5.3.2",
     "babel-relay-plugin": "^0.2.4",
     "del": "^1.2.0",
     "envify": "^3.4.0",


### PR DESCRIPTION
I was testing some fbjs changes and got tired of waiting ~23s for each build so I made it faster.

1. Removed duplicate `modules` task. We already run it for `dist` and `dist:min` (where it gets deduped) so we don't need to run it before then.
  
  *(saves ~5s)*
2. Removed the babel webpack loader. We've already transformed our code. `fbjs` is already transformed. We shouldn't need to transform again. There are some differences (https://gist.github.com/zpao/16e13b4a85010c6fbdff) as a result of this - mostly because we don't reprint, though there are also a couple `'use strict'` statements missing but that's probably ok.
  
  *(saves ~6-7s for each `dist` and `dist:min` but they run in parallel so only see the win once)*

I ran a few times before and after to get some stable numbers with a warm disk cache. I dropped from 23s to 12s.