### PR TITLE
Track fragments on null linked fields

### DIFF
--- a/src/traversal/diffRelayQuery.js
+++ b/src/traversal/diffRelayQuery.js
@@ -432,8 +432,11 @@ class RelayDiffQueryBuilder {
         trackedNode: null,
       };
     } else if (linkedIDs === null || linkedIDs.length === 0) {
-      // empty array means nothing to fetch
-      return null;
+      // Don't fetch if array is null or empty, but still track the fragment
+      return {
+        diffNode: null,
+        trackedNode: field,
+      };
     } else if (field.getInferredRootCallName() === NODE) {
       // The items in this array are fetchable and may have been filled in
       // from other sources, so check them all. For example, `Story{actors}`
@@ -508,9 +511,12 @@ class RelayDiffQueryBuilder {
         trackedNode: null,
       };
     }
-    // Skip if the connection is deleted.
+    // Don't fetch if connection is null, but continue to track the fragment
     if (connectionID === null) {
-      return null;
+      return {
+        diffNode: null,
+        trackedNode: field,
+      };
     }
     // If metadata fields but not edges are fetched, diff as a normal field.
     // In practice, `rangeInfo` is `undefined` if unfetched, `null` if the

--- a/src/traversal/diffRelayQuery.js
+++ b/src/traversal/diffRelayQuery.js
@@ -401,7 +401,10 @@ class RelayDiffQueryBuilder {
       };
     }
     if (nextDataID === null) {
-      return null;
+      return {
+        diffNode: null,
+        trackedNode: field,
+      };
     }
 
     return this.traverse(


### PR DESCRIPTION
This fixes #745.

Essentially, what's happening is that the query tracker isn't being updated by `diffRelayQuery` when the query is on a node that is currently `null` in the local store. This causes Relay to lose track of what queries the components are expecting and therefore future mutations form incorrect queries.

My current fix just changes a bit of logic in `diffRelayQuery` to always track null linked fields. I'm not sure it's correct though - I'd like to write some code that ensures the `RelayQueryTracker` correctly merges the two tracked queries that `diffRelayQuery` registers via `trackNodeForID`, but maybe that's already covered by existing tests.