### PR TITLE
[Relay] don't use the reserved word "await" as a method name

### DIFF
--- a/src/legacy/store/GraphQLQueryRunner.js
+++ b/src/legacy/store/GraphQLQueryRunner.js
@@ -255,7 +255,7 @@ function runQueries(
     );
   }
 
-  RelayTaskScheduler.await(() => {
+  RelayTaskScheduler.enqueue(() => {
     var forceIndex = fetchMode === DliteFetchModeConstants.FETCH_MODE_REFETCH ?
       generateForceIndex() : null;
 

--- a/src/store/RelayGarbageCollection.js
+++ b/src/store/RelayGarbageCollection.js
@@ -95,10 +95,10 @@ function scheduler(run: () => boolean): void {
     }
     // This is effectively a (possibly async) `while` loop
     if (hasNext) {
-      RelayTaskScheduler.await(runIteration);
+      RelayTaskScheduler.enqueue(runIteration);
     }
   };
-  RelayTaskScheduler.await(runIteration);
+  RelayTaskScheduler.enqueue(runIteration);
 }
 
 module.exports = RelayGarbageCollection;

--- a/src/store/RelayPendingQueryTracker.js
+++ b/src/store/RelayPendingQueryTracker.js
@@ -236,7 +236,7 @@ class PendingFetch {
   ): void {
     this._fetchedSubtractedQuery = true;
 
-    RelayTaskScheduler.await(() => {
+    RelayTaskScheduler.enqueue(() => {
       var response = result.response;
       invariant(
         response && typeof response === 'object',

--- a/src/tools/RelayTaskScheduler.js
+++ b/src/tools/RelayTaskScheduler.js
@@ -63,7 +63,7 @@ var RelayTaskScheduler = {
    * Otherwise, the returned promise will be resolved with the return value of
    * the last callback. For example:
    *
-   *   RelayTaskScheduler.await(
+   *   RelayTaskScheduler.enqueue(
    *     function() {
    *       return 'foo';
    *     },
@@ -76,7 +76,7 @@ var RelayTaskScheduler = {
    *     }
    *   );
    *
-   *   RelayTaskScheduler.await(
+   *   RelayTaskScheduler.enqueue(
    *     function() {
    *       return 'foo';
    *     },
@@ -91,7 +91,7 @@ var RelayTaskScheduler = {
    *   );
 
    */
-  await: function(...callbacks: Array<(value: any) => any>): Promise<any> {
+  enqueue: function(...callbacks: Array<(value: any) => any>): Promise<any> {
     var promise = new Promise((resolve, reject) => {
       var nextIndex = 0;
       var error = null;

--- a/src/tools/__tests__/RelayTaskScheduler-test.js
+++ b/src/tools/__tests__/RelayTaskScheduler-test.js
@@ -27,7 +27,7 @@ describe('RelayTaskScheduler', () => {
   describe('default scheduler', () => {
     it('resolves to undefined when no callbacks are supplied', () => {
       var mockFunction = jest.genMockFunction();
-      RelayTaskScheduler.await().then(mockFunction);
+      RelayTaskScheduler.enqueue().then(mockFunction);
 
       jest.runAllTimers();
 
@@ -36,7 +36,7 @@ describe('RelayTaskScheduler', () => {
 
     it('immediately invokes tasks', () => {
       var mockFunction = jest.genMockFunction();
-      RelayTaskScheduler.await(mockFunction);
+      RelayTaskScheduler.enqueue(mockFunction);
 
       jest.runAllTimers();
 
@@ -46,9 +46,9 @@ describe('RelayTaskScheduler', () => {
     it('invokes multiple awaited tasks in order', () => {
       var mockOrdering = [];
 
-      RelayTaskScheduler.await(() => mockOrdering.push('foo'));
-      RelayTaskScheduler.await(() => mockOrdering.push('bar'));
-      RelayTaskScheduler.await(() => mockOrdering.push('baz'));
+      RelayTaskScheduler.enqueue(() => mockOrdering.push('foo'));
+      RelayTaskScheduler.enqueue(() => mockOrdering.push('bar'));
+      RelayTaskScheduler.enqueue(() => mockOrdering.push('baz'));
 
       jest.runAllTimers();
 
@@ -58,12 +58,12 @@ describe('RelayTaskScheduler', () => {
     it('awaits tasks awaited by other tasks contiguously', () => {
       var mockOrdering = [];
 
-      RelayTaskScheduler.await(() => {
+      RelayTaskScheduler.enqueue(() => {
         mockOrdering.push('foo');
-        RelayTaskScheduler.await(() => mockOrdering.push('bar'));
+        RelayTaskScheduler.enqueue(() => mockOrdering.push('bar'));
       });
       // Although `baz` is enqueued before `bar`, `bar` should execute first.
-      RelayTaskScheduler.await(() => mockOrdering.push('baz'));
+      RelayTaskScheduler.enqueue(() => mockOrdering.push('baz'));
 
       jest.runAllTimers();
 
@@ -72,7 +72,7 @@ describe('RelayTaskScheduler', () => {
 
     it('resolves to the task\'s return value', () => {
       var mockFunction = jest.genMockFunction();
-      RelayTaskScheduler.await(() => 42).then(mockFunction);
+      RelayTaskScheduler.enqueue(() => 42).then(mockFunction);
 
       jest.runAllTimers();
 
@@ -82,7 +82,7 @@ describe('RelayTaskScheduler', () => {
     it('forwards return values for multiple callbacks', () => {
       var mockOrdering = [];
 
-      RelayTaskScheduler.await(
+      RelayTaskScheduler.enqueue(
         () => {
           mockOrdering.push('foo');
           return 'bar';
@@ -107,7 +107,7 @@ describe('RelayTaskScheduler', () => {
       var mockCallback = jest.genMockFunction();
       var mockFailureCallback = jest.genMockFunction();
 
-      RelayTaskScheduler.await(
+      RelayTaskScheduler.enqueue(
         () => 'foo',
         () => { throw mockError; },
         mockCallback,
@@ -125,11 +125,11 @@ describe('RelayTaskScheduler', () => {
       var mockFailureCallback = jest.genMockFunction();
       var mockSuccessCallback = jest.genMockFunction();
 
-      RelayTaskScheduler.await(
+      RelayTaskScheduler.enqueue(
         () => { throw mockError; },
       ).catch(mockFailureCallback);
 
-      RelayTaskScheduler.await(
+      RelayTaskScheduler.enqueue(
         mockCallback,
       ).then(mockSuccessCallback);
 
@@ -156,7 +156,7 @@ describe('RelayTaskScheduler', () => {
       RelayTaskScheduler.injectScheduler(mockScheduler);
 
       var mockFunction = jest.genMockFunction();
-      RelayTaskScheduler.await(mockFunction);
+      RelayTaskScheduler.enqueue(mockFunction);
 
       jest.runAllTimers();
 
@@ -173,11 +173,11 @@ describe('RelayTaskScheduler', () => {
 
       var mockOrdering = [];
 
-      RelayTaskScheduler.await(() => {
+      RelayTaskScheduler.enqueue(() => {
         mockOrdering.push('foo');
-        RelayTaskScheduler.await(() => mockOrdering.push('bar'));
+        RelayTaskScheduler.enqueue(() => mockOrdering.push('bar'));
       });
-      RelayTaskScheduler.await(() => mockOrdering.push('baz'));
+      RelayTaskScheduler.enqueue(() => mockOrdering.push('baz'));
 
       jest.runAllTimers();
 
@@ -206,7 +206,7 @@ describe('RelayTaskScheduler', () => {
       RelayTaskScheduler.injectScheduler(mockScheduler);
 
       var mockFunction = jest.genMockFunction();
-      RelayTaskScheduler.await(mockFunction);
+      RelayTaskScheduler.enqueue(mockFunction);
 
       jest.runAllTimers();
 


### PR DESCRIPTION
Apparently `await` is missing from some lists of reserved words. Typically Babel or minifiers should quote `await` like they quote `function` in `var x = {function: 1, await: 2}`.

Instead of waiting for changes in Babel or webpack to trickle down, let's rename this for now.

Fixes #665.