### PR TITLE
Compile babel-relay-plugin using Babel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-dist/
-lib/
+.nvmrc
 node_modules
 npm-debug.log
-website/build
-website/src/relay/docs
-website/src/relay/graphql
-website/src/relay/prototyping
-.nvmrc
+/dist/
+/lib/
+/website/build
+/website/src/relay/docs
+/website/src/relay/graphql
+/website/src/relay/prototyping

--- a/scripts/babel-relay-plugin/.gitignore
+++ b/scripts/babel-relay-plugin/.gitignore
@@ -1,3 +1,0 @@
-dist/
-lib/
-node_modules

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -1,0 +1,702 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var kinds = require('graphql/language/kinds');
+var printer = require('graphql/language/printer');
+var t = require('babel-core/lib/types');
+var types = require('graphql/type');
+var typeIntrospection = require('graphql/type/introspection');
+
+var util = require('util');
+
+var SchemaMetaFieldDef = typeIntrospection.SchemaMetaFieldDef;
+var TypeMetaFieldDef = typeIntrospection.TypeMetaFieldDef;
+var TypeNameMetaFieldDef = typeIntrospection.TypeNameMetaFieldDef;
+
+var NULL = t.literal(null);
+
+/**
+ * This is part of the Babel transform to convert embedded GraphQL RFC to
+ * JavaScript. It converts from GraphQL AST to a string of JavaScript code.
+ */
+function RelayQLPrinter(schema, rqlFunctionName) {
+  this.rqlFunctionName = rqlFunctionName;
+  this.schema = schema;
+}
+
+RelayQLPrinter.prototype.getCode = function (ast, substitutions) {
+  var options = {
+    rqlFunctionName: this.rqlFunctionName,
+    schema: this.schema,
+    substitutions: substitutions
+  };
+
+  var printedDocument;
+  switch (ast.kind) {
+    case kinds.OPERATION_DEFINITION:
+      switch (ast.operation) {
+        case 'query':
+          printedDocument = printQuery(ast, options);
+          break;
+        case 'mutation':
+          printedDocument = printOperation(ast, options);
+          break;
+      }
+      break;
+    case kinds.FRAGMENT_DEFINITION:
+      printedDocument = printQueryFragment(ast, options);
+      break;
+  }
+  if (!printedDocument) {
+    throw new Error('unexpected type: ' + ast.kind);
+  }
+
+  return t.functionExpression(null, options.substitutions.map(function (sub) {
+    return t.identifier(sub);
+  }), t.blockStatement([t.variableDeclaration('var', [t.variableDeclarator(t.identifier('GraphQL'), t.memberExpression(identify(options.rqlFunctionName), t.identifier('__GraphQL')))]), t.returnStatement(printedDocument)]));
+};
+
+function printQueryFragment(fragment, options) {
+  var typeName = getTypeName(fragment);
+  var type = options.schema.getType(typeName);
+  if (!type) {
+    throw new Error('Fragment was defined on nonexistent type ' + typeName);
+  }
+
+  var requisiteFields = {};
+  if (hasIdField(type)) {
+    requisiteFields.id = true;
+  }
+  if (types.isAbstractType(type)) {
+    requisiteFields.__typename = true;
+  }
+
+  var fieldsAndFragments = printFieldsAndFragments(fragment.selectionSet, type, options, requisiteFields, typeName);
+  var fields = fieldsAndFragments.fields;
+  var fragments = fieldsAndFragments.fragments;
+  var directives = printDirectives(fragment.directives);
+  var metadata = getRelayDirectiveMetadata(fragment);
+
+  return t.newExpression(t.memberExpression(t.identifier('GraphQL'), t.identifier('QueryFragment')), trimArguments([t.literal(getName(fragment)), t.literal(getTypeName(fragment)), fields, fragments, objectify(metadata), directives]));
+}
+
+/**
+ * Prints a top level query. This code is pretty similar to `printOperation`,
+ * unfortunately, GraphQL.Query is currently just different enough, to make it
+ * not worth unifying this code.
+ */
+function printQuery(query, options) {
+  var selections = getSelections(query);
+  if (selections.length !== 1) {
+    throw new Error('Expected only single top level query');
+  }
+
+  // Validate the name of the root call. Throws if it doesn't exist.
+  var rootField = selections[0];
+  var rootCallName = getName(rootField);
+  var rootCallDecl = getFieldDef(options.schema, options.schema.getQueryType(), rootField);
+  var type = types.getNamedType(rootCallDecl.type);
+
+  var requisiteFields = {};
+  var rootCall = getRootCallForType(options.schema, type);
+  if (rootCall) {
+    requisiteFields[rootCall.arg] = true;
+  }
+  if (types.isAbstractType(type)) {
+    requisiteFields.__typename = true;
+  }
+
+  var printedArgs = printArguments(rootField.arguments[0], options);
+
+  var fieldsAndFragments = printFieldsAndFragments(rootField.selectionSet, type, options, requisiteFields, types.getNamedType(type).name);
+  var fields = fieldsAndFragments.fields;
+  var fragments = fieldsAndFragments.fragments;
+  var directives = printDirectives(rootField.directives);
+  var metadata = {};
+
+  if (rootCallDecl.args.length > 1) {
+    throw new Error(util.format('Invalid root field `%s`; Relay only supports root fields with zero or ' + 'one argument', rootCallName));
+  } else if (rootCallDecl.args.length === 1) {
+    metadata.rootArg = rootCallDecl.args[0].name;
+
+    var rootCallTypeName = getTypeForMetadata(rootCallDecl.args[0].type);
+    if (rootCallTypeName) {
+      metadata.rootCallType = rootCallTypeName;
+    }
+  }
+
+  return t.newExpression(t.memberExpression(t.identifier('GraphQL'), t.identifier('Query')), trimArguments([t.literal(getName(rootField)), printedArgs, fields, fragments, objectify(metadata), t.literal(getName(query)), directives]));
+}
+
+function printOperation(operation, options) {
+  var selections = getSelections(operation);
+  if (selections.length !== 1) {
+    throw new Error('Expected only single top level field on operation');
+  }
+  var rootField = selections[0];
+
+  if (operation.operation !== 'mutation') {
+    throw new Error('Unexpected operation type: ' + operation.operation);
+  }
+
+  var className = 'Mutation';
+  var field = getFieldDef(options.schema, options.schema.getMutationType(), rootField);
+  if (!field) {
+    throw new Error('Provided mutation ' + getName(rootField) + ' does not exist in schema.');
+  }
+  var type = types.getNamedType(field.type);
+  var requisiteFields = { clientMutationId: true };
+
+  var printedCall = t.newExpression(t.memberExpression(t.identifier('GraphQL'), t.identifier('Callv')), trimArguments([t.literal(getName(rootField)), printCallVariable('input')]));
+
+  if (field.args.length !== 1) {
+    throw new Error(util.format('Expected operation `%s` to have a single input field.', getName(rootField)));
+  }
+  var metadata = {
+    inputType: field.args[0].type.toString()
+  };
+  var fieldsAndFragments = printFieldsAndFragments(rootField.selectionSet, type, options, requisiteFields, type.name);
+  var fields = fieldsAndFragments.fields;
+  var fragments = fieldsAndFragments.fragments;
+
+  return t.newExpression(t.memberExpression(t.identifier('GraphQL'), t.identifier(className)), trimArguments([t.literal(getName(operation)), t.literal(type.name), printedCall, fields, fragments, objectify(metadata)]));
+}
+
+function printFieldsAndFragments(selectionSet, type, options, requisiteFields, parentType) {
+  var fields = [];
+  var fragments = [];
+  if (selectionSet && selectionSet.selections) {
+    selectionSet.selections.forEach(function (selection) {
+      if (selection.kind === kinds.FRAGMENT_SPREAD) {
+        // We assume that all spreads were added by us
+        if (selection.directives && selection.directives.length) {
+          throw new Error('Directives are not yet supported for `${fragment}`-style ' + 'fragment references.');
+        }
+        fragments.push(printFragmentReference(getName(selection), options));
+      } else if (selection.kind === kinds.INLINE_FRAGMENT) {
+        fragments.push(printQueryFragment(selection, options));
+      } else if (selection.kind === kinds.FIELD) {
+        fields.push(selection);
+
+        if (getConnectionMetadataForType(type) && getName(selection) === 'edges' && type.getFields()['pageInfo']) {
+          requisiteFields.pageInfo = true;
+        }
+      } else {
+        throw new Error(util.format('Unsupported selection type `%s`.', selection.kind));
+      }
+    });
+  }
+
+  return {
+    fields: printFields(fields, type, options, requisiteFields, parentType),
+    fragments: fragments.length ? t.arrayExpression(fragments) : NULL
+  };
+}
+
+function printArguments(args) {
+  if (!args) {
+    return NULL;
+  }
+  var value = args.value;
+  if (value.kind === kinds.LIST) {
+    return t.arrayExpression(value.values.map(function (arg) {
+      return printArgument(arg);
+    }));
+  } else {
+    return printArgument(value);
+  }
+}
+
+function printArgument(arg) {
+  var value;
+  switch (arg.kind) {
+    case kinds.INT:
+      value = parseInt(arg.value, 10);
+      break;
+    case kinds.FLOAT:
+      value = parseFloat(arg.value);
+      break;
+    case kinds.STRING:
+    case kinds.ENUM:
+    case kinds.BOOLEAN:
+      value = arg.value;
+      break;
+    case kinds.VARIABLE:
+      if (!arg.name || arg.name.kind !== kinds.NAME) {
+        throw new Error('Expected variable to have a name');
+      }
+      return printCallVariable(arg.name.value);
+    default:
+      throw new Error('Unexpected arg kind: ' + arg.kind);
+  }
+  return printCallValue(value);
+}
+
+function printCallVariable(name) {
+  return t.newExpression(t.memberExpression(t.identifier('GraphQL'), t.identifier('CallVariable')), [t.literal(name)]);
+}
+
+function printCallValue(value) {
+  return t.newExpression(t.memberExpression(t.identifier('GraphQL'), t.identifier('CallValue')), [t.literal(value)]);
+}
+
+function printFields(fields, type, options, requisiteFields, parentType) {
+  var generateFields = {};
+  Object.keys(requisiteFields).forEach(function (name) {
+    generateFields[name] = true;
+  });
+
+  var printedFields = fields.map(function (field) {
+    var fieldName = getName(field);
+    delete generateFields[fieldName];
+    return printField(field, type, options, requisiteFields, false, parentType);
+  });
+  Object.keys(generateFields).forEach(function (fieldName) {
+    var generatedAST = {
+      kind: kinds.FIELD,
+      name: { kind: kinds.NAME, value: fieldName },
+      selectionSet: { selections: [] },
+      arguments: []
+    };
+    printedFields.push(printField(generatedAST, type, options, requisiteFields, true, parentType));
+  });
+  if (printedFields.length === 0) {
+    return NULL;
+  }
+  return t.arrayExpression(printedFields);
+}
+
+function printFragmentReference(substitutionName, options) {
+  return t.callExpression(t.memberExpression(identify(options.rqlFunctionName), t.identifier('__frag')), [t.identifier(substitutionName)]);
+}
+
+function printField(field, type, options, requisiteFields, isGenerated, parentType) {
+  var fieldName = getName(field);
+  var fieldDecl = getFieldDef(options.schema, type, field);
+  var metadata = {
+    parentType: parentType
+  };
+
+  if (!fieldDecl) {
+    throw new Error(util.format('Type `%s` doesn\'t have a field `%s`.', type.name, fieldName));
+  }
+
+  var subRequisiteFields = {};
+
+  if (hasIdField(types.getNamedType(fieldDecl.type))) {
+    subRequisiteFields.id = true;
+  }
+
+  // TODO: generalize to types that do not implement `Node`
+  // var rootCall = getRootCallForType(options.schema, fieldDecl.type);
+  // if (rootCall) {
+  //   metadata.rootCall = rootCall.name;
+  //   if (rootCall.arg) {
+  //     metadata.pk = rootCall.arg;
+  //   }
+  // }
+  if (alwaysImplementsNode(options.schema, fieldDecl.type)) {
+    metadata.rootCall = 'node';
+    metadata.pk = 'id';
+  }
+
+  var connectionMetadata = getConnectionMetadata(fieldDecl);
+  if (connectionMetadata) {
+    metadata.connection = true;
+
+    if (!getArgNamed(fieldDecl, 'find')) {
+      metadata.nonFindable = true;
+    }
+
+    if (hasArgument(field, 'first') && hasArgument(field, 'before')) {
+      throw new Error(util.format('Connections arguments `%s(before: <cursor>, first: <count>)` are ' + 'not supported. Use `(first: <count>)`, ' + '`(after: <cursor>, first: <count>)`, or ' + '`(before: <cursor>, last: <count>)`.', fieldName));
+    }
+    if (hasArgument(field, 'last') && hasArgument(field, 'after')) {
+      throw new Error(util.format('Connections arguments `%s(after: <cursor>, last: <count>)` are ' + 'not supported. Use `(last: <count>)`, ' + '`(before: <cursor>, last: <count>)`, or ' + '`(after: <cursor>, first: <count>)`.', fieldName));
+    }
+
+    var hasEdgesSelection = false;
+    var selections = getSelections(field);
+    selections.forEach(function (subfield) {
+      if (subfield.kind !== kinds.FIELD) {
+        return;
+      }
+      var subfieldName = getName(subfield);
+      var subfieldDecl = types.getNamedType(fieldDecl.type).getFields()[subfieldName];
+      var subfieldType = types.getNamedType(subfieldDecl.type);
+      if (subfieldName !== 'edges' && isList(subfieldDecl.type) && subfieldType.name === connectionMetadata.nodeType.name) {
+        // Detect eg `nodes{...}` instead of `edges{node{...}}`
+        throw new Error(util.format('Unsupported `%s{...}` field on connection `%s`. Use ' + '`edges{node{...}}` instead.', subfieldName, fieldName));
+      }
+    });
+  } else if (types.getNamedType(fieldDecl.type).name === 'PageInfo') {
+    subRequisiteFields.hasNextPage = true;
+    subRequisiteFields.hasPreviousPage = true;
+  } else if (isEdgeType(fieldDecl.type)) {
+    subRequisiteFields.cursor = true;
+    subRequisiteFields.node = true;
+  }
+
+  if (types.isAbstractType(fieldDecl.type)) {
+    metadata.dynamic = true;
+    subRequisiteFields.__typename = true;
+  }
+
+  if (isList(fieldDecl.type)) {
+    metadata.plural = true;
+  }
+
+  var fieldsAndFragments = printFieldsAndFragments(field.selectionSet, fieldDecl.type, options, subRequisiteFields, types.getNamedType(fieldDecl.type).name);
+  var fields = fieldsAndFragments.fields;
+  var fragments = fieldsAndFragments.fragments;
+  var directives = printDirectives(field.directives);
+
+  if (isGenerated) {
+    metadata.generated = true;
+  }
+  if (requisiteFields.hasOwnProperty(fieldName)) {
+    metadata.requisite = true;
+  }
+
+  var calls = printCalls(field, fieldDecl);
+  var fieldAlias = field.alias ? field.alias.value : null;
+
+  return t.newExpression(t.memberExpression(t.identifier('GraphQL'), t.identifier('Field')), trimArguments([t.literal(fieldName), fields, fragments, calls, t.literal(fieldAlias), NULL, objectify(metadata), directives]));
+}
+
+function printDirectives(directives) {
+  if (!directives || !directives.length) {
+    return NULL;
+  }
+  var printedDirectives;
+  directives.forEach(function (directive) {
+    var name = getName(directive);
+    if (name === 'relay') {
+      return;
+    }
+    printedDirectives = printedDirectives || [];
+    printedDirectives.push(t.objectExpression([property('name', t.literal(getName(directive))), property('arguments', t.arrayExpression(directive.arguments.map(function (argument) {
+      return t.objectExpression([property('name', t.literal(getName(argument))), property('value', printArgument(argument.value))]);
+    })))]));
+  });
+  if (!printedDirectives) {
+    return NULL;
+  }
+  return t.arrayExpression(printedDirectives);
+}
+
+function printCalls(field, fieldDecl, options) {
+  if (field.arguments.length === 0) {
+    return NULL;
+  }
+
+  // Each GraphQL RFC argument is mapped to a separate call. For GraphQL FB
+  // calls with multiple arguments, we use GraphQL RFC array literals.
+  var callStrings = field.arguments.map(function (arg) {
+    var callName = getName(arg);
+    var callDecl = getArgNamed(fieldDecl, callName);
+    if (!callDecl) {
+      throw new Error(util.format('Unknown call "%s" on field "%s".', callName, fieldDecl.name));
+    }
+
+    var metadata = {};
+    var typeName = getTypeForMetadata(callDecl.type);
+    if (typeName) {
+      metadata.type = typeName;
+    }
+    return t.newExpression(t.memberExpression(t.identifier('GraphQL'), t.identifier('Callv')), trimArguments([t.literal(callName), printArguments(arg), objectify(metadata)]));
+  });
+  return t.arrayExpression(callStrings);
+}
+
+/**
+ * Collects the values of the `@relay` directive in an object, if the directive
+ * is defined and has values.
+ *
+ * Input:
+ *   `fragment on User @relay(plural: true) {...}`
+ * Output:
+ *   `{plural: true}`
+ */
+function getRelayDirectiveMetadata(node) {
+  var relayDirective;
+  node.directives.forEach(function (directive) {
+    if (getName(directive) === 'relay') {
+      relayDirective = directive;
+    }
+  });
+  if (!relayDirective) {
+    return;
+  }
+  return relayDirective.arguments.reduce(function (acc, arg) {
+    acc[getName(arg)] = getScalarValue(arg);
+    return acc;
+  }, {});
+}
+
+function getScalarValue(node) {
+  if (node && node.value && node.value.kind) {
+    var kind = node.value.kind;
+    var value = node.value.value;
+    if (kind === 'BooleanValue') {
+      return !!value;
+    } else if (kind === 'IntValue') {
+      return parseInt(value, 10);
+    } else {
+      if (kind !== 'StringValue') {
+        throw new Error('Expected `@relay(...)` argument values to be scalars, got ' + kind);
+      }
+      return value;
+    }
+  }
+}
+
+function getTypeForMetadata(type) {
+  var namedType = types.getNamedType(type);
+  if (namedType instanceof types.GraphQLEnumType || namedType instanceof types.GraphQLInputObjectType) {
+    return String(type);
+  } else if (namedType instanceof types.GraphQLScalarType) {
+    return null;
+  }
+  throw new Error('Unsupported call value type ' + namedType.name);
+}
+
+function isEnum(type) {
+  return types.getNullableType(type) instanceof types.GraphQLEnumType;
+}
+
+function isList(type) {
+  return types.getNullableType(type) instanceof types.GraphQLList;
+}
+
+function getName(node) {
+  if (node && node.name && node.name.kind === kinds.NAME) {
+    return node.name.value;
+  } else if (node && node.typeCondition) {
+    return getTypeName(node);
+  }
+  throw new Error('Expected node to have a name');
+}
+
+function getTypeName(node) {
+  if (node && node.typeCondition) {
+    if (node.typeCondition.kind === kinds.NAMED_TYPE) {
+      return getName(node.typeCondition);
+    } else if (node.typeCondition.kind === kinds.NAME) {
+      return node.typeCondition.value;
+    }
+  }
+  throw new Error('Expected node to have a name');
+}
+
+function isOrImplementsNode(schema, type) {
+  var namedType = types.getNamedType(type);
+  if (namedType.name === 'Node') {
+    return true;
+  }
+  if (!(namedType instanceof types.GraphQLObjectType)) {
+    return false;
+  }
+  var node = schema.getType('Node');
+  return namedType.getInterfaces().indexOf(node) !== -1;
+}
+
+function mightImplementNode(schema, type) {
+  var namedType = types.getNamedType(type);
+  if (isOrImplementsNode(schema, namedType)) {
+    return true;
+  }
+
+  if (!types.isAbstractType(namedType)) {
+    return false;
+  }
+
+  return namedType.getPossibleTypes().some(function (subtype) {
+    return isOrImplementsNode(schema, subtype);
+  });
+}
+
+function alwaysImplementsNode(schema, type) {
+  var namedType = types.getNamedType(type);
+  if (isOrImplementsNode(schema, namedType)) {
+    return true;
+  }
+
+  if (!types.isAbstractType(namedType)) {
+    return false;
+  }
+
+  return namedType.getPossibleTypes().every(function (subtype) {
+    return isOrImplementsNode(schema, subtype);
+  });
+}
+
+function getRootCallForType(schema, type) {
+  if (alwaysImplementsNode(schema, type)) {
+    return { name: 'node', arg: 'id' };
+  }
+  return null;
+}
+
+function isConnectionType(type) {
+  return (/.+Connection$/.test(type.name)
+  );
+}
+
+function hasIdField(type) {
+  return !!(type.getFields && type.getFields()['id']);
+}
+
+function isEdgeType(type) {
+  var namedType = types.getNamedType(type);
+  return (/.+Edge$/.test(namedType.name) && !!namedType.getFields()['node'] && !!namedType.getFields()['cursor']
+  );
+}
+
+function getArgNamed(field, name) {
+  var remaining = field.args.filter(function (arg) {
+    return arg.name === name;
+  });
+  return remaining.length === 1 ? remaining[0] : null;
+}
+
+function getConnectionMetadata(fieldDecl) {
+  // Connections must be limitable.
+  if (!getArgNamed(fieldDecl, 'first') && !getArgNamed(fieldDecl, 'last')) {
+    return null;
+  }
+  return getConnectionMetadataForType(fieldDecl.type);
+}
+
+function getConnectionMetadataForType(type) {
+  if (!isConnectionType(type)) {
+    return null;
+  }
+
+  var fieldType = types.getNamedType(type);
+
+  // Connections must have a non-scalar `edges` field.
+  var edgesField = fieldType.getFields()['edges'];
+  if (!edgesField) {
+    return null;
+  }
+  var edgesType = types.getNamedType(edgesField.type);
+  if (edgesType instanceof types.GraphQLScalarType) {
+    return null;
+  }
+
+  // Connections' `edges` field must have a non-scalar `node` field.
+  var edgesType = types.getNamedType(edgesField.type);
+  var nodeField = edgesType.getFields()['node'];
+  if (!nodeField) {
+    return null;
+  }
+  var nodeType = types.getNamedType(nodeField.type);
+  if (nodeType instanceof types.GraphQLScalarType) {
+    return null;
+  }
+  // Connections' `edges` field must have a scalar `cursor` field.
+  var cursorField = edgesType.getFields()['cursor'];
+  if (!cursorField) {
+    return null;
+  }
+  var cursorType = types.getNamedType(cursorField.type);
+  if (!(cursorType instanceof types.GraphQLScalarType)) {
+    return null;
+  }
+  return {
+    cursorType: cursorType,
+    cursorField: cursorField,
+    edgesType: edgesType,
+    edgesField: edgesField,
+    nodeType: nodeType,
+    nodeField: nodeField
+  };
+}
+
+/**
+ * Returns the definition of the given `field` within the parent type,
+ * or introspection types for `__type`, `__schema`, and `__typename` fields.
+ *
+ * Note: this is adapted from `graphql`:
+ * https://github.com/graphql/graphql-js/blob/81a7d7add03adbb14dc852bbe45ab030c0601489/src/utilities/TypeInfo.js#L212-L237
+ */
+function getFieldDef(schema, parentType, field) {
+  var fieldName = getName(field);
+  if (fieldName === SchemaMetaFieldDef.name && schema.getQueryType() === parentType) {
+    return SchemaMetaFieldDef;
+  }
+  if (fieldName === TypeMetaFieldDef.name && schema.getQueryType() === parentType) {
+    return TypeMetaFieldDef;
+  }
+  if (fieldName === TypeNameMetaFieldDef.name && (parentType instanceof types.GraphQLObjectType || parentType instanceof types.GraphQLInterfaceType || parentType instanceof types.GraphQLUnionType)) {
+    return TypeNameMetaFieldDef;
+  }
+  return types.getNamedType(parentType).getFields()[fieldName];
+}
+
+function objectify(obj) {
+  if (obj == null) {
+    return NULL;
+  }
+  var keys = Object.keys(obj);
+  if (!keys.length) {
+    return NULL;
+  }
+  return t.objectExpression(keys.map(function (key) {
+    return property(key, t.literal(obj[key]));
+  }));
+}
+
+function identify(str) {
+  return str.split('.').reduce(function (acc, name) {
+    if (!acc) {
+      return t.identifier(name);
+    }
+    return t.memberExpression(acc, t.identifier(name));
+  }, null);
+}
+
+function property(name, value) {
+  return t.property('init', t.identifier(name), value);
+}
+
+function trimArguments(args) {
+  var lastIndex = -1;
+  for (var ii = args.length - 1; ii >= 0; ii--) {
+    if (args[ii] == null) {
+      throw new Error('Use `NULL` to indicate that output should be the literal value `null`.');
+    }
+    if (args[ii] !== NULL) {
+      lastIndex = ii;
+      break;
+    }
+  }
+  return args.slice(0, lastIndex + 1);
+}
+
+function getSelections(node) {
+  if (node.selectionSet && node.selectionSet.selections) {
+    return node.selectionSet.selections;
+  }
+  return [];
+}
+
+function hasArgument(field, argumentName) {
+  for (var ix = 0; ix < field.arguments.length; ix++) {
+    if (getName(field.arguments[ix]) === argumentName) {
+      return true;
+    }
+  }
+  return false;
+}
+
+module.exports = RelayQLPrinter;

