### PR TITLE
skip unmatched fragments in writer

### DIFF
--- a/src/store/RelayQueryWriter.js
+++ b/src/store/RelayQueryWriter.js
@@ -218,6 +218,21 @@ class RelayQueryWriter extends RelayQueryVisitor<WriterState> {
     this.traverse(root, state);
   }
 
+  visitFragment(
+    fragment: RelayQuery.Fragment,
+    state: WriterState
+  ): ?RelayQuery.Node {
+    var {recordID} = state;
+    var recordType = this._store.getType(recordID);
+    if (
+      !recordType ||
+      recordType === NODE ||
+      recordType === fragment.getType()
+    ) {
+      this.traverse(fragment, state);
+    }
+  }
+
   visitField(
     field: RelayQuery.Field,
     state: WriterState


### PR DESCRIPTION
`RelayQueryWriter` currently traverses *all* fragments when processing a payload and attempts to write their fields, regardless of whether the result type and fragment type actually match. For fields with an abstract/union type, we should instead only follow fragments whose type matches the actual result type.

Example:

```
// query
fragment on Type {
  id
  __typename
  ... on A { ... }
  ... on B { ... }
}

// response 
{
  id: "...",
  __typename: "A"
  ...
}
```

We should only write the results for the fragment on type "A".