### PR TITLE
Fix build-lib script for BSD sed

### DIFF
--- a/scripts/babel-relay-plugin/scripts/build-lib
+++ b/scripts/babel-relay-plugin/scripts/build-lib
@@ -6,5 +6,7 @@ cd $ROOT_DIR
 rm -r lib
 babel src --out-dir lib --ignore __tests__,tools
 for file in $(find lib -name \*.js); do
-  sed -i '1i // @''generated' $file
+  echo '// @''generated' > $file.generated
+  cat $file >> $file.generated
+  mv $file.generated $file
 done


### PR DESCRIPTION
GNU and BSD `sed` have some differences. Make the script compatible with both by
using neither of them.