--- a/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var assert = require('assert');
+var formatError = require('graphql/error').formatError;
+var RelayQLPrinter = require('./RelayQLPrinter');
+var parser = require('graphql/language/parser');
+var Source = require('graphql/language/source').Source;
+var validate = require('graphql/validation/validate').validate;
+var util = require('util');
+
+function RelayQLTransformer(schema /*: GraphQLSchema */) {
+  this.schema = schema;
+}
+
+RelayQLTransformer.prototype.transformQuery = function (queryAndSubstitutions, documentName, /*: string */
+tagName /*: string */
+) /*: string */{
+  var queryDocument = this.parseDocument(queryAndSubstitutions.text, documentName);
+  var printer = new RelayQLPrinter(this.schema, tagName);
+  return printer.getCode(queryDocument, queryAndSubstitutions.substitutions);
+};
+
+RelayQLTransformer.prototype.parseDocument = function (query, /*: string */
+documentName /*: string */
+) /*: string */{
+  var match = /^(fragment|mutation|query)\s*(\w*)?([\s\S]*)/.exec(query);
+  assert(match, util.format('GraphQL: expected query `%s...` to start with a document type. ' + 'Specify `fragment`, `mutation`, or `query`.', query.substr(0, 20)));
+  var type = match[1];
+  var name = match[2] || documentName;
+  var rest = match[3];
+
+  if (type === 'fragment' && name === 'on') {
+    // Allow `fragment on User {...}`
+    rest = 'on' + rest;
+    name = documentName;
+  }
+
+  name = this.getName(name);
+  var queryText = type + ' ' + name + ' ' + rest;
+  return parse(type, queryText, this.schema).definitions[0];
+};
+
+RelayQLTransformer.prototype.getName = function (documentName /*: string */
+) /*: string */{
+  if (!documentName || !documentName.length) {
+    throw new Error('RelayQLTransformer: expected document to have a name.');
+  }
+  return documentName[0].toUpperCase() + documentName.slice(1);
+};
+
+/**
+ * Parses a query document into an AST, returning the AST plus any validation
+ * errors.
+ */
+function parse(type, /*: string */
+text, /*: string */
+schema /*: GraphQLSchema */
+) /*: any */{
+  var source = new Source(text, 'GraphQL Document');
+  var documentAST = parser.parse(source);
+  var rules = [require('graphql/validation/rules/ArgumentsOfCorrectType').ArgumentsOfCorrectType, require('graphql/validation/rules/DefaultValuesOfCorrectType').DefaultValuesOfCorrectType, require('graphql/validation/rules/FieldsOnCorrectType').FieldsOnCorrectType, require('graphql/validation/rules/FragmentsOnCompositeTypes').FragmentsOnCompositeTypes, require('graphql/validation/rules/KnownArgumentNames').KnownArgumentNames, require('graphql/validation/rules/KnownTypeNames').KnownTypeNames, require('graphql/validation/rules/PossibleFragmentSpreads').PossibleFragmentSpreads, require('graphql/validation/rules/PossibleFragmentSpreads').PossibleFragmentSpreads, require('graphql/validation/rules/VariablesInAllowedPosition').VariablesInAllowedPosition];
+  if (type !== 'mutation') {
+    rules.push(require('graphql/validation/rules/ProvidedNonNullArguments').ProvidedNonNullArguments);
+  }
+  var validationErrors = validate(schema, documentAST, rules);
+  if (validationErrors && validationErrors.length > 0) {
+    validationErrors = validationErrors.map(formatError);
+    var error = new Error('This document is invalid');
+    error.validationErrors = validationErrors;
+    error.sourceText = text;
+    throw error;
+  }
+  return documentAST;
+}
+
+module.exports = RelayQLTransformer;

