### PR TITLE
new example use-case: bidirectional connections

### DIFF
--- a/examples/user-group/.gitignore
+++ b/examples/user-group/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+node_modules
+npm-debug.log
+data/schema.graphql

--- a/examples/user-group/LICENSE
+++ b/examples/user-group/LICENSE
@@ -1,0 +1,31 @@
+BSD License
+
+For Relay Starter Kit software
+
+Copyright (c) 2013-2015, Facebook, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/user-group/PATENTS
+++ b/examples/user-group/PATENTS
@@ -1,0 +1,33 @@
+Additional Grant of Patent Rights Version 2
+
+"Software" means the Relay Starter Kit software distributed by Facebook, Inc.
+
+Facebook, Inc. ("Facebook") hereby grants to each recipient of the Software
+("you") a perpetual, worldwide, royalty-free, non-exclusive, irrevocable
+(subject to the termination provision below) license under any Necessary
+Claims, to make, have made, use, sell, offer to sell, import, and otherwise
+transfer the Software. For avoidance of doubt, no license is granted under
+Facebook's rights in any patent claims that are infringed by (i) modifications
+to the Software made by you or any third party or (ii) the Software in
+combination with any software or other technology.
+
+The license granted hereunder will terminate, automatically and without notice,
+if you (or any of your subsidiaries, corporate affiliates or agents) initiate
+directly or indirectly, or take a direct financial interest in, any Patent
+Assertion: (i) against Facebook or any of its subsidiaries or corporate
+affiliates, (ii) against any party if such Patent Assertion arises in whole or
+in part from any software, technology, product or service of Facebook or any of
+its subsidiaries or corporate affiliates, or (iii) against any party relating
+to the Software. Notwithstanding the foregoing, if Facebook or any of its
+subsidiaries or corporate affiliates files a lawsuit alleging patent
+infringement against you in the first instance, and you respond by filing a
+patent infringement counterclaim in that lawsuit against that party that is
+unrelated to the Software, the license granted hereunder will not terminate
+under section (i) of this paragraph due to such counterclaim.
+
+A "Necessary Claim" is a claim of a patent owned by Facebook that is
+necessarily infringed by the Software standing alone.
+
+A "Patent Assertion" is any lawsuit or other action alleging direct, indirect,
+or contributory infringement or inducement to infringe any patent, including a
+cross-claim or counterclaim.

--- a/examples/user-group/README.md
+++ b/examples/user-group/README.md
@@ -1,0 +1,40 @@
+# Relay User Group
+
+## Installation
+
+```
+npm install
+```
+
+## Running
+
+Start a local server:
+
+```
+npm start
+```
+
+## Developing
+
+Any changes you make to files in the `js/` directory will cause the server to
+automatically rebuild the app and refresh your browser.
+
+If at any time you make changes to `data/schema.js`, stop the server,
+regenerate `data/schema.json`, and restart the server:
+
+```
+npm run update-schema
+npm start
+```
+
+## License
+
+    This file provided by Facebook is for non-commercial testing and evaluation
+    purposes only.  Facebook reserves all rights not expressly granted.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+    ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/examples/user-group/build/babelRelayPlugin.js
+++ b/examples/user-group/build/babelRelayPlugin.js
@@ -1,0 +1,4 @@
+var getbabelRelayPlugin = require('babel-relay-plugin');
+var schema = require('../data/schema.json');
+
+module.exports = getbabelRelayPlugin(schema.data);

