### PR TITLE
add commitUpdate method, deprecate update

### DIFF
--- a/docs/APIReference-Mutation.md
+++ b/docs/APIReference-Mutation.md
@@ -204,7 +204,7 @@ Create a mutation instance using the `new` keyword, optionally passing it some p
 
 ```
 var bookFlightMutation = new BuyPlaneTicketMutation({airport: 'yvr'});
-Relay.Store.update(bookFlightMutation);
+Relay.Store.commitUpdate(bookFlightMutation);
 ```
 
 ### getConfigs (abstract method)
@@ -405,7 +405,7 @@ class AttachDocumentMutation extends Relay.Mutation {
 class FileUploader extends React.Component {
   handleSubmit() {
     var fileToAttach = this.refs.fileInput.files.item(0);
-    Relay.Store.update(
+    Relay.Store.commitUpdate(
       new AttachDocumentMutation({file: fileToAttach})
     );
   }

--- a/docs/APIReference-Store.md
+++ b/docs/APIReference-Store.md
@@ -15,8 +15,8 @@ The Relay `Store` provides an API for dispatching mutations to the server.
 
 <ul class="apiIndex">
   <li>
-    <a href="#update-static-method">
-      <pre>static update(mutation, callbacks)</pre>
+    <a href="#commitupdate-static-method">
+      <pre>static commitUpdate(mutation, callbacks)</pre>
       Initiate processing of a mutation.
     </a>
   </li>
@@ -30,13 +30,13 @@ The Relay `Store` provides an API for dispatching mutations to the server.
 
 ## Methods
 
-### update (static method)
+### commitUpdate (static method)
 
 ```
-static update(mutation: RelayMutation, callbacks: {
+static commitUpdate(mutation: RelayMutation, callbacks: {
   onFailure?: (transaction: RelayMutationTransaction) => void;
   onSuccess?: (response: Object) => void;
-}): void
+}): RelayMutationTransaction
 
 // Argument to `onFailure` callback
 type Transaction = {
@@ -44,7 +44,7 @@ type Transaction = {
 }
 ```
 
-The `update` method is analagous to dispatching an action in Flux. Relay processes
+The `commitUpdate` method is analogous to dispatching an action in Flux. Relay processes
 the mutation as follows:
 
 - If the mutation defines an optimistic payload - a set of data to apply locally while waiting for the server response - Relay applies this change and updates any affected React components (note that optimistic updates do not overwrite known server data in the cache).
@@ -66,7 +66,7 @@ var onFailure = (transaction) => {
 };
 var mutation = new MyMutation({...});
 
-Relay.Store.update(mutation, {onFailure, onSuccess});
+Relay.Store.commitUpdate(mutation, {onFailure, onSuccess});
 ```
 
 ### applyUpdate (static method)

--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -79,8 +79,8 @@ Here's an example of this mutation in use by a `LikeButton` component:
 ```
 class LikeButton extends React.Component {
   _handleLike = () => {
-    // To perform a mutation, pass an instance of one to `Relay.Store.update`
-    Relay.Store.update(new LikeStoryMutation({story: this.props.story}));
+    // To perform a mutation, pass an instance of one to `Relay.Store.commitUpdate`
+    Relay.Store.commitUpdate(new LikeStoryMutation({story: this.props.story}));
   }
   render() {
     return (

--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -363,7 +363,7 @@ class App extends React.Component {
     if (this._isGameOver()) {
       return;
     }
-    Relay.Store.update(
+    Relay.Store.commitUpdate(
       new CheckHidingSpotForTreasureMutation({
         game: this.props.game,
         hidingSpot,

--- a/examples/relay-treasurehunt/js/components/App.js
+++ b/examples/relay-treasurehunt/js/components/App.js
@@ -41,7 +41,7 @@ class App extends React.Component {
     if (this._isGameOver()) {
       return;
     }
-    Relay.Store.update(
+    Relay.Store.commitUpdate(
       new CheckHidingSpotForTreasureMutation({
         game: this.props.game,
         hidingSpot,

--- a/examples/todo/js/components/Todo.js
+++ b/examples/todo/js/components/Todo.js
@@ -25,7 +25,7 @@ class Todo extends React.Component {
   };
   _handleCompleteChange = (e) => {
     var complete = e.target.checked;
-    Relay.Store.update(
+    Relay.Store.commitUpdate(
       new ChangeTodoStatusMutation({
         complete,
         todo: this.props.todo,
@@ -48,12 +48,12 @@ class Todo extends React.Component {
   }
   _handleTextInputSave = (text) => {
     this._setEditMode(false);
-    Relay.Store.update(
+    Relay.Store.commitUpdate(
       new RenameTodoMutation({todo: this.props.todo, text})
     );
   }
   _removeTodo() {
-    Relay.Store.update(
+    Relay.Store.commitUpdate(
       new RemoveTodoMutation({todo: this.props.todo, viewer: this.props.viewer})
     );
   }

--- a/examples/todo/js/components/TodoApp.js
+++ b/examples/todo/js/components/TodoApp.js
@@ -19,7 +19,7 @@ import Relay from 'react-relay';
 
 class TodoApp extends React.Component {
   _handleTextInputSave = (text) => {
-    Relay.Store.update(
+    Relay.Store.commitUpdate(
       new AddTodoMutation({text, viewer: this.props.viewer})
     );
   }

--- a/examples/todo/js/components/TodoList.js
+++ b/examples/todo/js/components/TodoList.js
@@ -19,7 +19,7 @@ import Relay from 'react-relay';
 class TodoList extends React.Component {
   _handleMarkAllChange = (e) => {
     var complete = e.target.checked;
-    Relay.Store.update(
+    Relay.Store.commitUpdate(
       new MarkAllTodosMutation({
         complete,
         todos: this.props.viewer.todos,

--- a/examples/todo/js/components/TodoListFooter.js
+++ b/examples/todo/js/components/TodoListFooter.js
@@ -18,7 +18,7 @@ import Relay from 'react-relay';
 
 class TodoListFooter extends React.Component {
   _handleRemoveCompletedTodosClick = () => {
-    Relay.Store.update(
+    Relay.Store.commitUpdate(
       new RemoveCompletedTodosMutation({
         todos: this.props.viewer.todos,
         viewer: this.props.viewer,

--- a/src/store/RelayStore.js
+++ b/src/store/RelayStore.js
@@ -22,6 +22,7 @@ var RelayStoreData = require('RelayStoreData');
 
 var forEachRootCallArg = require('forEachRootCallArg');
 var readRelayQueryData = require('readRelayQueryData');
+var warning = require('warning');
 
 import type {
   Abortable,
@@ -161,6 +162,10 @@ var RelayStore = {
     return new RelayQueryResultObservable(storeData, fragmentPointer);
   },
 
+  /**
+   * Adds an update to the store without committing it. The returned
+   * RelayMutationTransaction can be committed or rolled back at a later time.
+   */
   applyUpdate(
     mutation: RelayMutation,
     callbacks?: RelayMutationTransactionCommitCallbacks
@@ -171,11 +176,34 @@ var RelayStore = {
     );
   },
 
+  /**
+   * Adds an update to the store and commits it immediately. Returns
+   * the RelayMutationTransaction.
+   */
+  commitUpdate(
+    mutation: RelayMutation,
+    callbacks?: RelayMutationTransactionCommitCallbacks
+  ): RelayMutationTransaction {
+    const transaction = this.applyUpdate(mutation, callbacks);
+    transaction.commit();
+    return transaction;
+  },
+
+  /**
+   * @deprecated
+   *
+   * Method renamed to commitUpdate
+   */
   update(
     mutation: RelayMutation,
     callbacks?: RelayMutationTransactionCommitCallbacks
   ): void {
-    this.applyUpdate(mutation, callbacks).commit();
+    warning(
+      false,
+      '`Relay.Store.update` is deprecated. Please use' +
+      ' `Relay.Store.commitUpdate` or `Relay.Store.applyUpdate` instead.'
+    );
+    this.commitUpdate(mutation, callbacks);
   },
 };
 

--- a/src/store/__tests__/RelayStore-test.js
+++ b/src/store/__tests__/RelayStore-test.js
@@ -177,9 +177,9 @@ describe('RelayStore', () => {
       });
     });
 
-    describe('update', () => {
+    describe('commitUpdate', () => {
       it('creates a new RelayMutationTransaction and commits it', () => {
-        RelayStore.update(mockMutation, mockCallbacks);
+        let transaction = RelayStore.commitUpdate(mockMutation, mockCallbacks);
         expect(createTransactionMock).toBeCalledWith(
           mockMutation,
           mockCallbacks


### PR DESCRIPTION
Follow up to #599, #550 

Deprecate `RelayStore.update`, rename to `RelayStore.commitUpdate`

`commitUpdate` now returns the `RelayMutationTransaction` just like `applyUpdate`.

Changed to `commitUpdate` in the docs.

I used `warning` to deprecate and also call the correct method, let me know if this is the way we should deprecate the function.