### PR TITLE
Future-proof copyright year ranges

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -32,7 +32,7 @@ var PRODUCTION_HEADER = [
   '/**',
   ' * Relay v<%= version %>',
   ' *',
-  ' * Copyright 2013-2015, Facebook, Inc.',
+  ' * Copyright 2013-present, Facebook, Inc.',
   ' * All rights reserved.',
   ' *',
   ' * This source code is licensed under the BSD-style license found in the',

--- a/scripts/babel-relay-plugin/lib/GraphQL.js
+++ b/scripts/babel-relay-plugin/lib/GraphQL.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/GraphQLRelayDirective.js
+++ b/scripts/babel-relay-plugin/lib/GraphQLRelayDirective.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLAST.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/babelAdapter.js
+++ b/scripts/babel-relay-plugin/lib/babelAdapter.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/find.js
+++ b/scripts/babel-relay-plugin/lib/find.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/invariant.js
+++ b/scripts/babel-relay-plugin/lib/invariant.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/tools/generateSchemaJson.js
+++ b/scripts/babel-relay-plugin/lib/tools/generateSchemaJson.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/tools/readFixtures.js
+++ b/scripts/babel-relay-plugin/lib/tools/readFixtures.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/tools/regenerateFixtures.js
+++ b/scripts/babel-relay-plugin/lib/tools/regenerateFixtures.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
@@ -1,6 +1,6 @@
 // @generated
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/scripts/transform
+++ b/scripts/babel-relay-plugin/scripts/transform
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/GraphQL.js
+++ b/scripts/babel-relay-plugin/src/GraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/GraphQLRelayDirective.js
+++ b/scripts/babel-relay-plugin/src/GraphQLRelayDirective.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/src/RelayQLAST.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/src/RelayQLTransformer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/__tests__/BuildChecker-test.js
+++ b/scripts/babel-relay-plugin/src/__tests__/BuildChecker-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/__tests__/getBabelGraphQLPlugin-test.js
+++ b/scripts/babel-relay-plugin/src/__tests__/getBabelGraphQLPlugin-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/babelAdapter.js
+++ b/scripts/babel-relay-plugin/src/babelAdapter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/find.js
+++ b/scripts/babel-relay-plugin/src/find.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/invariant.js
+++ b/scripts/babel-relay-plugin/src/invariant.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/tools/generateSchemaJson.js
+++ b/scripts/babel-relay-plugin/src/tools/generateSchemaJson.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/tools/readFixtures.js
+++ b/scripts/babel-relay-plugin/src/tools/readFixtures.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/tools/regenerateFixtures.js
+++ b/scripts/babel-relay-plugin/src/tools/regenerateFixtures.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/scripts/jest/updateSchema.js
+++ b/scripts/jest/updateSchema.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env babel-node --optional es7.asyncFunctions
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/RelayPublic.js
+++ b/src/RelayPublic.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/Relay.js
+++ b/src/__forks__/Relay.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/container/RelayContainerProxy.js
+++ b/src/__forks__/container/RelayContainerProxy.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/container/__mocks__/RelayContainerProxy.js
+++ b/src/__forks__/container/__mocks__/RelayContainerProxy.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/container/__mocks__/prepareRelayContainerProps.js
+++ b/src/__forks__/container/__mocks__/prepareRelayContainerProps.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/container/prepareRelayContainerProps.js
+++ b/src/__forks__/container/prepareRelayContainerProps.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/interface/RelayConnectionInterface.js
+++ b/src/__forks__/interface/RelayConnectionInterface.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/interface/RelayNodeInterface.js
+++ b/src/__forks__/interface/RelayNodeInterface.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/interface/__mocks__/RelayConnectionInterface.js
+++ b/src/__forks__/interface/__mocks__/RelayConnectionInterface.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/interface/__mocks__/RelayNodeInterface.js
+++ b/src/__forks__/interface/__mocks__/RelayNodeInterface.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/traversal/__mocks__/printRelayQuery.js
+++ b/src/__forks__/traversal/__mocks__/printRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__forks__/traversal/printRelayQuery.js
+++ b/src/__forks__/traversal/printRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__mocks__/Relay.js
+++ b/src/__mocks__/Relay.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/__mocks__/RelayPublic.js
+++ b/src/__mocks__/RelayPublic.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/RelayContainerComparators.js
+++ b/src/container/RelayContainerComparators.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/RelayOSSContainerProxy.js
+++ b/src/container/RelayOSSContainerProxy.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/RelayPropTypes.js
+++ b/src/container/RelayPropTypes.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/RelayRenderer.js
+++ b/src/container/RelayRenderer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/RelayRootContainer.js
+++ b/src/container/RelayRootContainer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__mocks__/RelayContainer.js
+++ b/src/container/__mocks__/RelayContainer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__mocks__/RelayOSSContainerProxy.js
+++ b/src/container/__mocks__/RelayOSSContainerProxy.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__mocks__/RelayPropTypes.js
+++ b/src/container/__mocks__/RelayPropTypes.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__mocks__/getRelayQueries.js
+++ b/src/container/__mocks__/getRelayQueries.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__mocks__/isReactComponent.js
+++ b/src/container/__mocks__/isReactComponent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__mocks__/isRelayContainer.js
+++ b/src/container/__mocks__/isRelayContainer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__mocks__/prepareRelayOSSContainerProps.js
+++ b/src/container/__mocks__/prepareRelayOSSContainerProps.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayContainer-test.js
+++ b/src/container/__tests__/RelayContainer-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayContainer_Component-test.js
+++ b/src/container/__tests__/RelayContainer_Component-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayContainer_hasFragmentData-test.js
+++ b/src/container/__tests__/RelayContainer_hasFragmentData-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayContainer_hasOptimisticUpdate-test.js
+++ b/src/container/__tests__/RelayContainer_hasOptimisticUpdate-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayContainer_setVariables-test.js
+++ b/src/container/__tests__/RelayContainer_setVariables-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayRenderer_abort-test.js
+++ b/src/container/__tests__/RelayRenderer_abort-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayRenderer_context-test.js
+++ b/src/container/__tests__/RelayRenderer_context-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayRenderer_onReadyStateChange-test.js
+++ b/src/container/__tests__/RelayRenderer_onReadyStateChange-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayRenderer_render-test.js
+++ b/src/container/__tests__/RelayRenderer_render-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayRenderer_renderArgs-test.js
+++ b/src/container/__tests__/RelayRenderer_renderArgs-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayRenderer_requests-test.js
+++ b/src/container/__tests__/RelayRenderer_requests-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/RelayRenderer_validation-test.js
+++ b/src/container/__tests__/RelayRenderer_validation-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/getRelayQueries-test.js
+++ b/src/container/__tests__/getRelayQueries-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/isReactComponent-test.js
+++ b/src/container/__tests__/isReactComponent-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/__tests__/isRelayContainer-test.js
+++ b/src/container/__tests__/isRelayContainer-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/getRelayQueries.js
+++ b/src/container/getRelayQueries.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/isReactComponent.js
+++ b/src/container/isReactComponent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/isRelayContainer.js
+++ b/src/container/isRelayContainer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/container/prepareRelayOSSContainerProps.js
+++ b/src/container/prepareRelayOSSContainerProps.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/interface/RelayOSSConnectionInterface.js
+++ b/src/interface/RelayOSSConnectionInterface.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/interface/RelayOSSNodeInterface.js
+++ b/src/interface/RelayOSSNodeInterface.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/interface/__mocks__/RelayOSSConnectionInterface.js
+++ b/src/interface/__mocks__/RelayOSSConnectionInterface.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/interface/__mocks__/RelayOSSNodeInterface.js
+++ b/src/interface/__mocks__/RelayOSSNodeInterface.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/mutation/GraphQLMutatorConstants.js
+++ b/src/legacy/mutation/GraphQLMutatorConstants.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/mutation/__mocks__/GraphQLMutatorConstants.js
+++ b/src/legacy/mutation/__mocks__/GraphQLMutatorConstants.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/DliteFetchModeConstants.js
+++ b/src/legacy/store/DliteFetchModeConstants.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/GraphQLFragmentPointer.js
+++ b/src/legacy/store/GraphQLFragmentPointer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/GraphQLQueryRunner.js
+++ b/src/legacy/store/GraphQLQueryRunner.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/GraphQLRange.js
+++ b/src/legacy/store/GraphQLRange.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/GraphQLSegment.js
+++ b/src/legacy/store/GraphQLSegment.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/GraphQLStoreChangeEmitter.js
+++ b/src/legacy/store/GraphQLStoreChangeEmitter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/GraphQLStoreQueryResolver.js
+++ b/src/legacy/store/GraphQLStoreQueryResolver.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/GraphQLStoreRangeUtils.js
+++ b/src/legacy/store/GraphQLStoreRangeUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/GraphQLFragmentPointer.js
+++ b/src/legacy/store/__mocks__/GraphQLFragmentPointer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/GraphQLMutatorConstants.js
+++ b/src/legacy/store/__mocks__/GraphQLMutatorConstants.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/GraphQLQueryRunner.js
+++ b/src/legacy/store/__mocks__/GraphQLQueryRunner.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/GraphQLStoreChangeEmitter.js
+++ b/src/legacy/store/__mocks__/GraphQLStoreChangeEmitter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/GraphQLStoreQueryResolver.js
+++ b/src/legacy/store/__mocks__/GraphQLStoreQueryResolver.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/GraphQLStoreRangeUtils.js
+++ b/src/legacy/store/__mocks__/GraphQLStoreRangeUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/GraphQLStoreTestUtils.js
+++ b/src/legacy/store/__mocks__/GraphQLStoreTestUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/generateClientEdgeID.js
+++ b/src/legacy/store/__mocks__/generateClientEdgeID.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/generateClientID.js
+++ b/src/legacy/store/__mocks__/generateClientID.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/generateForceIndex.js
+++ b/src/legacy/store/__mocks__/generateForceIndex.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/generateRQLFieldAlias.js
+++ b/src/legacy/store/__mocks__/generateRQLFieldAlias.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__mocks__/recycleNodesInto.js
+++ b/src/legacy/store/__mocks__/recycleNodesInto.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__tests__/GraphQLFragmentPointer-test.js
+++ b/src/legacy/store/__tests__/GraphQLFragmentPointer-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__tests__/GraphQLQueryRunner-test.js
+++ b/src/legacy/store/__tests__/GraphQLQueryRunner-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__tests__/GraphQLRange-test.js
+++ b/src/legacy/store/__tests__/GraphQLRange-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__tests__/GraphQLSegment-test.js
+++ b/src/legacy/store/__tests__/GraphQLSegment-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__tests__/GraphQLStoreChangeEmitter-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreChangeEmitter-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__tests__/GraphQLStoreRangeUtils-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreRangeUtils-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__tests__/generateRQLFieldAlias-test.js
+++ b/src/legacy/store/__tests__/generateRQLFieldAlias-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/__tests__/recycleNodesInto-test.js
+++ b/src/legacy/store/__tests__/recycleNodesInto-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/generateClientEdgeID.js
+++ b/src/legacy/store/generateClientEdgeID.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/generateClientID.js
+++ b/src/legacy/store/generateClientID.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/generateForceIndex.js
+++ b/src/legacy/store/generateForceIndex.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/generateRQLFieldAlias.js
+++ b/src/legacy/store/generateRQLFieldAlias.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/legacy/store/recycleNodesInto.js
+++ b/src/legacy/store/recycleNodesInto.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/RelayMutation.js
+++ b/src/mutation/RelayMutation.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/RelayMutationQueue.js
+++ b/src/mutation/RelayMutationQueue.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/RelayMutationTransaction.js
+++ b/src/mutation/RelayMutationTransaction.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/RelayMutationTransactionStatus.js
+++ b/src/mutation/RelayMutationTransactionStatus.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/RelayMutationType.js
+++ b/src/mutation/RelayMutationType.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/__mocks__/RelayMutationQueue.js
+++ b/src/mutation/__mocks__/RelayMutationQueue.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/__mocks__/RelayMutationType.js
+++ b/src/mutation/__mocks__/RelayMutationType.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/__tests__/RelayMutation-test.js
+++ b/src/mutation/__tests__/RelayMutation-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/__tests__/RelayMutationQuery-test.js
+++ b/src/mutation/__tests__/RelayMutationQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/mutation/__tests__/RelayMutationQueue-test.js
+++ b/src/mutation/__tests__/RelayMutationQueue-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network-layer/default/__mocks__/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/__mocks__/RelayDefaultNetworkLayer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network/RelayMutationRequest.js
+++ b/src/network/RelayMutationRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network/RelayNetworkLayer.js
+++ b/src/network/RelayNetworkLayer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network/RelayQueryRequest.js
+++ b/src/network/RelayQueryRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network/__mocks__/RelayMutationRequest.js
+++ b/src/network/__mocks__/RelayMutationRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network/__mocks__/RelayNetworkLayer.js
+++ b/src/network/__mocks__/RelayNetworkLayer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network/__mocks__/RelayQueryRequest.js
+++ b/src/network/__mocks__/RelayQueryRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network/__mocks__/fetchRelayQuery.js
+++ b/src/network/__mocks__/fetchRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network/__tests__/RelayNetworkLayer-test.js
+++ b/src/network/__tests__/RelayNetworkLayer-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/network/fetchRelayQuery.js
+++ b/src/network/fetchRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query-config/RelayQueryConfig.js
+++ b/src/query-config/RelayQueryConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query-config/__mocks__/RelayQueryConfig.js
+++ b/src/query-config/__mocks__/RelayQueryConfig.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query-config/__tests__/RelayQueryConfig-test.js
+++ b/src/query-config/__tests__/RelayQueryConfig-test.js
@@ -1,5 +1,5 @@
  /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/ConcreteQuery.js
+++ b/src/query/ConcreteQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/QueryBuilder.js
+++ b/src/query/QueryBuilder.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/RelayFragmentReference.js
+++ b/src/query/RelayFragmentReference.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/RelayQL.js
+++ b/src/query/RelayQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/RelayQuery.js
+++ b/src/query/RelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/RelayQueryPath.js
+++ b/src/query/RelayQueryPath.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/RelayQueryTransform.js
+++ b/src/query/RelayQueryTransform.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/RelayQueryVisitor.js
+++ b/src/query/RelayQueryVisitor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/RelayRefQueryDescriptor.js
+++ b/src/query/RelayRefQueryDescriptor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/RelayRouteFragment.js
+++ b/src/query/RelayRouteFragment.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/QueryBuilder.js
+++ b/src/query/__mocks__/QueryBuilder.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/RelayFragmentReference.js
+++ b/src/query/__mocks__/RelayFragmentReference.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/RelayQL.js
+++ b/src/query/__mocks__/RelayQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/RelayQuery.js
+++ b/src/query/__mocks__/RelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/RelayQueryPath.js
+++ b/src/query/__mocks__/RelayQueryPath.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/RelayQueryTransform.js
+++ b/src/query/__mocks__/RelayQueryTransform.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/RelayQueryVisitor.js
+++ b/src/query/__mocks__/RelayQueryVisitor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/RelayRefQueryDescriptor.js
+++ b/src/query/__mocks__/RelayRefQueryDescriptor.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/RelayRouteFragment.js
+++ b/src/query/__mocks__/RelayRouteFragment.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/buildRQL.js
+++ b/src/query/__mocks__/buildRQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/callsFromGraphQL.js
+++ b/src/query/__mocks__/callsFromGraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/callsToGraphQL.js
+++ b/src/query/__mocks__/callsToGraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/createRelayQuery.js
+++ b/src/query/__mocks__/createRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/forEachRootCallArg.js
+++ b/src/query/__mocks__/forEachRootCallArg.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/fromGraphQL.js
+++ b/src/query/__mocks__/fromGraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/fromGraphQLQuery.js
+++ b/src/query/__mocks__/fromGraphQLQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/getConcreteFragmentHash.js
+++ b/src/query/__mocks__/getConcreteFragmentHash.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/serializeRelayQueryCall.js
+++ b/src/query/__mocks__/serializeRelayQueryCall.js
@@ -1,5 +1,5 @@
   /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/stableStringify.js
+++ b/src/query/__mocks__/stableStringify.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__mocks__/toGraphQL.js
+++ b/src/query/__mocks__/toGraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayFragmentReference-test.js
+++ b/src/query/__tests__/RelayFragmentReference-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQL-test.js
+++ b/src/query/__tests__/RelayQL-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQuery-getCallsWithValues-test.js
+++ b/src/query/__tests__/RelayQuery-getCallsWithValues-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQuery-test.js
+++ b/src/query/__tests__/RelayQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQueryField-test.js
+++ b/src/query/__tests__/RelayQueryField-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQueryFragment-test.js
+++ b/src/query/__tests__/RelayQueryFragment-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQueryMutation-test.js
+++ b/src/query/__tests__/RelayQueryMutation-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQueryPath-test.js
+++ b/src/query/__tests__/RelayQueryPath-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQueryTransform-test.js
+++ b/src/query/__tests__/RelayQueryTransform-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/RelayQueryVisitor-test.js
+++ b/src/query/__tests__/RelayQueryVisitor-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/buildRQL-test.js
+++ b/src/query/__tests__/buildRQL-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/callsToGraphQL-test.js
+++ b/src/query/__tests__/callsToGraphQL-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/createRelayQuery-test.js
+++ b/src/query/__tests__/createRelayQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/serializeRelayQueryCall-test.js
+++ b/src/query/__tests__/serializeRelayQueryCall-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/stableStringify-test.js
+++ b/src/query/__tests__/stableStringify-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/__tests__/toGraphQL-test.js
+++ b/src/query/__tests__/toGraphQL-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/buildRQL.js
+++ b/src/query/buildRQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/callsFromGraphQL.js
+++ b/src/query/callsFromGraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/callsToGraphQL.js
+++ b/src/query/callsToGraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/createRelayQuery.js
+++ b/src/query/createRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/forEachRootCallArg.js
+++ b/src/query/forEachRootCallArg.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/fromGraphQL.js
+++ b/src/query/fromGraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/getConcreteFragmentHash.js
+++ b/src/query/getConcreteFragmentHash.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/serializeRelayQueryCall.js
+++ b/src/query/serializeRelayQueryCall.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/stableStringify.js
+++ b/src/query/stableStringify.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/query/toGraphQL.js
+++ b/src/query/toGraphQL.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/route/RelayMetaRoute.js
+++ b/src/route/RelayMetaRoute.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/route/RelayRoute.js
+++ b/src/route/RelayRoute.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/route/__mocks__/RelayMetaRoute.js
+++ b/src/route/__mocks__/RelayMetaRoute.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/route/__mocks__/RelayRoute.js
+++ b/src/route/__mocks__/RelayRoute.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/route/__tests__/RelayMetaRoute-test.js
+++ b/src/route/__tests__/RelayMetaRoute-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/route/__tests__/RelayRoute-test.js
+++ b/src/route/__tests__/RelayRoute-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayChangeTracker.js
+++ b/src/store/RelayChangeTracker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayDiskCacheReader.js
+++ b/src/store/RelayDiskCacheReader.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayGarbageCollection.js
+++ b/src/store/RelayGarbageCollection.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayGarbageCollector.js
+++ b/src/store/RelayGarbageCollector.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayMutationTracker.js
+++ b/src/store/RelayMutationTracker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayPendingQueryTracker.js
+++ b/src/store/RelayPendingQueryTracker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayQueryResultObservable.js
+++ b/src/store/RelayQueryResultObservable.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayQueryTracker.js
+++ b/src/store/RelayQueryTracker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayQueryWriter.js
+++ b/src/store/RelayQueryWriter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayRecord.js
+++ b/src/store/RelayRecord.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayRecordState.js
+++ b/src/store/RelayRecordState.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayRecordStatusMap.js
+++ b/src/store/RelayRecordStatusMap.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayRecordStore.js
+++ b/src/store/RelayRecordStore.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayStore.js
+++ b/src/store/RelayStore.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayChangeTracker.js
+++ b/src/store/__mocks__/RelayChangeTracker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayDiskCacheReader.js
+++ b/src/store/__mocks__/RelayDiskCacheReader.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayGarbageCollector.js
+++ b/src/store/__mocks__/RelayGarbageCollector.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayMockCacheManager.js
+++ b/src/store/__mocks__/RelayMockCacheManager.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayMutationTracker.js
+++ b/src/store/__mocks__/RelayMutationTracker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayPendingQueryTracker.js
+++ b/src/store/__mocks__/RelayPendingQueryTracker.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayQueryResultObservable.js
+++ b/src/store/__mocks__/RelayQueryResultObservable.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayQueryWriter.js
+++ b/src/store/__mocks__/RelayQueryWriter.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayRecord.js
+++ b/src/store/__mocks__/RelayRecord.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayRecordState.js
+++ b/src/store/__mocks__/RelayRecordState.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayRecordStatusMap.js
+++ b/src/store/__mocks__/RelayRecordStatusMap.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayRecordStore.js
+++ b/src/store/__mocks__/RelayRecordStore.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayStore.js
+++ b/src/store/__mocks__/RelayStore.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/RelayStoreData.js
+++ b/src/store/__mocks__/RelayStoreData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/filterExclusiveKeys.js
+++ b/src/store/__mocks__/filterExclusiveKeys.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/readRelayQueryData.js
+++ b/src/store/__mocks__/readRelayQueryData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__mocks__/validateRelayReadQuery.js
+++ b/src/store/__mocks__/validateRelayReadQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayDiskCacheReader-test.js
+++ b/src/store/__tests__/RelayDiskCacheReader-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayGarbageCollector-test.js
+++ b/src/store/__tests__/RelayGarbageCollector-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayPendingQueryTracker-test.js
+++ b/src/store/__tests__/RelayPendingQueryTracker-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayQueryResultObservable-test.js
+++ b/src/store/__tests__/RelayQueryResultObservable-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayQueryTracker-test.js
+++ b/src/store/__tests__/RelayQueryTracker-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayRecord-test.js
+++ b/src/store/__tests__/RelayRecord-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayRecordStatusMap-test.js
+++ b/src/store/__tests__/RelayRecordStatusMap-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayRecordStore-test.js
+++ b/src/store/__tests__/RelayRecordStore-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayRecordStore_write-test.js
+++ b/src/store/__tests__/RelayRecordStore_write-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayStore-test.js
+++ b/src/store/__tests__/RelayStore-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayStoreData-test.js
+++ b/src/store/__tests__/RelayStoreData-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/RelayStoreData_cacheManager-test.js
+++ b/src/store/__tests__/RelayStoreData_cacheManager-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/filterExclusiveKeys-test.js
+++ b/src/store/__tests__/filterExclusiveKeys-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/readRelayQueryData-test.js
+++ b/src/store/__tests__/readRelayQueryData-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/__tests__/validateRelayReadQuery-test.js
+++ b/src/store/__tests__/validateRelayReadQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/filterExclusiveKeys.js
+++ b/src/store/filterExclusiveKeys.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/readRelayQueryData.js
+++ b/src/store/readRelayQueryData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/store/validateRelayReadQuery.js
+++ b/src/store/validateRelayReadQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/RelayError.js
+++ b/src/tools/RelayError.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/RelayInternalTypes.js
+++ b/src/tools/RelayInternalTypes.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/RelayInternals.js
+++ b/src/tools/RelayInternals.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/RelayMetricsRecorder.js
+++ b/src/tools/RelayMetricsRecorder.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/RelayProfiler.js
+++ b/src/tools/RelayProfiler.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/RelayTaskQueue.js
+++ b/src/tools/RelayTaskQueue.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/RelayTaskScheduler.js
+++ b/src/tools/RelayTaskScheduler.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/RelayTypes.js
+++ b/src/tools/RelayTypes.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__mocks__/RelayDeprecated.js
+++ b/src/tools/__mocks__/RelayDeprecated.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__mocks__/RelayError.js
+++ b/src/tools/__mocks__/RelayError.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__mocks__/RelayMetricsRecorder.js
+++ b/src/tools/__mocks__/RelayMetricsRecorder.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__mocks__/RelayProfiler.js
+++ b/src/tools/__mocks__/RelayProfiler.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__mocks__/RelayTaskScheduler.js
+++ b/src/tools/__mocks__/RelayTaskScheduler.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__mocks__/configureForRelayOSS.js
+++ b/src/tools/__mocks__/configureForRelayOSS.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__mocks__/isCompatibleRelayFragmentType.js
+++ b/src/tools/__mocks__/isCompatibleRelayFragmentType.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__mocks__/matchRecord.js
+++ b/src/tools/__mocks__/matchRecord.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__tests__/RelayMetricsRecorder-test.js
+++ b/src/tools/__tests__/RelayMetricsRecorder-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__tests__/RelayProfiler-test.js
+++ b/src/tools/__tests__/RelayProfiler-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__tests__/RelayTaskQueue-test.js
+++ b/src/tools/__tests__/RelayTaskQueue-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__tests__/RelayTaskScheduler-test.js
+++ b/src/tools/__tests__/RelayTaskScheduler-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/__tests__/isCompatibleRelayFragmentType-test.js
+++ b/src/tools/__tests__/isCompatibleRelayFragmentType-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/tools/isCompatibleRelayFragmentType.js
+++ b/src/tools/isCompatibleRelayFragmentType.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/checkRelayQueryData.js
+++ b/src/traversal/__mocks__/checkRelayQueryData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/containsRelayQueryRootCall.js
+++ b/src/traversal/__mocks__/containsRelayQueryRootCall.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/diffRelayQuery.js
+++ b/src/traversal/__mocks__/diffRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/filterRelayQuery.js
+++ b/src/traversal/__mocks__/filterRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/findRelayQueryLeaves.js
+++ b/src/traversal/__mocks__/findRelayQueryLeaves.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/flattenRelayQuery.js
+++ b/src/traversal/__mocks__/flattenRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/flattenSplitRelayQueries.js
+++ b/src/traversal/__mocks__/flattenSplitRelayQueries.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/inferRelayFieldsFromData.js
+++ b/src/traversal/__mocks__/inferRelayFieldsFromData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/intersectRelayQuery.js
+++ b/src/traversal/__mocks__/intersectRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/printRelayOSSQuery.js
+++ b/src/traversal/__mocks__/printRelayOSSQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/sortTypeFirst.js
+++ b/src/traversal/__mocks__/sortTypeFirst.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/splitDeferredRelayQueries.js
+++ b/src/traversal/__mocks__/splitDeferredRelayQueries.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/subtractRelayQuery.js
+++ b/src/traversal/__mocks__/subtractRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/transformRelayQueryPayload.js
+++ b/src/traversal/__mocks__/transformRelayQueryPayload.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/writeRelayQueryPayload.js
+++ b/src/traversal/__mocks__/writeRelayQueryPayload.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__mocks__/writeRelayUpdatePayload.js
+++ b/src/traversal/__mocks__/writeRelayUpdatePayload.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/checkRelayQueryData-test.js
+++ b/src/traversal/__tests__/checkRelayQueryData-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/containsRelayQueryRootCall-test.js
+++ b/src/traversal/__tests__/containsRelayQueryRootCall-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/diffRelayQuery-test.js
+++ b/src/traversal/__tests__/diffRelayQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/diffRelayQuery_connection-test.js
+++ b/src/traversal/__tests__/diffRelayQuery_connection-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/diffRelayQuery_fragments-test.js
+++ b/src/traversal/__tests__/diffRelayQuery_fragments-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/diffRelayQuery_scalar-test.js
+++ b/src/traversal/__tests__/diffRelayQuery_scalar-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/filterRelayQuery-test.js
+++ b/src/traversal/__tests__/filterRelayQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/findRelayQueryLeaves-test.js
+++ b/src/traversal/__tests__/findRelayQueryLeaves-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/flattenRelayQuery-test.js
+++ b/src/traversal/__tests__/flattenRelayQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/flattenSplitRelayQueries-test.js
+++ b/src/traversal/__tests__/flattenSplitRelayQueries-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/inferRelayFieldsFromData-test.js
+++ b/src/traversal/__tests__/inferRelayFieldsFromData-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/intersectRelayQuery-test.js
+++ b/src/traversal/__tests__/intersectRelayQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/sortTypeFirst-test.js
+++ b/src/traversal/__tests__/sortTypeFirst-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/splitDeferredRelayQueries-test.js
+++ b/src/traversal/__tests__/splitDeferredRelayQueries-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/subtractRelayQuery-test.js
+++ b/src/traversal/__tests__/subtractRelayQuery-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/transformRelayQueryPayload-test.js
+++ b/src/traversal/__tests__/transformRelayQueryPayload-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/writeRelayQueryPayload_connectionField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_connectionField-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/writeRelayQueryPayload_linkedField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_linkedField-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/writeRelayQueryPayload_pluralLinkedField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_pluralLinkedField-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/writeRelayQueryPayload_pluralScalarField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_pluralScalarField-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/writeRelayQueryPayload_rootRecord-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_rootRecord-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/writeRelayQueryPayload_scalarField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_scalarField-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/checkRelayQueryData.js
+++ b/src/traversal/checkRelayQueryData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/containsRelayQueryRootCall.js
+++ b/src/traversal/containsRelayQueryRootCall.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/diffRelayQuery.js
+++ b/src/traversal/diffRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/filterRelayQuery.js
+++ b/src/traversal/filterRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/findRelayQueryLeaves.js
+++ b/src/traversal/findRelayQueryLeaves.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/flattenRelayQuery.js
+++ b/src/traversal/flattenRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/flattenSplitRelayQueries.js
+++ b/src/traversal/flattenSplitRelayQueries.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/inferRelayFieldsFromData.js
+++ b/src/traversal/inferRelayFieldsFromData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/intersectRelayQuery.js
+++ b/src/traversal/intersectRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/printRelayOSSQuery.js
+++ b/src/traversal/printRelayOSSQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/sortTypeFirst.js
+++ b/src/traversal/sortTypeFirst.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/splitDeferredRelayQueries.js
+++ b/src/traversal/splitDeferredRelayQueries.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/subtractRelayQuery.js
+++ b/src/traversal/subtractRelayQuery.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/transformRelayQueryPayload.js
+++ b/src/traversal/transformRelayQueryPayload.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/writeRelayQueryPayload.js
+++ b/src/traversal/writeRelayQueryPayload.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website-prototyping-tools/HelloApp.js
+++ b/website-prototyping-tools/HelloApp.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website-prototyping-tools/HelloSchema.js
+++ b/website-prototyping-tools/HelloSchema.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website-prototyping-tools/RelayPlayground.js
+++ b/website-prototyping-tools/RelayPlayground.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website-prototyping-tools/babelRelayPlaygroundPlugin.js
+++ b/website-prototyping-tools/babelRelayPlaygroundPlugin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website-prototyping-tools/evalSchema.js
+++ b/website-prototyping-tools/evalSchema.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website-prototyping-tools/graphiql.js
+++ b/website-prototyping-tools/graphiql.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website-prototyping-tools/playground.js
+++ b/website-prototyping-tools/playground.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website-prototyping-tools/webpack.config.js
+++ b/website-prototyping-tools/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/core/DocsSidebar.js
+++ b/website/core/DocsSidebar.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/core/H2.js
+++ b/website/core/H2.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/core/HeaderLinks.js
+++ b/website/core/HeaderLinks.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/core/Marked.js
+++ b/website/core/Marked.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/core/SiteData.js
+++ b/website/core/SiteData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/core/center.js
+++ b/website/core/center.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/core/unindent.js
+++ b/website/core/unindent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/layout/DocsLayout.js
+++ b/website/layout/DocsLayout.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/layout/PageLayout.js
+++ b/website/layout/PageLayout.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/server/buildGraphQLSpec.js
+++ b/website/server/buildGraphQLSpec.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/server/generate.js
+++ b/website/server/generate.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/server/server.js
+++ b/website/server/server.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/src/relay/index.js
+++ b/website/src/relay/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/website/src/relay/support.js
+++ b/website/src/relay/support.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013-2015, Facebook, Inc.
+ * Copyright 2013-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
We use the "-present" range in other open source projects, so let's do the same here, which means we won't need to update these every year.