--- a/examples/user-group/data/database.js
+++ b/examples/user-group/data/database.js
@@ -1,0 +1,180 @@
+export class Viewer extends Object {}
+export class User extends Object {}
+export class Role extends Object {}
+
+// Mock authenticated ID
+const VIEWER_ID = 'me';
+
+// Mock data
+var busquets = Object.assign(
+  new User(), {
+    id: '1',
+    name: 'Sergio Busquets',
+    roles: ['2']
+  }
+);
+var rakitic = Object.assign(
+  new User(), {
+    id: '2',
+    name: 'Ivan Rakitic',
+    roles: ['2']
+  }
+);
+var iniesta = Object.assign(
+  new User(), {
+    id: '3',
+    name: 'Andres Iniesta',
+    roles: ['2','3']
+  }
+);
+var alves = Object.assign(
+  new User(), {
+    id: '4',
+    name: 'Dani Alves',
+    roles: ['1'],
+  }
+);
+var roberto = Object.assign(
+  new User(), {
+    id: '5',
+    name: 'Sergi Roberto',
+    roles: ['1','2'],
+  }
+);
+var mathieu = Object.assign(
+  new User(), {
+    id: '6',
+    name: 'Jeremy Mathieu',
+    roles: ['1','2'],
+  }
+);
+var mascherano = Object.assign(
+  new User(), {
+    id: '7',
+    name: 'Javier Mascherano',
+    roles: ['1','2']
+  }
+);
+var suarez = Object.assign(
+  new User(), {
+    id: '8',
+    name: 'Luis Suarez',
+    roles: ['3'],
+  }
+);
+var messi = Object.assign(
+  new User(), {
+    id: '9',
+    name: 'Lionel Messi',
+    roles: ['3'],
+  }
+);
+var neymar = Object.assign(
+  new User(), {
+    id: '10',
+    name: 'Neymar',
+    roles: ['3'],
+  }
+);
+
+var defender = Object.assign(
+  new Role(), {
+    id: '1',
+    name: 'Defender',
+    users: ['4','5','6','7']
+  }
+);
+var midfielder = Object.assign(
+  new Role(), {
+    id: '2',
+    name: 'Midfielder',
+    users: ['1','2','3','5','6','7']
+  }
+);
+var forward = Object.assign(
+  new Role(), {
+    id: '3',
+    name: 'Forward',
+    users: ['3','8','9','10']
+  }
+);
+
+var data = {
+  User: {
+    1: busquets,
+    2: rakitic,
+    3: iniesta,
+    4: alves,
+    5: roberto,
+    6: mathieu,
+    7: mascherano,
+    8: suarez,
+    9: messi,
+    10: neymar,
+  },
+  Role: {
+    1: defender,
+    2: midfielder,
+    3: forward,
+  },
+};
+
+var viewer = Object.assign(
+  new Viewer(), {
+    id: VIEWER_ID,
+    users: Object.keys(data.User),
+    roles: Object.keys(data.Role),
+  }
+);
+
+export function getViewer () {
+  return viewer;
+}
+
+export function getUser (id) {
+  return data.User[id];
+}
+
+export function getRole (id) {
+  return data.Role[id];
+}
+
+var nextUserId = 10;
+export function createUser(userName) {
+  var newUser = Object.assign(new User(), {
+    id: `${nextUserId += 1}`,
+    name: userName,
+    roles: [],
+  });
+  viewer.users.push(newUser.id);
+  data.User[newUser.id] = newUser;
+  return newUser.id;
+}
+
+export function addUserRole (userId, roleId) {
+  var user = getUser(userId);
+  var role = getRole(roleId);
+  var roleIndex = user.roles.indexOf(roleId);
+  var userIndex = role.users.indexOf(userId);
+
+  if (roleIndex > -1 && userIndex > -1) {
+    return console.error(`User ${userId} and role ${roleId} already connected.`);
+  }
+  user.roles.push(roleId);
+  role.users.push(userId);
+  return {user, role};
+}
+
+export function removeUserRole (userId, roleId) {
+  var user = getUser(userId);
+  var role = getRole(roleId);
+  var roleIndex = user.roles.indexOf(roleId);
+  var userIndex = role.users.indexOf(userId);
+
+  if (roleIndex === -1 || userIndex === -1) {
+    return console.error(`User ${userId} and role ${roleId} not connected.`);
+  }
+  user.roles.splice(roleIndex, 1);
+  role.users.splice(userIndex, 1);
+  return {user, role};
+}

