### PR TITLE
Don't require babel to be installed globally

### DIFF
--- a/examples/relay-treasurehunt/package.json
+++ b/examples/relay-treasurehunt/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "babel-node ./server.js",
     "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install --ignore-scripts"
+    "preinstall": "cd ../.. && npm install --ignore-scripts && cd scripts/babel-relay-plugin && npm install --ignore-scripts"
   },
   "dependencies": {
     "babel": "5.8.23",

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "babel-node ./server.js",
     "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install --ignore-scripts"
+    "preinstall": "cd ../.. && npm install --ignore-scripts && cd scripts/babel-relay-plugin && npm install --ignore-scripts"
   },
   "dependencies": {
     "babel": "5.8.23",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "start": "babel-node ./server.js",
     "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install --ignore-scripts"
+    "preinstall": "cd ../.. && npm install --ignore-scripts && cd scripts/babel-relay-plugin && npm install --ignore-scripts"
   },
   "dependencies": {
     "babel": "5.8.23",


### PR DESCRIPTION
While investigating an issue reported for the todomvc example
(https://github.com/facebook/relay/issues/408), I tried to repro as follows:

```
git checkout master
git fetch upstream
git merge upstream/master
npm install && npm run update-schema && npm run start
```

But it went boom during the `npm install` because I didn't have `babel`
installed globally:

```
sh: babel: command not found
```

(Full output at https://gist.github.com/wincent/3221694ee3fdc46084f4)

What's happening here:

- example's `preinstall` tries to run `install` from the top-level
- top-level `install` tries to install babel-relay-plugin dependency
- babel-relay-plugin `build` step runs and tries to shell out to `babel`
- `babel` call will blow up if not globally installed, even though babel
  is listed as a dev dependency

Workaround:

```
npm install -g babel
```

Fix employed here: we add `npm install --ignore-scripts` to the
babel-relay-plugin `build` recipe, causing it to become available in
`node_modules` and therefore the `$PATH` when the `babel` command later
runs. Note that without the `--ignore-scripts` we get into an infinite
loop, although I am not sure of the exact chain of cause and effect
because all we see on the console at that point is this, endlessly
repeated:

```
> babel-relay-plugin@0.2.6 build /Users/glh/code/relay/scripts/babel-relay-plugin
> rm -rf lib; npm install; npm run babel
```

Also note the use of `;` instead of `&&` in the interest of preserving
potential future compatibility with Windows.

I think this change should be ok for end users or the
babel-relay-plugin, as they don't end up running the `build` script and
instead just get whatever we built into `lib/`.

Test Plan: Blow away global babel (`npm uninstall -g babel`) and example
`node_modules` and then `npm install` from inside example or top-level,
see it no longer blows from.