### PR TITLE
use mutationNode name instead of constructor name for mutation queries

### DIFF
--- a/src/mutation/RelayMutationTransaction.js
+++ b/src/mutation/RelayMutationTransaction.js
@@ -194,7 +194,7 @@ class RelayMutationTransaction {
       this._query = RelayMutationQuery.buildQuery({
         configs: this._getConfigs(),
         fatQuery: this._getFatQuery(),
-        mutationName: this._mutation.constructor.name,
+        mutationName: this._getMutationNode().name,
         mutation: this._getMutationNode(),
         input: this._getInputVariable(),
       });


### PR DESCRIPTION
fixes https://github.com/facebook/relay/issues/445