### PR TITLE
Skip printing empty fragments

### DIFF
--- a/src/__forks__/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/__forks__/traversal/__tests__/printRelayOSSQuery-test.js
@@ -288,6 +288,30 @@ describe('printRelayOSSQuery', () => {
       `);
       expect(variables).toEqual({});
     });
+
+    it('omits empty inline fragments', () => {
+      var fragment = getNode(Relay.QL`
+        fragment on Viewer {
+          actor {
+            id
+          }
+          ... on Viewer {
+            actor @include(if: $false) {
+              name
+            }
+          }
+        }
+      `, {false: false});
+      var {text} = printRelayOSSQuery(fragment);
+      expect(text).toEqualPrintedQuery(`
+        fragment PrintRelayOSSQuery on Viewer {
+          actor {
+            id,
+            __typename
+          }
+        }
+      `);
+    });
   });
 
   describe('fields', () => {


### PR DESCRIPTION
Fragments can be empty if all non-generated fields are skipped due to `@include` or `@skip` directives - these shouldn't be printed.