### PR TITLE
Fixes #511 - Unable to use Relay with stateless components

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -52,6 +52,7 @@ var nullthrows = require('nullthrows');
 var prepareRelayContainerProps = require('prepareRelayContainerProps');
 var shallowEqual = require('shallowEqual');
 var warning = require('warning');
+var isReactComponent = require('isReactComponent');
 
 export type RelayContainerSpec = {
   initialVariables?: Variables;
@@ -808,7 +809,7 @@ function createContainerComponent(
           {...this.props}
           {...this.state.queryData}
           {...prepareRelayContainerProps(relayProps, this)}
-          ref="component"
+          ref={isReactComponent(Component) ? 'component' : null}
         />
       );
     }

--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -301,7 +301,7 @@ function createContainerComponent(
               }
             });
             if (callback) {
-              callback.call(this.refs.component, {...readyState, mounted});
+              callback.call(this.refs.component || null, {...readyState, mounted});
             }
           });
         } else {

--- a/src/container/__mocks__/isReactComponent.js
+++ b/src/container/__mocks__/isReactComponent.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = require.requireActual('isReactComponent');

--- a/src/container/__tests__/isReactComponent-test.js
+++ b/src/container/__tests__/isReactComponent-test.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+var React = require('React');
+var isReactComponent = require('isReactComponent');
+
+describe('isReactComponent', function() {
+  it('identifies components that extends React.Component', function() {
+    class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
+    expect(isReactComponent(MockComponent)).toBe(true);
+  });
+
+  it('identifies components created by React.createClass()', function() {
+    var MockComponent = React.createClass({
+      render: () => <div />
+    });
+    expect(isReactComponent(MockComponent)).toBe(true);
+  });
+
+  it('does not identify function components', function() {
+    var MockComponent = () => <div />;
+    expect(isReactComponent(MockComponent)).toBe(false);
+  });
+});

--- a/src/container/isReactComponent.js
+++ b/src/container/isReactComponent.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule isReactComponent
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+/**
+ * @internal
+ *
+ * Helper for checking if this is a React Component
+ * created with React.Component or React.createClass().
+ */
+function isReactComponent(component: any): boolean {
+  return (
+    component &&
+    component.prototype &&
+    !!component.prototype.isReactComponent
+  );
+}
+
+module.exports = isReactComponent;

--- a/src/container/isReactComponent.js
+++ b/src/container/isReactComponent.js
@@ -19,11 +19,11 @@
  * Helper for checking if this is a React Component
  * created with React.Component or React.createClass().
  */
-function isReactComponent(component: any): boolean {
-  return (
+function isReactComponent(component: mixed): boolean {
+  return !!(
     component &&
     component.prototype &&
-    !!component.prototype.isReactComponent
+    component.prototype.isReactComponent
   );
 }
 


### PR DESCRIPTION
Resolves the React warnings seen when passing a function component to Relay.createContainer().
Adds a check to skip adding a "ref" to the container component if it is a function component.

This does mean setVariables() & forceUpdate() callbacks will not be provided the component
if you passed createContainer() a function component. 

Please let me know if I am on the right track here or what needs more work. :)