--- a/scripts/babel-relay-plugin/lib/__tests__/getBabelGraphQLPlugin-test.js
+++ b/scripts/babel-relay-plugin/lib/__tests__/getBabelGraphQLPlugin-test.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var path = require('path');
+var readFixtures = require('../readFixtures');
+var transformGraphQL = require('../transformGraphQL');
+
+var SCHEMA_PATH = path.resolve(__dirname, './testschema.rfc.json');
+
+var transform = transformGraphQL.bind(null, SCHEMA_PATH);
+
+describe('getBabelRelayPlugin', function () {
+  var fixtures = readFixtures();
+
+  Object.keys(fixtures).forEach(function (testName) {
+    var fixture = fixtures[testName];
+    if (fixture.output !== undefined) {
+      var expected;
+      try {
+        expected = trimCode(transform(fixture.output, testName));
+      } catch (e) {
+        throw new Error('Failed to transform output for `' + testName + '`:\n' + e.stack);
+      }
+
+      it('transforms GraphQL RFC for `' + testName + '`', function () {
+        var actual = trimCode(transform(fixture.input, testName));
+        expect('\n' + actual + '\n').toBe('\n' + expected + '\n');
+      });
+    } else {
+      it('throws for GraphQL fixture: ' + testName, function () {
+        expect(function () {
+          transform(fixture.input, testName);
+        }).toThrow(fixtures.error);
+      });
+    }
+  });
+});
+
+function trimCode(code) {
+  return code.replace(/\s*([\[\]\(\){};,=:])\s*/g, '$1').replace(/;+/, ';').replace(/\s+/g, ' ');
+}

