### PR TITLE
Fix TODO example depenency versions

### DIFF
--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -19,7 +19,7 @@
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-relay": "file:../../",
-    "react-router": "^1.0.0",
+    "react-router": "1.0.0",
     "react-router-relay": "^0.8.0",
     "todomvc-app-css": "^2.0.3",
     "todomvc-common": "^1.0.2",


### PR DESCRIPTION
use fixed version of `react-router` to avoid breaking the peer dependency
currently it throws
```
npm ERR! peerinvalid The package history@1.13.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-router@1.0.3 wants history@^1.17.0
```