### PR TITLE
Allow Node 5 and npm 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "webpack-stream": "^2.1.0"
   },
   "devEngines": {
-    "node": "4.x",
-    "npm": "2.x"
+    "node": ">=4",
+    "npm": ">=2"
   },
   "jest": {
     "rootDir": "",


### PR DESCRIPTION
I think we can probably loosen our restriction on Node and npm versions
at this point.

I just tried this with Node 5.5.0 and npm 3.3.12, and compared with Node
4.2.6 and npm 2.15.12. There are no new lint or Flow issues under the
new versions, and install and build works. Also confirmed that examples
still run (actually found a real issue in one but will fix that
separately).

Closes: https://github.com/facebook/relay/issues/706