### PR TITLE
Cut lead-ins to non-existent formal definitions.

### DIFF
--- a/website/graphql/Connections.md
+++ b/website/graphql/Connections.md
@@ -249,7 +249,7 @@ To enable forward pagination, two arguments are required.
 
 The server should use those two arguments to modify the edges returned by
 the connection, returning edges after the `after` cursor, and returning at
-most `first` edges. More formally:
+most `first` edges.
 
 ## Backward pagination arguments
 
@@ -260,7 +260,7 @@ To enable backward pagination, two arguments are required.
 
 The server should use those two arguments to modify the edges returned by
 the connection, returning edges before the `before` cursor, and returning at
-most `last` edges. More formally:
+most `last` edges.
 
 ## Pagination algorithm
 


### PR DESCRIPTION
"Forward pagination arguments" & "Backward pagination arguments" both end with "More formally:", yet nothing follows.

![image](https://cloud.githubusercontent.com/assets/43438/10869104/a185a66e-80de-11e5-9966-d8d6fd6bf56a.png)
