### PR TITLE
RANGE_ADD - Better warning messages when new edge is missing

### DIFF
--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -30,6 +30,7 @@ const nullthrows = require('nullthrows');
 const inferRelayFieldsFromData = require('inferRelayFieldsFromData');
 const intersectRelayQuery = require('intersectRelayQuery');
 const invariant = require('invariant');
+const warning = require('warning');
 
 type BasicMutationFragmentBuilderConfig = {
   fatQuery: RelayQuery.Fragment;
@@ -214,6 +215,17 @@ var RelayMutationQuery = {
           });
         } else {
           // If the connection is not in `rangeBehaviors`, re-fetch it.
+          warning(
+            false,
+            'Relay.Mutation: Since the connection %s of ' +
+            'the field %s with id %s matched none of the rangeBehaviors ' +
+            'specified in your RANGE_ADD config, the entire connection will be ' +
+            'refetched. Configure a range behavior for this connection to fetch ' +
+            'only the new edge and to enable optimistic mutations.',
+            trackedConnection.getStorageKey(),
+            parentName,
+            parentID
+          );
           keysWithoutRangeBehavior[trackedConnection.getShallowHash()] = true;
         }
       });

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -15,8 +15,7 @@ require('configureForRelayOSS');
 
 jest
   .dontMock('GraphQLRange')
-  .dontMock('GraphQLSegment')
-  .mock('warning');
+  .dontMock('GraphQLSegment');
 
 const GraphQLMutatorConstants = require('GraphQLMutatorConstants');
 const Relay = require('Relay');
@@ -735,7 +734,7 @@ describe('writePayload()', () => {
       edgeID = generateClientEdgeID(connectionID, commentID);
     });
 
-    it('warns if the created `edge` field is missing in the payload', () => {
+    it('handles case when created `edge` field is missing in the payload', () => {
       var input = {
         actor_id: 'actor:123',
         [RelayConnectionInterface.CLIENT_MUTATION_ID]: '0',
@@ -786,13 +785,6 @@ describe('writePayload()', () => {
         payload,
         {configs, isOptimisticUpdate: true}
       );
-
-      expect([
-        'writeRelayUpdatePayload(): Expected response payload to include the ' +
-        'newly created edge `%s` and its `node` field. Did you forget to ' +
-        'update the `RANGE_ADD` mutation config?',
-        'feedbackCommentEdge',
-      ]).toBeWarnedNTimes(1);
 
       // feedback is updated, but the edge is not added
       expect(queueStore.getField(connectionID, 'count')).toBe(2);

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -331,13 +331,6 @@ function handleRangeAdd(
   const edge = getObject(payload, config.edgeName);
   const edgeNode = edge && getObject(edge, NODE);
   if (!edge || !edgeNode) {
-    warning(
-      false,
-      'writeRelayUpdatePayload(): Expected response payload to include the ' +
-      'newly created edge `%s` and its `node` field. Did you forget to ' +
-      'update the `RANGE_ADD` mutation config?',
-      config.edgeName
-    );
     return;
   }
 


### PR DESCRIPTION
Possible improvement for #542

Lot's of issues and misunderstanding with that one, range add mutations can be confusing with the current warning messages.

Better solution as @steveluscher said:
  - When relay does not query the new edge because it was not included in the intersection of tracked and fat queries, show a different warning saying it's a client-side problem ( Connection was never used in the app )
  - If the edge was queried but is not in the payload, explain it's a server side problem.

In `handleRangeAdd`, if the edge is missing from the payload, check if the operation `RelayQueryMutation` contained the newEdge field. If it didn't, it means the new edge was not included because it wasn't in the intersection of the tracked/fat query. If it did, it means the server should've returned that field and didn't.

I've added a function `getNodeByFieldName` to check if the operation contained the field to get the new edge. Not sure if it is the best way to check that, let me know.

The actual warning messages probably need some work, let me know what you think would be the best messages for these cases.


