### PR TITLE
Prefer node 4.x, npm 2.x in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "repository": "facebook/relay",
   "scripts": {
     "build": "gulp",
+    "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "prepublish": "npm run build",
     "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",
@@ -60,6 +61,10 @@
     "run-sequence": "^1.1.2",
     "webpack": "1.11.0",
     "webpack-stream": "^2.1.0"
+  },
+  "devEngines": {
+    "node": "4.x",
+    "npm": "2.x"
   },
   "jest": {
     "rootDir": "",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "repository": "facebook/relay",
   "scripts": {
     "build": "gulp",
+    "lint": "eslint .",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "prepublish": "npm run build",
     "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",
-    "update-schema": "babel-node ./scripts/jest/updateSchema.js",
-    "lint": "eslint ."
+    "update-schema": "babel-node ./scripts/jest/updateSchema.js"
   },
   "dependencies": {
     "babel-runtime": "5.8.24",


### PR DESCRIPTION
At the moment, our test suite won't run properly under npm 3.x, so let's
specify our requirement in the package.json.

Once npm 3.x goes "final" we'll make sure that we support both. In the
meantime, this will prevent developers running the tests from seeing
spurious failures like the ones reported here when using npm 3:

https://github.com/facebook/relay/issues/396

Tested by installing npm 3, then running `npm install`, and seeing the
expected error from the `check-dev-engines.js` script:

    AssertionError: Current npm version is not supported for
    development, expected "3.0.0" to satisfy "2.x".