### PR TITLE
Move subscription count handling to `RelayStoreData`.

### DIFF
--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -371,6 +371,26 @@ class RelayStoreData {
       clientMutationID
     );
   }
+
+  /**
+   * Decreases the number of subscriptions for the given dataID by 1
+   */
+  decreaseSubscriptionsFor(dataID: DataID): void {
+    if (this._garbageCollector) {
+      this._garbageCollector.decreaseSubscriptionsFor(dataID);
+    }
+  }
+
+  /**
+   * Increases the number of subscriptions for the given dataID by 1. If the
+   * dataID is not yet registered it will be registered.
+   */
+  increaseSubscriptionsFor(dataID: DataID): void {
+    if (this._garbageCollector) {
+      this._garbageCollector.increaseSubscriptionsFor(dataID);
+    }
+  }
+
 }
 
 RelayProfiler.instrumentMethods(RelayStoreData.prototype, {


### PR DESCRIPTION
Currently `GraphQLStoreQueryResolver` is aware of the
`RelayStoreGarbageCollection` and updates the subscription-count directly. This
unnecessarily makes the `GraphQLStoreQueryResolver` aware of garbage collection.
Using `RelayStoreData` as a layer between decouples the components. Furthermore
this will help implementing `RelayStoreData#reset` since we can in the future
keep track of active subscriptions in `RelayStoreData` itself.