### PR TITLE
Filter records in plural linked fields which are deleted

### DIFF
--- a/src/store/RelayRecordStore.js
+++ b/src/store/RelayRecordStore.js
@@ -480,7 +480,7 @@ class RelayRecordStore {
         dataID
       );
       return item.__dataID__;
-    });
+    }).filter(id => this.getRecordState(id) !== 'NONEXISTENT');
   }
 
   /**

--- a/src/store/RelayRecordStore.js
+++ b/src/store/RelayRecordStore.js
@@ -473,7 +473,7 @@ class RelayRecordStore {
     const linkedIDs = [];
     field.forEach((item, ii) => {
       invariant(
-        typeof item === 'object' && item.__dataID__,
+        typeof item === 'object' && item != null && item.__dataID__,
         'RelayRecordStore.getLinkedRecordIDs(): Expected element at index %s ' +
         'in field `%s` for record `%s` to be a linked record.',
         ii,

--- a/src/store/RelayRecordStore.js
+++ b/src/store/RelayRecordStore.js
@@ -459,7 +459,7 @@ class RelayRecordStore {
     dataID: DataID,
     storageKey: string
   ): ?Array<DataID> {
-    var field = this._getField(dataID, storageKey);
+    const field = this._getField(dataID, storageKey);
     if (field == null) {
       return field;
     }
@@ -470,17 +470,22 @@ class RelayRecordStore {
       storageKey,
       dataID
     );
-    return field.map((item, ii) => {
+    const linkedIDs = [];
+    field.forEach((item, ii) => {
+      const id = item.__dataID__;
       invariant(
-        typeof item === 'object' && item.__dataID__,
+        typeof item === 'object' && id,
         'RelayRecordStore.getLinkedRecordIDs(): Expected element at index %s ' +
         'in field `%s` for record `%s` to be a linked record.',
         ii,
         storageKey,
         dataID
       );
-      return item.__dataID__;
-    }).filter(id => this.getRecordState(id) !== 'NONEXISTENT');
+      if (this.getRecordState(id) !== 'NONEXISTENT') {
+        linkedIDs.push(id);
+      }
+    });
+    return linkedIDs;
   }
 
   /**

--- a/src/store/RelayRecordStore.js
+++ b/src/store/RelayRecordStore.js
@@ -472,15 +472,15 @@ class RelayRecordStore {
     );
     const linkedIDs = [];
     field.forEach((item, ii) => {
-      const id = item.__dataID__;
       invariant(
-        typeof item === 'object' && id,
+        typeof item === 'object' && item.__dataID__,
         'RelayRecordStore.getLinkedRecordIDs(): Expected element at index %s ' +
         'in field `%s` for record `%s` to be a linked record.',
         ii,
         storageKey,
         dataID
       );
+      const id = item.__dataID__;
       if (this.getRecordState(id) !== 'NONEXISTENT') {
         linkedIDs.push(id);
       }

--- a/src/store/__tests__/RelayDiskCacheReader-test.js
+++ b/src/store/__tests__/RelayDiskCacheReader-test.js
@@ -919,8 +919,6 @@ describe('RelayDiskCacheReader', () => {
 
       expect(callbacks.onFailure.mock.calls.length).toBe(0);
       expect(callbacks.onSuccess.mock.calls.length).toBe(1);
-      expect(store.getLinkedRecordIDs('1055790163', 'screennames'))
-        .toEqual(['sn1']);
       expect(store.getRecordState('sn1')).toBe('NONEXISTENT');
       expect(changeTracker.getChangeSet()).toEqual({
         created: {},

--- a/src/store/__tests__/RelayRecordStore-test.js
+++ b/src/store/__tests__/RelayRecordStore-test.js
@@ -426,10 +426,39 @@ describe('RelayRecordStore', () => {
             {__dataID__: 'item:2'},
           ],
         },
+        'item:1': {
+          __dataID__: 'item:1',
+        },
+        'item:2': {
+          __dataID__: 'item:2',
+        },
       };
       var store = new RelayRecordStore({records});
       expect(store.getLinkedRecordIDs('4', 'actors')).toEqual([
         'item:1',
+        'item:2',
+      ]);
+    });
+    it('filters data ID of deleted items', () => {
+      var records = {
+        '4': {
+          id: '4',
+          __dataID__: '4',
+          actors: [
+            {__dataID__: 'item:1'},
+            {__dataID__: 'item:2'},
+          ],
+        },
+        'item:1': {
+          __dataID__: 'item:1',
+        },
+        'item:2': {
+          __dataID__: 'item:2',
+        },
+      };
+      var store = new RelayRecordStore({records});
+      store.deleteRecord('item:1');
+      expect(store.getLinkedRecordIDs('4', 'actors')).toEqual([
         'item:2',
       ]);
     });

--- a/src/store/__tests__/RelayRecordStore-test.js
+++ b/src/store/__tests__/RelayRecordStore-test.js
@@ -381,7 +381,7 @@ describe('RelayRecordStore', () => {
   });
 
   describe('getLinkedRecordIDs()', () => {
-    it('throws if the data is an unexpected format', () => {
+    it('ensures that the data is an valid object', () => {
       var records = {
         'story': {
           actors: ['not an object'],
@@ -390,7 +390,19 @@ describe('RelayRecordStore', () => {
       var store = new RelayRecordStore({records});
       expect(() => {
         store.getLinkedRecordIDs('story', 'actors');
-      }).toThrow();
+      }).toThrowError(/Expected element at index/);
+    });
+
+    it('ensures that the data does not contain null values', () => {
+      var records = {
+        'story': {
+          actors: [null],
+        },
+      };
+      var store = new RelayRecordStore({records});
+      expect(() => {
+        store.getLinkedRecordIDs('story', 'actors');
+      }).toThrowError(/Expected element at index/);
     });
 
     it('returns undefined for unfetched fields', () => {


### PR DESCRIPTION
This is a fix for issue #693.

The method `getLinkedRecordIDs` in `RelayRecordStore` now filters ids of records,
which are marked as "NONEXISTENT".

A new test is added and a single assertion in `readRelayDiskCache-test` is removed,
which failed after the change and was not really relevant for the test.