--- a/examples/user-group/data/schema.js
+++ b/examples/user-group/data/schema.js
@@ -1,0 +1,295 @@
+import {
+  GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+} from 'graphql';
+
+import {
+  connectionArgs,
+  connectionDefinitions,
+  connectionFromArray,
+  cursorForObjectInConnection,
+  fromGlobalId,
+  globalIdField,
+  mutationWithClientMutationId,
+  nodeDefinitions,
+} from 'graphql-relay';
+
+import {
+  Viewer,
+  Role,
+  User,
+  getViewer,
+  getRole,
+  getUser,
+  createUser,
+  addUserRole,
+  removeUserRole,
+} from './database';
+
+var {nodeInterface, nodeField} = nodeDefinitions(
+  (globalId) => {
+    var {type, id} = fromGlobalId(globalId);
+    if (type === 'Viewer') {
+      return getViewer();
+    } else if (type === 'Role') {
+      return getRole(id);
+    } else if (type === 'User') {
+      return getUser(id);
+    } else {
+      return null;
+    }
+  },
+  (obj) => {
+    if (obj instanceof Viewer) {
+      return GraphQLViewer;
+    } else if (obj instanceof Role) {
+      return GraphQLRole;
+    } else if (obj instanceof User) {
+      return GraphQLUser;
+    } else {
+      return null;
+    }
+  }
+);
+
+var GraphQLUser = new GraphQLObjectType({
+  name: 'User',
+  description: 'A person who uses our app.',
+  fields: () => ({
+    id: globalIdField('User'),
+    name: {
+      type: GraphQLString,
+      description: 'A person\'s name.',
+    },
+    roles: {
+      type: RoleConnection,
+      description: 'A person\'s list of labor inputs.',
+      args: connectionArgs,
+      resolve: (_, args) => connectionFromArray(
+        _.roles.map(id => getRole(id)),
+        args
+      ),
+    },
+  }),
+  interfaces: [nodeInterface],
+});
+
+var {
+  connectionType: UserConnection,
+  edgeType: GraphQLUserEdge
+} = connectionDefinitions({
+  name: 'User',
+  nodeType: GraphQLUser,
+});
+
+var GraphQLRole = new GraphQLObjectType({
+  name: 'Role',
+  description: 'A labor input.',
+  fields: {
+    id: globalIdField('Role'),
+    name: {
+      type: GraphQLString,
+      description: 'A labor input\'s name.',
+    },
+    users: {
+      type: UserConnection,
+      description: 'A labor input\'s list of users.',
+      args: connectionArgs,
+      resolve: (_, args) => connectionFromArray(
+        _.users.map(id => getUser(id)),
+        args
+      ),
+    },
+  },
+  interfaces: [nodeInterface],
+});
+
+var {
+  connectionType: RoleConnection,
+  edgeType: GraphQLRoleEdge
+} = connectionDefinitions({
+  name: 'Role',
+  nodeType: GraphQLRole,
+});
+
+var GraphQLViewer = new GraphQLObjectType({
+  name: 'Viewer',
+  description: 'A root-level client wrapper.',
+  fields: {
+    id: globalIdField('Viewer'),
+    roles: {
+      type: RoleConnection,
+      args: connectionArgs,
+      resolve: (_, args) => connectionFromArray(
+        _.roles.map(id => getRole(id)),
+        args
+      ),
+    },
+    users: {
+      type: UserConnection,
+      args: connectionArgs,
+      resolve: (_, args) => connectionFromArray(
+        _.users.map(id => getUser(id)),
+        args
+      ),
+    },
+  },
+  interfaces: [nodeInterface],
+});
+
+var Root = new GraphQLObjectType({
+  name: 'Root',
+  fields: {
+    viewer: {
+      type: GraphQLViewer,
+      resolve: () => getViewer(),
+    },
+    node: nodeField,
+  },
+});
+
+var GraphQLNewUserMutation = mutationWithClientMutationId({
+  name: 'NewUser',
+  inputFields: {
+    userName: {
+      type: new GraphQLNonNull(GraphQLString)
+    }
+  },
+  outputFields: {
+    userEdge: {
+      type: GraphQLUserEdge,
+      resolve: ({localUserId}) => {
+        var viewer = getViewer();
+        var user = getUser(localUserId);
+        return {
+          cursor: cursorForObjectInConnection(
+            viewer.users.map(id => getUser(id)),
+            user
+          ),
+          node: user,
+        };
+      }
+    },
+    viewer: {
+      type: GraphQLViewer,
+      resolve: () => getViewer(),
+    }
+  },
+  mutateAndGetPayload: ({userName}) => {
+    var localUserId = createUser(userName);
+    return {localUserId};
+  }
+});
+
+var GraphQLAddUserRoleMutation = mutationWithClientMutationId({
+  name: 'AddUserRole',
+  inputFields: {
+    userId: {
+      type: new GraphQLNonNull(GraphQLID)
+    },
+    roleId: {
+      type: new GraphQLNonNull(GraphQLID)
+    }
+  },
+  outputFields: {
+    userEdge: {
+      type: GraphQLUserEdge,
+      resolve: ({localRoleId, localUserId}) => {
+        var role = getRole(localRoleId);
+        var user = getUser(localUserId);
+        return {
+          cursor: cursorForObjectInConnection(
+            role.users.map(id => getUser(id)),
+            user
+          ),
+          node: user,
+        };
+      }
+    },
+    roleEdge: {
+      type: GraphQLRoleEdge,
+      resolve: ({localRoleId, localUserId}) => {
+        var role = getRole(localRoleId);
+        var user = getUser(localUserId);
+        return {
+          cursor: cursorForObjectInConnection(
+            user.roles.map(id => getRole(id)), 
+            role
+          ),
+          node: role,
+        };
+      }
+    },
+    user: {
+      type: GraphQLUser,
+      resolve: ({localUserId}) => getUser(localUserId),
+    },
+    role: {
+      type: GraphQLRole,
+      resolve: ({localRoleId}) => getRole(localRoleId),
+    },
+  },
+  mutateAndGetPayload: ({userId, roleId}) => {
+    var localUserId = fromGlobalId(userId).id;
+    var localRoleId = fromGlobalId(roleId).id;
+    addUserRole(localUserId, localRoleId);
+    return { localUserId, localRoleId };
+  }
+});
+
+var GraphQLRemoveUserRoleMutation = mutationWithClientMutationId({
+  name: 'RemoveUserRole',
+  inputFields: {
+    userId: {
+      type: new GraphQLNonNull(GraphQLID)
+    },
+    roleId: {
+      type: new GraphQLNonNull(GraphQLID)
+    }
+  },
+  outputFields: {
+    user: {
+      type: GraphQLUser,
+      resolve: ({localUserId}) => getUser(localUserId),
+    },
+    role: {
+      type: GraphQLRole,
+      resolve: ({localRoleId}) => getRole(localRoleId),
+    },
+    removedUserID: {
+      type: GraphQLID,
+      resolve: ({localUserId}) => localUserId,
+    },
+    removedRoleID: {
+      type: GraphQLID,
+      resolve: ({localRoleId}) => localRoleId,
+    },
+  },
+  mutateAndGetPayload: ({userId, roleId}) => {
+    var localUserId = fromGlobalId(userId).id;
+    var localRoleId = fromGlobalId(roleId).id;
+    removeUserRole(localUserId, localRoleId);
+    return { localUserId, localRoleId };
+  }
+});
+
+var Mutation = new GraphQLObjectType({
+  name: 'Mutation',
+  fields: () => ({
+    newUser: GraphQLNewUserMutation,
+    addUserRole: GraphQLAddUserRoleMutation,
+    removeUserRole: GraphQLRemoveUserRoleMutation,
+  })
+});
+
+export var Schema = new GraphQLSchema({
+  query: Root,
+  mutation: Mutation
+});

