### PR TITLE
Replace babel-relay-plugin build script with node script

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -24,7 +24,9 @@
     "babel-jest": "^5.3.0",
     "flow-bin": "0.17.0",
     "jest-cli": "^0.5.8",
-    "minimist": "^1.1.3"
+    "minimist": "^1.1.3",
+    "node-find-files": "0.0.4",
+    "rimraf": "2.4.3"
   },
   "dependencies": {
     "babel-core": "^5.8.25",

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -25,8 +25,8 @@
     "flow-bin": "0.17.0",
     "jest-cli": "^0.5.8",
     "minimist": "^1.1.3",
-    "node-find-files": "0.0.4",
-    "rimraf": "2.4.3"
+    "node-find-files": "^0.0.2",
+    "rimraf": "^2.1"
   },
   "dependencies": {
     "babel-core": "^5.8.25",

--- a/scripts/babel-relay-plugin/scripts/build-lib
+++ b/scripts/babel-relay-plugin/scripts/build-lib
@@ -1,12 +1,46 @@
-#!/bin/bash
+#!/usr/bin/env node
 
-ROOT_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
+var FindFiles = require('node-find-files');
+var child_process = require('child_process');
+var fs = require('fs');
+var path = require('path');
+var rimraf = require('rimraf');
 
-cd $ROOT_DIR
-rm -r lib
-babel src --ignore __tests__ --out-dir lib
-for file in $(find lib -name \*.js); do
-  echo '// @''generated' > $file.generated
-  cat $file >> $file.generated
-  mv $file.generated $file
-done
+var root = path.resolve(__dirname, '..');
+var lib = path.join(root, 'lib');
+var src = path.join(root, 'src');
+
+// Blow away prior build artefacts.
+rimraf.sync(lib);
+
+// Transform with babel (src -> lib).
+var babel = child_process.spawn(
+  'babel', [src, '--ignore', '__tests__', '--out-dir', lib]
+);
+babel.stdout.on('data', process.stdout.write.bind(process.stdout));
+babel.stderr.on('data', process.stderr.write.bind(process.stderr));
+babel.on('close', function(status) {
+  if (status) {
+    process.exit(status);
+  }
+
+  // Prepend @generated annotations to all JS files.
+  var finder = new FindFiles({
+    rootFolder: lib,
+    filterFunction: function(pathName) {
+      return path.extname(pathName) === '.js';
+    },
+  });
+
+  finder.on('match', function(pathName) {
+    var data = fs.readFileSync(pathName);
+    var file = fs.openSync(pathName, 'w');
+    var buffer = new Buffer('// @generated\n');
+    fs.writeSync(file, buffer, 0, buffer.length);
+    fs.writeSync(file, data, 0, data.length);
+    fs.close(file);
+  });
+
+  finder.on('error', process.exit.bind(process, 1));
+  finder.startSearch();
+});


### PR DESCRIPTION
We've [had reports](https://github.com/facebook/relay/issues/484) of `npm install` not working on Windows because our `build-lib` script makes platform-specific assumptions,

This commit rewrites it in JS, which in theory should run everywhere `node` runs. (Note, I haven't actually tested this on Windows yet, although I have confirmed that it continues to do the right thing on OS X.)

Thing is, JS isn't actually that awesome for "shell" scripting, so I am relying on a couple of third-party modules -- rimraf for an equivalent to `rm -rf` and node-find-files to stand in for `find` -- which I chose based on the fact that we've previously used them at FB (at least, copies exist under `scripts/third_party/node_modules`).