### PR TITLE
[relay] fix dependencies of examples

### DIFF
--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -15,7 +15,7 @@
     "express-graphql": "^0.4.0",
     "graphql": "0.4.13",
     "graphql-relay": "^0.3.3",
-    "history": "^1.13.0",
+    "history": "1.13.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-relay": "file:../../",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-static-container": "^1.0.0-alpha.1"
   },
   "peerDependencies": {
-    "babel-relay-plugin": "0.6.0",
+    "babel-relay-plugin": "0.6.1",
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
   },


### PR DESCRIPTION
`npm install` of the todo example failed for 2 reasons:

- The version of babel-relay-plugin was bumped to 6.0.1 without an update of the
  `peerDependency` or `relay` itself. I published 6.0.1 and bumped the peer
  dependency.
- `history@0.14` and `react-router` had incompatible dependencies. We should
  probably fix all dependency versions and bump them with a test instead of
  having them update whenever new versions are published.