### PR TITLE
Make rangeBehaviors a function

### DIFF
--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -329,9 +329,10 @@ Given a parent, a connection, and the name of the newly created edge in the resp
 
   The field name in the response that represents the newly created edge
 
-- `rangeBehaviors: {[call: string]: GraphQLMutatorConstants.RANGE_OPERATIONS}`
+- `rangeBehaviors: (connectionArgs: {[argName:string]: argValue: string}) =>
+  ?$Enum<typeof GraphQLMutatorConstants.RANGE_OPERATIONS>`
 
-  A map between printed, dot-separated GraphQL calls *in alphabetical order*, and the behavior we want Relay to exhibit when adding the new edge to connections under the influence of those calls. Behaviors can be one of `'append'`, `'prepend'`, or `'remove'`.
+  A function receiving an object of range filter calls returning the behavior we want Relay to exhibit when adding the new edge to connections under the influence of those calls. Behaviors can be one of `'append'`, `'prepend'`, or `'remove'`.
 
 #### Example
 
@@ -359,12 +360,15 @@ class IntroduceShipMutation extends Relay.Mutation {
       parentID: this.props.faction.id,
       connectionName: 'ships',
       edgeName: 'newShipEdge',
-      rangeBehaviors: {
-        // When the ships connection is not under the influence
-        // of any call, append the ship to the end of the connection
-        '': 'append',
+      rangeBehaviors: ({orderby}) {
         // Prepend the ship, wherever the connection is sorted by age
-        'orderby(newest)': 'prepend',
+        if (orderby === 'newest') {
+          return 'prepend';
+        } else {
+          // When the ships connection is not under the influence
+          // of any call, append the ship to the end of the connection
+          return 'append'
+        }
       },
     }];
   }

