### PR TITLE
Update APIReference-Container.md typo

### DIFF
--- a/docs/APIReference-Container.md
+++ b/docs/APIReference-Container.md
@@ -158,8 +158,8 @@ This method is also called after the partial set of variables from `setVariables
 
 ```{3-9}
 module.exports = Relay.createContainer(ProfilePicture, {
-  static initialVariables = {size: 50};
-  static prepareVariables = prevVariables => {
+  initialVariables: {size: 50};
+  prepareVariables: prevVariables => {
     return {
       ...prevVariables,
       // If devicePixelRatio is `2`, the new size will be `100`.

--- a/docs/APIReference-Container.md
+++ b/docs/APIReference-Container.md
@@ -158,14 +158,14 @@ This method is also called after the partial set of variables from `setVariables
 
 ```{3-9}
 module.exports = Relay.createContainer(ProfilePicture, {
-  initialVariables: {size: 50};
+  initialVariables: {size: 50},
   prepareVariables: prevVariables => {
     return {
       ...prevVariables,
       // If devicePixelRatio is `2`, the new size will be `100`.
       size: prevVariables.size * window.devicePixelRatio,
     };
-  };
+  },
   // ...
 });
 ```


### PR DESCRIPTION
In the current docs it says we should use `prepareVariables` and `initialVariables` as `static` variables of a class.

That doesn't work and is misleading, so I updated it to display it the way it actually works: As keys of an Object.

i.e.: 
```js
// from
Relay.createContainer(Component, {
  static initialVariables = {...}
  ...
}

// to
Relay.createContainer(Component, {
  initialVariables: {...}
  ...
}
```

Hope it helps.