--- a/scripts/babel-relay-plugin/lib/generateSchemaJson.js
+++ b/scripts/babel-relay-plugin/lib/generateSchemaJson.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * Running this script from the base directory will regenerate
+ * testschema.rfc.json from testschema.rfc.graphql
+ */
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var schema = require('graphql/language/schema');
+var utilities = require('graphql/utilities');
+var graphql = require('graphql');
+
+try {
+  var inFile = path.resolve(__dirname, '__tests__', 'testschema.rfc.graphql');
+  var outFile = path.resolve(__dirname, '__tests__', 'testschema.rfc.json');
+
+  var body = fs.readFileSync(inFile, 'utf8');
+  var ast = schema.parseSchemaIntoAST(body);
+  var astSchema = utilities.buildASTSchema(ast, 'Root', 'Mutation');
+  graphql.graphql(astSchema, utilities.introspectionQuery).then(function (result) {
+    var out = JSON.stringify(result, null, 2);
+    fs.writeFileSync(outFile, out);
+  });
+} catch (error) {
+  console.error(error);
+  console.error(error.stack);
+}

--- a/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var RelayQLTransformer = require('./RelayQLTransformer');
+var buildClientSchema = require('graphql/utilities/buildClientSchema').buildClientSchema;
+
+var assert = require('assert');
+var path = require('path');
+
+var PROVIDES_MODULE = 'providesModule';
+
+/**
+ * Extract text from a template string.
+ */
+function extractTemplate(node) {
+  var text = '';
+  var substitutions = [];
+  var templateElements = node.quasi.quasis;
+  for (var ii = 0; ii < templateElements.length; ii++) {
+    var template = templateElements[ii];
+    text += template.value.cooked.trim();
+    if (!template.tail) {
+      var sub = 'sub_' + ii;
+      substitutions.push(sub);
+      text += '...' + sub;
+
+      var nextTemplate = templateElements[ii + 1];
+      if (nextTemplate && !/^\s*[,\}]/.test(nextTemplate)) {
+        text += ',';
+      }
+    }
+  }
+  return { text: text, substitutions: substitutions };
+}
+
+/**
+ * Returns a new Babel Transformer that uses the supplied schema to transform
+ * template strings tagged with `Relay.QL` into an internal representation of
+ * GraphQL queries.
+ */
+function getBabelRelayPlugin(schemaProvider, /*: Object | Function */
+options /*: ?Object */
+) {
+  return function (babel) {
+    var Plugin = babel.Plugin;
+    var t = babel.types;
+
+    options = options || {};
+
+    var warning = options.suppressWarnings ? function () {} : console.warn.bind(console);
+
+    return new Plugin('relay-query', {
+      visitor: {
+        /**
+         * Extract the module name from `@providesModule`.
+         */
+        Program: function Program(node, parent, scope, state) {
+          if (state.opts.extra.documentName) {
+            return;
+          }
+          var documentName;
+          if (parent.comments && parent.comments.length) {
+            var docblock = parent.comments[0].value || '';
+            var propertyRegex = /@(\S+) *(\S*)/g;
+            var match;
+            while (match = propertyRegex.exec(docblock)) {
+              var property = match[1];
+              var value = match[2];
+              if (property === PROVIDES_MODULE) {
+                documentName = value.replace(/[\.-:]/g, '_');
+                break;
+              }
+            }
+          }
+          var filename = state.opts.filename;
+          if (filename && !documentName) {
+            var basename = path.basename(filename);
+            var captures = basename.match(/^[_A-Za-z][_0-9A-Za-z]*/);
+            if (captures) {
+              documentName = captures[0];
+            }
+          }
+          if (documentName) {
+            state.opts.extra.documentName = documentName;
+          }
+        },
+
+        /**
+         * Transform Relay.QL`...`.
+         */
+        TaggedTemplateExpression: function TaggedTemplateExpression(node, parent, scope, state) {
+          if (!this.get('tag').matchesPattern('Relay.QL')) {
+            return;
+          }
+
+          var documentTransformer = state.opts.extra.documentTransformer;
+          if (!documentTransformer) {
+            var schema = getSchema(schemaProvider);
+            documentTransformer = new RelayQLTransformer(schema);
+            state.opts.extra.documentTransformer = documentTransformer;
+          }
+          assert(documentTransformer instanceof RelayQLTransformer, 'getBabelRelayPlugin(): Expected a document transformer to be ' + 'configured for this instance of the plugin.');
+
+          var extractedTemplate = extractTemplate(node);
+          var documentName = state.opts.extra.documentName || 'UnknownFile';
+          var code;
+          try {
+            code = documentTransformer.transformQuery(extractedTemplate, documentName, 'Relay.QL');
+          } catch (error) {
+            // Print a console warning and replace the code with a function
+            // that will immediately throw an error in the browser.
+            var filename = state.opts.filename || 'UnknownFile';
+            var sourceText = error.sourceText;
+            var validationErrors = error.validationErrors;
+            var errorMessages;
+            if (validationErrors && sourceText) {
+              var sourceLines = sourceText.split('\n');
+              validationErrors.forEach(function (validationError) {
+                errorMessages = errorMessages || [];
+                errorMessages.push(validationError.message);
+                warning('\n-- GraphQL Validation Error -- %s --\n', path.basename(filename));
+                warning('Error: ' + validationError.message + '\n' + 'File:  ' + filename + '\n' + 'Source:');
+                validationError.locations.forEach(function (location) {
+                  var preview = sourceLines[location.line - 1];
+                  var prefix = '> ';
+                  var highlight = repeat(' ', location.column - 1) + '^^^';
+                  if (preview) {
+                    warning(prefix);
+                    warning(prefix + preview);
+                    warning(prefix + highlight);
+                  }
+                });
+              });
+            } else {
+              errorMessages = [error.message];
+              warning('\n-- Relay Transform Error -- %s --\n', path.basename(filename));
+              warning('Error: ' + error.message + '\n' + 'File:  ' + filename + '\n');
+            }
+
+            var message = 'GraphQL validation/transform error ``' + errorMessages.join(' ') + '`` in file `' + filename + '`.';
+            code = t.functionExpression(null, [], t.blockStatement([t.throwStatement(t.newExpression(t.identifier('Error'), [t.literal(message)]))]));
+
+            if (options.debug) {
+              console.log(error.message);
+              console.log(error.stack);
+            }
+            if (options.abortOnError) {
+              throw new Error('Aborting due to GraphQL validation/transform error(s).');
+            }
+          }
+
+          // Immediately invoke the function with substitutions as arguments.
+          var substitutions = node.quasi.expressions;
+          var funcCall = t.callExpression(code, substitutions);
+          this.replaceWith(funcCall);
+        }
+      }
+    });
+  };
+}
+
+function repeat(char, count) {
+  var str = '';
+  while (str.length < count) {
+    str += char;
+  }
+  return str;
+}
+
+function getSchema(schemaProvider /*: Object | Function */
+) /*: GraphQLSchema */{
+  var schemaData = typeof schemaProvider === 'function' ? schemaProvider() : schemaProvider;
+  assert(typeof schemaData === 'object' && schemaData !== null && typeof schemaData.__schema === 'object' && schemaData.__schema !== null, 'getBabelRelayPlugin(): Expected schema to be an object with a ' + '`__schema` property.');
+  return buildClientSchema(schemaData);
+}
+
+module.exports = getBabelRelayPlugin;
+/*: Object */

