### PR TITLE
Make GraphQLStoreRangeUtils contextual

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -549,7 +549,7 @@ function createContainerComponent(
           }
         } else if (!queryResolver) {
           queryResolver = new GraphQLStoreQueryResolver(
-            storeData.getQueuedStore(),
+            storeData,
             fragmentPointer,
             this._handleFragmentDataUpdate.bind(this)
           );

--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -16,7 +16,6 @@
 import type {ConcreteFragment} from 'ConcreteQuery';
 var ErrorUtils = require('ErrorUtils');
 var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
-var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
 var GraphQLStoreDataHandler = require('GraphQLStoreDataHandler');
 var GraphQLStoreQueryResolver = require('GraphQLStoreQueryResolver');
 var React = require('React');
@@ -74,16 +73,16 @@ export type RootQueries = {
   [queryName: string]: RelayQLQueryBuilder;
 };
 
-GraphQLStoreChangeEmitter.injectBatchingStrategy(
-  ReactDOM.unstable_batchedUpdates
-);
-
 var containerContextTypes = {
   route: RelayPropTypes.QueryConfig.isRequired,
 };
 var nextContainerID = 0;
 
 var storeData = RelayStoreData.getDefaultInstance();
+
+storeData.getChangeEmitter().injectBatchingStrategy(
+  ReactDOM.unstable_batchedUpdates
+);
 
 /**
  * @public

--- a/src/legacy/store/GraphQLStoreChangeEmitter.js
+++ b/src/legacy/store/GraphQLStoreChangeEmitter.js
@@ -14,7 +14,6 @@
 'use strict';
 
 var ErrorUtils = require('ErrorUtils');
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 
 var resolveImmediate = require('resolveImmediate');
 
@@ -54,10 +53,9 @@ class GraphQLStoreChangeEmitter {
   }
 
   addListenerForIDs(
-    ids: Array<string>,
+    subscribedIDs: Array<string>,
     callback: SubscriptionCallback
   ): ChangeSubscription {
-    var subscribedIDs = ids.map(getBroadcastID);
     var index = this._subscribers.length;
     this._subscribers.push({subscribedIDs, callback});
     return {
@@ -75,7 +73,7 @@ class GraphQLStoreChangeEmitter {
     }
     // Record index of the last subscriber so we do not later unintentionally
     // invoke callbacks that were subscribed after this broadcast.
-    scheduledIDs[getBroadcastID(id)] = this._subscribers.length - 1;
+    scheduledIDs[id] = this._subscribers.length - 1;
   }
 
   injectBatchingStrategy(batchStrategy: Function): void {
@@ -124,15 +122,6 @@ class GraphQLStoreChangeEmitter {
       }
     }
   }
-}
-
-/**
- * Ranges publish events for the entire range, not the specific view of that
- * range. For example, if "client:1" is a range, the event is on "client:1",
- * not "client:1_first(5)".
- */
-function getBroadcastID(id: string): string {
-  return GraphQLStoreRangeUtils.getCanonicalClientID(id);
 }
 
 module.exports = GraphQLStoreChangeEmitter;

--- a/src/legacy/store/GraphQLStoreQueryResolver.js
+++ b/src/legacy/store/GraphQLStoreQueryResolver.js
@@ -15,7 +15,6 @@
 
 import type {ChangeSubscription} from 'GraphQLStoreChangeEmitter';
 import type GraphQLFragmentPointer from 'GraphQLFragmentPointer';
-var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
 var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 import type RelayStoreGarbageCollector from 'RelayStoreGarbageCollector';
 import type {DataID} from 'RelayInternalTypes';
@@ -245,7 +244,8 @@ class GraphQLStoreSingleQueryResolver {
       if (subscribedIDs) {
         // always subscribe to the root ID
         subscribedIDs[nextID] = true;
-        this._subscription = GraphQLStoreChangeEmitter.addListenerForIDs(
+        var changeEmitter = this._storeData.getChangeEmitter();
+        this._subscription = changeEmitter.addListenerForIDs(
           Object.keys(subscribedIDs),
           this._handleChange.bind(this)
         );

--- a/src/legacy/store/GraphQLStoreQueryResolver.js
+++ b/src/legacy/store/GraphQLStoreQueryResolver.js
@@ -15,7 +15,6 @@
 
 import type {ChangeSubscription} from 'GraphQLStoreChangeEmitter';
 import type GraphQLFragmentPointer from 'GraphQLFragmentPointer';
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 import type RelayStoreGarbageCollector from 'RelayStoreGarbageCollector';
 import type {DataID} from 'RelayInternalTypes';
 var RelayProfiler = require('RelayProfiler');
@@ -246,7 +245,7 @@ class GraphQLStoreSingleQueryResolver {
         subscribedIDs[nextID] = true;
         var changeEmitter = this._storeData.getChangeEmitter();
         this._subscription = changeEmitter.addListenerForIDs(
-          Object.keys(subscribedIDs),
+          Object.keys(subscribedIDs).map(id => this._getCanonicalID(id)),
           this._handleChange.bind(this)
         );
         this._updateGarbageCollectorSubscriptionCount(subscribedIDs);
@@ -268,7 +267,7 @@ class GraphQLStoreSingleQueryResolver {
    * not "client:1_first(5)".
    */
   _getCanonicalID(id: DataID): DataID {
-    return GraphQLStoreRangeUtils.getCanonicalClientID(id);
+    return this._storeData.getRangeData().getCanonicalClientID(id);
   }
 
   _handleChange(): void {

--- a/src/legacy/store/GraphQLStoreRangeUtils.js
+++ b/src/legacy/store/GraphQLStoreRangeUtils.js
@@ -15,8 +15,6 @@
 var callsFromGraphQL = require('callsFromGraphQL');
 var printRelayQueryCall = require('printRelayQueryCall');
 
-var rangeData = {};
-
 /**
  * Utilities used by GraphQLStore for storing ranges
  *
@@ -45,7 +43,10 @@ var rangeData = {};
  *
  * @internal
  */
-var GraphQLStoreRangeUtils = {
+class GraphQLStoreRangeUtils {
+  constructor() {
+    this._rangeData = {};
+  }
 
   /**
    * Returns a token that can be parsed using parseRangeClientID to recover
@@ -57,21 +58,21 @@ var GraphQLStoreRangeUtils = {
    * @param {string} dataID
    * @return {string}
    */
-  getClientIDForRangeWithID: function(calls, callValues, dataID) {
+  getClientIDForRangeWithID(calls, callValues, dataID) {
     var callsAsString = callsFromGraphQL(calls, callValues)
       .map(call => printRelayQueryCall(call).substring(1))
       .join(',');
     var key = dataID + '_' + callsAsString;
-    var edge = rangeData[key];
+    var edge = this._rangeData[key];
     if (!edge) {
-      rangeData[key] = {
+      this._rangeData[key] = {
         dataID: dataID,
         calls: calls,
         callValues: callValues
       };
     }
     return key;
-  },
+  }
 
   /**
    * Parses an ID back into its data ID and calls
@@ -79,9 +80,9 @@ var GraphQLStoreRangeUtils = {
    * @param {string} rangeSpecificClientID
    * @return {?object}
    */
-  parseRangeClientID: function(rangeSpecificClientID) {
-    return rangeData[rangeSpecificClientID] || null;
-  },
+  parseRangeClientID(rangeSpecificClientID) {
+    return this._rangeData[rangeSpecificClientID] || null;
+  }
 
   /**
    * If given the client id for a range view, returns the canonical client id
@@ -91,9 +92,9 @@ var GraphQLStoreRangeUtils = {
    * @param {string} dataID
    * @return {string}
    */
-  getCanonicalClientID: function(dataID) {
-    return rangeData[dataID] ? rangeData[dataID].dataID : dataID;
-  },
-};
+  getCanonicalClientID(dataID) {
+    return this._rangeData[dataID] ? this._rangeData[dataID].dataID : dataID;
+  }
+}
 
 module.exports = GraphQLStoreRangeUtils;

--- a/src/legacy/store/__mocks__/GraphQLStoreChangeEmitter.js
+++ b/src/legacy/store/__mocks__/GraphQLStoreChangeEmitter.js
@@ -11,13 +11,17 @@
 
 var GraphQLStoreChangeEmitter = jest.genMockFromModule('GraphQLStoreChangeEmitter');
 
-GraphQLStoreChangeEmitter.addListenerForIDs.mock.remove = [];
-GraphQLStoreChangeEmitter.addListenerForIDs.mockImplementation(() => {
-  var returnValue = {remove: jest.genMockFunction()};
-  GraphQLStoreChangeEmitter.addListenerForIDs.mock.remove.push(
-    returnValue.remove
-  );
-  return returnValue;
+GraphQLStoreChangeEmitter.mockImplementation(function() {
+  this.addListenerForIDs.mock.remove = [];
+  this.addListenerForIDs.mockImplementation(() => {
+    var returnValue = {remove: jest.genMockFunction()};
+    this.addListenerForIDs.mock.remove.push(
+      returnValue.remove
+    );
+    return returnValue;
+  });
+
+  return this;
 });
 
 module.exports = GraphQLStoreChangeEmitter;

--- a/src/legacy/store/__tests__/GraphQLStoreChangeEmitter-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreChangeEmitter-test.js
@@ -18,11 +18,14 @@ var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
 var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 
 describe('GraphQLStoreChangeEmitter', () => {
+  var changeEmitter;
   var mockCallback;
 
   beforeEach(() => {
     jest.resetModuleRegistry();
 
+    changeEmitter = new GraphQLStoreChangeEmitter();
+    
     GraphQLStoreRangeUtils.getCanonicalClientID.mockImplementation(id => id);
 
     ErrorUtils.applyWithGuard.mockImplementation(callback => {
@@ -34,8 +37,8 @@ describe('GraphQLStoreChangeEmitter', () => {
   });
 
   it('should broadcast changes asynchronously', () => {
-    GraphQLStoreChangeEmitter.addListenerForIDs(['foo'], mockCallback);
-    GraphQLStoreChangeEmitter.broadcastChangeForID('foo');
+    changeEmitter.addListenerForIDs(['foo'], mockCallback);
+    changeEmitter.broadcastChangeForID('foo');
 
     expect(mockCallback).not.toBeCalled();
     jest.runAllTimers();
@@ -43,8 +46,8 @@ describe('GraphQLStoreChangeEmitter', () => {
   });
 
   it('should broadcast exclusively to subscribed IDs', () => {
-    GraphQLStoreChangeEmitter.addListenerForIDs(['foo'], mockCallback);
-    GraphQLStoreChangeEmitter.broadcastChangeForID('bar');
+    changeEmitter.addListenerForIDs(['foo'], mockCallback);
+    changeEmitter.broadcastChangeForID('bar');
 
     jest.runAllTimers();
 
@@ -52,8 +55,8 @@ describe('GraphQLStoreChangeEmitter', () => {
   });
 
   it('should not broadcast to removed callbacks', () => {
-    GraphQLStoreChangeEmitter.addListenerForIDs(['foo'], mockCallback).remove();
-    GraphQLStoreChangeEmitter.broadcastChangeForID('foo');
+    changeEmitter.addListenerForIDs(['foo'], mockCallback).remove();
+    changeEmitter.broadcastChangeForID('foo');
 
     jest.runAllTimers();
 
@@ -61,8 +64,8 @@ describe('GraphQLStoreChangeEmitter', () => {
   });
 
   it('should only invoke callbacks subscribed at the time of broadcast', () => {
-    GraphQLStoreChangeEmitter.broadcastChangeForID('foo');
-    GraphQLStoreChangeEmitter.addListenerForIDs(['foo'], mockCallback);
+    changeEmitter.broadcastChangeForID('foo');
+    changeEmitter.addListenerForIDs(['foo'], mockCallback);
 
     jest.runAllTimers();
 
@@ -70,16 +73,16 @@ describe('GraphQLStoreChangeEmitter', () => {
   });
 
   it('should only broadcast once per execution loop', () => {
-    GraphQLStoreChangeEmitter.addListenerForIDs(['foo', 'bar'], mockCallback);
-    GraphQLStoreChangeEmitter.broadcastChangeForID('foo');
-    GraphQLStoreChangeEmitter.broadcastChangeForID('bar');
+    changeEmitter.addListenerForIDs(['foo', 'bar'], mockCallback);
+    changeEmitter.broadcastChangeForID('foo');
+    changeEmitter.broadcastChangeForID('bar');
 
     jest.runAllTimers();
 
     expect(mockCallback.mock.calls.length).toBe(1);
 
-    GraphQLStoreChangeEmitter.broadcastChangeForID('bar');
-    GraphQLStoreChangeEmitter.broadcastChangeForID('foo');
+    changeEmitter.broadcastChangeForID('bar');
+    changeEmitter.broadcastChangeForID('foo');
 
     jest.runAllTimers();
 
@@ -91,8 +94,8 @@ describe('GraphQLStoreChangeEmitter', () => {
       id => id === 'baz_first(5)' ? 'baz' : id
     );
 
-    GraphQLStoreChangeEmitter.addListenerForIDs(['baz_first(5)'], mockCallback);
-    GraphQLStoreChangeEmitter.broadcastChangeForID('baz');
+    changeEmitter.addListenerForIDs(['baz_first(5)'], mockCallback);
+    changeEmitter.broadcastChangeForID('baz');
 
     jest.runAllTimers();
 
@@ -104,9 +107,9 @@ describe('GraphQLStoreChangeEmitter', () => {
       throw new Error();
     });
 
-    GraphQLStoreChangeEmitter.addListenerForIDs(['foo'], mockThrowingCallback);
-    GraphQLStoreChangeEmitter.addListenerForIDs(['foo'], mockCallback);
-    GraphQLStoreChangeEmitter.broadcastChangeForID('foo');
+    changeEmitter.addListenerForIDs(['foo'], mockThrowingCallback);
+    changeEmitter.addListenerForIDs(['foo'], mockCallback);
+    changeEmitter.broadcastChangeForID('foo');
 
     expect(() => {
       jest.runAllTimers();
@@ -125,14 +128,14 @@ describe('GraphQLStoreChangeEmitter', () => {
         mockBatching = false;
       }
     );
-    GraphQLStoreChangeEmitter.injectBatchingStrategy(mockBatchingStrategy);
+    changeEmitter.injectBatchingStrategy(mockBatchingStrategy);
 
     mockCallback.mockImplementation(() => {
       expect(mockBatching).toBe(true);
     });
 
-    GraphQLStoreChangeEmitter.addListenerForIDs(['foo'], mockCallback);
-    GraphQLStoreChangeEmitter.broadcastChangeForID('foo');
+    changeEmitter.addListenerForIDs(['foo'], mockCallback);
+    changeEmitter.broadcastChangeForID('foo');
 
     expect(mockBatchingStrategy.mock.calls.length).toBe(0);
     jest.runAllTimers();
@@ -143,13 +146,13 @@ describe('GraphQLStoreChangeEmitter', () => {
     var mockBatchingStrategy = jest.genMockFunction().mockImplementation(
       callback => callback()
     );
-    GraphQLStoreChangeEmitter.injectBatchingStrategy(mockBatchingStrategy);
+    changeEmitter.injectBatchingStrategy(mockBatchingStrategy);
 
-    GraphQLStoreChangeEmitter.addListenerForIDs(['foo'], () => {
-      GraphQLStoreChangeEmitter.broadcastChangeForID('bar');
+    changeEmitter.addListenerForIDs(['foo'], () => {
+      changeEmitter.broadcastChangeForID('bar');
     });
-    GraphQLStoreChangeEmitter.addListenerForIDs(['bar'], mockCallback);
-    GraphQLStoreChangeEmitter.broadcastChangeForID('foo');
+    changeEmitter.addListenerForIDs(['bar'], mockCallback);
+    changeEmitter.broadcastChangeForID('foo');
 
     jest.runAllTimers();
 

--- a/src/legacy/store/__tests__/GraphQLStoreChangeEmitter-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreChangeEmitter-test.js
@@ -15,7 +15,6 @@ jest.dontMock('GraphQLStoreChangeEmitter');
 
 var ErrorUtils = require('ErrorUtils');
 var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 
 describe('GraphQLStoreChangeEmitter', () => {
   var changeEmitter;
@@ -25,8 +24,6 @@ describe('GraphQLStoreChangeEmitter', () => {
     jest.resetModuleRegistry();
 
     changeEmitter = new GraphQLStoreChangeEmitter();
-    
-    GraphQLStoreRangeUtils.getCanonicalClientID.mockImplementation(id => id);
 
     ErrorUtils.applyWithGuard.mockImplementation(callback => {
       try {
@@ -87,19 +84,6 @@ describe('GraphQLStoreChangeEmitter', () => {
     jest.runAllTimers();
 
     expect(mockCallback.mock.calls.length).toBe(2);
-  });
-
-  it('should correctly broadcast changes to range IDs', () => {
-    GraphQLStoreRangeUtils.getCanonicalClientID.mockImplementation(
-      id => id === 'baz_first(5)' ? 'baz' : id
-    );
-
-    changeEmitter.addListenerForIDs(['baz_first(5)'], mockCallback);
-    changeEmitter.broadcastChangeForID('baz');
-
-    jest.runAllTimers();
-
-    expect(mockCallback).toBeCalled();
   });
 
   it('should guard against callback errors', () => {

--- a/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
@@ -25,6 +25,8 @@ var RelayStoreData = require('RelayStoreData');
 var RelayStoreGarbageCollector = require('RelayStoreGarbageCollector');
 
 describe('GraphQLStoreQueryResolver', () => {
+  var storeData;
+
   var mockCallback;
   var mockQueryFragment;
   var mockPluralQueryFragment;
@@ -42,6 +44,8 @@ describe('GraphQLStoreQueryResolver', () => {
 
   beforeEach(() => {
     jest.resetModuleRegistry();
+
+    storeData = new RelayStoreData();
 
     mockCallback = jest.genMockFunction();
     mockQueryFragment = getNode(Relay.QL`fragment on Node{id,name}`);
@@ -64,7 +68,7 @@ describe('GraphQLStoreQueryResolver', () => {
     readRelayQueryData.mockReturnValue({data: mockResult});
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointer,
       mockCallback
     );
@@ -90,7 +94,7 @@ describe('GraphQLStoreQueryResolver', () => {
     mockReader(mockResult);
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointer,
       mockCallback
     );
@@ -110,7 +114,7 @@ describe('GraphQLStoreQueryResolver', () => {
     var mockResultB = {__dataID__: '1038750002', id: '1038750002', name: 'Tim'};
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointer,
       mockCallback
     );
@@ -134,7 +138,7 @@ describe('GraphQLStoreQueryResolver', () => {
     var mockResultB = {__dataID__: '1038750002', id: '1038750002', name: 'Tee'};
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointer,
       mockCallback
     );
@@ -168,7 +172,7 @@ describe('GraphQLStoreQueryResolver', () => {
     );
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointerA,
       mockCallback
     );
@@ -193,7 +197,7 @@ describe('GraphQLStoreQueryResolver', () => {
     };
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointer,
       mockCallback
     );
@@ -219,7 +223,7 @@ describe('GraphQLStoreQueryResolver', () => {
     mockReader(mockResults);
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointer,
       mockCallback
     );
@@ -249,7 +253,7 @@ describe('GraphQLStoreQueryResolver', () => {
     mockReader(mockResults);
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointer,
       mockCallback
     );
@@ -272,7 +276,7 @@ describe('GraphQLStoreQueryResolver', () => {
     mockReader(mockResults);
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointer,
       mockCallback
     );
@@ -311,7 +315,7 @@ describe('GraphQLStoreQueryResolver', () => {
     mockReader(mockResults);
 
     var resolver = new GraphQLStoreQueryResolver(
-      RelayStoreData.getDefaultInstance().getQueuedStore(),
+      storeData,
       fragmentPointer,
       mockCallback
     );
@@ -386,7 +390,7 @@ describe('GraphQLStoreQueryResolver', () => {
       });
 
       var resolver = new GraphQLStoreQueryResolver(
-        RelayStoreData.getDefaultInstance().getQueuedStore(),
+        storeData,
         fragmentPointer,
         mockCallback
       );

--- a/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
@@ -18,13 +18,13 @@ jest.dontMock('GraphQLStoreQueryResolver');
 
 var Relay = require('Relay');
 var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
-var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
 var GraphQLStoreQueryResolver = require('GraphQLStoreQueryResolver');
 var readRelayQueryData = require('readRelayQueryData');
 var RelayStoreData = require('RelayStoreData');
 var RelayStoreGarbageCollector = require('RelayStoreGarbageCollector');
 
 describe('GraphQLStoreQueryResolver', () => {
+  var changeEmitter;
   var storeData;
 
   var mockCallback;
@@ -46,6 +46,7 @@ describe('GraphQLStoreQueryResolver', () => {
     jest.resetModuleRegistry();
 
     storeData = new RelayStoreData();
+    changeEmitter = storeData.getChangeEmitter();
 
     mockCallback = jest.genMockFunction();
     mockQueryFragment = getNode(Relay.QL`fragment on Node{id,name}`);
@@ -100,7 +101,7 @@ describe('GraphQLStoreQueryResolver', () => {
     );
     resolver.resolve(fragmentPointer);
 
-    var addListenersForIDs = GraphQLStoreChangeEmitter.addListenerForIDs;
+    var addListenersForIDs = changeEmitter.addListenerForIDs;
     expect(addListenersForIDs).toBeCalled();
     expect(addListenersForIDs.mock.calls[0][0]).toEqual(['1038750002']);
   });
@@ -148,7 +149,7 @@ describe('GraphQLStoreQueryResolver', () => {
     });
     var resolvedA = resolver.resolve(fragmentPointer);
 
-    var callback = GraphQLStoreChangeEmitter.addListenerForIDs.mock.calls[0][1];
+    var callback = changeEmitter.addListenerForIDs.mock.calls[0][1];
     callback(['1038750002']);
 
     mockReader({
@@ -205,7 +206,7 @@ describe('GraphQLStoreQueryResolver', () => {
     mockReader(mockResult);
     resolver.resolve(fragmentPointer);
 
-    var callback = GraphQLStoreChangeEmitter.addListenerForIDs.mock.calls[0][1];
+    var callback = changeEmitter.addListenerForIDs.mock.calls[0][1];
     callback(['1038750002']);
 
     expect(mockCallback).toBeCalled();
@@ -284,7 +285,7 @@ describe('GraphQLStoreQueryResolver', () => {
     var resolvedA = resolver.resolve(fragmentPointer);
 
     mockResults['1'] = {__dataID__: '1', name: 'Won'};
-    var callback = GraphQLStoreChangeEmitter.addListenerForIDs.mock.calls[0][1];
+    var callback = changeEmitter.addListenerForIDs.mock.calls[0][1];
     callback(['1']);
 
     var resolvedB = resolver.resolve(fragmentPointer);
@@ -398,7 +399,7 @@ describe('GraphQLStoreQueryResolver', () => {
       // Resolve the fragment pointer with the mocked data
       resolver.resolve(fragmentPointer);
       var callback =
-        GraphQLStoreChangeEmitter.addListenerForIDs.mock.calls[0][1];
+        changeEmitter.addListenerForIDs.mock.calls[0][1];
       // On first resolve we get data for all added ids
       expect(getIncreaseSubscriptionsParameters(2)).toEqual([
         'address', 'chris'

--- a/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
@@ -178,7 +178,7 @@ describe('GraphQLStoreQueryResolver', () => {
       mockCallback
     );
 
-    require('GraphQLStoreRangeUtils').getCanonicalClientID =
+    RelayStoreData.getDefaultInstance().getRangeData().getCanonicalClientID =
       // The canonical ID of a range customarily excludes the calls
       jest.genMockFunction().mockReturnValue('client:123');
 

--- a/src/legacy/store/__tests__/GraphQLStoreRangeUtils-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreRangeUtils-test.js
@@ -20,6 +20,11 @@ var QueryBuilder = require('QueryBuilder');
 var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 
 describe('GraphQLStoreRangeUtils', () => {
+  var rangeData;
+
+  beforeEach(() => {
+    rangeData = new GraphQLStoreRangeUtils();
+  });
 
   it('should encode and decode', () => {
     var id = 'client:1';
@@ -37,7 +42,7 @@ describe('GraphQLStoreRangeUtils', () => {
 
     var calls = [firstCall, afterCall];
 
-    var rangeID = GraphQLStoreRangeUtils.getClientIDForRangeWithID(
+    var rangeID = rangeData.getClientIDForRangeWithID(
       calls,
       callValues,
       id
@@ -49,7 +54,7 @@ describe('GraphQLStoreRangeUtils', () => {
     // a different ID or different calls.
     expect(rangeID).toEqual('client:1_first(1),after(123456)');
 
-    var parsed = GraphQLStoreRangeUtils.parseRangeClientID(rangeID);
+    var parsed = rangeData.parseRangeClientID(rangeID);
     expect(parsed.dataID).toBe(id);
     expect(parsed.calls).toBe(calls);
     expect(parsed.callValues).toBe(callValues);

--- a/src/store/RelayQueryResultObservable.js
+++ b/src/store/RelayQueryResultObservable.js
@@ -15,7 +15,7 @@
 
 var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
 var GraphQLStoreQueryResolver = require('GraphQLStoreQueryResolver');
-import type RelayRecordStore from 'RelayRecordStore';
+import type RelayStoreData from 'RelayStoreData';
 import type {
   StoreReaderData,
   Subscription,
@@ -48,18 +48,18 @@ class RelayQueryResultObservable {
   _data: ?StoreReaderData;
   _fragmentPointer: GraphQLFragmentPointer;
   _queryResolver: ?GraphQLStoreQueryResolver;
-  _store: RelayRecordStore;
+  _storeData: RelayStoreData;
   _subscriptionCallbacks: Array<SubscriptionCallbacks<?StoreReaderData>>;
   _subscriptionCount: number;
 
   constructor(
-    store: RelayRecordStore,
+    storeData: RelayStoreData,
     fragmentPointer: GraphQLFragmentPointer
   ) {
     this._data = undefined;
     this._fragmentPointer = fragmentPointer;
     this._queryResolver = null;
-    this._store = store;
+    this._storeData = storeData;
     this._subscriptionCallbacks = [];
     this._subscriptionCount = 0;
   }
@@ -96,7 +96,7 @@ class RelayQueryResultObservable {
       'RelayQueryResultObservable: Initialized twice.'
     );
     var queryResolver = new GraphQLStoreQueryResolver(
-      this._store,
+      this._storeData,
       this._fragmentPointer,
       () => this._onUpdate(queryResolver)
     );

--- a/src/store/RelayRecordStore.js
+++ b/src/store/RelayRecordStore.js
@@ -16,8 +16,8 @@
 const GraphQLMutatorConstants = require('GraphQLMutatorConstants');
 const GraphQLRange = require('GraphQLRange');
 const GraphQLStoreDataHandler = require('GraphQLStoreDataHandler');
-const GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 const RelayConnectionInterface = require('RelayConnectionInterface');
+const RelayStoreData = require('RelayStoreData');
 import type {
   Call,
   ClientMutationID,
@@ -252,7 +252,7 @@ class RelayRecordStore {
    * Returns whether a given record is affected by an optimistic update.
    */
   hasOptimisticUpdate(dataID: DataID): boolean {
-    dataID = GraphQLStoreRangeUtils.getCanonicalClientID(dataID);
+    dataID = RelayStoreData.getDefaultInstance().getRangeData().getCanonicalClientID(dataID);
     invariant(
       this._queuedRecords,
       'RelayRecordStore.hasOptimisticUpdate(): Optimistic updates require ' +
@@ -267,7 +267,7 @@ class RelayRecordStore {
    * null if the record isn't affected by any optimistic updates.
    */
   getClientMutationIDs(dataID: DataID): ?Array<ClientMutationID> {
-    dataID = GraphQLStoreRangeUtils.getCanonicalClientID(dataID);
+    dataID = RelayStoreData.getDefaultInstance().getRangeData().getCanonicalClientID(dataID);
     invariant(
       this._queuedRecords,
       'RelayRecordStore.getClientMutationIDs(): Optimistic updates require ' +

--- a/src/store/RelayStore.js
+++ b/src/store/RelayStore.js
@@ -158,7 +158,7 @@ var RelayStore = {
       fragment.isPlural()? [dataID] : dataID,
       fragment
     );
-    return new RelayQueryResultObservable(queuedStore, fragmentPointer);
+    return new RelayQueryResultObservable(storeData, fragmentPointer);
   },
 
   update(

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -17,6 +17,7 @@ var GraphQLDeferredQueryTracker = require('GraphQLDeferredQueryTracker');
 var GraphQLQueryRunner = require('GraphQLQueryRunner');
 var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
 var GraphQLStoreDataHandler = require('GraphQLStoreDataHandler');
+var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 var RelayChangeTracker = require('RelayChangeTracker');
 var RelayConnectionInterface = require('RelayConnectionInterface');
 import type {ChangeSet} from 'RelayChangeTracker';
@@ -69,11 +70,12 @@ class RelayStoreData {
   _garbageCollector: ?RelayStoreGarbageCollector;
   _nodeRangeMap: NodeRangeMap;
   _records: Records;
+  _queryRunner: GraphQLQueryRunner;
+  _queryTracker: RelayQueryTracker;
   _queuedRecords: Records;
   _queuedStore: RelayRecordStore;
+  _rangeData: GraphQLStoreRangeUtils;
   _recordStore: RelayRecordStore;
-  _queryTracker: RelayQueryTracker;
-  _queryRunner: GraphQLQueryRunner;
   _rootCalls: RootCallMap;
 
   /**
@@ -112,12 +114,13 @@ class RelayStoreData {
     this._deferredQueryTracker =
       new GraphQLDeferredQueryTracker(this.getRecordStore());
     this._nodeRangeMap = nodeRangeMap;
+    this._rangeData = new GraphQLStoreRangeUtils();
     this._records = records;
+    this._queryTracker = new RelayQueryTracker();
+    this._queryRunner = new GraphQLQueryRunner(this);
     this._queuedRecords = queuedRecords;
     this._queuedStore = queuedStore;
     this._recordStore = recordStore;
-    this._queryTracker = new RelayQueryTracker();
-    this._queryRunner = new GraphQLQueryRunner(this);
     this._rootCalls = rootCallMap;
   }
 
@@ -388,6 +391,10 @@ class RelayStoreData {
 
   getChangeEmitter(): GraphQLStoreChangeEmitter {
     return this._changeEmitter;
+  }
+
+  getRangeData(): GraphQLStoreRangeUtils {
+    return this._rangeData;
   }
 
   /**

--- a/src/store/__tests__/RelayQueryResultObservable-test.js
+++ b/src/store/__tests__/RelayQueryResultObservable-test.js
@@ -18,15 +18,18 @@ jest
 var RelayTestUtils = require('RelayTestUtils');
 RelayTestUtils.unmockRelay();
 
-var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
 var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
+var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
 var Relay = require('Relay');
 var RelayQueryResultObservable = require('RelayQueryResultObservable');
 var RelayRecordStore = require('RelayRecordStore');
+var RelayStoreData = require('RelayStoreData');
 
 var readRelayQueryData = require('readRelayQueryData');
 
 describe('RelayQueryResultObservable', () => {
+  var storeData;
+
   var query;
   var records;
   var results;
@@ -55,7 +58,7 @@ describe('RelayQueryResultObservable', () => {
       dataID,
       query
     );
-    return new RelayQueryResultObservable(store, fragmentPointer);
+    return new RelayQueryResultObservable(storeData, fragmentPointer);
   }
 
   beforeEach(() => {
@@ -76,6 +79,11 @@ describe('RelayQueryResultObservable', () => {
       name: 'Joe',
     };
     store = new RelayRecordStore({records});
+    storeData = new RelayStoreData();
+
+    storeData.getQueuedStore = jest.genMockFunction().mockImplementation(() => {
+      return store;
+    });
 
     jest.addMatchers(RelayTestUtils.matchers);
   });

--- a/src/store/__tests__/RelayQueryResultObservable-test.js
+++ b/src/store/__tests__/RelayQueryResultObservable-test.js
@@ -12,13 +12,13 @@
 'use strict';
 
 jest
+  .dontMock('RelayStoreData')
   .dontMock('GraphQLStoreChangeEmitter')
   .dontMock('GraphQLStoreQueryResolver');
 
 var RelayTestUtils = require('RelayTestUtils');
 RelayTestUtils.unmockRelay();
 
-var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
 var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
 var Relay = require('Relay');
 var RelayQueryResultObservable = require('RelayQueryResultObservable');
@@ -29,6 +29,7 @@ var readRelayQueryData = require('readRelayQueryData');
 
 describe('RelayQueryResultObservable', () => {
   var storeData;
+  var changeEmitter;
 
   var query;
   var records;
@@ -85,6 +86,7 @@ describe('RelayQueryResultObservable', () => {
       return store;
     });
 
+    changeEmitter = storeData.getChangeEmitter();
     jest.addMatchers(RelayTestUtils.matchers);
   });
 
@@ -145,7 +147,7 @@ describe('RelayQueryResultObservable', () => {
 
     store.putField('123', 'name', 'Joseph');
     results.name = 'Joseph';
-    GraphQLStoreChangeEmitter.broadcastChangeForID('123');
+    changeEmitter.broadcastChangeForID('123');
     jest.runAllTimers();
 
     subscribers.forEach(subscriber => {
@@ -164,7 +166,7 @@ describe('RelayQueryResultObservable', () => {
 
     store.putField('123', 'name', 'Joseph');
     results.name = 'Joseph';
-    GraphQLStoreChangeEmitter.broadcastChangeForID('123');
+    changeEmitter.broadcastChangeForID('123');
     jest.runAllTimers();
 
     expect(subscriber.onCompleted).not.toBeCalled();
@@ -184,7 +186,7 @@ describe('RelayQueryResultObservable', () => {
 
     // fetching the record calls onNext
     store.putRecord('oops');
-    GraphQLStoreChangeEmitter.broadcastChangeForID('oops');
+    changeEmitter.broadcastChangeForID('oops');
     jest.runAllTimers();
     expect(subscriber.onCompleted).not.toBeCalled();
     expect(subscriber.onError).not.toBeCalled();
@@ -201,7 +203,7 @@ describe('RelayQueryResultObservable', () => {
 
     // deleting the record calls onNext
     store.deleteRecord('123');
-    GraphQLStoreChangeEmitter.broadcastChangeForID('123');
+    changeEmitter.broadcastChangeForID('123');
     jest.runAllTimers();
     expect(subscriber.onCompleted).not.toBeCalled();
     expect(subscriber.onError).not.toBeCalled();
@@ -210,7 +212,7 @@ describe('RelayQueryResultObservable', () => {
 
     // restoring the record calls onNext
     store.putRecord('123');
-    GraphQLStoreChangeEmitter.broadcastChangeForID('123');
+    changeEmitter.broadcastChangeForID('123');
     jest.runAllTimers();
     expect(subscriber.onCompleted).not.toBeCalled();
     expect(subscriber.onError).not.toBeCalled();
@@ -227,7 +229,7 @@ describe('RelayQueryResultObservable', () => {
 
     // evicting the record calls onNext
     store.removeRecord('123');
-    GraphQLStoreChangeEmitter.broadcastChangeForID('123');
+    changeEmitter.broadcastChangeForID('123');
     jest.runAllTimers();
     expect(subscriber.onCompleted).not.toBeCalled();
     expect(subscriber.onError).not.toBeCalled();
@@ -236,7 +238,7 @@ describe('RelayQueryResultObservable', () => {
 
     // restoring the record calls onNext
     store.putRecord('123');
-    GraphQLStoreChangeEmitter.broadcastChangeForID('123');
+    changeEmitter.broadcastChangeForID('123');
     jest.runAllTimers();
     expect(subscriber.onCompleted).not.toBeCalled();
     expect(subscriber.onError).not.toBeCalled();

--- a/src/store/__tests__/readRelayQueryData-test.js
+++ b/src/store/__tests__/readRelayQueryData-test.js
@@ -16,10 +16,10 @@ RelayTestUtils.unmockRelay();
 
 var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
 var GraphQLRange = require('GraphQLRange');
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 var Relay = require('Relay');
 var RelayConnectionInterface = require('RelayConnectionInterface');
 var RelayFragmentReference = require('RelayFragmentReference');
+var RelayStoreData = require('RelayStoreData');
 var RelayRecordStatusMap = require('RelayRecordStatusMap');
 var callsToGraphQL = require('callsToGraphQL');
 var readRelayQueryData = require('readRelayQueryData');
@@ -319,7 +319,7 @@ describe('readRelayQueryData', () => {
         count
       }
     `);
-    var rangeID = GraphQLStoreRangeUtils.getClientIDForRangeWithID(
+    var rangeID = RelayStoreData.getDefaultInstance().getRangeData().getClientIDForRangeWithID(
       callsToGraphQL([
         {name: 'is_viewer_friend', value: null},
         {name: 'first', value: 10},

--- a/src/store/readRelayQueryData.js
+++ b/src/store/readRelayQueryData.js
@@ -15,13 +15,13 @@
 
 var GraphQLStoreDataHandler = require('GraphQLStoreDataHandler');
 var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 var RelayConnectionInterface = require('RelayConnectionInterface');
 import type {DataID} from 'RelayInternalTypes';
 var RelayProfiler = require('RelayProfiler');
 var RelayQuery = require('RelayQuery');
 var RelayQueryVisitor = require('RelayQueryVisitor');
 var RelayRecordState = require('RelayRecordState');
+var RelayStoreData = require('RelayStoreData');
 import type RelayRecordStore from 'RelayRecordStore';
 import type {RangeInfo} from 'RelayRecordStore';
 import type {
@@ -33,6 +33,8 @@ var callsFromGraphQL = require('callsFromGraphQL');
 var callsToGraphQL = require('callsToGraphQL');
 var invariant = require('invariant');
 var validateRelayReadQuery = require('validateRelayReadQuery');
+
+var rangeUtils = RelayStoreData.getDefaultInstance().getRangeData();
 
 export type DataIDSet = {[key: string]: boolean};
 export type StoreReaderResult = {
@@ -100,7 +102,7 @@ class RelayStoreReader extends RelayQueryVisitor<State> {
       data: (undefined: $FlowIssue),
       dataIDs: ({}: $FlowIssue),
     };
-    var rangeData = GraphQLStoreRangeUtils.parseRangeClientID(dataID);
+    var rangeData = rangeUtils.parseRangeClientID(dataID);
     var status = this._recordStore.getRecordState(
       rangeData ? rangeData.dataID : dataID
     );
@@ -363,7 +365,7 @@ class RelayStoreReader extends RelayQueryVisitor<State> {
    * so, unpacks the range metadata, stashing it into (and overriding) `state`.
    */
   _handleRangeInfo(node: RelayQuery.Field, state: State): void {
-    var rangeData = GraphQLStoreRangeUtils.parseRangeClientID(
+    var rangeData = rangeUtils.parseRangeClientID(
       state.storeDataID
     );
     if (rangeData != null) {
@@ -423,7 +425,7 @@ function getConnectionClientID(
   if (!RelayConnectionInterface.hasRangeCalls(calls)) {
     return connectionID;
   }
-  return GraphQLStoreRangeUtils.getClientIDForRangeWithID(
+  return rangeUtils.getClientIDForRangeWithID(
     callsToGraphQL(calls),
     {},
     connectionID


### PR DESCRIPTION
Builds on #565. Part of #558

@josephsavona ~~It seemed important that `GraphQLStoreRangeUtils` continue converting IDs -> broadcast IDs, for non-`RelayStoreData` users like `GraphQLStoreQueryResolver`. That said, since `GraphQLStoreQueryResolver` also relies on `RelayStoreData`, maybe that could change.~~ _edit:_ nvm.

I think it might make sense to rename `GraphQLStoreRangeUtils` to `GraphQLStoreRangeData`... let me know what you think.