### PR TITLE
fix non-stardard arrow function call syntax on updateSchema

### DIFF
--- a/examples/relay-treasurehunt/scripts/updateSchema.js
+++ b/examples/relay-treasurehunt/scripts/updateSchema.js
@@ -18,7 +18,7 @@ import { graphql } from 'graphql';
 import { introspectionQuery, printSchema } from 'graphql/utilities';
 
 // Save JSON of full schema introspection for Babel Relay Plugin to use
-async () => {
+(async () => {
   var result = await (graphql(schema, introspectionQuery));
   if (result.errors) {
     console.error(
@@ -31,7 +31,7 @@ async () => {
       JSON.stringify(result, null, 2)
     );
   }
-}();
+})();
 
 // Save user readable type system shorthand of schema
 fs.writeFileSync(

--- a/examples/star-wars/scripts/updateSchema.js
+++ b/examples/star-wars/scripts/updateSchema.js
@@ -18,7 +18,7 @@ import { graphql } from 'graphql';
 import { introspectionQuery, printSchema } from 'graphql/utilities';
 
 // Save JSON of full schema introspection for Babel Relay Plugin to use
-async () => {
+(async () => {
   var result = await (graphql(schema, introspectionQuery));
   if (result.errors) {
     console.error(
@@ -31,7 +31,7 @@ async () => {
       JSON.stringify(result, null, 2)
     );
   }
-}();
+})();
 
 // Save user readable type system shorthand of schema
 fs.writeFileSync(

--- a/examples/todo/scripts/updateSchema.js
+++ b/examples/todo/scripts/updateSchema.js
@@ -18,7 +18,7 @@ import { graphql } from 'graphql';
 import { introspectionQuery, printSchema } from 'graphql/utilities';
 
 // Save JSON of full schema introspection for Babel Relay Plugin to use
-async () => {
+(async () => {
   var result = await (graphql(schema, introspectionQuery));
   if (result.errors) {
     console.error(
@@ -31,7 +31,7 @@ async () => {
       JSON.stringify(result, null, 2)
     );
   }
-}();
+})();
 
 // Save user readable type system shorthand of schema
 fs.writeFileSync(


### PR DESCRIPTION
based on this [discussion](https://phabricator.babeljs.io/T2027), this:

```
() => {}()
```

is a a non-standard arrow function call syntax allowed on babel 5, but it doesn't work on babel 6