### PR TITLE
Remove fragmentPointer field from GraphQLStoreQueryResolver

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -471,7 +471,6 @@ function createContainerComponent(
         } else if (!queryResolver) {
           queryResolver = new GraphQLStoreQueryResolver(
             storeData,
-            fragmentPointer,
             this._handleFragmentDataUpdate.bind(this)
           );
           queryResolvers[fragmentName] = queryResolver;

--- a/src/legacy/store/GraphQLStoreQueryResolver.js
+++ b/src/legacy/store/GraphQLStoreQueryResolver.js
@@ -38,7 +38,6 @@ type DataIDSet = {[dataID: DataID]: any};
  */
 class GraphQLStoreQueryResolver {
   _callback: Function;
-  _fragmentPointer: GraphQLFragmentPointer;
   _resolver: ?(
     GraphQLStorePluralQueryResolver |
     GraphQLStoreSingleQueryResolver
@@ -47,12 +46,10 @@ class GraphQLStoreQueryResolver {
 
   constructor(
     storeData: RelayStoreData,
-    fragmentPointer: GraphQLFragmentPointer,
     callback: Function
   ) {
     this.reset();
     this._callback = callback;
-    this._fragmentPointer = fragmentPointer;
     this._resolver = null;
     this._storeData = storeData;
   }
@@ -72,7 +69,7 @@ class GraphQLStoreQueryResolver {
   ): ?(StoreReaderData | Array<?StoreReaderData>) {
     var resolver = this._resolver;
     if (!resolver) {
-      resolver = this._fragmentPointer.getFragment().isPlural() ?
+      resolver = fragmentPointer.getFragment().isPlural() ?
         new GraphQLStorePluralQueryResolver(this._storeData, this._callback) :
         new GraphQLStoreSingleQueryResolver(this._storeData, this._callback);
       this._resolver = resolver;

--- a/src/legacy/store/__mocks__/GraphQLStoreQueryResolver.js
+++ b/src/legacy/store/__mocks__/GraphQLStoreQueryResolver.js
@@ -11,12 +11,11 @@
 
 class GraphQLStoreQueryResolver {
 
-  constructor(store, queryFragment, callback) {
+  constructor(store, callback) {
     var mockInstances = GraphQLStoreQueryResolver.mock.instances;
     this.mock = {
       callback,
       index: mockInstances.length,
-      queryFragment,
       store,
     };
     this.resolve = jest.genMockFunction().mockImplementation((...args) => {

--- a/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
@@ -74,7 +74,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointer,
       mockCallback
     );
     var resolved = resolver.resolve(fragmentPointer);
@@ -100,7 +99,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointer,
       mockCallback
     );
     resolver.resolve(fragmentPointer);
@@ -120,7 +118,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointer,
       mockCallback
     );
 
@@ -144,7 +141,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointer,
       mockCallback
     );
 
@@ -178,7 +174,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointerA,
       mockCallback
     );
 
@@ -203,7 +198,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointer,
       mockCallback
     );
 
@@ -229,7 +223,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointer,
       mockCallback
     );
 
@@ -259,7 +252,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointer,
       mockCallback
     );
 
@@ -282,7 +274,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointer,
       mockCallback
     );
 
@@ -321,7 +312,6 @@ describe('GraphQLStoreQueryResolver', () => {
 
     var resolver = new GraphQLStoreQueryResolver(
       storeData,
-      fragmentPointer,
       mockCallback
     );
 
@@ -397,7 +387,6 @@ describe('GraphQLStoreQueryResolver', () => {
       );
       const queryResolver = new GraphQLStoreQueryResolver(
         storeData,
-        fragmentPointer,
         jest.genMockFunction()
       );
       // read data and set up subscriptions
@@ -419,7 +408,6 @@ describe('GraphQLStoreQueryResolver', () => {
       );
       const queryResolver = new GraphQLStoreQueryResolver(
         storeData,
-        fragmentPointer,
         jest.genMockFunction()
       );
       // read data and increment GC ref counts
@@ -452,7 +440,6 @@ describe('GraphQLStoreQueryResolver', () => {
       );
       const queryResolver = new GraphQLStoreQueryResolver(
         storeData,
-        fragmentPointer,
         jest.genMockFunction()
       );
       // read data and increment GC ref counts

--- a/src/store/RelayQueryResultObservable.js
+++ b/src/store/RelayQueryResultObservable.js
@@ -97,7 +97,6 @@ class RelayQueryResultObservable {
     );
     var queryResolver = new GraphQLStoreQueryResolver(
       this._storeData,
-      this._fragmentPointer,
       () => this._onUpdate(queryResolver)
     );
     this._queryResolver = queryResolver;


### PR DESCRIPTION
The fragmentPointer field was not used except in the resolve function. But resolve gets a fragmentPointer anyway, so just use that. 

This makes it also more consistent and less confusing imho.
