### PR TITLE
Improve tutorial

### DIFF
--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -382,6 +382,7 @@ class App extends React.Component {
     return this.props.game.hidingSpots.edges.map(edge => {
       return (
         <div
+          key={edge.node.id}
           onClick={this._handleHidingSpotClick.bind(this, edge.node)}
           style={this._getHidingSpotStyle(edge.node)}
         />

--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -268,6 +268,8 @@ export default class extends Relay.Route {
 Next, let's create a file in `./js/mutations/CheckHidingSpotForTreasureMutation.js` and create subclass of `Relay.Mutation` called `CheckHidingSpotForTreasureMutation` to hold our mutation implementation:
 
 ```
+import Relay from 'react-relay';
+
 export default class CheckHidingSpotForTreasureMutation extends Relay.Mutation {
   static fragments = {
     game: () => Relay.QL`

--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -253,7 +253,7 @@ npm start
 
 ## Writing the game
 
-Let's tweak the file `./routes/AppHomeRoute.js` to anchor our game to the `game` root field of the schema:
+Let's tweak the file `./js/routes/AppHomeRoute.js` to anchor our game to the `game` root field of the schema:
 
 ```
 export default class extends Relay.Route {
@@ -265,7 +265,7 @@ export default class extends Relay.Route {
 }
 ```
 
-Next, let's create a file in `./mutations/CheckHidingSpotForTreasureMutation.js` and create subclass of `Relay.Mutation` called `CheckHidingSpotForTreasureMutation` to hold our mutation implementation:
+Next, let's create a file in `./js/mutations/CheckHidingSpotForTreasureMutation.js` and create subclass of `Relay.Mutation` called `CheckHidingSpotForTreasureMutation` to hold our mutation implementation:
 
 ```
 export default class CheckHidingSpotForTreasureMutation extends Relay.Mutation {
@@ -329,7 +329,7 @@ export default class CheckHidingSpotForTreasureMutation extends Relay.Mutation {
 }
 ```
 
-Finally, let's tie it all together in `./components/App.js`:
+Finally, let's tie it all together in `./js/components/App.js`:
 
 ```
 import CheckHidingSpotForTreasureMutation from '../mutations/CheckHidingSpotForTreasureMutation';


### PR DESCRIPTION
1. Some of the relative paths mentioned in the tutorial are not accurate. This fixes those affected paths.
2. Explicitly import `react-relay` in the mutation section.
3. Add the `key` attribute to each cell created by `renderGameBoard`. The key attribute already exist in the example directory.