### PR TITLE
Documentation for null initialization of initialVariables

### DIFF
--- a/docs/APIReference-Container.md
+++ b/docs/APIReference-Container.md
@@ -134,6 +134,9 @@ module.exports = Relay.createContainer(ProfilePicture, {
   fragments: {
     user: () => Relay.QL`
       # The variable defined above is available here as `$size`.
+      # Any variable referenced here is required to have been defined in initialVariables above.
+      # An `undefined` variable value will throw an `Invariant Violation` exception.
+      # Use `null` to initialize unknown values.
       fragment on User { profilePicture(size: $size) { ... } }
     `,
   },


### PR DESCRIPTION
Added information in Container API docs for null usage in initialVariables. Fixes https://github.com/facebook/relay/issues/700