### PR TITLE
Fix RelayDefaultNetworkLayer tests

### DIFF
--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -104,6 +104,7 @@ describe('RelayDefaultNetworkLayer', () => {
 
       expect(method).toBe('POST');
       expect(headers).toEqual({
+        'Accept': '*/*',
         'Content-Encoding': 'gzip',
         'Content-Type': 'application/json'
       });
@@ -230,6 +231,7 @@ describe('RelayDefaultNetworkLayer', () => {
       }));
       expect(fetchTimeout).toBe(networkConfig.init.fetchTimeout);
       expect(headers).toEqual({
+        'Accept': '*/*',
         'Content-Encoding': 'gzip',
         'Content-Type': 'application/json',
       });


### PR DESCRIPTION
I broke this in https://github.com/facebook/relay/commit/0e68725c495ad4c23.