--- a/scripts/babel-relay-plugin/lib/readFixtures.js
+++ b/scripts/babel-relay-plugin/lib/readFixtures.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var FIXTURE_PATH = path.join(__dirname, '__fixtures__');
+
+function readFixtures() {
+  var fileNames = fs.readdirSync(FIXTURE_PATH);
+  var fixtures = {};
+  fileNames.forEach(function (filename) {
+    var match = filename.match(/^\w+\.fixture$/);
+    if (match === null) {
+      return;
+    }
+    var name = match[0];
+    var data = fs.readFileSync(path.join(FIXTURE_PATH, filename), { encoding: 'utf8' });
+    var parts;
+
+    // Matches a file of form:
+    //   Input:
+    //   <code>
+    //   Output:
+    //   <code>
+    parts = data.match(new RegExp('(?:^|\\n)' + ['Input:\\n([\\s\\S]*)', 'Output:\\n([\\s\\S]*)'].join('\\n') + '$'));
+    if (parts) {
+      fixtures[name] = {
+        input: parts[1].trim(),
+        output: parts[2].trim()
+      };
+      return;
+    }
+
+    // Matches a file of form:
+    //   Input:
+    //   <code>
+    //   Error:
+    //   <code>
+    parts = data.match(new RegExp('(?:^|\\n)' + ['Input:\\n([\\s\\S]*)', 'Error:\\n([\\s\\S]*)'].join('\\n') + '$'));
+    if (parts) {
+      fixtures[name] = {
+        input: parts[1].trim(),
+        error: parts[2].trim()
+      };
+      return;
+    }
+
+    throw new Error('Invalid fixture file: ' + filename);
+  });
+
+  return fixtures;
+}
+
+module.exports = readFixtures;

