### PR TITLE
Moved postinstall => prepublish in relay/package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   "scripts": {
     "build": "gulp",
     "lint": "eslint .",
-    "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
-    "prepublish": "npm run build",
+    "prepublish": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && npm run build",
     "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",
     "update-schema": "babel-node ./scripts/jest/updateSchema.js"


### PR DESCRIPTION
Fixes #505 Moved postinstall => prepublish to fix broken dependency when using relay pointing to a local path. This fixes `npm install` in all three examples.