### PR TITLE
Added babel-core to suppress npm v2 warning

### DIFF
--- a/examples/relay-treasurehunt/package.json
+++ b/examples/relay-treasurehunt/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "babel": "5.8.23",
+    "babel-core": "^5.8.25",
     "babel-loader": "5.3.2",
     "babel-relay-plugin": "file:../../scripts/babel-relay-plugin/",
     "classnames": "^2.1.3",

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "babel": "5.8.23",
+    "babel-core": "^5.8.25",
     "babel-eslint": "4.1.0",
     "babel-loader": "5.3.2",
     "babel-relay-plugin": "file:../../scripts/babel-relay-plugin/",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "babel": "5.8.23",
+    "babel-core": "^5.8.25",
     "babel-eslint": "4.1.0",
     "babel-loader": "5.3.2",
     "babel-relay-plugin": "file:../../scripts/babel-relay-plugin/",


### PR DESCRIPTION
Installing projects in `examples/` with npm v2 outputs a warning.

<img width="845" alt="screenshot 2015-09-25 21 44 28" src="https://cloud.githubusercontent.com/assets/3792228/10115943/61aebf00-63d1-11e5-85e0-a0e4baacccad.png">

Added the latest version of babel-core (same as the one used in `relay/`) to fix the warning.
