### PR TITLE
Bump React peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "react-static-container": "^1.0.0-alpha.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0-rc",
-    "react-dom": "^0.14.0-rc"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "babel-core": "^5.8.25",


### PR DESCRIPTION
We should track the latest released version of React, to avoid this kind
of clash with other packages that want the latest React:

    npm ERR! peerinvalid The package react@0.14.0-rc1 does not satisfy
                         its siblings' peerDependencies requirements!
    npm ERR! peerinvalid Peer react-relay@0.3.2 wants react@^0.14.0-rc
    npm ERR! peerinvalid Peer react-router-relay@0.6.2 wants react@^0.14.0

(Either this, or we should loosen our requirements.)