### PR TITLE
make babel-relay-plugin a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "react-static-container": "^1.0.0-alpha.1"
   },
   "peerDependencies": {
+    "babel-relay-plugin": "^0.3.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.1",
-    "babel-relay-plugin": "^0.3.0",
     "del": "^1.2.0",
     "envify": "^3.4.0",
     "eslint": "^1.3.1",


### PR DESCRIPTION
Currently there is nothing to guarantee that the version of `babel-relay-plugin` being used by an application matches the version of Relay. This can cause features to break when an upgraded Relay expects metadata that is not provided by older versions of the plugin - see #470 for an example.

Making the plugin a peer dependency helps to ensure that versions match.