### PR TITLE
Lock to a version of GraphQL before the new restrictions on the size of a GraphQLInt

### DIFF
--- a/examples/relay-treasurehunt/package.json
+++ b/examples/relay-treasurehunt/package.json
@@ -13,7 +13,7 @@
     "classnames": "^2.1.3",
     "express": "^4.13.1",
     "express-graphql": "^0.4.0",
-    "graphql": "^0.4.7",
+    "graphql": "0.4.13",
     "graphql-relay": "^0.3.3",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -13,7 +13,7 @@
     "classnames": "^2.1.3",
     "express": "^4.13.1",
     "express-graphql": "^0.4.0",
-    "graphql": "^0.4.7",
+    "graphql": "0.4.13",
     "graphql-relay": "^0.3.3",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -13,7 +13,7 @@
     "classnames": "^2.1.5",
     "express": "^4.13.3",
     "express-graphql": "^0.4.0",
-    "graphql": "^0.4.7",
+    "graphql": "0.4.13",
     "graphql-relay": "^0.3.3",
     "history": "^1.13.0",
     "react": "^0.14.0",

--- a/website-prototyping-tools/package.json
+++ b/website-prototyping-tools/package.json
@@ -16,7 +16,7 @@
     "css-loader": "0.16.0",
     "file-loader": "0.8.4",
     "graphiql": "0.1.3",
-    "graphql": "0.4.2",
+    "graphql": "0.4.13",
     "graphql-relay": "0.3.2",
     "html-webpack-plugin": "1.6.1",
     "json-loader": "0.5.3",


### PR DESCRIPTION
New limits were imposed on the size of a `GraphQLInt`. While we figure out what to do about this, this pull request will ensure that the examples keep working.