--- a/examples/user-group/data/schema.json
+++ b/examples/user-group/data/schema.json
@@ -1,0 +1,1891 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Root"
+      },
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Root",
+          "description": null,
+          "fields": [
+            {
+              "name": "viewer",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Viewer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "Fetches an object given its ID",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "The ID of an object",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Node",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Viewer",
+          "description": "A root-level client wrapper.",
+          "fields": [
+            {
+              "name": "id",
+              "description": "The ID of an object",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "roles",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RoleConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "users",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UserConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Node",
+          "description": "An object with an ID",
+          "fields": [
+            {
+              "name": "id",
+              "description": "The id of the object.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Role",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Viewer",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "User",
+          "description": "A person who uses our app.",
+          "fields": [
+            {
+              "name": "id",
+              "description": "The ID of an object",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "A person's name.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "roles",
+              "description": "A person's list of labor inputs.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RoleConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^53 - 1) and 2^53 - 1 since represented in JSON as double-precision floating point numbers specifiedby [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RoleConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RoleEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PageInfo",
+          "description": "Information about pagination in a connection.",
+          "fields": [
+            {
+              "name": "hasNextPage",
+              "description": "When paginating forwards, are there more items?",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasPreviousPage",
+              "description": "When paginating backwards, are there more items?",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startCursor",
+              "description": "When paginating backwards, the cursor to continue.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endCursor",
+              "description": "When paginating forwards, the cursor to continue.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RoleEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Role",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Role",
+          "description": "A labor input.",
+          "fields": [
+            {
+              "name": "id",
+              "description": "The ID of an object",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "A labor input's name.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "users",
+              "description": "A labor input's list of users.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UserConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UserConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "UserEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UserEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "description": null,
+          "fields": [
+            {
+              "name": "newUser",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "NewUserInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "NewUserPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "addUserRole",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "AddUserRoleInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AddUserRolePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "removeUserRole",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "RemoveUserRoleInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RemoveUserRolePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "NewUserInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "userName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NewUserPayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "userEdge",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UserEdge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "viewer",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Viewer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AddUserRoleInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "userId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "roleId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AddUserRolePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "userEdge",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "UserEdge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "roleEdge",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RoleEdge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "user",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Role",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "RemoveUserRoleInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "userId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "roleId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RemoveUserRolePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "user",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Role",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "removedUserID",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "removedRoleID",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given `__Type` is.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": "A Directives provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onOperation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onFragment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onField",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "onOperation": false,
+          "onFragment": true,
+          "onField": true
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "onOperation": false,
+          "onFragment": true,
+          "onField": true
+        }
+      ]
+    }
+  }
+}

--- a/examples/user-group/js/app.js
+++ b/examples/user-group/js/app.js
@@ -1,0 +1,15 @@
+import 'babel/polyfill';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Relay from 'react-relay';
+import App from './components/App';
+import HomeRoute from './routes/HomeRoute';
+
+ReactDOM.render(
+  <Relay.RootContainer
+    Component={App}
+    route={new HomeRoute()}
+  />,
+  document.getElementById('root')
+);
+

--- a/examples/user-group/js/components/App.js
+++ b/examples/user-group/js/components/App.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import Relay from 'react-relay';
+import NewUser from './NewUser';
+import UserDetail from './UserDetail';
+import RoleDetail from './RoleDetail';
+
+class App extends React.Component {
+  getStyles () {
+    return {
+      container: {
+        display: 'flex',
+        flexWrap: 'wrap',
+        lineHeight: '1.34em',
+      },
+      list: {
+        flexGrow: 1,
+        padding: 0,
+        minWidth: 200,
+        maxWidth: 260,
+        listStyleType: 'none',
+      },
+    };
+  }
+  render () {
+    var {viewer} = this.props;
+    var styles = this.getStyles();
+    var {users, roles} = viewer;
+
+    return <div style={styles.container}>
+      <ul style={styles.list}>
+        {users.edges.map(edge => <li key={edge.node.id}>
+          <UserDetail user={edge.node} roles={roles} />
+        </li>)}
+        <li><NewUser viewer={viewer}/></li>
+      </ul>
+      <ul style={styles.list}>
+        {roles.edges.map(edge => <li key={edge.node.id}>
+          <RoleDetail role={edge.node} />
+        </li>)}
+      </ul>
+    </div>;
+  }
+}
+
+export default Relay.createContainer(App, {
+  fragments: {
+    viewer: () => Relay.QL`
+      fragment on Viewer {
+        users(first: 18) {
+          edges {
+            node {
+              id,
+              ${UserDetail.getFragment('user')},
+            },
+          }
+        },
+        roles(first: 5) {
+          edges {
+            node {
+              id,
+              ${RoleDetail.getFragment('role')},
+            },
+          }
+          ${UserDetail.getFragment('roles')},
+        },
+        ${NewUser.getFragment('viewer')},
+      }
+    `,
+  },
+});
+

--- a/examples/user-group/js/components/NewUser.js
+++ b/examples/user-group/js/components/NewUser.js
@@ -1,0 +1,46 @@
+import NewUserMutation from '../mutations/NewUserMutation';
+import React from 'react';
+import Relay from 'react-relay';
+import TextInput from './TextInput';
+
+class NewUser extends React.Component {
+  _handleTextInputSave = (text) => {
+    Relay.Store.update(
+      new NewUserMutation({userName: text, viewer: this.props.viewer})
+    );
+  }
+  render () {
+    return (
+      <TextInput
+        style={style.input}
+        autoFocus={true}
+        onSave={this._handleTextInputSave}
+        placeholder='Name'
+      />
+    );
+  }
+}
+
+export default Relay.createContainer(NewUser, {
+  fragments: {
+    viewer: () => Relay.QL`
+      fragment on Viewer {
+        users(first: 18) {
+          edges {
+            node {
+              id,
+            },
+          }
+        },
+        ${NewUserMutation.getFragment('viewer')},
+      }
+    `,
+  },
+});
+
+var style = {
+  input: {
+    color: 'red',
+  },
+};
+

--- a/examples/user-group/js/components/RoleDetail.js
+++ b/examples/user-group/js/components/RoleDetail.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import Relay from 'react-relay';
+import UserSwitch from './UserSwitch';
+
+class RoleDetail extends React.Component {
+  getStyles () {
+    return {
+      container: {
+        padding: '0 1.34em',
+      },
+      name: {
+        margin: 0,
+        fontWeight: 'bold',
+      },
+      list: {
+        margin: '0.4em 0 0.67em 1em',
+        padding: 0,
+        listStyleType: 'none',
+      },
+    };
+  }
+  render () {
+    var {role} = this.props;
+    var styles = this.getStyles();
+    return <div style={styles.container}>
+      <div style={styles.name}>{role.name}</div>
+      <ul style={styles.list}>
+        {role.users.edges.map(edge => <li key={edge.node.id}>
+          <UserSwitch role={role} user={edge.node} />
+        </li>)}
+      </ul>
+    </div>;
+  }
+}
+
+export default Relay.createContainer(RoleDetail, {
+  fragments: {
+    role: () => Relay.QL`
+      fragment on Role {
+        name,
+        users(first: 10) {
+          edges {
+            node {
+              id,
+              ${UserSwitch.getFragment('user')},
+            }
+          }
+        },
+        ${UserSwitch.getFragment('role')},
+      }
+    `,
+  },
+});
+

--- a/examples/user-group/js/components/RoleSwitch.js
+++ b/examples/user-group/js/components/RoleSwitch.js
@@ -1,0 +1,63 @@
+import RemoveUserRoleMutation from '../mutations/RemoveUserRoleMutation';
+import AddUserRoleMutation from '../mutations/AddUserRoleMutation';
+import React from 'react';
+import Relay from 'react-relay';
+
+class RoleSwitch extends React.Component {
+  getStyles () {
+    var {connected} = this.props;
+    return {
+      container: {
+        display: 'inline-block',
+        fontWeight: connected ? 'bold' : 'normal',
+      },
+    };
+  }
+  _handleClick = () => {
+    this.props.connected ? this._removeRole() : this._addRole();
+  }
+  _removeRole () {
+    Relay.Store.update(
+      new RemoveUserRoleMutation({
+        user: this.props.user,
+        role: this.props.role,
+      })
+    );
+  }
+  _addRole () {
+    Relay.Store.update(
+      new AddUserRoleMutation({
+        user: this.props.user,
+        role: this.props.role,
+      })
+    );
+  }
+  render () {
+    var {role} = this.props;
+    var styles = this.getStyles();
+    return <div style={styles.container} onClick={this._handleClick}>
+      {role.name.charAt(0)}
+    </div>;
+  }
+}
+
+export default Relay.createContainer(RoleSwitch, {
+  fragments: {
+    role: () => Relay.QL`
+      fragment on Role {
+        id,
+        name,
+        ${RemoveUserRoleMutation.getFragment('role')},
+        ${AddUserRoleMutation.getFragment('role')},
+      }
+    `,
+    user: () => Relay.QL`
+      fragment on User {
+        id,
+        ${RemoveUserRoleMutation.getFragment('user')},
+        ${AddUserRoleMutation.getFragment('user')},
+      }
+    `,
+  },
+});
+

--- a/examples/user-group/js/components/TEMPLATE.js
+++ b/examples/user-group/js/components/TEMPLATE.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import Relay from 'react-relay';
+
+class TEMPLATE extends React.Component {
+  render () {
+    return <div>TEMPLATE</div>;
+  }
+}
+
+export default Relay.createContainer(TEMPLATE, {
+  fragments: {
+    QUERY: () => Relay.QL`
+      fragment on QUERYNAME {
+        array {
+          edges {
+            node {
+              id,
+              name,
+            },
+          },
+        },
+      }
+    `,
+  },
+});
+

--- a/examples/user-group/js/components/TextInput.js
+++ b/examples/user-group/js/components/TextInput.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+var {PropTypes} = React;
+
+var ENTER_KEY_CODE = 13;
+var ESC_KEY_CODE = 27;
+
+export default class TextInput extends React.Component {
+  static defaultProps = {
+    commitOnBlur: false,
+  }
+  static propTypes = {
+    style: PropTypes.object,
+    commitOnBlur: PropTypes.bool.isRequired,
+    initialValue: PropTypes.string,
+    onCancel: PropTypes.func,
+    onDelete: PropTypes.func,
+    onSave: PropTypes.func.isRequired,
+    placeholder: PropTypes.string,
+  }
+  state = {
+    isEditing: false,
+    text: this.props.initialValue || '',
+  };
+  componentDidMount() {
+    ReactDOM.findDOMNode(this).focus();
+  }
+  _commitChanges = () => {
+    var newText = this.state.text.trim();
+    if (this.props.onDelete && newText === '') {
+      this.props.onDelete();
+    } else if (this.props.onCancel && newText === this.props.initialValue) {
+      this.props.onCancel();
+    } else if (newText !== '') {
+      this.props.onSave(newText);
+      this.setState({text: ''});
+    }
+  }
+  _handleBlur = () => {
+    if (this.props.commitOnBlur) {
+      this._commitChanges();
+    }
+  }
+  _handleChange = (e) => {
+    this.setState({text: e.target.value});
+  }
+  _handleKeyDown = (e) => {
+    if (this.props.onCancel && e.keyCode === ESC_KEY_CODE) {
+      this.props.onCancel();
+    } else if (e.keyCode === ENTER_KEY_CODE) {
+      this._commitChanges();
+    }
+  }
+  render() {
+    return (
+      <input
+        style={this.props.style}
+        onBlur={this._handleBlur}
+        onChange={this._handleChange}
+        onKeyDown={this._handleKeyDown}
+        placeholder={this.props.placeholder}
+        value={this.state.text}
+      />
+    );
+  }
+}
+

--- a/examples/user-group/js/components/UserDetail.js
+++ b/examples/user-group/js/components/UserDetail.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import Relay from 'react-relay';
+import RoleSwitch from './RoleSwitch';
+
+class UserDetail extends React.Component {
+  getStyles () {
+    return {
+      name: {
+        display: 'inline-block',
+        width: '70%',
+      },
+      listContainer: {
+        display: 'inline-block',
+        width: '30%',
+      },
+      list: {
+        display: 'flex',
+        padding: 0,
+        listStyleType: 'none',
+      },
+      item: {
+        flexGrow: 1,
+      },
+    };
+  }
+  render () {
+    var {user, roles} = this.props;
+    var styles = this.getStyles();
+    var userRoleIds = user.roles.edges.map(edge => edge.node.id);
+
+    return <div style={styles.container}>
+      <span style={styles.name}>{user.name}</span>
+      <div style={styles.listContainer}>
+        <ul style={styles.list}>
+          {roles.edges.map(edge => <li key={edge.node.id} style={styles.item}>
+            <RoleSwitch
+              user={user}
+              role={edge.node}
+              connected={!!userRoleIds.find(id => id === edge.node.id)}
+            />
+          </li>)}
+        </ul>
+      </div>
+    </div>;
+  }
+}
+
+export default Relay.createContainer(UserDetail, {
+  fragments: {
+    user: () => Relay.QL`
+      fragment on User {
+        name,
+        roles(first: 10) {
+          edges {
+            node {
+              id,
+            }
+          }
+        },
+        ${RoleSwitch.getFragment('user')},
+      }
+    `,
+    roles: () => Relay.QL`
+      fragment on RoleConnection {
+        edges {
+          node {
+            id,
+            ${RoleSwitch.getFragment('role')},
+          }
+        }
+      }
+    `,
+  },
+});
+

--- a/examples/user-group/js/components/UserSwitch.js
+++ b/examples/user-group/js/components/UserSwitch.js
@@ -1,0 +1,40 @@
+import RemoveUserRoleMutation from '../mutations/RemoveUserRoleMutation';
+import React from 'react';
+import Relay from 'react-relay';
+
+class UserSwitch extends React.Component {
+  _handleDestroyClick = () => {
+    this._removeUser();
+  }
+  _removeUser () {
+    Relay.Store.update(
+      new RemoveUserRoleMutation({
+        user: this.props.user,
+        role: this.props.role,
+      })
+    );
+  }
+  render () {
+    var {user} = this.props;
+    return <div onClick={this._handleDestroyClick}>{user.name}</div>;
+  }
+}
+
+export default Relay.createContainer(UserSwitch, {
+  fragments: {
+    role: () => Relay.QL`
+      fragment on Role {
+        id,
+        ${RemoveUserRoleMutation.getFragment('role')},
+      }
+    `,
+    user: () => Relay.QL`
+      fragment on User {
+        id,
+        name,
+        ${RemoveUserRoleMutation.getFragment('user')},
+      }
+    `,
+  },
+});
+

--- a/examples/user-group/js/mutations/AddUserRoleMutation.js
+++ b/examples/user-group/js/mutations/AddUserRoleMutation.js
@@ -1,0 +1,58 @@
+import Relay from 'react-relay';
+
+export default class AddUserRoleMutation extends Relay.Mutation {
+  static fragments = {
+    user: () => Relay.QL`
+      fragment on User {
+        id,
+      }
+    `,
+    role: () => Relay.QL`
+      fragment on Role {
+        id,
+      }
+    `,
+  };
+  getMutation () {
+    return Relay.QL`mutation{addUserRole}`;
+  }
+  getFatQuery () {
+    return Relay.QL`
+      fragment on AddUserRolePayload {
+        user,
+        role,
+        userEdge,
+        roleEdge,
+      }
+    `;
+  }
+  getConfigs () {
+    return [{
+      type: 'RANGE_ADD',
+      parentName: 'user',
+      parentID: this.props.user.id,
+      connectionName: 'roles',
+      edgeName: 'roleEdge',
+      rangeBehaviors: {
+        '': 'append',
+      },
+    },
+    {
+      type: 'RANGE_ADD',
+      parentName: 'role',
+      parentID: this.props.role.id,
+      connectionName: 'users',
+      edgeName: 'userEdge',
+      rangeBehaviors: {
+        '': 'append',
+      },
+    }];
+  }
+  getVariables () {
+    return {
+      userId: this.props.user.id,
+      roleId: this.props.role.id,
+    };
+  }
+}
+

--- a/examples/user-group/js/mutations/NewUserMutation.js
+++ b/examples/user-group/js/mutations/NewUserMutation.js
@@ -1,0 +1,41 @@
+import Relay from 'react-relay';
+
+export default class NewUserMutation extends Relay.Mutation {
+  static fragments = {
+    viewer: () => Relay.QL`
+      fragment on Viewer {
+        id,
+      }
+    `,
+  };
+  getMutation () {
+    return Relay.QL`mutation{newUser}`;
+  }
+  getFatQuery () {
+    return Relay.QL`
+      fragment on NewUserPayload {
+        userEdge,
+        viewer {
+          users,
+        },
+      }
+    `;
+  }
+  getConfigs () {
+    return [{
+      type: 'RANGE_ADD',
+      parentName: 'viewer',
+      parentID: this.props.viewer.id,
+      connectionName: 'users',
+      edgeName: 'userEdge',
+      rangeBehaviors: {
+        '': 'append',
+      },
+    }];
+  }
+  getVariables () {
+    return {
+      userName: this.props.userName,
+    };
+  }
+}

--- a/examples/user-group/js/mutations/RemoveUserRoleMutation.js
+++ b/examples/user-group/js/mutations/RemoveUserRoleMutation.js
@@ -1,0 +1,54 @@
+import Relay from 'react-relay';
+
+export default class RemoveUserRoleMutation extends Relay.Mutation {
+  static fragments = {
+    user: () => Relay.QL`
+      fragment on User {
+        id,
+      }
+    `,
+    role: () => Relay.QL`
+      fragment on Role {
+        id,
+      }
+    `,
+  };
+  getMutation () {
+    return Relay.QL`mutation{removeUserRole}`;
+  }
+  getFatQuery () {
+    return Relay.QL`
+      fragment on RemoveUserRolePayload {
+        user,
+        role,
+        removedUserID,
+        removedRoleID,
+      }
+    `;
+  }
+  getConfigs () {
+    return [
+      {
+        type: 'NODE_DELETE',
+        parentName: 'user',
+        parentID: this.props.user.id,
+        connectionName: 'roles',
+        deletedIDFieldName: 'removedRoleID',
+      },
+      {
+        type: 'NODE_DELETE',
+        parentName: 'role',
+        parentID: this.props.role.id,
+        connectionName: 'users',
+        deletedIDFieldName: 'removedUserID',
+      },
+    ];
+  }
+  getVariables () {
+    return {
+      userId: this.props.user.id,
+      roleId: this.props.role.id,
+    };
+  }
+}
+

--- a/examples/user-group/js/routes/HomeRoute.js
+++ b/examples/user-group/js/routes/HomeRoute.js
@@ -1,0 +1,8 @@
+import Relay from 'react-relay';
+
+export default class extends Relay.Route {
+  static queries = {
+    viewer: () => Relay.QL`query { viewer }`
+  };
+  static routeName = 'HomeRoute';
+}

--- a/examples/user-group/package.json
+++ b/examples/user-group/package.json
@@ -1,0 +1,25 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "babel-node ./server.js",
+    "update-schema": "babel-node ./scripts/updateSchema.js"
+  },
+  "dependencies": {
+    "babel": "5.8.21",
+    "babel-loader": "5.3.2",
+    "babel-relay-plugin": "^0.3.0",
+    "classnames": "^2.1.3",
+    "express": "^4.13.1",
+    "express-graphql": "^0.4.0",
+    "graphql": "^0.4.7",
+    "graphql-relay": "^0.3.3",
+    "history": "^1.13.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "react-relay": "^0.4.0",
+    "react-router": "^1.0.0",
+    "react-router-relay": "^0.8.0",
+    "webpack": "^1.10.5",
+    "webpack-dev-server": "^1.10.1"
+  }
+}

--- a/examples/user-group/public/index.html
+++ b/examples/user-group/public/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Relay • User Group</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/javascript">
+      // Force `fetch` polyfill to workaround Chrome not displaying request body
+      // in developer tools for the native `fetch`.
+      self.fetch = null;
+    </script>
+    <script src="http://localhost:3000/webpack-dev-server.js"></script>
+    <script src="js/app.js"></script>
+  </body>
+</html>

--- a/examples/user-group/scripts/updateSchema.js
+++ b/examples/user-group/scripts/updateSchema.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env babel-node --optional es7.asyncFunctions
+
+import fs from 'fs';
+import path from 'path';
+import { Schema } from '../data/schema';
+import { graphql }  from 'graphql';
+import { introspectionQuery, printSchema } from 'graphql/utilities';
+
+// Save JSON of full schema introspection for Babel Relay Plugin to use
+async () => {
+  var result = await (graphql(Schema, introspectionQuery));
+  if (result.errors) {
+    console.error(
+      'ERROR introspecting schema: ',
+      JSON.stringify(result.errors, null, 2)
+    );
+  } else {
+    fs.writeFileSync(
+      path.join(__dirname, '../data/schema.json'),
+      JSON.stringify(result, null, 2)
+    );
+  }
+}();
+
+// Save user readable type system shorthand of schema
+fs.writeFileSync(
+  path.join(__dirname, '../data/schema.graphql'),
+  printSchema(Schema)
+);

--- a/examples/user-group/server.js
+++ b/examples/user-group/server.js
@@ -1,0 +1,47 @@
+import express from 'express';
+import graphQLHTTP from 'express-graphql';
+import path from 'path';
+import webpack from 'webpack';
+import WebpackDevServer from 'webpack-dev-server';
+import {Schema} from './data/schema';
+
+const APP_PORT = 3000;
+const GRAPHQL_PORT = 8080;
+
+// Expose a GraphQL endpoint
+var graphQLServer = express();
+graphQLServer.use('/', graphQLHTTP({
+  graphiql: true,
+  pretty: true,
+  schema: Schema,
+}));
+graphQLServer.listen(GRAPHQL_PORT, () => console.log(
+  `GraphQL Server is now running on http://localhost:${GRAPHQL_PORT}`
+));
+
+// Serve the Relay app
+var compiler = webpack({
+  entry: path.resolve(__dirname, 'js', 'app.js'),
+  module: {
+    loaders: [
+      {
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {stage: 0, plugins: ['./build/babelRelayPlugin']},
+        test: /\.js$/,
+      }
+    ]
+  },
+  output: {filename: 'app.js', path: '/'}
+});
+var app = new WebpackDevServer(compiler, {
+  contentBase: '/public/',
+  proxy: {'/graphql': `http://localhost:${GRAPHQL_PORT}`},
+  publicPath: '/js/',
+  stats: {colors: true, chunks: false}
+});
+// Serve static resources
+app.use('/', express.static(path.resolve(__dirname, 'public')));
+app.listen(APP_PORT, () => {
+  console.log(`App is now running on http://localhost:${APP_PORT}`);
+});


### PR DESCRIPTION
Issue #609
The use-case I was going for with this example is bidirectional data relationships. In an app, at any given point, you may wish to have the UI show a user and her associated groups. In another place you may want to show a group and its associated users. I didn't see this represented in the current examples.
```
user { groups }
group { users }
```
In this example users are soccer players and the groups are their positions. In the UI, each player is listed with switches that can be turned on/off to indicate whether that player can play a given position.

Next to the list of players is a list of positions. Below each position is a list of players who are switched on for that position.

You can also add a new player via the text input below the player list.