--- a/scripts/babel-relay-plugin/lib/regenerateFixtures.js
+++ b/scripts/babel-relay-plugin/lib/regenerateFixtures.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var transformGraphQL = require('./transformGraphQL');
+var readFixtures = require('./readFixtures');
+
+var FIXTURE_PATH = path.join(__dirname, '__fixtures__');
+var SCHEMA_PATH = path.resolve(__dirname, '__tests__', './testschema.rfc.json');
+
+function writeFile(basename, text) {
+  fs.writeFileSync(path.join(FIXTURE_PATH, basename), text, 'utf8');
+}
+
+var transform = transformGraphQL.bind(null, SCHEMA_PATH);
+
+function genFixtures() {
+  var fixtures = readFixtures();
+  Object.keys(fixtures).forEach(function (filename) {
+    var fixture = fixtures[filename];
+    if (fixture.output !== undefined) {
+      // fixture for valid input, update the expected output
+      try {
+        var graphql = transform(fixture.input, filename);
+        writeFile(filename, ['Input:', fixture.input, '', // newline
+        'Output:', graphql].join('\n'));
+        console.log('Updated fixture `%s`.', filename);
+      } catch (e) {
+        console.error('Failed to transform fixture `%s`: %s: %s', filename, e.message, e.stack);
+      }
+    } // else: fixture for invalid code, nothing to update
+  });
+}
+
+genFixtures();

