### PR TITLE
Fixed return an incorrect promise in RelayDefaultNetworkLayer.sendQueries.

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -89,7 +89,8 @@ class RelayDefaultNetworkLayer {
         }
       }).catch(
         error => request.reject(error)
-      )
+      ),
+      request
     )));
   }
 


### PR DESCRIPTION
There is return an other promise in sendQueries function. When you do 
```javascript
request.resolve({response: payload.data})
```
you resolve request's promise, but you don't return it further. So we have problem in upper functions which wait for resolving or rejecting promise in sendQueries.