### PR TITLE
Fix Relay website build

### DIFF
--- a/website-prototyping-tools/package.json
+++ b/website-prototyping-tools/package.json
@@ -29,7 +29,7 @@
     "raw-loader": "0.5.1",
     "react": "^0.14.0-rc",
     "react-codemirror": "0.1.5",
-    "relay-local-schema": "0.2.1",
+    "relay-local-schema": "0.3.0",
     "react-relay": "../",
     "style-loader": "0.12.3",
     "webpack": "1.12.0"

--- a/website/README.md
+++ b/website/README.md
@@ -3,7 +3,7 @@
 Install the supporting infrastructure.
 
 ```
-(cd ../; npm install) && (cd ../website-prototyping-tools; npm install) && npm install
+(cd ../; npm install) && (cd ../scripts/babel-relay-plugin; npm install) && (cd ../website-prototyping-tools; npm install) && npm install
 ```
 
 # Developing


### PR DESCRIPTION
Bumped relay-local-schema to the latest version.
<img width="1137" alt="screenshot 2015-10-25 15 45 22" src="https://cloud.githubusercontent.com/assets/3792228/10718900/49acacde-7b3a-11e5-8a21-7d222ed5909e.png">

Also added local `npm install` of `babel-relay plugin` to the website's installation command because otherwise `babel-relay-plugin` would not build due to some dependencies of its build script only available as `devDependencies`.
<img width="882" alt="screenshot 2015-10-25 17 15 23" src="https://cloud.githubusercontent.com/assets/3792228/10718984/0d24db36-7b3c-11e5-8527-0429688de528.png">