--- a/examples/todo/js/mutations/AddTodoMutation.js
+++ b/examples/todo/js/mutations/AddTodoMutation.js
@@ -42,12 +42,15 @@ export default class AddTodoMutation extends Relay.Mutation {
       parentID: this.props.viewer.id,
       connectionName: 'todos',
       edgeName: 'todoEdge',
-      rangeBehaviors: {
-        '': 'append',
-        'status(any)': 'append',
-        'status(active)': 'append',
-        'status(completed)': null,
-      },
+      rangeBehaviors: ({status}) => {
+        if (status === 'any' || status === 'active') {
+          return 'append';
+        } else if (status === 'completed') {
+          return null;
+        } else {
+          return 'append';
+        }
+      }
     }];
   }
   getVariables() {

--- a/src/mutation/RelayMutation.js
+++ b/src/mutation/RelayMutation.js
@@ -122,14 +122,15 @@ class RelayMutation<Tp: Object> {
    *      connectionName: string;
    *      edgeName: string;
    *      rangeBehaviors:
-   *        {[call: string]: GraphQLMutatorConstants.RANGE_OPERATIONS};
+   *        (connectionArgs: {[argName:string]: argValue: string}) =>
+   *          ?$Enum<typeof GraphQLMutatorConstants.RANGE_OPERATIONS>;
    *    }
    *    where `parentName` is the field in the fatQuery that contains the range,
    *    `parentID` is the DataID of `parentName` in the store, `connectionName`
    *    is the name of the range, `edgeName` is the name of the key in server
-   *    response that contains the newly created edge, `rangeBehaviors` maps
-   *    stringified representation of calls on the connection to
-   *    GraphQLMutatorConstants.RANGE_OPERATIONS.
+   *    response that contains the newly created edge, `rangeBehaviors` returns
+   *    one of GraphQLMutatorConstants.RANGE_OPERATIONS, receiving as argument an
+   *      an object containing the range filter calls.
    *
    * -  NODE_DELETE provides configuration for deleting a node and the
    *    corresponding edge from a range.

--- a/src/mutation/RelayMutationQueue.js
+++ b/src/mutation/RelayMutationQueue.js
@@ -414,6 +414,7 @@ class PendingTransaction {
         var optimisticConfigs = this.getOptimisticConfigs();
         if (optimisticConfigs) {
           this._optimisticQuery = RelayMutationQuery.buildQuery({
+            recordStore: storeData.getRecordStore(),
             configs: optimisticConfigs,
             fatQuery: this.getFatQuery(),
             input: this.getInputVariable(),
@@ -451,6 +452,7 @@ class PendingTransaction {
   getQuery(storeData: RelayStoreData): RelayQuery.Mutation {
     if (!this._query) {
       this._query = RelayMutationQuery.buildQuery({
+        recordStore: storeData.getRecordStore(),
         configs: this.getConfigs(),
         fatQuery: this.getFatQuery(),
         input: this.getInputVariable(),

--- a/src/mutation/__tests__/RelayMutationQuery-test.js
+++ b/src/mutation/__tests__/RelayMutationQuery-test.js
@@ -26,6 +26,7 @@ var filterRelayQuery = require('filterRelayQuery');
 var fromGraphQL = require('fromGraphQL');
 var intersectRelayQuery = require('intersectRelayQuery');
 var inferRelayFieldsFromData = require('inferRelayFieldsFromData');
+var RelayStoreData = require('RelayStoreData');
 
 describe('RelayMutationQuery', () => {
   function getNodeChildren(fragment) {
@@ -277,7 +278,7 @@ describe('RelayMutationQuery', () => {
   });
 
   describe('edge insertion', () => {
-    var fatQuery, rangeBehaviors;
+    var fatQuery, rangeBehaviors, recordStore;
 
     beforeEach(() => {
       fatQuery = fromGraphQL.Fragment(Relay.QL`
@@ -294,10 +295,17 @@ describe('RelayMutationQuery', () => {
           }
         }
       `);
-      rangeBehaviors = {
-        '': GraphQLMutatorConstants.PREPEND,
-        'orderby(toplevel)': GraphQLMutatorConstants.PREPEND,
+      rangeBehaviors = function({orderby}) {
+        return GraphQLMutatorConstants.PREPEND;
       };
+
+      recordStore = RelayStoreData.getDefaultInstance().getRecordStore();
+      recordStore.getConnectionIDsForField =
+        jest.genMockFunction().mockReturnValue([1]);
+      recordStore.getRangeFilterCalls = jest.genMockFunction().mockReturnValue([{
+        name: 'orderby',
+        value: 'toplevel',
+      }]);
     });
 
     it('includes edge fields for connections with range config', () => {
@@ -314,7 +322,9 @@ describe('RelayMutationQuery', () => {
           }
         }
       `));
+
       var node = RelayMutationQuery.buildFragmentForEdgeInsertion({
+        recordStore,
         fatQuery,
         tracker,
         connectionName: 'comments',
@@ -370,6 +380,7 @@ describe('RelayMutationQuery', () => {
         }
       `));
       var node = RelayMutationQuery.buildFragmentForEdgeInsertion({
+        recordStore,
         fatQuery,
         tracker,
         connectionName: 'comments',
@@ -425,6 +436,7 @@ describe('RelayMutationQuery', () => {
         }
       `));
       var node = RelayMutationQuery.buildFragmentForEdgeInsertion({
+        recordStore,
         fatQuery,
         tracker,
         connectionName: 'comments',
@@ -467,6 +479,7 @@ describe('RelayMutationQuery', () => {
         }
       `));
       var node = RelayMutationQuery.buildFragmentForEdgeInsertion({
+        recordStore,
         fatQuery,
         tracker,
         connectionName: 'comments',
@@ -503,6 +516,7 @@ describe('RelayMutationQuery', () => {
         }
       `));
       var node = RelayMutationQuery.buildFragmentForEdgeInsertion({
+        recordStore,
         fatQuery,
         tracker,
         connectionName: 'comments',
@@ -534,6 +548,7 @@ describe('RelayMutationQuery', () => {
       `));
       expect(() => {
         RelayMutationQuery.buildFragmentForEdgeInsertion({
+          recordStore,
           fatQuery,
           tracker,
           connectionName: 'comments',
@@ -624,6 +639,11 @@ describe('RelayMutationQuery', () => {
   });
 
   describe('query', () => {
+    var recordStore;
+    beforeEach(() => {
+      recordStore = RelayStoreData.getDefaultInstance().getRecordStore();
+    });
+
     it('creates a query for RANGE_ADD', () => {
       tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
         fragment on Feedback {
@@ -655,8 +675,8 @@ describe('RelayMutationQuery', () => {
       var parentID = '123';
       var connectionName = 'comments';
       var edgeName = 'feedbackCommentEdge';
-      var rangeBehaviors = {
-        '': GraphQLMutatorConstants.PREPEND,
+      var rangeBehaviors = function() {
+        return GraphQLMutatorConstants.PREPEND;
       };
       var configs = [
         {
@@ -673,6 +693,7 @@ describe('RelayMutationQuery', () => {
       var mutationName = 'CommentAddMutation';
       var variables = {input: ''};
       var query = RelayMutationQuery.buildQuery({
+        recordStore,
         tracker,
         fatQuery,
         configs,
@@ -751,6 +772,7 @@ describe('RelayMutationQuery', () => {
       var mutationName = 'CommentDeleteMutation';
       var variables = {input: ''};
       var query = RelayMutationQuery.buildQuery({
+        recordStore,
         tracker,
         fatQuery,
         configs,
@@ -818,6 +840,7 @@ describe('RelayMutationQuery', () => {
       var mutationName = 'CommentDeleteMutation';
       var variables = {input: ''};
       var query = RelayMutationQuery.buildQuery({
+        recordStore,
         tracker,
         fatQuery,
         configs,
@@ -874,6 +897,7 @@ describe('RelayMutationQuery', () => {
       var mutationName = 'FeedbackLikeMutation';
       var variables = {input: ''};
       var query = RelayMutationQuery.buildQuery({
+        recordStore,
         tracker,
         fatQuery,
         configs,
@@ -932,8 +956,8 @@ describe('RelayMutationQuery', () => {
       var parentID = '123';
       var connectionName = 'comments';
       var edgeName = 'feedbackCommentEdge';
-      var rangeBehaviors = {
-        '': GraphQLMutatorConstants.PREPEND,
+      var rangeBehaviors = function() {
+        return GraphQLMutatorConstants.PREPEND;
       };
       var configs = [
         {
@@ -960,6 +984,7 @@ describe('RelayMutationQuery', () => {
       var mutationName = 'CommentAddMutation';
       var variables = {input: ''};
       var query = RelayMutationQuery.buildQuery({
+        recordStore,
         tracker,
         fatQuery,
         configs,
@@ -1041,8 +1066,8 @@ describe('RelayMutationQuery', () => {
       var parentID = '123';
       var connectionName = 'comments';
       var edgeName = 'feedbackCommentEdge';
-      var rangeBehaviors = {
-        '': GraphQLMutatorConstants.PREPEND,
+      var rangeBehaviors = function() {
+        return GraphQLMutatorConstants.PREPEND;
       };
       var fieldIDs = {
         feedback: '123',
@@ -1066,6 +1091,7 @@ describe('RelayMutationQuery', () => {
       var mutationName = 'CommentAddAndLikeMutation';
       var variables = {input: ''};
       var query = RelayMutationQuery.buildQuery({
+        recordStore,
         tracker,
         fatQuery,
         configs,

--- a/src/mutation/__tests__/RelayMutationQueue-test.js
+++ b/src/mutation/__tests__/RelayMutationQueue-test.js
@@ -68,6 +68,8 @@ describe('RelayMutationQueue', () => {
       mockMutation.getVariables.mockReturnValue(input);
       mockMutation.getOptimisticResponse.mockReturnValue({});
       mockMutation.getOptimisticConfigs.mockReturnValue('optimisticConfigs');
+      let recordStore = storeData.getRecordStore();
+
       RelayMutationQuery.buildQuery.mockReturnValue('optimisticQuery');
 
       var transaction = mutationQueue.createTransaction(mockMutation);
@@ -83,6 +85,7 @@ describe('RelayMutationQueue', () => {
           [RelayConnectionInterface.CLIENT_MUTATION_ID]: '0',
         },
         mutation: mutationNode,
+        recordStore: recordStore,
         mutationName: 'RelayMutation',
         tracker: storeData.getQueryTracker(),
       }]]);

--- a/src/query/RelayQuery.js
+++ b/src/query/RelayQuery.js
@@ -1095,6 +1095,20 @@ class RelayQueryField extends RelayQueryNode {
     return rangeBehaviorKey;
   }
 
+  getRangeBehaviors(): Array<Call> {
+    invariant(
+      this.isConnection(),
+      'RelayQueryField: Range behaviors are associated exclusively with ' +
+      'connection fields. `getRangeBehaviors()` was called on the ' +
+      'non-connection field `%s`.',
+      this.getSchemaName()
+    );
+
+    return this.getCallsWithValues().filter(arg => {
+      return this._isCoreArg(arg);
+    });
+  }
+
   /**
    * The name for the field when serializing the query or interpreting query
    * responses from the server. The serialization key is derived from

--- a/src/store/__tests__/RelayStoreData_cacheManager-test.js
+++ b/src/store/__tests__/RelayStoreData_cacheManager-test.js
@@ -488,7 +488,9 @@ describe('RelayStoreData', function() {
       type: RelayMutationType.RANGE_ADD,
       connectionName: 'comments',
       edgeName: 'feedbackCommentEdge',
-      rangeBehaviors: {'': GraphQLMutatorConstants.PREPEND},
+      rangeBehaviors: () => {
+        return GraphQLMutatorConstants.PREPEND;
+      },
     }];
 
     var mutationQuery = getNode(Relay.QL`

--- a/src/tools/RelayInternalTypes.js
+++ b/src/tools/RelayInternalTypes.js
@@ -85,6 +85,5 @@ export type UpdateOptions = {
   isOptimisticUpdate: boolean;
 };
 
-export type RangeBehaviors = {
-  [key: string]: $Enum<GraphQLMutatorConstants.RANGE_OPERATIONS>;
-};
+export type RangeBehaviors = (connectionArgs: {[argName: string]: string}) =>
+  $Enum<GraphQLMutatorConstants.RANGE_OPERATIONS>;

--- a/src/tools/RelayTypes.js
+++ b/src/tools/RelayTypes.js
@@ -13,6 +13,8 @@
 
 'use strict';
 
+var GraphQLMutatorConstants = require('GraphQLMutatorConstants');
+
 /**
  * Types that Relay framework users may find useful.
  */
@@ -103,8 +105,8 @@ export type RelayMutationConfig = {
   parentID: string,
   connectionName: string,
   edgeName: string,
-  // from GraphQLMutatorConstants.RANGE_OPERATIONS
-  rangeBehaviors: {[call: string]: 'append' | 'prepend' | 'remove'},
+  rangeBehaviors: (connectionArgs: {[argName:string]: string}) =>
+    ?$Enum<typeof GraphQLMutatorConstants.RANGE_OPERATIONS>;
 } | {
   type: 'NODE_DELETE',
   parentName: string;

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -758,7 +758,9 @@ describe('writePayload()', () => {
         type: RelayMutationType.RANGE_ADD,
         connectionName: 'topLevelComments',
         edgeName: 'feedbackCommentEdge',
-        rangeBehaviors: {'': GraphQLMutatorConstants.PREPEND},
+        rangeBehaviors: () => {
+          return GraphQLMutatorConstants.PREPEND;
+        },
       }];
       var payload = {
         [RelayConnectionInterface.CLIENT_MUTATION_ID]:
@@ -844,7 +846,9 @@ describe('writePayload()', () => {
         type: RelayMutationType.RANGE_ADD,
         connectionName: 'topLevelComments',
         edgeName: 'feedbackCommentEdge',
-        rangeBehaviors: {'': GraphQLMutatorConstants.PREPEND},
+        rangeBehaviors: () => {
+          return GraphQLMutatorConstants.PREPEND;
+        },
       }];
 
       var nextCursor = 'comment789:cursor';
@@ -974,7 +978,9 @@ describe('writePayload()', () => {
         type: RelayMutationType.RANGE_ADD,
         connectionName: 'topLevelComments',
         edgeName: 'feedbackCommentEdge',
-        rangeBehaviors: {'': GraphQLMutatorConstants.PREPEND},
+        rangeBehaviors: () => {
+          return GraphQLMutatorConstants.PREPEND;
+        },
       }];
 
       var nextCursor = 'comment789:cursor';

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -558,10 +558,27 @@ function getRangeBehavior(
   rangeBehaviors: RangeBehaviors,
   calls: Array<Call>
 ): ?string {
-  var call = calls.map(printRelayQueryCall).sort().join('').slice(1);
-  return rangeBehaviors[call] || null;
+  let rangeFilterCalls = getObjectFromCalls(calls);
+  return rangeBehaviors(rangeFilterCalls);
 }
 
+/**
+ * Returns an object representation of the rangeFilterCalls that
+ * will be passed to config.rangeBehaviors
+ *
+ * Ex:
+ * calls: `[{name: 'orderby', value: 'recent'}]`
+ *
+ * Returns `{orderby: 'recent'}`
+ */
+function getObjectFromCalls(
+  calls: Array<Call>
+): {[argName: string]: string} {
+  return calls.reduce((rangeFilterCalls, currentCall) => {
+    rangeFilterCalls[currentCall.name] = currentCall.value;
+    return rangeFilterCalls;
+  },{})
+}
 /**
  * Given a payload of data and a path of fields, extracts the `id` of the node
  * specified by the path.


### PR DESCRIPTION
Fix for #615, proposed in #538

Makes `rangeBehaviors` a function that receives the connection arguments and returns one of `GraphQLMutatorConstants.RANGE_OPERATIONS`.

Will try and write a codemod for this during the week if I have time.

To check if the tracked connections where included in rangeBehaviors, the old behavior was to check if the connection's `rangeBehaviorKey` was in the `rangeBehaviors` map. Now that we don't have access to the `rangeBehaviors` map I've followed @josephsavona 's advice. I am fetching the connectionIds and calling `getRangeFilterCalls` on each one to get all the `rangeBehaviors` using the parentID.

Since these rangeBehaviors are not in the same format I've wrote a new function for connections called `getRangeBehaviors`. It is almost the same as `getRangeBehaviorKey` except it returns a list of the actual calls instead of a string representation. I can then make the correct check using these values.

Other thing I've added is a function `getObjectFromCalls` in `writeRelayUpdatePayload`. It transforms calls like this  `[{name: 'orderby', value: 'recent'}]` to an object like this `{orderby: 'recent'}` that can be passed to the `rangeBehaviors` function.

Rest is pretty straight forward I think, let me know what you think! 