### PR TITLE
Remove context from RelayRecordStore

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -333,7 +333,7 @@ function createContainerComponent(
         'RelayContainer.hasOptimisticUpdate(): Expected a record in `%s`.',
         componentName
       );
-      return storeData.getQueuedStore().hasOptimisticUpdate(dataID);
+      return storeData.hasOptimisticUpdate(dataID);
     }
 
     /**
@@ -346,8 +346,7 @@ function createContainerComponent(
         'RelayContainer.getPendingTransactions(): Expected a record in `%s`.',
         componentName
       );
-      const mutationIDs =
-        storeData.getQueuedStore().getClientMutationIDs(dataID);
+      var mutationIDs = storeData.getClientMutationIDs(dataID);
       if (!mutationIDs) {
         return null;
       }

--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -27,7 +27,6 @@ var RelayFragmentReference = require('RelayFragmentReference');
 import type {DataID, RelayQuerySet} from 'RelayInternalTypes';
 var RelayMetaRoute = require('RelayMetaRoute');
 var RelayMutationTransaction = require('RelayMutationTransaction');
-var RelayPendingQueryTracker = require('RelayPendingQueryTracker');
 var RelayPropTypes = require('RelayPropTypes');
 var RelayProfiler = require('RelayProfiler');
 var RelayQuery = require('RelayQuery');
@@ -402,7 +401,7 @@ function createContainerComponent(
       record: Object
     ): boolean {
       if (
-        !RelayPendingQueryTracker.hasPendingQueries() &&
+        !storeData.getPendingQueryTracker().hasPendingQueries() &&
         !this._deferredErrors
       ) {
         // nothing can be missing => must have data

--- a/src/container/__tests__/RelayContainer_hasFragmentData-test.js
+++ b/src/container/__tests__/RelayContainer_hasFragmentData-test.js
@@ -17,7 +17,6 @@ RelayTestUtils.unmockRelay();
 var GraphQLStoreQueryResolver = require('GraphQLStoreQueryResolver');
 var React = require('React');
 var Relay = require('Relay');
-var RelayPendingQueryTracker = require('RelayPendingQueryTracker');
 var RelayStoreData = require('RelayStoreData');
 
 describe('RelayContainer.hasFragmentData', function() {
@@ -25,12 +24,14 @@ describe('RelayContainer.hasFragmentData', function() {
   var mockRender;
   var mockPointer;
   var deferredQueryTracker;
+  var pendingQueryTracker;
 
   beforeEach(function() {
     jest.resetModuleRegistry();
 
-    deferredQueryTracker =
-      RelayStoreData.getDefaultInstance().getDeferredQueryTracker();
+    var storeData = RelayStoreData.getDefaultInstance();
+    deferredQueryTracker = storeData.getDeferredQueryTracker();
+    pendingQueryTracker = storeData.getPendingQueryTracker();
 
     var render = jest.genMockFunction().mockImplementation(() => <div />);
     var MockComponent = React.createClass({render});
@@ -59,7 +60,7 @@ describe('RelayContainer.hasFragmentData', function() {
 
   it('has query data when no pending queries', () => {
     var instance = mockRender();
-    spyOn(RelayPendingQueryTracker, 'hasPendingQueries').andReturn(false);
+    spyOn(pendingQueryTracker, 'hasPendingQueries').andReturn(false);
 
     expect(
       instance.hasFragmentData(MockContainer.getFragment('foo'), mockPointer)
@@ -68,7 +69,7 @@ describe('RelayContainer.hasFragmentData', function() {
 
   it('has query data when no pending query matches', () => {
     var instance = mockRender();
-    spyOn(RelayPendingQueryTracker, 'hasPendingQueries').andReturn(true);
+    spyOn(pendingQueryTracker, 'hasPendingQueries').andReturn(true);
     deferredQueryTracker.isQueryPending.mockReturnValue(false);
 
     expect(
@@ -78,7 +79,7 @@ describe('RelayContainer.hasFragmentData', function() {
 
   it('does not have query data when a pending query matches', () => {
     var instance = mockRender();
-    spyOn(RelayPendingQueryTracker, 'hasPendingQueries').andReturn(true);
+    spyOn(pendingQueryTracker, 'hasPendingQueries').andReturn(true);
     deferredQueryTracker.isQueryPending.mockReturnValue(true);
 
     expect(
@@ -89,7 +90,7 @@ describe('RelayContainer.hasFragmentData', function() {
   it('does not have query data if a deferred query fails', () => {
     var instance = mockRender();
     var hasPendingQueriesSpy =
-      spyOn(RelayPendingQueryTracker, 'hasPendingQueries');
+      spyOn(pendingQueryTracker, 'hasPendingQueries');
     hasPendingQueriesSpy.andReturn(true);
     deferredQueryTracker.isQueryPending.mockReturnValue(true);
 

--- a/src/legacy/store/GraphQLQueryRunner.js
+++ b/src/legacy/store/GraphQLQueryRunner.js
@@ -17,7 +17,6 @@ var DliteFetchModeConstants = require('DliteFetchModeConstants');
 import type {RelayQuerySet} from 'RelayInternalTypes';
 import type {PendingFetch} from 'RelayPendingQueryTracker';
 var RelayNetworkLayer = require('RelayNetworkLayer');
-var RelayPendingQueryTracker = require('RelayPendingQueryTracker');
 var RelayProfiler = require('RelayProfiler');
 import type RelayQuery from 'RelayQuery';
 import type RelayStoreData from 'RelayStoreData';
@@ -264,7 +263,7 @@ function runQueries(
       generateForceIndex() : null;
 
     splitAndFlattenQueries(queries).forEach(query => {
-      var pendingFetch = RelayPendingQueryTracker.add(
+      var pendingFetch = storeData.getPendingQueryTracker().add(
         {query, fetchMode, forceIndex, storeData}
       );
       var queryID = query.getID();

--- a/src/legacy/store/GraphQLStoreChangeEmitter.js
+++ b/src/legacy/store/GraphQLStoreChangeEmitter.js
@@ -14,7 +14,6 @@
 'use strict';
 
 var ErrorUtils = require('ErrorUtils');
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 
 var resolveImmediate = require('resolveImmediate');
 
@@ -55,10 +54,9 @@ class GraphQLStoreChangeEmitter {
   }
 
   addListenerForIDs(
-    ids: Array<string>,
+    subscribedIDs: Array<string>,
     callback: SubscriptionCallback
   ): ChangeSubscription {
-    var subscribedIDs = ids.map(getBroadcastID);
     var index = this._subscribers.length;
     this._subscribers.push({subscribedIDs, callback});
     return {
@@ -76,7 +74,7 @@ class GraphQLStoreChangeEmitter {
     }
     // Record index of the last subscriber so we do not later unintentionally
     // invoke callbacks that were subscribed after this broadcast.
-    scheduledIDs[getBroadcastID(id)] = this._subscribers.length - 1;
+    scheduledIDs[id] = this._subscribers.length - 1;
   }
 
   injectBatchingStrategy(batchStrategy: BatchStrategy): void {
@@ -125,15 +123,6 @@ class GraphQLStoreChangeEmitter {
       }
     }
   }
-}
-
-/**
- * Ranges publish events for the entire range, not the specific view of that
- * range. For example, if "client:1" is a range, the event is on "client:1",
- * not "client:1_first(5)".
- */
-function getBroadcastID(id: string): string {
-  return GraphQLStoreRangeUtils.getCanonicalClientID(id);
 }
 
 module.exports = GraphQLStoreChangeEmitter;

