### PR TITLE
Updating npm dependency to support newer npm versions in the 3.x range

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "devEngines": {
     "node": "4.x",
-    "npm": "2.x"
+    "npm": "2.x || 3.x"
   },
   "jest": {
     "rootDir": "",


### PR DESCRIPTION
Currently, when cloning from master and running `npm install` while running any version of `npm@3.x` you'll receive an Assertion Error during the prepublish step saying: `Current npm version is not supported for development, expected "3.3.9" to satisfy "2.x".`

This PR just updates the semver range of the npm devEngine to support `npm@3.x` versions in addition to `npm@2.x` ranges.