### PR TITLE
Do not reject request when there are errors unless data is null

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -72,13 +72,22 @@ class RelayDefaultNetworkLayer {
         result => result.json()
       ).then(payload => {
         if (payload.hasOwnProperty('errors')) {
-          var error = new Error(
-            'Server request for query `' + request.getDebugName() + '` ' +
-            'failed for the following reasons:\n\n' +
-            formatRequestErrors(request, payload.errors)
-          );
-          (error: any).source = payload;
-          request.reject(error);
+          if (payload.data && Object.keys(payload.data).length) {
+            console.error('Server request for query `' +
+              request.getDebugName() + '` ' +
+              'resolved with errors:\n\n' +
+              formatRequestErrors(request, payload.errors)
+            );
+            request.resolve({response: payload.data});
+          } else {
+            var error = new Error(
+              'Server request for query `' + request.getDebugName() + '` ' +
+              'failed for the following reasons:\n\n' +
+              formatRequestErrors(request, payload.errors)
+            );
+            (error: any).source = payload;
+            request.reject(error);
+          }
         } else if (!payload.hasOwnProperty('data')) {
           request.reject(new Error(
             'Server response was missing for query `' + request.getDebugName() +

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -80,7 +80,7 @@ class RelayDefaultNetworkLayer {
             );
             request.resolve({response: payload.data});
           } else {
-            var error = new Error(
+            const error = new Error(
               'Server request for query `' + request.getDebugName() + '` ' +
               'failed for the following reasons:\n\n' +
               formatRequestErrors(request, payload.errors)

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -285,7 +285,7 @@ describe('RelayDefaultNetworkLayer', () => {
       );
     });
 
-    it('rejects errors in query responses', () => {
+    it('rejects errors in query responses when data is null or empty', () => {
       var rejectCallback = jest.genMockFunction();
       networkLayer.sendQueries([requestA]);
       requestA.getPromise().catch(rejectCallback);
@@ -315,6 +315,46 @@ describe('RelayDefaultNetworkLayer', () => {
         '         ^^^',
       ].join('\n'));
       expect(error.source).toEqual(payloadA);
+    });
+
+    it('doesnt reject errors in query responses when data is non-null', () => {
+      var resolveCallback = jest.genMockFunction();
+      // Mock console.error so we can spy on it
+      console.error = jest.genMockFunction();
+      networkLayer.sendQueries([requestA]);
+      requestA.getPromise().done(resolveCallback);
+      jest.runAllTimers();
+
+      var payloadA = {
+        data: {
+          '123': {
+            id: '123'
+          }
+        },
+        errors: [{
+          message: 'Something went wrong with this field.',
+          locations: [{
+            column: 7,
+            line: 1,
+          }],
+        }],
+      };
+      fetchWithRetries.mock.deferreds[0].resolve(genResponse(payloadA));
+      jest.runAllTimers();
+
+      expect(console.error).toBeCalledWith([
+        'Server request for query `RelayDefaultNetworkLayer` resolved ' +
+          'with errors:',
+        '',
+        '1. Something went wrong with this field.',
+        '   ' + requestA.getQueryString().substr(0, 60),
+        '         ^^^',
+      ].join('\n'));
+
+      expect(resolveCallback.mock.calls.length).toBe(1);
+      expect(resolveCallback.mock.calls[0][0]).toEqual({
+        response: payloadA.data,
+      });
     });
 
     it('rejects requests with missing responses', () => {


### PR DESCRIPTION
Some improvement for #487 

Errors on fields should only make the request rejected if the data is empty or null. If we receive some data from the GraphQL server and also errors, `console.error` them but resolve the request.

Implemented this in `RelayDefaultNetworkLayer`
  -  if payload has errors
    -  if data is not null/undefined and is not an empty object.
      - log the errors and resolve the request
    - else ( data is null or an empty object )
      - reject the request with errors

Let me know if the logic can be made simpler and if the error message should be different!
    