### PR TITLE
Don't try to setState after a fragment data update if component not mounted

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -480,6 +480,9 @@ function createContainerComponent(
     }
 
     _handleFragmentDataUpdate(): void {
+      if (!this.mounted) {
+        return;
+      }
       var queryData = this._getQueryData(this.props);
       var updateProfiler = RelayProfiler.profile(
         'RelayContainer.handleFragmentDataUpdate'


### PR DESCRIPTION
In certain cases, if a RelayContainer is mounted and unmounted quickly, a warning about setting state on an unmounted component is thrown.

This happens due to the fact that in the callback for fragment data updates from the GraphQLStoreQueryResolver, we `setState` without checking whether or not the component is mounted.

This PR resolves that issue.