### PR TITLE
Fixes Windows build error as described at #638

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -6,7 +6,7 @@
   "repository": "facebook/relay",
   "main": "lib/getBabelRelayPlugin.js",
   "scripts": {
-    "build": "scripts/build-lib",
+    "build": "node scripts/build-lib",
     "prepublish": "npm run build",
     "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",


### PR DESCRIPTION
`npm run build` on Windows caused:

> 'scripts' is not recognized as an internal or external command,
operable program or batch file.

This fixes it by manually specifying the `node` executable.