### PR TITLE
Handle unmatched fragment types in diffRelayQuery

### DIFF
--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -407,6 +407,52 @@ type NonNodeStory implements FeedUnit {
   tracking: String
 }
 
+type PhotoStory implements FeedUnit Node {
+  # PhotoStory
+  photo: Image
+
+  # FeedUnit
+  canViewerDelete: Boolean
+  seenState: String
+
+  # Node
+  actor: Actor
+  actors: [Actor]
+  actorCount: Int
+  address: StreetAddress
+  allPhones: [Phone]
+  author: User
+  backgroundImage: Image
+  birthdate: Date
+  body: Text
+  canViewerComment: Boolean
+  canViewerLike: Boolean
+  comments(first: String, last: Int, orderby: String): CommentsConnection
+  doesViewerLike: Boolean
+  emailAddresses: [String]
+  feedback: Feedback
+  firstName(if: Boolean, unless: Boolean): String
+  friends(after: String, first: String, orderby: [String], find: String, isViewerFriend: Boolean, if: Boolean, unless: Boolean): FriendsConnection
+  hometown: Page
+  id: ID!
+  lastName: String
+  likers(first: String): LikersOfContentConnection
+  likeSentence: Text
+  message: Text
+  name: String
+  profilePicture(size: [String], preset: PhotoSize): Image
+  segments(first: String): Segments
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: String): SubscribersConnection
+  topLevelComments(first: String): TopLevelCommentsConnection
+  tracking: String
+  url(relative: Boolean, site: String): String
+  websites: [String]
+  username: String
+  viewerSavedState: String
+}
+
 type Story implements FeedUnit Node {
   # FeedUnit
   canViewerDelete: Boolean
@@ -472,6 +518,7 @@ type SubscribersEdge {
 
 type Text {
   text: String
+  ranges: [String]
 }
 
 type TimezoneInfo {

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -1753,6 +1753,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "PhotoStory",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Story",
               "ofType": null
             },
@@ -3772,6 +3777,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "ranges",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -5028,9 +5049,21 @@
         },
         {
           "kind": "OBJECT",
-          "name": "Story",
+          "name": "PhotoStory",
           "description": null,
           "fields": [
+            {
+              "name": "photo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "canViewerDelete",
               "description": null,
@@ -5826,6 +5859,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "PhotoStory",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Story",
               "ofType": null
             }
@@ -5918,6 +5956,713 @@
             {
               "kind": "INTERFACE",
               "name": "FeedUnit",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Story",
+          "description": null,
+          "fields": [
+            {
+              "name": "canViewerDelete",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "seenState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "actor",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Actor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "actors",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Actor",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "actorCount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "address",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "StreetAddress",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allPhones",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Phone",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "author",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "backgroundImage",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "birthdate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "body",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Text",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canViewerComment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "canViewerLike",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comments",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderby",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CommentsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "doesViewerLike",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "emailAddresses",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feedback",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Feedback",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "firstName",
+              "description": null,
+              "args": [
+                {
+                  "name": "if",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "unless",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "friends",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderby",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "find",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "isViewerFriend",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "if",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "unless",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FriendsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hometown",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Page",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "likers",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LikersOfContentConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "likeSentence",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Text",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "message",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Text",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "profilePicture",
+              "description": null,
+              "args": [
+                {
+                  "name": "size",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "preset",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "PhotoSize",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Image",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "segments",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Segments",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "screennames",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Screenname",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscribeStatus",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscribers",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubscribersConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "topLevelComments",
+              "description": null,
+              "args": [
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "TopLevelCommentsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tracking",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [
+                {
+                  "name": "relative",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "site",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "websites",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "username",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "viewerSavedState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "FeedUnit",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
               "ofType": null
             }
           ],

--- a/src/traversal/__tests__/diffRelayQuery_fragments-test.js
+++ b/src/traversal/__tests__/diffRelayQuery_fragments-test.js
@@ -1,0 +1,313 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+var RelayTestUtils = require('RelayTestUtils');
+RelayTestUtils.unmockRelay();
+
+jest
+  .dontMock('GraphQLRange')
+  .dontMock('GraphQLSegment');
+
+var Relay = require('Relay');
+var RelayConnectionInterface = require('RelayConnectionInterface');
+var RelayQueryTracker = require('RelayQueryTracker');
+var diffRelayQuery = require('diffRelayQuery');
+
+describe('diffRelayQuery - fragments', () => {
+  var RelayRecordStore;
+
+  var {getNode, writePayload} = RelayTestUtils;
+  var HAS_NEXT_PAGE, HAS_PREV_PAGE, PAGE_INFO;
+
+  var rootCallMap = {
+    'viewer': {'': 'client:1'},
+  };
+
+  beforeEach(() => {
+    jest.resetModuleRegistry();
+
+    RelayRecordStore = require('RelayRecordStore');
+    ({HAS_NEXT_PAGE, HAS_PREV_PAGE, PAGE_INFO} = RelayConnectionInterface);
+
+    jest.addMatchers(RelayTestUtils.matchers);
+  });
+
+  it('removes matching fragments with fetched fields', () => {
+    var records = {};
+    var store = new RelayRecordStore({records});
+    var tracker = new RelayQueryTracker();
+
+    var query = getNode(Relay.QL`
+      query {
+        node(id:"123") {
+          ... on User {
+            firstName
+          }
+        }
+      }
+    `);
+    var payload = {
+      node: {
+        id: '123',
+        __typename: 'User',
+        firstName: 'Joe'
+      }
+    };
+    writePayload(store, query, payload, tracker);
+
+    var diffQueries = diffRelayQuery(query, store, tracker);
+    expect(diffQueries.length).toBe(0);
+  });
+
+  it('refetches matching fragments with missing fields', () => {
+    var records = {};
+    var store = new RelayRecordStore({records});
+    var tracker = new RelayQueryTracker();
+
+    var query = getNode(Relay.QL`
+      query {
+        node(id:"123") {
+          ... on User {
+            firstName
+            lastName
+          }
+        }
+      }
+    `);
+    var payload = {
+      node: {
+        id: '123',
+        __typename: 'User',
+        firstName: 'Joe'
+      }
+    };
+    writePayload(store, query, payload, tracker);
+
+    var diffQueries = diffRelayQuery(query, store, tracker);
+    expect(diffQueries.length).toBe(1);
+    expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
+      query {
+        node(id:"123") {
+          ... on User {
+            lastName
+          }
+        }
+      }
+    `));
+  });
+
+  it('removes non-matching fragments if other fields are fetched', () => {
+    var records = {};
+    var store = new RelayRecordStore({records});
+    var tracker = new RelayQueryTracker();
+
+    var query = getNode(Relay.QL`
+      query {
+        node(id:"123") {
+          ... on User {
+            firstName
+          }
+          ... on Page {
+            name
+          }
+        }
+      }
+    `);
+    var payload = {
+      node: {
+        id: '123',
+        __typename: 'User',
+        firstName: 'Joe'
+      }
+    };
+    writePayload(store, query, payload, tracker);
+
+    var diffQueries = diffRelayQuery(query, store, tracker);
+    expect(diffQueries.length).toBe(0);
+  });
+
+  it('refetches non-matching fragments if other fields are missing', () => {
+    var records = {};
+    var store = new RelayRecordStore({records});
+    var tracker = new RelayQueryTracker();
+
+    var query = getNode(Relay.QL`
+      query {
+        node(id:"123") {
+          ... on User {
+            firstName
+            lastName
+          }
+          ... on Page {
+            name
+          }
+        }
+      }
+    `);
+    var payload = {
+      node: {
+        id: '123',
+        __typename: 'User',
+        firstName: 'Joe'
+      }
+    };
+    writePayload(store, query, payload, tracker);
+
+    var diffQueries = diffRelayQuery(query, store, tracker);
+    expect(diffQueries.length).toBe(1);
+    expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
+      query {
+        node(id:"123") {
+          ... on User {
+            lastName
+          }
+          ... on Page {
+            name
+          }
+        }
+      }
+    `));
+  });
+
+  it('removes non-matching fragments if connection fields are fetched', () => {
+    var records = {};
+    var store = new RelayRecordStore({records}, {rootCallMap});
+    var tracker = new RelayQueryTracker();
+
+    var payload = {
+      viewer: {
+        newsFeed: {
+          edges: [
+            {
+              cursor: 'c1',
+              node: {
+                id: 's1',
+                __typename: 'Story',
+                message: {text: 's1'},
+              },
+            },
+          ],
+          [PAGE_INFO]: {
+            [HAS_NEXT_PAGE]: true,
+            [HAS_PREV_PAGE]: false,
+          },
+        },
+      },
+    };
+    var query = getNode(Relay.QL`
+      query {
+        viewer {
+          newsFeed(first:"1") {
+            edges {
+              node {
+                ... on Story {
+                  message {
+                    text
+                  }
+                }
+                ... on PhotoStory {
+                  photo {
+                    uri
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `);
+    writePayload(store, query, payload, tracker);
+
+    var diffQueries = diffRelayQuery(query, store, tracker);
+    expect(diffQueries.length).toBe(0);
+  });
+
+  it(
+    'refetches non-matching fragments if connection fields are missing',
+    () => {
+      var records = {};
+      var store = new RelayRecordStore({records}, {rootCallMap});
+      var tracker = new RelayQueryTracker();
+
+      var payload = {
+        viewer: {
+          newsFeed: {
+            edges: [
+              {
+                cursor: 'c1',
+                node: {
+                  id: 's1',
+                  __typename: 'Story',
+                  message: {
+                    text: 's1', // missing `ranges`
+                  },
+                },
+              },
+            ],
+            [PAGE_INFO]: {
+              [HAS_NEXT_PAGE]: true,
+              [HAS_PREV_PAGE]: false,
+            },
+          },
+        },
+      };
+      var query = getNode(Relay.QL`
+        query {
+          viewer {
+            newsFeed(first:"1") {
+              edges {
+                node {
+                  ... on Story {
+                    message {
+                      text
+                      ranges
+                    }
+                  }
+                  ... on PhotoStory {
+                    photo {
+                      uri
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `);
+      writePayload(store, query, payload, tracker);
+
+      var diffQueries = diffRelayQuery(query, store, tracker);
+      expect(diffQueries.length).toBe(1);
+      expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
+      query {
+        node(id:"s1") {
+          ... on Story {
+            message {
+              ranges
+            }
+          }
+          ... on PhotoStory {
+            photo {
+              uri
+            }
+          }
+          ... on FeedUnit {
+            id
+            __typename
+          }
+        }
+      }
+    `));
+    }
+  );
+});


### PR DESCRIPTION
`RelayQueryWriter` no longer writes the results of unmatched fragments. However, `diffRelayQuery` still attempts to diff fragments that don't match the known type. The logic is:

- when diffing, we shouldn't look at fragments whose types don't match
- but we can't *remove* those fragments, because if we end up refetching the node, it might be a different record whose type could match that fragment
- so we should treat non-matching fragments as requisite fields and only keep them if the node would otherwise be refetched