--- a/src/legacy/store/GraphQLStoreQueryResolver.js
+++ b/src/legacy/store/GraphQLStoreQueryResolver.js
@@ -15,12 +15,10 @@
 
 import type {ChangeSubscription} from 'GraphQLStoreChangeEmitter';
 import type GraphQLFragmentPointer from 'GraphQLFragmentPointer';
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 import type RelayStoreGarbageCollector from 'RelayStoreGarbageCollector';
 import type {DataID} from 'RelayInternalTypes';
 var RelayProfiler = require('RelayProfiler');
 import type RelayQuery from 'RelayQuery';
-import type RelayRecordStore from 'RelayRecordStore';
 import type RelayStoreData from 'RelayStoreData';
 import type {StoreReaderData} from 'RelayTypes';
 
@@ -246,7 +244,7 @@ class GraphQLStoreSingleQueryResolver {
         subscribedIDs[nextID] = true;
         var changeEmitter = this._storeData.getChangeEmitter();
         this._subscription = changeEmitter.addListenerForIDs(
-          Object.keys(subscribedIDs),
+          Object.keys(subscribedIDs).map(id => this._getCanonicalID(id)),
           this._handleChange.bind(this)
         );
         this._updateGarbageCollectorSubscriptionCount(subscribedIDs);
@@ -268,7 +266,7 @@ class GraphQLStoreSingleQueryResolver {
    * not "client:1_first(5)".
    */
   _getCanonicalID(id: DataID): DataID {
-    return GraphQLStoreRangeUtils.getCanonicalClientID(id);
+    return this._storeData.getCanonicalClientID(id);
   }
 
   _handleChange(): void {

--- a/src/legacy/store/GraphQLStoreQueryResolver.js
+++ b/src/legacy/store/GraphQLStoreQueryResolver.js
@@ -214,8 +214,7 @@ class GraphQLStoreSingleQueryResolver {
       ) {
         // same canonical ID,
         // but the data, call(s), route, and/or variables have changed
-        [nextResult, subscribedIDs] = resolveFragment(
-          this._storeData.getQueuedStore(),
+        [nextResult, subscribedIDs] = this._resolveFragment(
           nextFragment,
           nextID
         );
@@ -226,8 +225,7 @@ class GraphQLStoreSingleQueryResolver {
       }
     } else {
       // Pointer has a different ID or is/was fake data.
-      [nextResult, subscribedIDs] = resolveFragment(
-        this._storeData.getQueuedStore(),
+      [nextResult, subscribedIDs] = this._resolveFragment(
         nextFragment,
         nextID
       );
@@ -276,6 +274,14 @@ class GraphQLStoreSingleQueryResolver {
     }
   }
 
+  _resolveFragment(
+    fragment: RelayQuery.Fragment,
+    dataID: DataID
+  ): [StoreReaderData, DataIDSet] {
+    var {data, dataIDs} = readRelayQueryData(this._storeData, fragment, dataID);
+    return [data, dataIDs];
+  }
+
   /**
    * Updates bookkeeping about the number of subscribers on each record.
    */
@@ -292,15 +298,6 @@ class GraphQLStoreSingleQueryResolver {
       removed.forEach(id => garbageCollector.decreaseSubscriptionsFor(id));
     }
   }
-}
-
-function resolveFragment(
-  store: RelayRecordStore,
-  fragment: RelayQuery.Fragment,
-  dataID: DataID
-): [StoreReaderData, DataIDSet] {
-  var {data, dataIDs} = readRelayQueryData(store, fragment, dataID);
-  return [data, dataIDs];
 }
 
 RelayProfiler.instrumentMethods(GraphQLStoreQueryResolver.prototype, {

--- a/src/legacy/store/GraphQLStoreRangeUtils.js
+++ b/src/legacy/store/GraphQLStoreRangeUtils.js
@@ -15,8 +15,6 @@
 var callsFromGraphQL = require('callsFromGraphQL');
 var printRelayQueryCall = require('printRelayQueryCall');
 
-var rangeData = {};
-
 /**
  * Utilities used by GraphQLStore for storing ranges
  *
@@ -45,7 +43,10 @@ var rangeData = {};
  *
  * @internal
  */
-var GraphQLStoreRangeUtils = {
+class GraphQLStoreRangeUtils {
+  constructor() {
+    this._rangeData = {};
+  }
 
   /**
    * Returns a token that can be parsed using parseRangeClientID to recover
@@ -57,21 +58,21 @@ var GraphQLStoreRangeUtils = {
    * @param {string} dataID
    * @return {string}
    */
-  getClientIDForRangeWithID: function(calls, callValues, dataID) {
+  getClientIDForRangeWithID(calls, callValues, dataID) {
     var callsAsString = callsFromGraphQL(calls, callValues)
       .map(call => printRelayQueryCall(call).substring(1))
       .join(',');
     var key = dataID + '_' + callsAsString;
-    var edge = rangeData[key];
+    var edge = this._rangeData[key];
     if (!edge) {
-      rangeData[key] = {
+      this._rangeData[key] = {
         dataID: dataID,
         calls: calls,
         callValues: callValues
       };
     }
     return key;
-  },
+  }
 
   /**
    * Parses an ID back into its data ID and calls
@@ -79,9 +80,9 @@ var GraphQLStoreRangeUtils = {
    * @param {string} rangeSpecificClientID
    * @return {?object}
    */
-  parseRangeClientID: function(rangeSpecificClientID) {
-    return rangeData[rangeSpecificClientID] || null;
-  },
+  parseRangeClientID(rangeSpecificClientID) {
+    return this._rangeData[rangeSpecificClientID] || null;
+  }
 
   /**
    * If given the client id for a range view, returns the canonical client id
@@ -91,9 +92,9 @@ var GraphQLStoreRangeUtils = {
    * @param {string} dataID
    * @return {string}
    */
-  getCanonicalClientID: function(dataID) {
-    return rangeData[dataID] ? rangeData[dataID].dataID : dataID;
-  },
-};
+  getCanonicalClientID(dataID) {
+    return this._rangeData[dataID] ? this._rangeData[dataID].dataID : dataID;
+  }
+}
 
 module.exports = GraphQLStoreRangeUtils;

--- a/src/legacy/store/__tests__/GraphQLStoreChangeEmitter-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreChangeEmitter-test.js
@@ -15,7 +15,6 @@ jest.dontMock('GraphQLStoreChangeEmitter');
 
 var ErrorUtils = require('ErrorUtils');
 var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 
 describe('GraphQLStoreChangeEmitter', () => {
   var changeEmitter;
@@ -25,8 +24,6 @@ describe('GraphQLStoreChangeEmitter', () => {
     jest.resetModuleRegistry();
 
     changeEmitter = new GraphQLStoreChangeEmitter();
-
-    GraphQLStoreRangeUtils.getCanonicalClientID.mockImplementation(id => id);
 
     ErrorUtils.applyWithGuard.mockImplementation(callback => {
       try {
@@ -87,19 +84,6 @@ describe('GraphQLStoreChangeEmitter', () => {
     jest.runAllTimers();
 
     expect(mockCallback.mock.calls.length).toBe(2);
-  });
-
-  it('should correctly broadcast changes to range IDs', () => {
-    GraphQLStoreRangeUtils.getCanonicalClientID.mockImplementation(
-      id => id === 'baz_first(5)' ? 'baz' : id
-    );
-
-    changeEmitter.addListenerForIDs(['baz_first(5)'], mockCallback);
-    changeEmitter.broadcastChangeForID('baz');
-
-    jest.runAllTimers();
-
-    expect(mockCallback).toBeCalled();
   });
 
   it('should guard against callback errors', () => {

--- a/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
@@ -178,7 +178,7 @@ describe('GraphQLStoreQueryResolver', () => {
       mockCallback
     );
 
-    require('GraphQLStoreRangeUtils').getCanonicalClientID =
+    RelayStoreData.getDefaultInstance().getCanonicalClientID =
       // The canonical ID of a range customarily excludes the calls
       jest.genMockFunction().mockReturnValue('client:123');
 

--- a/src/legacy/store/__tests__/GraphQLStoreRangeUtils-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreRangeUtils-test.js
@@ -20,6 +20,11 @@ var QueryBuilder = require('QueryBuilder');
 var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 
 describe('GraphQLStoreRangeUtils', () => {
+  var rangeData;
+
+  beforeEach(() => {
+    rangeData = new GraphQLStoreRangeUtils();
+  });
 
   it('should encode and decode', () => {
     var id = 'client:1';
@@ -37,7 +42,7 @@ describe('GraphQLStoreRangeUtils', () => {
 
     var calls = [firstCall, afterCall];
 
-    var rangeID = GraphQLStoreRangeUtils.getClientIDForRangeWithID(
+    var rangeID = rangeData.getClientIDForRangeWithID(
       calls,
       callValues,
       id
@@ -49,7 +54,7 @@ describe('GraphQLStoreRangeUtils', () => {
     // a different ID or different calls.
     expect(rangeID).toEqual('client:1_first(1),after(123456)');
 
-    var parsed = GraphQLStoreRangeUtils.parseRangeClientID(rangeID);
+    var parsed = rangeData.parseRangeClientID(rangeID);
     expect(parsed.dataID).toBe(id);
     expect(parsed.calls).toBe(calls);
     expect(parsed.callValues).toBe(callValues);

--- a/src/store/RelayPendingQueryTracker.js
+++ b/src/store/RelayPendingQueryTracker.js
@@ -32,7 +32,6 @@ type PendingQueryParameters = {
   fetchMode: DliteFetchModeConstants;
   forceIndex: ?number;
   query: RelayQuery.Root;
-  storeData: RelayStoreData;
 };
 type PendingState = {
   fetch: PendingFetch;
@@ -68,7 +67,8 @@ class PendingFetch {
   _errors: Array<?Error>;
 
   constructor(
-    {fetchMode, forceIndex, query, storeData}: PendingQueryParameters
+    {fetchMode, forceIndex, query}: PendingQueryParameters,
+    storeData: RelayStoreData
   ) {
     var queryID = query.getID();
     this._storeData = storeData;
@@ -291,37 +291,39 @@ function hasItems(map: Object): boolean {
  * `RelayPendingQueryTracker` maintains a registry of pending queries, and
  * "subtracts" those from any new queries that callers enqueue.
  */
-var RelayPendingQueryTracker = {
+class RelayPendingQueryTracker {
+  _storeData: RelayStoreData;
+
+  constructor(storeData: RelayStoreData) {
+    this._storeData = storeData;
+  }
 
   /**
    * Used by `GraphQLQueryRunner` to enqueue new queries.
    */
   add(params: PendingQueryParameters): PendingFetch {
-    return new PendingFetch(params);
-  },
+    return new PendingFetch(params, this._storeData);
+  }
 
   hasPendingQueries(): boolean {
     return hasItems(pendingFetchMap);
-  },
+  }
 
   /**
    * Clears all pending query tracking. Does not cancel the queries themselves.
    */
   resetPending(): void {
     pendingFetchMap = {};
-  },
+  }
 
   resolvePreloadQuery(queryID: string, result: Object): void {
     preloadQueryMap.resolveKey(queryID, result);
-  },
+  }
 
   rejectPreloadQuery(queryID: string, error: Error): void {
     preloadQueryMap.rejectKey(queryID, error);
-  },
+  }
+}
 
-  // TODO: Use `export type`.
-  PendingFetch,
-
-};
-
+export type {PendingFetch};
 module.exports = RelayPendingQueryTracker;

--- a/src/store/RelayRecordStore.js
+++ b/src/store/RelayRecordStore.js
@@ -16,7 +16,6 @@
 const GraphQLMutatorConstants = require('GraphQLMutatorConstants');
 const GraphQLRange = require('GraphQLRange');
 const GraphQLStoreDataHandler = require('GraphQLStoreDataHandler');
-const GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 const RelayConnectionInterface = require('RelayConnectionInterface');
 import type {
   Call,
@@ -252,7 +251,6 @@ class RelayRecordStore {
    * Returns whether a given record is affected by an optimistic update.
    */
   hasOptimisticUpdate(dataID: DataID): boolean {
-    dataID = GraphQLStoreRangeUtils.getCanonicalClientID(dataID);
     invariant(
       this._queuedRecords,
       'RelayRecordStore.hasOptimisticUpdate(): Optimistic updates require ' +
@@ -267,7 +265,6 @@ class RelayRecordStore {
    * null if the record isn't affected by any optimistic updates.
    */
   getClientMutationIDs(dataID: DataID): ?Array<ClientMutationID> {
-    dataID = GraphQLStoreRangeUtils.getCanonicalClientID(dataID);
     invariant(
       this._queuedRecords,
       'RelayRecordStore.getClientMutationIDs(): Optimistic updates require ' +

--- a/src/store/RelayStore.js
+++ b/src/store/RelayStore.js
@@ -108,7 +108,7 @@ var RelayStore = {
     dataID: DataID,
     options?: StoreReaderOptions
   ): ?StoreReaderData {
-    return readRelayQueryData(queuedStore, node, dataID, options).data;
+    return readRelayQueryData(storeData, node, dataID, options).data;
   },
 
   /**
@@ -120,7 +120,7 @@ var RelayStore = {
     options?: StoreReaderOptions
   ): Array<?StoreReaderData> {
     return dataIDs.map(
-      dataID => readRelayQueryData(queuedStore, node, dataID, options).data
+      dataID => readRelayQueryData(storeData, node, dataID, options).data
     );
   },
 

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -17,6 +17,7 @@ var GraphQLDeferredQueryTracker = require('GraphQLDeferredQueryTracker');
 var GraphQLQueryRunner = require('GraphQLQueryRunner');
 var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
 var GraphQLStoreDataHandler = require('GraphQLStoreDataHandler');
+var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 var RelayChangeTracker = require('RelayChangeTracker');
 import type {ChangeSet} from 'RelayChangeTracker';
 var RelayConnectionInterface = require('RelayConnectionInterface');
@@ -71,11 +72,12 @@ class RelayStoreData {
   _mutationQueue: RelayMutationQueue;
   _nodeRangeMap: NodeRangeMap;
   _records: Records;
+  _queryRunner: GraphQLQueryRunner;
+  _queryTracker: RelayQueryTracker;
   _queuedRecords: Records;
   _queuedStore: RelayRecordStore;
+  _rangeData: GraphQLStoreRangeUtils;
   _recordStore: RelayRecordStore;
-  _queryTracker: RelayQueryTracker;
-  _queryRunner: GraphQLQueryRunner;
   _rootCalls: RootCallMap;
 
   /**
@@ -114,12 +116,13 @@ class RelayStoreData {
     this._deferredQueryTracker = new GraphQLDeferredQueryTracker(recordStore);
     this._mutationQueue = new RelayMutationQueue(this);
     this._nodeRangeMap = nodeRangeMap;
+    this._rangeData = new GraphQLStoreRangeUtils();
     this._records = records;
+    this._queryTracker = new RelayQueryTracker();
+    this._queryRunner = new GraphQLQueryRunner(this);
     this._queuedRecords = queuedRecords;
     this._queuedStore = queuedStore;
     this._recordStore = recordStore;
-    this._queryTracker = new RelayQueryTracker();
-    this._queryRunner = new GraphQLQueryRunner(this);
     this._rootCalls = rootCallMap;
   }
 
@@ -196,6 +199,28 @@ class RelayStoreData {
 
   hasCacheManager(): boolean {
     return !!this._cacheManager;
+  }
+
+  /**
+   * Returns whether a given record is affected by an optimistic update.
+   */
+  hasOptimisticUpdate(dataID: DataID): boolean {
+    dataID = this.getCanonicalClientID(dataID);
+    return this.getQueuedStore().hasOptimisticUpdate(dataID);
+  }
+
+  /**
+   * Returns a list of client mutation IDs for queued mutations whose optimistic
+   * updates are affecting the record corresponding the given dataID. Returns
+   * null if the record isn't affected by any optimistic updates.
+   */
+  getClientMutationIDs(dataID: DataID): ?Array<ClientMutationID> {
+    dataID = this.getCanonicalClientID(dataID);
+    return this.getQueuedStore().getClientMutationIDs(dataID);
+  }
+
+  getCanonicalClientID(dataID: DataID): DataID {
+    return this.getRangeData().getCanonicalClientID(dataID);
   }
 
   /**
@@ -394,6 +419,10 @@ class RelayStoreData {
 
   getChangeEmitter(): GraphQLStoreChangeEmitter {
     return this._changeEmitter;
+  }
+
+  getRangeData(): GraphQLStoreRangeUtils {
+    return this._rangeData;
   }
 
   /**

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -19,6 +19,8 @@ var GraphQLStoreChangeEmitter = require('GraphQLStoreChangeEmitter');
 var GraphQLStoreDataHandler = require('GraphQLStoreDataHandler');
 var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 var RelayChangeTracker = require('RelayChangeTracker');
+var RelayConnectionInterface = require('RelayConnectionInterface');
+var RelayPendingQueryTracker = require('RelayPendingQueryTracker');
 import type {ChangeSet} from 'RelayChangeTracker';
 var RelayConnectionInterface = require('RelayConnectionInterface');
 var RelayMutationQueue = require('RelayMutationQueue');
@@ -71,6 +73,7 @@ class RelayStoreData {
   _garbageCollector: ?RelayStoreGarbageCollector;
   _mutationQueue: RelayMutationQueue;
   _nodeRangeMap: NodeRangeMap;
+  _pendingQueryTracker: RelayPendingQueryTracker;
   _records: Records;
   _queryRunner: GraphQLQueryRunner;
   _queryTracker: RelayQueryTracker;
@@ -116,6 +119,7 @@ class RelayStoreData {
     this._deferredQueryTracker = new GraphQLDeferredQueryTracker(recordStore);
     this._mutationQueue = new RelayMutationQueue(this);
     this._nodeRangeMap = nodeRangeMap;
+    this._pendingQueryTracker = new RelayPendingQueryTracker(this);
     this._rangeData = new GraphQLStoreRangeUtils();
     this._records = records;
     this._queryTracker = new RelayQueryTracker();
@@ -423,6 +427,10 @@ class RelayStoreData {
 
   getRangeData(): GraphQLStoreRangeUtils {
     return this._rangeData;
+  }
+
+  getPendingQueryTracker(): RelayPendingQueryTracker {
+    return this._pendingQueryTracker;
   }
 
   /**

--- a/src/store/__mocks__/RelayPendingQueryTracker.js
+++ b/src/store/__mocks__/RelayPendingQueryTracker.js
@@ -40,11 +40,15 @@ class MockPendingFetch {
   }
 }
 
-RelayPendingQueryTracker.add.mock.fetches = [];
-RelayPendingQueryTracker.add.mockImplementation(params => {
-  var mockFetch = new MockPendingFetch(params.query);
-  RelayPendingQueryTracker.add.mock.fetches.push(mockFetch);
-  return mockFetch;
+RelayPendingQueryTracker.mockImplementation(function() {
+  this.add.mock.fetches = [];
+  this.add.mockImplementation(params => {
+    var mockFetch = new MockPendingFetch(params.query);
+    this.add.mock.fetches.push(mockFetch);
+    return mockFetch;
+  });
+
+  return this;
 });
 
 module.exports = RelayPendingQueryTracker;

--- a/src/store/__tests__/RelayPendingQueryTracker-test.js
+++ b/src/store/__tests__/RelayPendingQueryTracker-test.js
@@ -25,6 +25,8 @@ var subtractRelayQuery = require('subtractRelayQuery');
 var writeRelayQueryPayload = require('writeRelayQueryPayload');
 
 describe('RelayPendingQueryTracker', () => {
+  var queryTracker;
+
   var addPending;
 
   var consoleError;
@@ -36,15 +38,16 @@ describe('RelayPendingQueryTracker', () => {
   beforeEach(() => {
     jest.resetModuleRegistry();
 
+    queryTracker = new RelayPendingQueryTracker(new RelayStoreData());
+
     subtractRelayQuery.mockImplementation(query => query);
 
     addPending = ({query, fetchMode}) => {
       fetchMode = fetchMode || DliteFetchModeConstants.FETCH_MODE_CLIENT;
-      return RelayPendingQueryTracker.add({
+      return queryTracker.add({
         query,
         fetchMode,
         forceIndex: null,
-        storeData: RelayStoreData.getDefaultInstance(),
       }).getResolvedPromise();
     };
 
@@ -368,14 +371,14 @@ describe('RelayPendingQueryTracker', () => {
       fetchMode: DliteFetchModeConstants.FETCH_MODE_PRELOAD,
     });
 
-    RelayPendingQueryTracker.resolvePreloadQuery(
+    queryTracker.resolvePreloadQuery(
       mockQuery.getID(),
       {response: {viewer:{}}}
     );
 
     jest.runAllTimers();
 
-    expect(RelayPendingQueryTracker.hasPendingQueries()).toBeFalsy();
+    expect(queryTracker.hasPendingQueries()).toBeFalsy();
     var writeCalls = writeRelayQueryPayload.mock.calls;
     expect(writeCalls.length).toBe(1);
     expect(writeCalls[0][1]).toEqualQueryRoot(mockQuery);
@@ -389,7 +392,7 @@ describe('RelayPendingQueryTracker', () => {
       }
     `);
 
-    RelayPendingQueryTracker.resolvePreloadQuery(
+    queryTracker.resolvePreloadQuery(
       mockQuery.getID(),
       {response: {viewer:{}}}
     );
@@ -401,7 +404,7 @@ describe('RelayPendingQueryTracker', () => {
 
     jest.runAllTimers();
 
-    expect(RelayPendingQueryTracker.hasPendingQueries()).toBeFalsy();
+    expect(queryTracker.hasPendingQueries()).toBeFalsy();
     var writeCalls = writeRelayQueryPayload.mock.calls;
     expect(writeCalls.length).toBe(1);
     expect(writeCalls[0][1]).toEqualQueryRoot(mockQuery);
@@ -423,7 +426,7 @@ describe('RelayPendingQueryTracker', () => {
     mockPending.catch(mockCallback);
 
     var mockError = new Error('Expected error.');
-    RelayPendingQueryTracker.rejectPreloadQuery(
+    queryTracker.rejectPreloadQuery(
       mockQuery.getID(),
       mockError
     );
@@ -431,7 +434,7 @@ describe('RelayPendingQueryTracker', () => {
 
     jest.runAllTimers();
 
-    expect(RelayPendingQueryTracker.hasPendingQueries()).toBeFalsy();
+    expect(queryTracker.hasPendingQueries()).toBeFalsy();
     expect(mockCallback).toBeCalledWith(mockError);
   });
 
@@ -444,7 +447,7 @@ describe('RelayPendingQueryTracker', () => {
     addPending({query: mockQueryA});
     jest.runAllTimers();
 
-    expect(RelayPendingQueryTracker.hasPendingQueries()).toBeTruthy();
+    expect(queryTracker.hasPendingQueries()).toBeTruthy();
   });
 
   it('has no pending queries when queries are all resolved', () => {
@@ -459,7 +462,7 @@ describe('RelayPendingQueryTracker', () => {
     fetchRelayQuery.mock.requests[0].resolve({viewer:{}});
     jest.runAllTimers();
 
-    expect(RelayPendingQueryTracker.hasPendingQueries()).toBeFalsy();
+    expect(queryTracker.hasPendingQueries()).toBeFalsy();
   });
 
   it('has no pending queries after being reset', () => {
@@ -471,8 +474,8 @@ describe('RelayPendingQueryTracker', () => {
     addPending({query: mockQueryA});
     jest.runAllTimers();
 
-    RelayPendingQueryTracker.resetPending();
+    queryTracker.resetPending();
 
-    expect(RelayPendingQueryTracker.hasPendingQueries()).toBeFalsy();
+    expect(queryTracker.hasPendingQueries()).toBeFalsy();
   });
 });

--- a/src/store/__tests__/RelayQueryResultObservable-test.js
+++ b/src/store/__tests__/RelayQueryResultObservable-test.js
@@ -111,7 +111,7 @@ describe('RelayQueryResultObservable', () => {
     observer.subscribe(subscriber);
 
     expect(readRelayQueryData).toBeCalledWith(
-      store,
+      storeData,
       query,
       '123'
     );

--- a/src/store/__tests__/readRelayQueryData-test.js
+++ b/src/store/__tests__/readRelayQueryData-test.js
@@ -16,10 +16,10 @@ RelayTestUtils.unmockRelay();
 
 var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
 var GraphQLRange = require('GraphQLRange');
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 var Relay = require('Relay');
 var RelayConnectionInterface = require('RelayConnectionInterface');
 var RelayFragmentReference = require('RelayFragmentReference');
+var RelayStoreData = require('RelayStoreData');
 var RelayRecordStatusMap = require('RelayRecordStatusMap');
 var callsToGraphQL = require('callsToGraphQL');
 var readRelayQueryData = require('readRelayQueryData');
@@ -319,7 +319,7 @@ describe('readRelayQueryData', () => {
         count
       }
     `);
-    var rangeID = GraphQLStoreRangeUtils.getClientIDForRangeWithID(
+    var rangeID = RelayStoreData.getDefaultInstance().getRangeData().getClientIDForRangeWithID(
       callsToGraphQL([
         {name: 'is_viewer_friend', value: null},
         {name: 'first', value: 10},

--- a/src/store/readRelayQueryData.js
+++ b/src/store/readRelayQueryData.js
@@ -21,7 +21,7 @@ var RelayProfiler = require('RelayProfiler');
 var RelayQuery = require('RelayQuery');
 var RelayQueryVisitor = require('RelayQueryVisitor');
 var RelayRecordState = require('RelayRecordState');
-var RelayStoreData = require('RelayStoreData');
+import type RelayStoreData from 'RelayStoreData';
 import type RelayRecordStore from 'RelayRecordStore';
 import type {RangeInfo} from 'RelayRecordStore';
 import type {
@@ -33,8 +33,6 @@ var callsFromGraphQL = require('callsFromGraphQL');
 var callsToGraphQL = require('callsToGraphQL');
 var invariant = require('invariant');
 var validateRelayReadQuery = require('validateRelayReadQuery');
-
-var rangeUtils = RelayStoreData.getDefaultInstance().getRangeData();
 
 export type DataIDSet = {[key: string]: boolean};
 export type StoreReaderResult = {
@@ -59,12 +57,12 @@ var {EDGES, PAGE_INFO} = RelayConnectionInterface;
  * Retrieves data from the `RelayStore`.
  */
 function readRelayQueryData(
-  store: RelayRecordStore,
+  storeData: RelayStoreData,
   queryNode: RelayQuery.Node,
   dataID: DataID,
   options?: StoreReaderOptions
 ): StoreReaderResult {
-  var reader = new RelayStoreReader(store, options);
+  var reader = new RelayStoreReader(storeData, options);
   var data = reader.retrieveData(queryNode, dataID);
 
   // We validate only after retrieving the data, to give our `invariant`
@@ -76,15 +74,17 @@ function readRelayQueryData(
 
 class RelayStoreReader extends RelayQueryVisitor<State> {
   _recordStore: RelayRecordStore;
+  _storeData: RelayStoreData;
   _traverseFragmentReferences: boolean;
   _traverseGeneratedFields: boolean;
 
   constructor(
-    recordStore: RelayRecordStore,
+    storeData: RelayStoreData,
     options?: StoreReaderOptions
   ) {
     super();
-    this._recordStore = recordStore;
+    this._recordStore = storeData.getQueuedStore();
+    this._storeData = storeData;
     this._traverseFragmentReferences =
       (options && options.traverseFragmentReferences) || false;
     this._traverseGeneratedFields =
@@ -102,7 +102,7 @@ class RelayStoreReader extends RelayQueryVisitor<State> {
       data: (undefined: $FlowIssue),
       dataIDs: ({}: $FlowIssue),
     };
-    var rangeData = rangeUtils.parseRangeClientID(dataID);
+    var rangeData = this._storeData.getRangeData().parseRangeClientID(dataID);
     var status = this._recordStore.getRecordState(
       rangeData ? rangeData.dataID : dataID
     );
@@ -233,7 +233,7 @@ class RelayStoreReader extends RelayQueryVisitor<State> {
     enforceRangeCalls(node);
     var metadata = this._recordStore.getRangeMetadata(dataID, calls);
     var nextState = {
-      componentDataID: getConnectionClientID(node, dataID),
+      componentDataID: this._getConnectionClientID(node, dataID),
       data: getDataValue(state, applicationName),
       parent: node,
       rangeInfo: metadata && calls.length ? metadata : null,
@@ -361,11 +361,31 @@ class RelayStoreReader extends RelayQueryVisitor<State> {
   }
 
   /**
+   * Obtains a client ID (eg. `someDataID_first(10)`) for the connection
+   * identified by `connectionID`. If there are no range calls on the supplied
+   * `node`, then a call-less connection ID (eg. `someDataID`) will be returned
+   * instead.
+   */
+  _getConnectionClientID(
+    node: RelayQuery.Field, connectionID: DataID
+  ): DataID {
+    var calls = node.getCallsWithValues();
+    if (!RelayConnectionInterface.hasRangeCalls(calls)) {
+      return connectionID;
+    }
+    return this._storeData.getRangeData().getClientIDForRangeWithID(
+      callsToGraphQL(calls),
+      {},
+      connectionID
+    );
+  }
+
+  /**
    * Checks to see if we have a range client ID (eg. `someID_first(25)`), and if
    * so, unpacks the range metadata, stashing it into (and overriding) `state`.
    */
   _handleRangeInfo(node: RelayQuery.Field, state: State): void {
-    var rangeData = rangeUtils.parseRangeClientID(
+    var rangeData = this._storeData.getRangeData().parseRangeClientID(
       state.storeDataID
     );
     if (rangeData != null) {
@@ -411,26 +431,6 @@ class RelayRangeCallEnforcer extends RelayQueryVisitor<RelayQuery.Field> {
   }
 }
 var rangeCallEnforcer = new RelayRangeCallEnforcer();
-
-/**
- * Obtains a client ID (eg. `someDataID_first(10)`) for the connection
- * identified by `connectionID`. If there are no range calls on the supplied
- * `node`, then a call-less connection ID (eg. `someDataID`) will be returned
- * instead.
- */
-function getConnectionClientID(
-  node: RelayQuery.Field, connectionID: DataID
-): DataID {
-  var calls = node.getCallsWithValues();
-  if (!RelayConnectionInterface.hasRangeCalls(calls)) {
-    return connectionID;
-  }
-  return rangeUtils.getClientIDForRangeWithID(
-    callsToGraphQL(calls),
-    {},
-    connectionID
-  );
-}
 
 /**
  * Returns the component-specific DataID stored in `state`, falling back to the

--- a/src/store/readRelayQueryData.js
+++ b/src/store/readRelayQueryData.js
@@ -15,13 +15,13 @@
 
 var GraphQLStoreDataHandler = require('GraphQLStoreDataHandler');
 var GraphQLFragmentPointer = require('GraphQLFragmentPointer');
-var GraphQLStoreRangeUtils = require('GraphQLStoreRangeUtils');
 var RelayConnectionInterface = require('RelayConnectionInterface');
 import type {DataID} from 'RelayInternalTypes';
 var RelayProfiler = require('RelayProfiler');
 var RelayQuery = require('RelayQuery');
 var RelayQueryVisitor = require('RelayQueryVisitor');
 var RelayRecordState = require('RelayRecordState');
+var RelayStoreData = require('RelayStoreData');
 import type RelayRecordStore from 'RelayRecordStore';
 import type {RangeInfo} from 'RelayRecordStore';
 import type {
@@ -33,6 +33,8 @@ var callsFromGraphQL = require('callsFromGraphQL');
 var callsToGraphQL = require('callsToGraphQL');
 var invariant = require('invariant');
 var validateRelayReadQuery = require('validateRelayReadQuery');
+
+var rangeUtils = RelayStoreData.getDefaultInstance().getRangeData();
 
 export type DataIDSet = {[key: string]: boolean};
 export type StoreReaderResult = {
@@ -100,7 +102,7 @@ class RelayStoreReader extends RelayQueryVisitor<State> {
       data: (undefined: $FlowIssue),
       dataIDs: ({}: $FlowIssue),
     };
-    var rangeData = GraphQLStoreRangeUtils.parseRangeClientID(dataID);
+    var rangeData = rangeUtils.parseRangeClientID(dataID);
     var status = this._recordStore.getRecordState(
       rangeData ? rangeData.dataID : dataID
     );
@@ -363,7 +365,7 @@ class RelayStoreReader extends RelayQueryVisitor<State> {
    * so, unpacks the range metadata, stashing it into (and overriding) `state`.
    */
   _handleRangeInfo(node: RelayQuery.Field, state: State): void {
-    var rangeData = GraphQLStoreRangeUtils.parseRangeClientID(
+    var rangeData = rangeUtils.parseRangeClientID(
       state.storeDataID
     );
     if (rangeData != null) {
@@ -423,7 +425,7 @@ function getConnectionClientID(
   if (!RelayConnectionInterface.hasRangeCalls(calls)) {
     return connectionID;
   }
-  return GraphQLStoreRangeUtils.getClientIDForRangeWithID(
+  return rangeUtils.getClientIDForRangeWithID(
     callsToGraphQL(calls),
     {},
     connectionID


### PR DESCRIPTION
Builds on #569. Part of #558

As part of the bundle of changes, RelayRecordStore (and its users) became implicitly dependent on a singleton RelayStoreData. This PR removes that dependency by moving ID canonicalization into RelayStoreData proper.

*edit*: This could probably use tests.