### PR TITLE
Set Accept header to fix GraphiQL issue in Firefox

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -130,6 +130,7 @@ class RelayDefaultNetworkLayer {
         }),
         headers: {
           ...this._init.headers,
+          'Accept': '*/*',
           'Content-Type': 'application/json',
         },
         method: 'POST',
@@ -150,6 +151,7 @@ class RelayDefaultNetworkLayer {
       }),
       headers: {
         ...this._init.headers,
+        'Accept': '*/*',
         'Content-Type': 'application/json',
       },
       method: 'POST',


### PR DESCRIPTION
Reported here: https://github.com/graphql/express-graphql/issues/29

Chrome sends an `Accept` header of `Accept: */*`, but Firefox sends `Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`, which is causing "express-graphql" to return the HTML for GraphiQL to Relay clients running on Firefox, rather than the response for the query. In other words, Relay is completely broken on Firefox.

I tested this with `Accept: */*` and `Accept: application/json` on Firefox. Both work, but I've gone with the more liberal `*/*` for a few reasons:

- Match existing Chrome behavior, because consistency is good (even if just consistency with pre-existing behavior).
- Historical issues with IE not liking `application/json`.
- Don't want to introduce a breaking change for people serving GraphQL
  on some non-JS environment that may be picky about JSON MIME types.