### PR TITLE
Fix variables for implicit fragment

### DIFF
--- a/src/query/__tests__/buildRQL-test.js
+++ b/src/query/__tests__/buildRQL-test.js
@@ -36,11 +36,8 @@ describe('buildRQL', () => {
     });
     MockComponent = React.createClass({render});
     MockContainer = Relay.createContainer(MockComponent, {
-      initialVariables: {
-        if: null,
-      },
       fragments: {
-        foo: () => Relay.QL`fragment on Node { firstName(if: $if) }`,
+        foo: () => Relay.QL`fragment on Node { name }`,
       },
     });
 
@@ -213,6 +210,14 @@ describe('buildRQL', () => {
     });
 
     it('produces equal results for implicit and explicit definitions', () => {
+      const MockContainer2 = Relay.createContainer(MockComponent, {
+        initialVariables: {
+          if: null,
+        },
+        fragments: {
+          foo: () => Relay.QL`fragment on Node { firstName(if: $if) }`,
+        },
+      });
       const implicitBuilder = () => Relay.QL`
         query {
           viewer
@@ -228,13 +233,13 @@ describe('buildRQL', () => {
       const initialVariables = {if: null};
       const implicitNode = buildRQL.Query(
         implicitBuilder,
-        MockContainer,
+        MockContainer2,
         'foo',
         initialVariables,
       );
       const explicitNode = buildRQL.Query(
         explicitBuilder,
-        MockContainer,
+        MockContainer2,
         'foo',
         initialVariables,
       );

--- a/src/query/buildRQL.js
+++ b/src/query/buildRQL.js
@@ -134,10 +134,10 @@ var buildRQL = {
               '`node(id: $id)`, not `node(id: $id) { ... }`.',
               query.fieldName
             );
-            const fragmentValues = filterObject(values, (_, name) =>
+            const fragmentVariables = filterObject(variables, (_, name) =>
               Component.hasVariable(name)
             );
-            children.push(Component.getFragment(queryName, fragmentValues));
+            children.push(Component.getFragment(queryName, fragmentVariables));
             node = {
               ...query,
               children,


### PR DESCRIPTION
The problem was that variables of the implicit query fragment were not updated after query parameters had changed. The query produced by `buildRQL.Query` for an implicit definition was not equal to the query produced for an analogous explicit definition (see the added test).