### PR TITLE
Make babel-relay-plugin run before other transforms

### DIFF
--- a/scripts/babel-relay-plugin/lib/babelAdapter.js
+++ b/scripts/babel-relay-plugin/lib/babelAdapter.js
@@ -19,8 +19,37 @@ var path = require('path');
 
 function babelAdapter(Plugin, t, name, visitorsBuilder) {
   if (Plugin == null) {
-    // Babel 6.
-    return visitorsBuilder(t);
+    var _ret = (function () {
+      // Babel 6.
+
+      var _visitorsBuilder = visitorsBuilder(t);
+
+      var _visitorsBuilder$visitor = _visitorsBuilder.visitor;
+      var _Program = _visitorsBuilder$visitor.Program;
+      var _TaggedTemplateExpression = _visitorsBuilder$visitor.TaggedTemplateExpression;
+
+      var taggedTemplateExpressionVisitor = {
+        TaggedTemplateExpression: function TaggedTemplateExpression(path) {
+          return _TaggedTemplateExpression(path, this);
+        }
+      };
+
+      /**
+       * Run both transforms on Program, to make sure that they run before other plugins
+       */
+      return {
+        v: {
+          visitor: {
+            Program: function Program(path, state) {
+              _Program(path, state);
+              path.traverse(taggedTemplateExpressionVisitor, state);
+            }
+          }
+        }
+      };
+    })();
+
+    if (typeof _ret === 'object') return _ret.v;
   }
   // Babel 5.
   var legacyT = _extends({}, t, {

--- a/scripts/babel-relay-plugin/lib/babelAdapter.js
+++ b/scripts/babel-relay-plugin/lib/babelAdapter.js
@@ -30,12 +30,12 @@ function babelAdapter(Plugin, t, name, visitorsBuilder) {
 
       var taggedTemplateExpressionVisitor = {
         TaggedTemplateExpression: function TaggedTemplateExpression(path) {
-          return _TaggedTemplateExpression(path, this);
+          _TaggedTemplateExpression(path, this);
         }
       };
 
       /**
-       * Run both transforms on Program, to make sure that they run before other plugins
+       * Run both transforms on Program to make sure that they run before other plugins.
        */
       return {
         v: {

--- a/scripts/babel-relay-plugin/src/babelAdapter.js
+++ b/scripts/babel-relay-plugin/src/babelAdapter.js
@@ -26,7 +26,25 @@ function babelAdapter(
 ): mixed {
   if (Plugin == null) {
     // Babel 6.
-    return visitorsBuilder(t);
+    const { visitor: { Program, TaggedTemplateExpression } } = visitorsBuilder(t);
+
+    const taggedTemplateExpressionVisitor = {
+      TaggedTemplateExpression(path) {
+        return TaggedTemplateExpression(path, this);
+      }
+    }
+
+    /**
+     * Run both transforms on Program, to make sure that they run before other plugins
+     */
+    return {
+      visitor: {
+        Program(path, state) {
+          Program(path, state);
+          path.traverse(taggedTemplateExpressionVisitor, state);
+        }
+      }
+    }
   }
   // Babel 5.
   const legacyT = {

--- a/scripts/babel-relay-plugin/src/babelAdapter.js
+++ b/scripts/babel-relay-plugin/src/babelAdapter.js
@@ -26,16 +26,16 @@ function babelAdapter(
 ): mixed {
   if (Plugin == null) {
     // Babel 6.
-    const { visitor: { Program, TaggedTemplateExpression } } = visitorsBuilder(t);
+    const {visitor: {Program, TaggedTemplateExpression}} = visitorsBuilder(t);
 
     const taggedTemplateExpressionVisitor = {
       TaggedTemplateExpression(path) {
-        return TaggedTemplateExpression(path, this);
+        TaggedTemplateExpression(path, this);
       }
     }
 
     /**
-     * Run both transforms on Program, to make sure that they run before other plugins
+     * Run both transforms on Program to make sure that they run before other plugins.
      */
     return {
       visitor: {


### PR DESCRIPTION
`babel-relay-plugin` depends transforms the “Relay.QL” TaggedTemplateExpression nodes in the source. If it does not run before the “es2015-template-literals” transform, it will not transform the Relay.QL template literals correctly.

This is important, because with Babel 6, you can’t control the plugin order. And so in a case like React Native, where plugins from React Native’s babelrc are loaded before the projects babelrc, it’s impossible to use the Babel Relay Plugin without overriding the entire transform list.

Note - I made this change in the babelAdapter, rather than in the plugin code itself, in order to retain Babel 5 compatibility.