### PR TITLE
Fix master tests in Relay OSS, really

### DIFF
--- a/src/store/__tests__/readRelayDiskCache-test.js
+++ b/src/store/__tests__/readRelayDiskCache-test.js
@@ -20,7 +20,6 @@ var Relay = require('Relay');
 var RelayRecordStore = require('RelayRecordStore');
 
 var readRelayDiskCache = require('readRelayDiskCache');
-var resolveImmediate = require('resolveImmediate');
 
 describe('readRelayDiskCache', () => {
   var {getNode} = RelayTestUtils;
@@ -50,14 +49,14 @@ describe('readRelayDiskCache', () => {
 
     var cacheManager = {
       readNode: jest.genMockFunction().mockImplementation((id, callback) => {
-        resolveImmediate(() => {
+        setTimeout(() => {
           callback(undefined, diskCacheData[id]);
         });
       }),
       readRootCall: jest.genMockFunction().mockImplementation(
         (callName, callArg, callback) => {
           var rootKey = callName + '*' + callArg;
-          resolveImmediate(() => {
+          setTimeout(() => {
             callback(undefined, diskCacheData[rootKey]);
           });
         }


### PR DESCRIPTION
I actually fixed this in two ways, first by adding a `setImmediate` shim (which worked) and then by switching to `resolveImmediate` (which didn't work, but I failed to adequately test this). It seems the tests are very sensitive, with their use of `jest.run{All,OnlyPending}Timers`.

Third time lucky; let's just use `setTimeout`, which should be fine as this is just the test suite.