### PR TITLE
Don't store __typename for optimistic records

### DIFF
--- a/src/store/RelayQueryWriter.js
+++ b/src/store/RelayQueryWriter.js
@@ -85,7 +85,10 @@ class RelayQueryWriter extends RelayQueryVisitor<WriterState> {
     recordID: DataID,
     payload: Object
   ): ?string {
-    if (GraphQLStoreDataHandler.isClientID(recordID)) {
+    if (
+      this._isOptimisticUpdate ||
+      GraphQLStoreDataHandler.isClientID(recordID)
+    ) {
       return null;
     }
     var typeName = payload[TYPENAME];


### PR DESCRIPTION
Addresses #618 - developers shouldn't have to write `__typename`s for optimistic records. `RelayQueryWriter` already traverses *any* fragment when handling optimistic payloads, and the other place where we would use the type - the cache writer - doesn't receive optimistic writes either.