### PR TITLE
Fix tests on master

### DIFF
--- a/src/store/__tests__/readRelayDiskCache-test.js
+++ b/src/store/__tests__/readRelayDiskCache-test.js
@@ -20,7 +20,6 @@ var Relay = require('Relay');
 var RelayRecordStore = require('RelayRecordStore');
 
 var readRelayDiskCache = require('readRelayDiskCache');
-var setImmediate = require('setImmediate');
 
 describe('readRelayDiskCache', () => {
   var {getNode} = RelayTestUtils;


### PR DESCRIPTION
Tests were broken due to a minor bug in [this recent commit](https://github.com/facebook/relay/commit/cc7c0e5b16999e045937a5f75a4ef0fe05b4695e) where the `setImmediate()` module is imported. However, there is no need to import `setImmediate()`, it seems to be a native function in Node.