### PR TITLE
Fix issue where queries with multiple fields on the same Connection get sorted out of order

### DIFF
--- a/src/traversal/__tests__/sortTypeFirst-test.js
+++ b/src/traversal/__tests__/sortTypeFirst-test.js
@@ -20,9 +20,9 @@ describe('sortTypeFirst', () => {
     expect(sortTypeFirst('__type__', '__type__')).toBe(0);
   });
 
-  it('compares non-`__type__` strings', () => {
-    expect(sortTypeFirst('a', 'b')).toBe(-1);
-    expect(sortTypeFirst('b', 'a')).toBe(1);
+  it('does not compare non-`__type__` strings', () => {
+    expect(sortTypeFirst('a', 'b')).toBe(0);
+    expect(sortTypeFirst('b', 'a')).toBe(0);
     expect(sortTypeFirst('a', 'a')).toBe(0);
   });
 });

--- a/src/traversal/flattenRelayQuery.js
+++ b/src/traversal/flattenRelayQuery.js
@@ -17,11 +17,11 @@ var RelayProfiler = require('RelayProfiler');
 import type RelayQuery from 'RelayQuery';
 var RelayQueryVisitor = require('RelayQueryVisitor');
 
+var Map = require('Map');
 var sortTypeFirst = require('sortTypeFirst');
 
 type FlattenedQuery = {
   node: RelayQuery.Node;
-  // flattenedFieldMap: {[key: string]: FlattenedQuery};
   flattenedFieldMap: Map;
 };
 

--- a/src/traversal/sortTypeFirst.js
+++ b/src/traversal/sortTypeFirst.js
@@ -25,11 +25,7 @@ function sortTypeFirst(a: string, b: string): number {
   if (b === TYPE) {
     return 1;
   }
-  if (a < b) {
-    return -1;
-  }
-  // a > b
-  return 1;
+  return 0;
 }
 
 module.exports = sortTypeFirst;


### PR DESCRIPTION
This is related to #478, where having multiple fields that query for different ranges on a Connection come back in random order causing the RelayQueryWriter to get confused and fail to build all the edges.

It is also related to #490. The difference between the PR and #490 is that this request uses a type first sorting that does not otherwise change the order of the elements in the array.