### PR TITLE
Fetch __typename of RANGE_ADD new edges

### DIFF
--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -424,6 +424,10 @@ function buildEdgeField(
       fieldName: 'cursor',
       type: 'String',
     }),
+    RelayQuery.Field.build({
+      fieldName: TYPENAME,
+      type: 'String',
+    }),
   ];
   if (RelayConnectionInterface.EDGES_HAVE_SOURCE_FIELD &&
       !GraphQLStoreDataHandler.isClientID(parentID)) {

--- a/src/mutation/__tests__/RelayMutationQuery-test.js
+++ b/src/mutation/__tests__/RelayMutationQuery-test.js
@@ -327,6 +327,7 @@ describe('RelayMutationQuery', () => {
       var expected = getNodeWithoutSource(Relay.QL`
         fragment on CommentCreateResponsePayload {
           feedbackCommentEdge {
+            __typename
             cursor,
             node {
               body {
@@ -382,6 +383,7 @@ describe('RelayMutationQuery', () => {
       var expected = getNodeWithoutSource(Relay.QL`
         fragment on CommentCreateResponsePayload {
           feedbackCommentEdge {
+            __typename
             cursor,
             node {
               author {
@@ -437,6 +439,7 @@ describe('RelayMutationQuery', () => {
       var expected = getNodeWithoutSource(Relay.QL`
         fragment on CommentCreateResponsePayload {
           feedbackCommentEdge {
+            __typename
             cursor,
             node {
               body {
@@ -693,6 +696,7 @@ describe('RelayMutationQuery', () => {
                   }
                 }
                 feedbackCommentEdge {
+                  __typename
                   cursor,
                   node {
                     body {
@@ -982,6 +986,7 @@ describe('RelayMutationQuery', () => {
                   }
                 }
                 feedbackCommentEdge {
+                  __typename
                   cursor,
                   node {
                     body {
@@ -1088,6 +1093,7 @@ describe('RelayMutationQuery', () => {
                   likers,
                 },
                 feedbackCommentEdge {
+                  __typename
                   cursor,
                   node {
                     body {


### PR DESCRIPTION
Addresses the warning noted in #474 and #653, fetching `__typename` for newly created edges. 