### PR TITLE
Fix minor issue in the new relay docs

### DIFF
--- a/docs/QuickStart-ThinkingInGraphQL.md
+++ b/docs/QuickStart-ThinkingInGraphQL.md
@@ -25,7 +25,7 @@ rest.get('/stories').then(stories =>
   ))
 ).then(stories => {
   // This resolves to a list of story items:
-  // `[ { id: "...", message: "..." } ]`
+  // `[ { id: "...", text: "..." } ]`
   console.log(stories);
 });
 ```
@@ -33,10 +33,10 @@ rest.get('/stories').then(stories =>
 Note that this approach requires *n+1* requests to the server: 1 to fetch the list, and *n* to fetch each item. With GraphQL we can fetch the same data in a single network request to the server (without creating a custom endpoint that we'd then have to maintain):
 
 ```javascript
-graphql.get(`query { stories { id, message } }`).then(
+graphql.get(`query { stories { id, text } }`).then(
   stories => {
     // A list of story items:
-    // `[ { id: "...", message: "..." } ]`
+    // `[ { id: "...", text: "..." } ]`
     console.log(stories);
   }
 );
@@ -83,13 +83,13 @@ Now, requests for previously cached data can be answered immediately without mak
 With GraphQL it is very common for the results of multiple queries to overlap. However, our response cache from the previous section doesn't account for this overlap - it caches based on distinct queries. For example, if we issue a query to fetch stories:
 
 ```
-query { stories { id, message, likeCount } }
+query { stories { id, text, likeCount } }
 ```
 
 and then later refetch one of the stories whose `likeCount` has since been incremented:
 
 ```
-query { story(id: "123") { id, message, likeCount } }
+query { story(id: "123") { id, text, likeCount } }
 ```
 
 We'll now see different `likeCount`s depending on how the story is accessed. A view that uses the first query will see an outdated count, while a view using the second query will see the updated count.
@@ -116,7 +116,7 @@ And here's a possible response:
 ```
 query: {
   story: {
-     message: "Relay is open-source!",
+     text: "Relay is open-source!",
      author: {
        name: "Jan"
      }
@@ -130,7 +130,7 @@ Although the response is hierarchical, we'll cache it by flattening all the reco
 Map {
   // `story(id: "1")`
   1: Map {
-    message: 'Relay is open-source!',
+    text: 'Relay is open-source!',
     author: Link(2),
   },
   // `story.author`
@@ -165,7 +165,7 @@ Note that this normalized cache structure allows overlapping results to be cache
 The first query was for a list of stories:
 
 ```
-query { stories { id, message, likeCount } }
+query { stories { id, text, likeCount } }
 ```
 
 With a normalized response cache, a record would be created for each story in the list. The `stories` field would store links to each of these records.
@@ -173,7 +173,7 @@ With a normalized response cache, a record would be created for each story in th
 The second query refetched the information for one of those stories:
 
 ```
-query { story(id: "123") { id, message, likeCount } }
+query { story(id: "123") { id, text, likeCount } }
 ```
 
 When this response is normalized, Relay can detect that this result overlaps with existing data based on its `id`. Rather than create a new record, Relay will update the existing `123` record. The new `likeCount` is therefore available to *both* queries, as well as any other query that might reference this story.

--- a/docs/QuickStart-ThinkingInRelay.md
+++ b/docs/QuickStart-ThinkingInRelay.md
@@ -7,7 +7,7 @@ permalink: docs/thinking-in-relay.html
 next: videos
 ---
 
-Relay's approach to data-fetching is heavily inspired by our experience with React. In particular, React breaks complex interfaces into reusable **components**, allowing developers to reason about discrete units of an application in isolation, and reducing the coupling between disparate parts of an application. Even more important is that these components are **declarative**: they allow developers to specify *what* the UI should like look for a given state, and not have to worry about *how* to show that UI. Unlike previous approaches that used imperative commands to manipulate native views (e.g. the DOM), React uses a UI description to automatically determine the necessary commands.
+Relay's approach to data-fetching is heavily inspired by our experience with React. In particular, React breaks complex interfaces into reusable **components**, allowing developers to reason about discrete units of an application in isolation, and reducing the coupling between disparate parts of an application. Even more important is that these components are **declarative**: they allow developers to specify *what* the UI should look like for a given state, and not have to worry about *how* to show that UI. Unlike previous approaches that used imperative commands to manipulate native views (e.g. the DOM), React uses a UI description to automatically determine the necessary commands.
 
 Let's look at some product use-cases to understand how we incorporated these ideas into Relay. We'll assume a basic familiarity with React.
 
@@ -27,7 +27,7 @@ Relay allows developers to annotate their React components with data dependencie
 
 ```
 fragment on Story {
-  message,
+  text,
   author {
     name,
     photo
@@ -48,7 +48,7 @@ var StoryContainer = Relay.createContainer(Story, {
     // Define a fragment with a name matching the `story` prop expected above
     story: () => Relay.QL`
       fragment on Story {
-        message,
+        text,
         author { ... }
       }
     `


### PR DESCRIPTION
In the Relay new docs, the query specifies a `text` field but the response has `message` instead. Feel free to ignore if I misunderstood anything. Thank you!