### PR TITLE
Fix import react and relay in the tutorial example

### DIFF
--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -335,6 +335,8 @@ Finally, let's tie it all together in `./js/components/App.js`:
 
 ```
 import CheckHidingSpotForTreasureMutation from '../mutations/CheckHidingSpotForTreasureMutation';
+import React from 'react';
+import Relay from 'react-relay';
 
 class App extends React.Component {
   _getHidingSpotStyle(hidingSpot) {


### PR DESCRIPTION
Add missing imports to fix the the tutorial following the example in the relay repository: https://github.com/facebook/relay/blob/master/examples/relay-treasurehunt/js/components/App.js