--- a/scripts/babel-relay-plugin/lib/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/lib/transformGraphQL.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var babel = require('babel-core');
+var fs = require('fs');
+var path = require('path');
+var util = require('util');
+
+var getBabelRelayPlugin = require('./getBabelRelayPlugin');
+
+var _schemas = {};
+function getSchema(schemaPath) {
+  try {
+    var schema = _schemas[schemaPath];
+    if (!schema) {
+      schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')).data;
+      _schemas[schemaPath] = schema;
+    }
+    return schema;
+  } catch (e) {
+    throw new Error(util.format('transformGraphQL(): Failed to read schema path `%s`. Error: %s, %s', schemaPath, e.message, e.stack));
+  }
+}
+
+function transformGraphQL(schemaPath, source, filename) {
+  var plugin = getBabelRelayPlugin(getSchema(schemaPath), {
+    abortOnError: false,
+    suppressWarnings: true
+  });
+  return babel.transform(source, {
+    compact: false,
+    filename: filename,
+    plugins: [plugin],
+    blacklist: ['strict'],
+    extra: {
+      providesModule: 'Fixture',
+      debug: false
+    }
+  }).code;
+}
+
+module.exports = transformGraphQL;

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -4,19 +4,22 @@
   "description": "Babel Relay Plugin for transpiling GraphQL queries for use with Relay.",
   "license": "BSD-3-Clause",
   "repository": "facebook/relay",
-  "main": "src/getBabelRelayPlugin.js",
+  "main": "lib/getBabelRelayPlugin.js",
   "scripts": {
+    "build": "babel src --out-dir lib --ignore __tests__",
+    "prepublish": "npm run build",
     "test": "./testjs",
-    "update-schema": "node ./src/tools/generateSchemaJson.js",
-    "update-fixtures": "node ./src/tools/regenerateFixtures.js"
+    "update-schema": "babel-node ./src/tools/generateSchemaJson.js",
+    "update-fixtures": "babel-node ./src/tools/regenerateFixtures.js"
   },
   "files": [
     "LICENSE",
     "PATENTS",
     "README.md",
-    "src/"
+    "lib/"
   ],
   "devDependencies": {
+    "babel": "^5.8.23",
     "jasmine-node": "1.14.5",
     "minimist": "^1.1.3"
   },


### PR DESCRIPTION
Changes `babel-relay-plugin` to be compiled via Babel. This will let us start using ES2015 features without having to require all users to use node v4+.

Tested by removing all `node_modules` and `lib` directories and running installation steps on the `README.md`.