### PR TITLE
Change clientMutationID invariant to a conditional check to work with subscriptions

### DIFF
--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -24,6 +24,10 @@ type Mutation {
   viewerNotificationsUpdateAllSeenState(input: UpdateAllSeenStateInput): ViewerNotificationsUpdateAllSeenStateResponsePayload
 }
 
+type Subscription {
+  commentCreate(input: CommentCreateSubscriptionInput): CommentCreateSubscriptionResponsePayload
+}
+
 input ActorSubscribeInput {
   clientMutationId: String
   subscribeeId: ID
@@ -36,6 +40,11 @@ input ApplicationRequestDeleteAllInput {
 
 input CommentCreateInput {
   clientMutationId: String
+  feedbackId: ID
+}
+
+input CommentCreateSubscriptionInput {
+  clientSubscriptionId: String,
   feedbackId: ID
 }
 
@@ -117,6 +126,13 @@ type Comment implements Node {
 
 type CommentCreateResponsePayload {
   clientMutationId: String
+  comment: Comment
+  feedback: Feedback
+  feedbackCommentEdge: CommentsEdge
+}
+
+type CommentCreateSubscriptionResponsePayload {
+  clientSubscriptionId: String
   comment: Comment
   feedback: Feedback
   feedbackCommentEdge: CommentsEdge

--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -25,7 +25,7 @@ type Mutation {
 }
 
 type Subscription {
-  commentCreate(input: CommentCreateSubscriptionInput): CommentCreateSubscriptionResponsePayload
+  commentCreateSubscribe(input: CommentCreateSubscribeInput): CommentCreateSubscribeResponsePayload
 }
 
 input ActorSubscribeInput {
@@ -43,7 +43,7 @@ input CommentCreateInput {
   feedbackId: ID
 }
 
-input CommentCreateSubscriptionInput {
+input CommentCreateSubscribeInput {
   clientSubscriptionId: String,
   feedbackId: ID
 }
@@ -131,7 +131,7 @@ type CommentCreateResponsePayload {
   feedbackCommentEdge: CommentsEdge
 }
 
-type CommentCreateSubscriptionResponsePayload {
+type CommentCreateSubscribeResponsePayload {
   clientSubscriptionId: String
   comment: Comment
   feedback: Feedback

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -8054,7 +8054,7 @@
           "description": null,
           "fields": [
             {
-              "name": "commentCreate",
+              "name": "commentCreateSubscribe",
               "description": null,
               "args": [
                 {
@@ -8062,7 +8062,7 @@
                   "description": null,
                   "type": {
                     "kind": "INPUT_OBJECT",
-                    "name": "CommentCreateSubscriptionInput",
+                    "name": "CommentCreateSubscribeInput",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -8070,7 +8070,7 @@
               ],
               "type": {
                 "kind": "OBJECT",
-                "name": "CommentCreateSubscriptionResponsePayload",
+                "name": "CommentCreateSubscribeResponsePayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -8084,7 +8084,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "CommentCreateSubscriptionInput",
+          "name": "CommentCreateSubscribeInput",
           "description": null,
           "fields": null,
           "inputFields": [
@@ -8115,7 +8115,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "CommentCreateSubscriptionResponsePayload",
+          "name": "CommentCreateSubscribeResponsePayload",
           "description": null,
           "fields": [
             {

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -7,7 +7,9 @@
       "mutationType": {
         "name": "Mutation"
       },
-      "subscriptionType": null,
+      "subscriptionType": {
+        "name": "Subscription"
+      },
       "types": [
         {
           "kind": "OBJECT",
@@ -8036,6 +8038,130 @@
                   "name": "Story",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "description": null,
+          "fields": [
+            {
+              "name": "commentCreate",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CommentCreateSubscriptionInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CommentCreateSubscriptionResponsePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CommentCreateSubscriptionInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientSubscriptionId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "feedbackId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CommentCreateSubscriptionResponsePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "clientSubscriptionId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Comment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feedback",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Feedback",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feedbackCommentEdge",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CommentsEdge",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/scripts/jest/updateSchema.js
+++ b/scripts/jest/updateSchema.js
@@ -20,7 +20,7 @@ try {
 
   var body = fs.readFileSync(inFile, 'utf8');
   var ast = parse(body);
-  var astSchema = buildASTSchema(ast, 'Root', 'Mutation');
+  var astSchema = buildASTSchema(ast, 'Root', 'Mutation', 'Subscription');
   graphql(astSchema, introspectionQuery).then(
     function(result) {
       var out = JSON.stringify(result, null, 2);

--- a/src/interface/RelayOSSConnectionInterface.js
+++ b/src/interface/RelayOSSConnectionInterface.js
@@ -36,6 +36,7 @@ var REQUIRED_RANGE_CALLS = {
  */
 var RelayOSSConnectionInterface = {
   CLIENT_MUTATION_ID: 'clientMutationId',
+  CLIENT_SUBSCRIPTION_ID: 'clientSubscriptionId',
   CURSOR: 'cursor',
   EDGES: 'edges',
   END_CURSOR: 'endCursor',

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1246,7 +1246,7 @@ describe('writePayload()', () => {
 
       var subscription = getNode(Relay.QL`
         subscription {
-          commentCreate(input:$input) {
+          commentCreateSubscribe(input:$input) {
             feedback {
               id,
               topLevelComments {

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1049,7 +1049,7 @@ describe('writePayload()', () => {
           node: {
             id: nextNodeID,
             body: {
-              text: messageText,
+              text: input.message.text,
             },
           },
           source: {
@@ -1201,7 +1201,7 @@ describe('writePayload()', () => {
 
       writeRelayUpdatePayload(
         writer,
-        subscription,
+        mutation,
         payload,
         {configs, isOptimisticUpdate: false}
       );
@@ -1227,7 +1227,7 @@ describe('writePayload()', () => {
       expect(store.getField(nextNodeID, 'id')).toBe(nextNodeID);
       expect(store.getType(nextNodeID)).toBe('Comment');
       expect(store.getLinkedRecordID(nextNodeID, 'body')).toBe(bodyID);
-      expect(store.getField(bodyID, 'text')).toBe(messageText);
+      expect(store.getField(bodyID, 'text')).toBe(input.message.text);
       expect(store.getRangeMetadata(
         connectionID,
         [{name: 'first', value: '2'}]
@@ -1240,8 +1240,8 @@ describe('writePayload()', () => {
     it('non-optimistically prepends comments for subscriptions', () => {
       // create the subscription and payload
       var input = {
-        feedbackId: feedbackID,
         [RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID]: '0',
+        feedbackId: feedbackID,
       };
 
       var subscription = getNode(Relay.QL`
@@ -1296,7 +1296,7 @@ describe('writePayload()', () => {
           node: {
             id: nextNodeID,
             body: {
-              text: input.message.text,
+              text: messageText,
             },
           },
           source: {
@@ -1310,13 +1310,14 @@ describe('writePayload()', () => {
       var queryTracker = new RelayQueryTracker();
       var writer = new RelayQueryWriter(
         store,
+        writer,
         queryTracker,
         changeTracker
       );
 
       writeRelayUpdatePayload(
         writer,
-        mutation,
+        subscription,
         payload,
         {configs, isOptimisticUpdate: false}
       );
@@ -1342,7 +1343,7 @@ describe('writePayload()', () => {
       expect(store.getField(nextNodeID, 'id')).toBe(nextNodeID);
       expect(store.getType(nextNodeID)).toBe('Comment');
       expect(store.getLinkedRecordID(nextNodeID, 'body')).toBe(bodyID);
-      expect(store.getField(bodyID, 'text')).toBe(input.message.text);
+      expect(store.getField(bodyID, 'text')).toBe(messageText);
       expect(store.getRangeMetadata(
         connectionID,
         [{name: 'first', value: '2'}]

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1201,7 +1201,7 @@ describe('writePayload()', () => {
 
       writeRelayUpdatePayload(
         writer,
-        mutation,
+        subscription,
         payload,
         {configs, isOptimisticUpdate: false}
       );
@@ -1244,7 +1244,7 @@ describe('writePayload()', () => {
         [RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID]: '0',
       };
 
-      var mutation = getNode(Relay.QL`
+      var subscription = getNode(Relay.QL`
         subscription {
           commentCreate(input:$input) {
             feedback {

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1049,7 +1049,7 @@ describe('writePayload()', () => {
           node: {
             id: nextNodeID,
             body: {
-              text: input.message.text,
+              text: messageText,
             },
           },
           source: {
@@ -1227,7 +1227,7 @@ describe('writePayload()', () => {
       expect(store.getField(nextNodeID, 'id')).toBe(nextNodeID);
       expect(store.getType(nextNodeID)).toBe('Comment');
       expect(store.getLinkedRecordID(nextNodeID, 'body')).toBe(bodyID);
-      expect(store.getField(bodyID, 'text')).toBe(input.message.text);
+      expect(store.getField(bodyID, 'text')).toBe(messageText);
       expect(store.getRangeMetadata(
         connectionID,
         [{name: 'first', value: '2'}]
@@ -1237,19 +1237,15 @@ describe('writePayload()', () => {
       ]);
     });
 
-    it('non-optimistically prepends comments without a client mutation ID', () => {
-      // create the mutation and payload
+    it('non-optimistically prepends comments for subscriptions', () => {
+      // create the subscription and payload
       var input = {
-        actor_id: 'actor:123',
-        feedback_id: feedbackID,
-        message: {
-          text: 'Hello!',
-          ranges: [],
-        },
+        feedbackId: feedbackID,
+        [RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID]: '0',
       };
 
       var mutation = getNode(Relay.QL`
-        mutation {
+        subscription {
           commentCreate(input:$input) {
             feedback {
               id,
@@ -1281,11 +1277,14 @@ describe('writePayload()', () => {
         rangeBehaviors: {'': GraphQLMutatorConstants.PREPEND},
       }];
 
+      var messageText = 'Hello!';
       var nextCursor = 'comment789:cursor';
       var nextNodeID = 'comment789';
       var bodyID = 'client:2';
       var nextEdgeID = generateClientEdgeID(connectionID, nextNodeID);
       var payload = {
+        [RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID]:
+          input[RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID],
         feedback: {
           id: feedbackID,
           topLevelComments: {

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -321,13 +321,6 @@ function handleRangeAdd(
   config: OperationConfig,
   isOptimisticUpdate: boolean
 ): void {
-  const clientMutationID = getString(payload, CLIENT_MUTATION_ID);
-  invariant(
-    clientMutationID,
-    'writeRelayUpdatePayload(): Expected operation `%s` to have a `%s`.',
-    operation.getName(),
-    CLIENT_MUTATION_ID
-  );
   const store = writer.getRecordStore();
 
   // Extracts the new edge from the payload
@@ -384,25 +377,29 @@ function handleRangeAdd(
     ));
   }
 
-  if (isOptimisticUpdate) {
-    // optimistic updates need to record the generated client ID for
-    // a to-be-created node
-    RelayMutationTracker.putClientIDForMutation(
-      nodeID,
-      clientMutationID
-    );
-  } else {
-    // non-optimistic updates check for the existence of a generated client
-    // ID (from the above `if` clause) and link the client ID to the actual
-    // server ID.
-    const clientNodeID =
-      RelayMutationTracker.getClientIDForMutation(clientMutationID);
-    if (clientNodeID) {
-      RelayMutationTracker.updateClientServerIDMap(
-        clientNodeID,
-        nodeID
+  const clientMutationID = getString(payload, CLIENT_MUTATION_ID);
+  // subscriptions won't have a clientMutationID so never optimistically add
+  if (clientMutationID) {
+    if (isOptimisticUpdate) {
+      // optimistic updates need to record the generated client ID for
+      // a to-be-created node
+      RelayMutationTracker.putClientIDForMutation(
+        nodeID,
+        clientMutationID
       );
-      RelayMutationTracker.deleteClientIDForMutation(clientMutationID);
+    } else {
+      // non-optimistic updates check for the existence of a generated client
+      // ID (from the above `if` clause) and link the client ID to the actual
+      // server ID.
+      const clientNodeID =
+        RelayMutationTracker.getClientIDForMutation(clientMutationID);
+      if (clientNodeID) {
+        RelayMutationTracker.updateClientServerIDMap(
+          clientNodeID,
+          nodeID
+        );
+        RelayMutationTracker.deleteClientIDForMutation(clientMutationID);
+      }
     }
   }
 }

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -377,9 +377,15 @@ function handleRangeAdd(
     ));
   }
 
-  const clientMutationID = getString(payload, CLIENT_MUTATION_ID);
-  // subscriptions won't have a clientMutationID so never optimistically add
-  if (clientMutationID) {
+  if (operation instanceof RelayQuery.Mutation) {
+    const clientMutationID = getString(payload, CLIENT_MUTATION_ID);
+    invariant(
+      clientMutationID,
+      'writeRelayUpdatePayload(): Expected operation `%s` to have a `%s`.',
+      operation.getName(),
+      CLIENT_MUTATION_ID
+    );
+
     if (isOptimisticUpdate) {
       // optimistic updates need to record the generated client ID for
       // a to-be-created node


### PR DESCRIPTION
I'm working on #541 and `handleRangeAdd` in `writeRelayUpdatePayload` has an invariant on `clientMutationID` being in the payload.  This won't be the case for a subscription payload configured as a RANGE_ADD.

From what I can tell the `clientMutationID` is used in order to link up a temporary node ID added by an optimistic mutation with the real one from the mutation payload.  This won't be necessary for subscriptions.

I replaced the invariant with a conditional check on the `clientMutationID`.  I also duplicated the test the for non-optimistic RANGE_ADD's without a `clientMutationID` which I'm not sure is necessary or not.