### PR TITLE
fix RelayMetricsRecorder-test with OSS jest version

### DIFF
--- a/src/tools/__tests__/RelayMetricsRecorder-test.js
+++ b/src/tools/__tests__/RelayMetricsRecorder-test.js
@@ -98,7 +98,7 @@ describe('RelayMetricsRecorder', () => {
 
     mockPerformanceNowSequence([1, 1001]);
     fetchRelayQuery(query);
-    jest.runOnlyPendingTimers();
+    jest.runAllTimers();
     var requests = RelayNetworkLayer.sendQueries.mock.calls[0][0];
     expect(requests.length).toBe(1);
     requests[0].resolve();


### PR DESCRIPTION
Not sure why this worked internally but not in OSS, but suspect it has to do with the jest version (?).