### PR TITLE
React Native Compatibility

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,6 +64,7 @@ var babelOpts = {
   _moduleMap: objectAssign({}, require('fbjs/module-map'), {
     'React': 'react',
     'ReactDOM': 'react-dom',
+    'ReactNative': 'react-native',
     'StaticContainer.react': 'react-static-container',
   }),
 };

--- a/package.json
+++ b/package.json
@@ -29,13 +29,12 @@
   },
   "dependencies": {
     "babel-runtime": "5.8.24",
-    "fbjs": "^0.5.1",
+    "fbjs": "^0.7.0",
     "react-static-container": "^1.0.0-alpha.1"
   },
   "peerDependencies": {
     "babel-relay-plugin": "0.6.1",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^0.14.0"
   },
   "devDependencies": {
     "babel": "^5.8.25",
@@ -55,15 +54,15 @@
     "gulp-util": "^3.0.6",
     "jest-cli": "^0.8.1",
     "object-assign": "^3.0.0",
-    "react": "^0.14.0-rc",
-    "react-dom": "^0.14.0-rc",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "run-sequence": "^1.1.2",
     "webpack": "1.11.0",
     "webpack-stream": "^2.1.0"
   },
   "devEngines": {
-    "node": "4.x",
-    "npm": "2.x"
+    "node": ">=4.x",
+    "npm": ">=2.x"
   },
   "jest": {
     "rootDir": "",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "persistModuleRegistryBetweenSpecs": true,
     "modulePathIgnorePatterns": [
       "<rootDir>/lib/",
+      "<rootDir>/src/(.*).native.js",
       "<rootDir>/node_modules/(?!(fbjs/lib/|react/lib/))"
     ],
     "preprocessorIgnorePatterns": [
@@ -84,6 +85,7 @@
       "<rootDir>/src/"
     ],
     "unmockedModulePathPatterns": [
+      "<rootDir>/src/tools/RelayUnstableBatchedUpdates.js",
       "<rootDir>/node_modules/fbjs/node_modules/core-js/",
       "<rootDir>/node_modules/fbjs-scripts/node_modules/core-js/",
       "<rootDir>/node_modules/fbjs/node_modules/promise/",

--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -5,7 +5,7 @@
 .*/react-static-container/node_modules/.*
 
 [include]
-../node_modules/fbjs/flow/include
+../node_modules/fbjs/lib
 ../node_modules/fbjs/node_modules/promise
 ../node_modules/react
 ../node_modules/react-static-container/lib

--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -19,7 +19,6 @@ const GraphQLFragmentPointer = require('GraphQLFragmentPointer');
 const GraphQLStoreDataHandler = require('GraphQLStoreDataHandler');
 const GraphQLStoreQueryResolver = require('GraphQLStoreQueryResolver');
 const React = require('React');
-const ReactDOM = require('ReactDOM');
 const RelayContainerComparators = require('RelayContainerComparators');
 const RelayContainerProxy = require('RelayContainerProxy');
 const RelayFragmentReference = require('RelayFragmentReference');
@@ -31,6 +30,7 @@ const RelayProfiler = require('RelayProfiler');
 const RelayQuery = require('RelayQuery');
 const RelayStore = require('RelayStore');
 const RelayStoreData = require('RelayStoreData');
+const unstable_batchedUpdates = require('RelayUnstableBatchedUpdates');
 import type {
   Abortable,
   ComponentReadyStateChangeCallback,
@@ -80,7 +80,7 @@ var containerContextTypes = {
 var storeData = RelayStoreData.getDefaultInstance();
 
 storeData.getChangeEmitter().injectBatchingStrategy(
-  ReactDOM.unstable_batchedUpdates
+  unstable_batchedUpdates
 );
 
 /**
@@ -286,7 +286,7 @@ function createContainerComponent(
         var mounted = this.mounted;
         if (mounted) {
           var updateProfiler = RelayProfiler.profile('RelayContainer.update');
-          ReactDOM.unstable_batchedUpdates(() => {
+          unstable_batchedUpdates(() => {
             this.setState(partialState, () => {
               updateProfiler.stop();
               if (isComplete) {

--- a/src/tools/RelayUnstableBatchedUpdates.js
+++ b/src/tools/RelayUnstableBatchedUpdates.js
@@ -1,0 +1,19 @@
+
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule RelayUnstableBatchedUpdates
+ * @flow
+ * @typechecks
+ */
+
+'use strict';
+
+const ReactDOM = require('ReactDOM');
+
+module.exports = ReactDOM.unstable_batchedUpdates;

--- a/src/tools/RelayUnstableBatchedUpdates.native.js
+++ b/src/tools/RelayUnstableBatchedUpdates.native.js
@@ -1,0 +1,19 @@
+
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule RelayUnstableBatchedUpdates
+ * @flow
+ * @typechecks
+ */
+
+'use strict';
+
+const ReactNative = require('ReactNative');
+
+module.exports = ReactNative.unstable_batchedUpdates;

--- a/src/tools/RelayUnstableBatchedUpdates.native.js
+++ b/src/tools/RelayUnstableBatchedUpdates.native.js
@@ -8,8 +8,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule RelayUnstableBatchedUpdates
- * @flow
- * @typechecks
  */
 
 'use strict';


### PR DESCRIPTION
**This PR depends on an unreleased version of `fbjs`, so DO NOT MERGE.**

When merged along with https://github.com/facebook/react-native/pull/5084, https://github.com/facebook/fbjs/pull/95, and whatever PR fixes https://github.com/facebook/react-native/issues/4062 (which I will update this issue with when I push it), this fixes #26.

The changes to Relay itself are super minor here:

1. Remove the reliance on ReactDOM. The only use of ReactDOM is `unstable_batchedupdates`. So to fix, I abstracted the reference to `unstable_batchedupdates` to it's own module, and then took advantage of the "react-native" `package.json` option, supported by the React Native packager, to load the correct version of this function given the execution context.
2. Removed `react-dom` from peerDependencies (but kept it in devDependencies, for use in tests), and also upgrade the `fbjs` dependency to a (yet unreleased) version that provides better compatibility with React Native.