### PR TITLE
Relay: Simplify RQLTransformer Construction

### DIFF
--- a/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
@@ -33,13 +33,15 @@ var PROVIDES_MODULE = 'providesModule';
  * GraphQL queries.
  */
 function getBabelRelayPlugin(schemaProvider, pluginOptions) {
+  var schema = getSchema(schemaProvider);
+  var transformer = new RelayQLTransformer(schema);
+
   var options = pluginOptions || {};
+  var warning = options.suppressWarnings ? function () {} : console.warn.bind(console);
 
-  return function (babel) {
-    var Plugin = babel.Plugin;
-    var t = babel.types;
-
-    var warning = options.suppressWarnings ? function () {} : console.warn.bind(console);
+  return function (_ref) {
+    var Plugin = _ref.Plugin;
+    var t = _ref.types;
 
     return new Plugin('relay-query', {
       visitor: {
@@ -85,14 +87,6 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
             return;
           }
 
-          var transformer = state.opts.extra.transformer;
-          if (!transformer) {
-            var schema = getSchema(schemaProvider);
-            transformer = new RelayQLTransformer(schema);
-            state.opts.extra.transformer = transformer;
-          }
-          invariant(transformer instanceof RelayQLTransformer, 'getBabelRelayPlugin(): Expected RQLTransformer to be configured ' + 'for this instance of the plugin.');
-
           var documentName = state.opts.extra.documentName;
 
           invariant(documentName, 'Expected `documentName` to have been set.');
@@ -110,9 +104,9 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
             var errorMessages = [];
             if (validationErrors && sourceText) {
               var sourceLines = sourceText.split('\n');
-              validationErrors.forEach(function (_ref) {
-                var message = _ref.message;
-                var locations = _ref.locations;
+              validationErrors.forEach(function (_ref2) {
+                var message = _ref2.message;
+                var locations = _ref2.locations;
 
                 errorMessages.push(message);
                 warning('\n-- GraphQL Validation Error -- %s --\n', path.basename(filename));
@@ -147,9 +141,9 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
 }
 
 function getSchema(schemaProvider) {
-  var schemaData = typeof schemaProvider === 'function' ? schemaProvider() : schemaProvider;
-  invariant(typeof schemaData === 'object' && schemaData !== null && typeof schemaData.__schema === 'object' && schemaData.__schema !== null, 'getBabelRelayPlugin(): Expected schema to be an object with a ' + '`__schema` property.');
-  return buildClientSchema(schemaData);
+  var introspection = typeof schemaProvider === 'function' ? schemaProvider() : schemaProvider;
+  invariant(typeof introspection === 'object' && introspection && typeof introspection.__schema === 'object' && introspection.__schema, 'Invalid introspection data supplied to `getBabelRelayPlugin()`. The ' + 'resulting schema is not an object with a `__schema` property.');
+  return buildClientSchema(introspection);
 }
 
 module.exports = getBabelRelayPlugin;

--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -23,6 +23,7 @@ const util = require('util');
 const PROVIDES_MODULE = 'providesModule';
 
 type GraphQLSchema = Object;
+type GraphQLSchemaProvider = (Object | () => Object);
 
 /**
  * Returns a new Babel Transformer that uses the supplied schema to transform
@@ -30,23 +31,22 @@ type GraphQLSchema = Object;
  * GraphQL queries.
  */
 function getBabelRelayPlugin(
-  schemaProvider: Object | Function,
+  schemaProvider: GraphQLSchemaProvider,
   pluginOptions?: ?{
     abortOnError?: ?boolean;
     debug?: ?boolean;
     suppressWarnings?: ?boolean;
   }
 ): Function {
+  const schema = getSchema(schemaProvider);
+  const transformer = new RelayQLTransformer(schema);
+
   const options = pluginOptions || {};
+  const warning = options.suppressWarnings ?
+    function() {} :
+    console.warn.bind(console);
 
-  return babel => {
-    const Plugin = babel.Plugin;
-    const t = babel.types;
-
-    const warning = options.suppressWarnings ?
-      function() {} :
-      console.warn.bind(console);
-
+  return function({Plugin, types: t}) {
     return new Plugin('relay-query', {
       visitor: {
         /**
@@ -93,18 +93,6 @@ function getBabelRelayPlugin(
           if (!tagName) {
             return;
           }
-
-          let transformer = state.opts.extra.transformer;
-          if (!transformer) {
-            const schema = getSchema(schemaProvider);
-            transformer = new RelayQLTransformer(schema);
-            state.opts.extra.transformer = transformer;
-          }
-          invariant(
-            transformer instanceof RelayQLTransformer,
-            'getBabelRelayPlugin(): Expected RQLTransformer to be configured ' +
-            'for this instance of the plugin.'
-          );
 
           const {documentName} = state.opts.extra;
           invariant(documentName, 'Expected `documentName` to have been set.');
@@ -187,24 +175,20 @@ function getBabelRelayPlugin(
         }
       }
     });
-  }
+  };
 }
 
-function getSchema(
-  schemaProvider: Object | Function
-): GraphQLSchema {
-  const schemaData = typeof schemaProvider === 'function' ?
+function getSchema(schemaProvider: GraphQLSchemaProvider): GraphQLSchema {
+  const introspection = typeof schemaProvider === 'function' ?
     schemaProvider() :
     schemaProvider;
   invariant(
-    typeof schemaData === 'object' &&
-    schemaData !== null &&
-    typeof schemaData.__schema === 'object' &&
-    schemaData.__schema !== null,
-    'getBabelRelayPlugin(): Expected schema to be an object with a ' +
-    '`__schema` property.'
+    typeof introspection === 'object' && introspection &&
+    typeof introspection.__schema === 'object' && introspection.__schema,
+    'Invalid introspection data supplied to `getBabelRelayPlugin()`. The ' +
+    'resulting schema is not an object with a `__schema` property.'
   );
-  return buildClientSchema(schemaData);
+  return buildClientSchema(introspection);
 }
 
 module.exports = getBabelRelayPlugin;


### PR DESCRIPTION
Summary:
Instead of mutating `state.opts.extra`, this constructs a single `RQLTransformer` per plugin. (Yay, less global mutable state.)

Test Plan:
```
npm test
```
Also, verify that Relay Playground still works.