### PR TITLE
More accurate definition for node root field in Star Wars example comments

### DIFF
--- a/examples/star-wars/data/schema.js
+++ b/examples/star-wars/data/schema.js
@@ -213,7 +213,7 @@ var factionType = new GraphQLObjectType({
  * This implements the following type system shorthand:
  *   type Query {
  *     factions(names: [FactionName]): [Faction]
- *     node(id: String!): Node
+ *     node(id: ID!): Node
  *   }
  */
 var queryType = new GraphQLObjectType({
@@ -283,7 +283,7 @@ var shipMutation = mutationWithClientMutationId({
  *
  * This implements the following type system shorthand:
  *   type Mutation {
- *     introduceShip(input IntroduceShipInput!): IntroduceShipPayload
+ *     introduceShip(input: IntroduceShipInput!): IntroduceShipPayload
  *   }
  */
 var mutationType = new GraphQLObjectType({


### PR DESCRIPTION
I'm not sure if this is right, feel free to discard. The `id` input argument to the `nodeField` query type seems to be an `ID!` as indicated in graphql-relay-js [here](https://github.com/graphql/graphql-relay-js/blob/9e7401450c2458c6a45048a049c785100f3a622b/src/node/node.js#L68). If I understand it correctly, the node query type can only be fetched using a base64 unique ID? It would then be more accurate to label the `nodeField` type as `node(id: ID!): Node`.