### PR TITLE
Fix a few lint warnings

### DIFF
--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -19,7 +19,7 @@ const RelayQuery = require('RelayQuery');
 const RelayTestUtils = require('RelayTestUtils');
 
 describe('RelayQueryRoot', () => {
-  var {defer, getNode} = RelayTestUtils;
+  var {getNode} = RelayTestUtils;
 
   var me;
   var usernames;

--- a/src/query/toGraphQL.js
+++ b/src/query/toGraphQL.js
@@ -21,7 +21,6 @@ import type {
 const QueryBuilder = require('QueryBuilder');
 const RelayQuery = require('RelayQuery');
 
-const base62 = require('base62');
 const callsToGraphQL = require('callsToGraphQL');
 const invariant = require('invariant');
 
@@ -100,11 +99,6 @@ const toGraphQL = {
     return field;
   },
 };
-
-let clientFragmentCount = 0;
-function createClientFragmentHash(): string {
-  return '_toGraphQL_' + base62(clientFragmentCount++);
-}
 
 function toGraphQLSelection(
   node: RelayQuery.Node

--- a/src/store/RelayPendingQueryTracker.js
+++ b/src/store/RelayPendingQueryTracker.js
@@ -119,7 +119,7 @@ class PendingFetch {
 
   constructor(
     {fetchMode, forceIndex, query}: PendingQueryParameters,
-    {pendingFetchMap, preloadQueryMap, storeData, }: { // babel-eslint issue
+    {pendingFetchMap, preloadQueryMap, storeData}: {
       pendingFetchMap: {[queryID: string]: PendingState};
       preloadQueryMap: PromiseMap<Object, Error>;
       storeData: RelayStoreData;

--- a/src/store/RelayRecordStatusMap.js
+++ b/src/store/RelayRecordStatusMap.js
@@ -24,14 +24,14 @@ var ERROR_MASK = 0x02;
 function set(status: ?number, value: boolean, mask: number): number {
   status = status || 0;
   if (value) {
-    return status | mask;
+    return status | mask; // eslint-disable-line no-bitwise
   } else {
-    return status & ~mask;
+    return status & ~mask; // eslint-disable-line no-bitwise
   }
 }
 
 function check(status: ?number, mask: number): boolean {
-  return ((status || 0) & mask) != 0;
+  return ((status || 0) & mask) != 0; // eslint-disable-line no-bitwise
 }
 /**
  * A set of functions for modifying `__status__` on records inside of

--- a/src/store/__tests__/RelayRecordStore-test.js
+++ b/src/store/__tests__/RelayRecordStore-test.js
@@ -18,7 +18,6 @@ jest.mock('warning');
 const GraphQLRange = require('GraphQLRange');
 const Relay = require('Relay');
 const RelayQueryPath = require('RelayQueryPath');
-const RelayRecordStatusMap = require('RelayRecordStatusMap');
 const RelayTestUtils = require('RelayTestUtils');
 
 describe('RelayRecordStore', () => {


### PR DESCRIPTION
Specifically:

```
src/query/__tests__/RelayQueryRoot-test.js
  22:8  warning  "defer" is defined but never used                         no-unused-vars

src/query/toGraphQL.js
  105:10  warning  "createClientFragmentHash" is defined but never used      no-unused-vars

src/store/__tests__/RelayRecordStore-test.js
  21:7  warning  "RelayRecordStatusMap" is defined but never used          no-unused-vars

src/store/RelayPendingQueryTracker.js
  122:49  warning  Unexpected trailing comma                                 comma-dangle

src/store/RelayRecordStatusMap.js
  27:12  warning  Unexpected use of '|'                                     no-bitwise
  29:12  warning  Unexpected use of '&'                                     no-bitwise
  29:21  warning  Unexpected use of '~'                                     no-bitwise
  34:11  warning  Unexpected use of '&'                                     no-bitwise
```