### PR TITLE
queued transaction can be also rollbacked

### DIFF
--- a/src/mutation/RelayMutationQueue.js
+++ b/src/mutation/RelayMutationQueue.js
@@ -134,6 +134,19 @@ class RelayMutationQueue {
 
   rollback(id: ClientMutationID): void {
     const transaction = this._get(id);
+    const collisionKey = transaction.getCollisionKey();
+    if (collisionKey) {
+      const collisionQueue = this._collisionQueueMap[collisionKey];
+      if (collisionQueue) {
+        const index = collisionQueue.indexOf(transaction);
+        if (index !== -1) {
+          collisionQueue.splice(index, 1);
+        }
+        if (collisionQueue.length === 0) {
+          delete this._collisionQueueMap[collisionKey];
+        }
+      }
+    }
     this._handleRollback(transaction);
   }
 

--- a/src/mutation/RelayMutationTransaction.js
+++ b/src/mutation/RelayMutationTransaction.js
@@ -59,9 +59,10 @@ class RelayMutationTransaction {
     invariant(
       status === RelayMutationTransactionStatus.UNCOMMITTED ||
       status === RelayMutationTransactionStatus.COMMIT_FAILED ||
-      status === RelayMutationTransactionStatus.COLLISION_COMMIT_FAILED,
+      status === RelayMutationTransactionStatus.COLLISION_COMMIT_FAILED ||
+      status === RelayMutationTransactionStatus.COMMIT_QUEUED,
       'RelayMutationTransaction: Only transactions with status `UNCOMMITTED` ' +
-      '`COMMIT_FAILED` or `COLLISION_COMMIT_FAILED` can be rolledback.'
+      '`COMMIT_FAILED` or `COLLISION_COMMIT_FAILED` or `COMMIT_QUEUED` can be rolledback.'
     );
 
     this._mutationQueue.rollback(this._id);


### PR DESCRIPTION
This is follow up to #607 that adds posibility to rollback transaction with status `COMMIT_QUEUED`.

There is one more missing piece for this use case that I was not sure how to approach. 

To replace transaction that is queued I need to first check if its status is still `COMMIT_QUEUED`. Issue is that transaction is removed from pendingTransactionMap once its successfully committed. So I can easily end up with exception from `getStatus()`, which is bit overreaction :-).

So maybe return some status like `FINISHED` instead of throwing if its not in pending queue? I am of course very opened about naming :-).