### PR TITLE
RFC: disallow non-root `node(id:...)` fields

### DIFF
--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -35,6 +35,7 @@ var RelayQLFragmentSpread = _require.RelayQLFragmentSpread;
 var RelayQLInlineFragment = _require.RelayQLInlineFragment;
 var RelayQLMutation = _require.RelayQLMutation;
 var RelayQLQuery = _require.RelayQLQuery;
+var RelayQLType = _require.RelayQLType;
 
 var invariant = require('./invariant');
 var t = require('babel-core/lib/types');
@@ -206,6 +207,8 @@ var RelayQLPrinter = (function () {
         requisiteFields.id = true;
       }
 
+      validateField(field, parent.getType());
+
       // TODO: Generalize to non-`Node` types.
       if (fieldType.alwaysImplements('Node')) {
         metadata.rootCall = 'node';
@@ -343,6 +346,13 @@ var RelayQLPrinter = (function () {
 
   return RelayQLPrinter;
 })();
+
+function validateField(field, parentType) {
+  if (field.getName() === 'node') {
+    var args = field.getArguments();
+    invariant(args.length !== 1 || args[0].getName() !== 'id', 'You defined a `node(id: %s)` field on type `%s`, but Relay requires ' + 'the `node` field to be defined on the root type. See the Object ' + 'Identification Guide: \n' + 'http://facebook.github.io/relay/docs/graphql-object-identification.html', args[0] && args[0].getType().getName({ modifiers: true }), parentType.getName({ modifiers: false }));
+  }
+}
 
 function validateConnectionField(field) {
   invariant(!field.hasArgument('first') || !field.hasArgument('before'), 'Connection arguments `%s(before: <cursor>, first: <count>)` are ' + 'not supported. Use `(first: <count>)`, ' + '`(after: <cursor>, first: <count>)`, or ' + '`(before: <cursor>, last: <count>)`.', field.getName());

--- a/scripts/babel-relay-plugin/src/__fixtures__/nonRootNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/nonRootNodeField.fixture
@@ -1,0 +1,17 @@
+Input:
+var Relay = require('Relay');
+var fragment = Relay.QL`
+  fragment on InvalidType {
+    node(id: 123) {
+      ... on User {
+        name
+      }
+    }
+  }
+`;
+
+Output:
+var Relay = require('Relay');
+var fragment = (function () {
+  throw new Error('GraphQL validation/transform error ``You defined a `node(id: Int)` field on type `InvalidType`, but Relay requires the `node` field to be defined on the root type. See the Object Identification Guide: \nhttp://facebook.github.io/relay/docs/graphql-object-identification.html`` in file `nonRootNodeField.fixture`.');
+})();

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -4,6 +4,11 @@ type Root {
   media(id: Int): Media
   viewer: Viewer
   search(query: [SearchInput!]): [SearchResult]
+  _invalid: InvalidType
+}
+
+type InvalidType {
+  node(id: Int): Node
 }
 
 type SearchResult {

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -136,6 +136,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "_invalid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "InvalidType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1262,6 +1274,40 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InvalidType",
+          "description": null,
+          "fields": [
+            {
+              "name": "node",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Node",
                 "ofType": null
               },
               "isDeprecated": false,


### PR DESCRIPTION
Despite the Object Identification documentation, there has been some confusion in the community about whether the `node` field should be at the root or nested inside `Viewer`. This adds a validation check to the babel relay plugin to reject non-root `node(id: ...)` fields.