### PR TITLE
Exclude nodes that should be skipped because of directives in getChildren

### DIFF
--- a/src/__forks__/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/__forks__/traversal/__tests__/printRelayOSSQuery-test.js
@@ -559,7 +559,6 @@ describe('printRelayOSSQuery', () => {
         }
       }
       fragment ${fragmentID} on User @include(if: true) {
-        name @skip(if: true),
         id
       }
     `);

--- a/src/query/RelayQuery.js
+++ b/src/query/RelayQuery.js
@@ -54,6 +54,10 @@ var UNLESS = 'unless';
 var TRUE = 'true';
 var FALSE = 'false';
 
+// directive names
+var SKIP = 'skip';
+var INCLUDE = 'include';
+
 var QUERY_ID_PREFIX = 'q';
 var REF_PARAM_PREFIX = 'ref_';
 
@@ -204,7 +208,7 @@ class RelayQueryNode {
           this.__route__,
           this.__variables__
         );
-        if (node) {
+        if (node && node.shouldBeIncluded()) {
           nextChildren.push(node);
         }
       });
@@ -212,6 +216,36 @@ class RelayQueryNode {
       children = nextChildren;
     }
     return children;
+  }
+
+  shouldBeIncluded(): ?boolean {
+    var directives = this.getDirectives();
+
+    var skipNode = directives.find(
+      directive => directive.name === SKIP
+    );
+    if (skipNode) {
+      var skipIf = skipNode.arguments.find(
+        arg => arg.name === IF
+      );
+      if (skipIf) {
+        return !skipIf.value;
+      }
+    }
+
+    var includeNode = directives.find(
+      directive => directive.name === INCLUDE
+    );
+    if (includeNode) {
+      var includeIf = includeNode.arguments.find(
+        arg => arg.name === IF
+      );
+      if (includeIf) {
+        return Boolean(includeIf.value);
+      }
+    }
+
+    return true
   }
 
   getDirectives(): Array<Directive> {

--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -73,6 +73,38 @@ describe('RelayQueryRoot', () => {
     expect(children[2].isGenerated()).toBe(true);
   });
 
+  it('does not return skipped children', () => {
+    var query = getNode(Relay.QL`
+      query {
+        me {
+          id,
+          firstName @skip(if: $cond),
+          lastName @include(if: $cond2),
+        }
+      }
+    `, {cond: true, cond2: false});
+    var children = query.getChildren();
+    expect(children.length).toBe(1);
+    expect(children[0].getSchemaName()).toBe('id');
+  });
+
+  it('does return included children', () => {
+    var query = getNode(Relay.QL`
+      query {
+        me {
+          id,
+          firstName @skip(if: $cond),
+          lastName @include(if: $cond2),
+        }
+      }
+    `, {cond: false, cond2: true});
+    var children = query.getChildren();
+    expect(children.length).toBe(3);
+    expect(children[0].getSchemaName()).toBe('id');
+    expect(children[1].getSchemaName()).toBe('firstName');
+    expect(children[2].getSchemaName()).toBe('lastName');
+  });
+
   it('returns same object when cloning with same fields', () => {
     var children = me.getChildren();
     expect(me.clone(children)).toBe(me);

--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -78,11 +78,11 @@ describe('RelayQueryRoot', () => {
       query {
         me {
           id,
-          firstName @skip(if: $cond),
-          lastName @include(if: $cond2),
+          firstName @skip(if: $true),
+          lastName @include(if: $false),
         }
       }
-    `, {cond: true, cond2: false});
+    `, {true: true, false: false});
     var children = query.getChildren();
     expect(children.length).toBe(1);
     expect(children[0].getSchemaName()).toBe('id');
@@ -93,11 +93,11 @@ describe('RelayQueryRoot', () => {
       query {
         me {
           id,
-          firstName @skip(if: $cond),
-          lastName @include(if: $cond2),
+          firstName @skip(if: $false),
+          lastName @include(if: $true),
         }
       }
-    `, {cond: false, cond2: true});
+    `, {false: false, true: true});
     var children = query.getChildren();
     expect(children.length).toBe(3);
     expect(children[0].getSchemaName()).toBe('id');

--- a/src/tools/__tests__/RelayMetricsRecorder-test.js
+++ b/src/tools/__tests__/RelayMetricsRecorder-test.js
@@ -70,7 +70,7 @@ describe('RelayMetricsRecorder', () => {
     var recorder = new RelayMetricsRecorder();
     performanceNow.mockReturnValue(0);
     recorder.start();
-    mockPerformanceNowSequence([1, 1001]);
+    mockPerformanceNowSequence([1, 101, 201, 301, 401, 501, 601, 1001]);
     query.getChildren();
     performanceNow.mockReturnValue(3000);
     recorder.stop();
@@ -78,8 +78,12 @@ describe('RelayMetricsRecorder', () => {
     expect(recorder.getMetrics()).toEqual({
       measurements: {
         'RelayQueryNode.prototype.getChildren': {
-          aggregateTime: 1000,
+          aggregateTime: 700,
           callCount: 1,
+        },
+        'RelayQueryNode.prototype.getDirectives': {
+          aggregateTime: 300,
+          callCount: 3,
         },
       },
       profiles: [],


### PR DESCRIPTION
Fixes #536 

I've been working with graphql-ruby and relay and been wanting to use directives. I found #536 yesterday night and tried to work on a solution today.

Following what @josephsavona said in the issue, I've modified`RelayQueryNode.getChildren` so it only return children that are not skipped (meaning `skip if: true` and `include if: false`). I've implemented the function `RelayQueryNode.shouldBeIncluded` which
  - Checks if a skip directive is present ( It has priority over include)
     - If an if argument is present, return the negated value
  - Checks if an include directive is present
     - if an if argument, return the value
  - return true in all other cases

I've tried to take into consideration that other directives and arguments other than `if:` might be added, which might make the code a little bit more complicated, let me know if I should just assume that the argument is if right now.

Let me know if the solution makes sense. I've added 2 tests, modified a printing test that included a field that should be skipped and also modified the metric test since the getChildren method now calls getDirectives for every field.

Haven't had much chance to look at Relay in detail so let me know how I can improve this!