### PR TITLE
Removing extra renameTodo import from the Todo example schema file

### DIFF
--- a/examples/todo/data/schema.js
+++ b/examples/todo/data/schema.js
@@ -44,7 +44,6 @@ import {
   getViewer,
   markAllTodos,
   removeCompletedTodos,
-  removeTodo,
   renameTodo,
 } from './database';
 


### PR DESCRIPTION
Just a removal of an extra `renameTodo` in the imports from `./database`.