### PR TITLE
DefaultNetworkLayer returns more valuable promise

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -60,9 +60,11 @@ class RelayDefaultNetworkLayer {
       } else {
         request.resolve({response: payload.data});
       }
-    }).catch(
-      error => request.reject(error)
-    );
+      return request;
+    }).catch(error => {
+      request.reject(error);
+      return request;
+    });
   }
 
   sendQueries(requests: Array<RelayQueryRequest>): Promise {
@@ -86,9 +88,11 @@ class RelayDefaultNetworkLayer {
         } else {
           request.resolve({response: payload.data});
         }
-      }).catch(
-        error => request.reject(error)
-      )
+        return request;
+      }).catch(error => {
+        request.reject(error);
+        return request;
+      })
     )));
   }
 


### PR DESCRIPTION
`sendMutation` / `sendQueries` returns promise, but always fulfilled with undefined.  This PR suggest to return `request` promise which is what most people would expect I think. 

For me its valuable that I can do some extra logging/error detecting stuff by extending DefaultNetworkLayer class.

Let me know if that change makes sense and if you want tests for it.