### PR TITLE
network layer support for subscriptions

### DIFF
--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -24,6 +24,10 @@ type Mutation {
   viewerNotificationsUpdateAllSeenState(input: UpdateAllSeenStateInput): ViewerNotificationsUpdateAllSeenStateResponsePayload
 }
 
+type Subscription {
+  commentCreate(input: CommentCreateSubscriptionInput): CommentCreateSubscriptionResponsePayload
+}
+
 input ActorSubscribeInput {
   clientMutationId: String
   subscribeeId: ID
@@ -36,6 +40,11 @@ input ApplicationRequestDeleteAllInput {
 
 input CommentCreateInput {
   clientMutationId: String
+  feedbackId: ID
+}
+
+input CommentCreateSubscriptionInput {
+  clientSubscriptionId: String,
   feedbackId: ID
 }
 
@@ -117,6 +126,13 @@ type Comment implements Node {
 
 type CommentCreateResponsePayload {
   clientMutationId: String
+  comment: Comment
+  feedback: Feedback
+  feedbackCommentEdge: CommentsEdge
+}
+
+type CommentCreateSubscriptionResponsePayload {
+  clientSubscriptionId: String
   comment: Comment
   feedback: Feedback
   feedbackCommentEdge: CommentsEdge

--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -25,7 +25,7 @@ type Mutation {
 }
 
 type Subscription {
-  commentCreate(input: CommentCreateSubscriptionInput): CommentCreateSubscriptionResponsePayload
+  commentCreateSubscribe(input: CommentCreateSubscribeInput): CommentCreateSubscribeResponsePayload
 }
 
 input ActorSubscribeInput {
@@ -43,7 +43,7 @@ input CommentCreateInput {
   feedbackId: ID
 }
 
-input CommentCreateSubscriptionInput {
+input CommentCreateSubscribeInput {
   clientSubscriptionId: String,
   feedbackId: ID
 }
@@ -131,7 +131,7 @@ type CommentCreateResponsePayload {
   feedbackCommentEdge: CommentsEdge
 }
 
-type CommentCreateSubscriptionResponsePayload {
+type CommentCreateSubscribeResponsePayload {
   clientSubscriptionId: String
   comment: Comment
   feedback: Feedback

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -8122,7 +8122,7 @@
           "description": null,
           "fields": [
             {
-              "name": "commentCreate",
+              "name": "commentCreateSubscribe",
               "description": null,
               "args": [
                 {
@@ -8130,7 +8130,7 @@
                   "description": null,
                   "type": {
                     "kind": "INPUT_OBJECT",
-                    "name": "CommentCreateSubscriptionInput",
+                    "name": "CommentCreateSubscribeInput",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -8138,7 +8138,7 @@
               ],
               "type": {
                 "kind": "OBJECT",
-                "name": "CommentCreateSubscriptionResponsePayload",
+                "name": "CommentCreateSubscribeResponsePayload",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -8152,7 +8152,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "CommentCreateSubscriptionInput",
+          "name": "CommentCreateSubscribeInput",
           "description": null,
           "fields": null,
           "inputFields": [
@@ -8183,7 +8183,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "CommentCreateSubscriptionResponsePayload",
+          "name": "CommentCreateSubscribeResponsePayload",
           "description": null,
           "fields": [
             {

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -7,7 +7,9 @@
       "mutationType": {
         "name": "Mutation"
       },
-      "subscriptionType": null,
+      "subscriptionType": {
+        "name": "Subscription"
+      },
       "types": [
         {
           "kind": "OBJECT",
@@ -8104,6 +8106,130 @@
                   "name": "Story",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "description": null,
+          "fields": [
+            {
+              "name": "commentCreate",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CommentCreateSubscriptionInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CommentCreateSubscriptionResponsePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CommentCreateSubscriptionInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "clientSubscriptionId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "feedbackId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CommentCreateSubscriptionResponsePayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "clientSubscriptionId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Comment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feedback",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Feedback",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feedbackCommentEdge",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CommentsEdge",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/scripts/jest/updateSchema.js
+++ b/scripts/jest/updateSchema.js
@@ -20,7 +20,7 @@ try {
 
   var body = fs.readFileSync(inFile, 'utf8');
   var ast = parse(body);
-  var astSchema = buildASTSchema(ast, 'Root', 'Mutation');
+  var astSchema = buildASTSchema(ast, 'Root', 'Mutation', 'Subscription');
   graphql(astSchema, introspectionQuery).then(
     function(result) {
       var out = JSON.stringify(result, null, 2);

--- a/src/interface/RelayOSSConnectionInterface.js
+++ b/src/interface/RelayOSSConnectionInterface.js
@@ -36,6 +36,7 @@ var REQUIRED_RANGE_CALLS = {
  */
 var RelayOSSConnectionInterface = {
   CLIENT_MUTATION_ID: 'clientMutationId',
+  CLIENT_SUBSCRIPTION_ID: 'clientSubscriptionId',
   CURSOR: 'cursor',
   EDGES: 'edges',
   END_CURSOR: 'endCursor',

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -15,6 +15,8 @@
 
 import type RelayMutationRequest from 'RelayMutationRequest';
 import type RelayQueryRequest from 'RelayQueryRequest';
+import type RelaySubscriptionRequest from 'RelaySubscriptionRequest';
+import type {Subscription} from 'RelayTypes';
 
 const fetch = require('fetch');
 const fetchWithRetries = require('fetchWithRetries');
@@ -42,6 +44,7 @@ class RelayDefaultNetworkLayer {
     var self: any = this;
     self.sendMutation = this.sendMutation.bind(this);
     self.sendQueries = this.sendQueries.bind(this);
+    self.sendSubscription = this.sendSubscription.bind(this);
     self.supports = this.supports.bind(this);
   }
 
@@ -90,6 +93,13 @@ class RelayDefaultNetworkLayer {
         error => request.reject(error)
       )
     )));
+  }
+
+  sendSubscription(request: RelaySubscriptionRequest): Subscription {
+    throw new Error(
+      'RelayDefaultNetworkLayer: `sendSubscription` is not implemented in the ' +
+      'default network layer.  A custom network layer must be injected.'
+    );
   }
 
   supports(...options: Array<string>): boolean {

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -21,6 +21,7 @@ import type {Subscription} from 'RelayTypes';
 const fetch = require('fetch');
 const fetchWithRetries = require('fetchWithRetries');
 import type {InitWithRetries} from 'fetchWithRetries';
+const invariant = require('invariant');
 
 type GraphQLError = {
   message: string;
@@ -96,7 +97,8 @@ class RelayDefaultNetworkLayer {
   }
 
   sendSubscription(request: RelaySubscriptionRequest): Subscription {
-    throw new Error(
+    invariant(
+      false,
       'RelayDefaultNetworkLayer: `sendSubscription` is not implemented in the ' +
       'default network layer.  A custom network layer must be injected.'
     );

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -347,6 +347,7 @@ describe('RelayDefaultNetworkLayer', () => {
   describe('sendSubscription', () => {
     let request;
     let variables;
+    let observer;
 
     beforeEach(() => {
       variables = {
@@ -364,9 +365,14 @@ describe('RelayDefaultNetworkLayer', () => {
         }
       `, variables);
 
-      const observer = {};
+      observer = {
+        onNext: jest.genMockFunction(),
+        onError: jest.genMockFunction(),
+        onCompleted: jest.genMockFunction(),
+      };
 
-      request = new RelaySubscriptionRequest(subscription, observer);
+      request = new RelaySubscriptionRequest(subscription);
+      request.subscribe(observer);
     });
 
     it('throws on all subscription requests', () => {
@@ -375,9 +381,9 @@ describe('RelayDefaultNetworkLayer', () => {
         'default network layer.  A custom network layer must be injected.'
       );
 
-      expect(request.onNext).not.toBeCalled();
-      expect(request.onError).not.toBeCalled();
-      expect(request.onCompleted).not.toBeCalled();
+      expect(observer.onNext).not.toBeCalled();
+      expect(observer.onError).not.toBeCalled();
+      expect(observer.onCompleted).not.toBeCalled();
     });
   });
 });

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -370,7 +370,7 @@ describe('RelayDefaultNetworkLayer', () => {
     });
 
     it('throws on all subscription requests', () => {
-      expect(() => networkLayer.sendSubscription(request)).toThrowError(
+      expect(() => networkLayer.sendSubscription(request)).toFailInvariant(
         'RelayDefaultNetworkLayer: `sendSubscription` is not implemented in the ' +
         'default network layer.  A custom network layer must be injected.'
       );

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -20,6 +20,7 @@ const RelayMetaRoute = require('RelayMetaRoute');
 const RelayMutationRequest = require('RelayMutationRequest');
 const RelayQuery = require('RelayQuery');
 const RelayQueryRequest = require('RelayQueryRequest');
+const RelaySubscriptionRequest = require('RelaySubscriptionRequest');
 const RelayTestUtils = require('RelayTestUtils');
 
 const fetch = require('fetch');
@@ -340,6 +341,43 @@ describe('RelayDefaultNetworkLayer', () => {
       expect(rejectACallback.mock.calls[0][0].message).toEqual(
         'Server response was missing for query `RelayDefaultNetworkLayer`.'
       );
+    });
+  });
+
+  describe('sendSubscription', () => {
+    let request;
+    let variables;
+
+    beforeEach(() => {
+      variables = {
+        input: {
+          [RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID]: 'client:a',
+          feedbackId: 4,
+        },
+      };
+
+      const subscription = RelayTestUtils.getNode(Relay.QL`
+        subscription {
+          commentCreateSubscribe(input:$input) {
+            clientSubscriptionId
+          }
+        }
+      `, variables);
+
+      const observer = {};
+
+      request = new RelaySubscriptionRequest(subscription, observer);
+    });
+
+    it('throws on all subscription requests', () => {
+      expect(() => networkLayer.sendSubscription(request)).toThrowError(
+        'RelayDefaultNetworkLayer: `sendSubscription` is not implemented in the ' +
+        'default network layer.  A custom network layer must be injected.'
+      );
+
+      expect(request.onNext).not.toBeCalled();
+      expect(request.onError).not.toBeCalled();
+      expect(request.onCompleted).not.toBeCalled();
     });
   });
 });

--- a/src/network/RelaySubscriptionRequest.js
+++ b/src/network/RelaySubscriptionRequest.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule RelaySubscriptionRequest
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+import type {PrintedQuery} from 'RelayInternalTypes';
+import type RelayQuery from 'RelayQuery';
+import type {SubscriptionResult, SubscriptionCallbacks, Variables} from 'RelayTypes';
+
+const printRelayQuery = require('printRelayQuery');
+
+/**
+ * @internal
+ *
+ * Instances of these are made available via `RelayNetworkLayer.sendSubscription`.
+ */
+class RelaySubscriptionRequest {
+  _subscription: RelayQuery.Subscription;
+  _printedQuery: ?PrintedQuery;
+  _observer: SubscriptionCallbacks<SubscriptionResult>;
+
+  constructor(
+    subscription: RelayQuery.Subscription,
+    observer: SubscriptionCallbacks<SubscriptionResult>
+  ) {
+    this._subscription = subscription;
+    this._observer = observer;
+    this._printedQuery = null;
+  }
+
+  /**
+   * @public
+   *
+   * Gets a string name used to refer to this request for printing debug output.
+   */
+  getDebugName(): string {
+    return this._subscription.getName();
+  }
+
+  /**
+   * @public
+   *
+   * Gets the variables used by the subscription. These variables should be
+   * serialized and sent in the GraphQL request.
+   */
+  getVariables(): Variables {
+    let printedQuery = this._printedQuery;
+    if (!printedQuery) {
+      printedQuery = printRelayQuery(this._subscription);
+      this._printedQuery = printedQuery;
+    }
+    return printedQuery.variables;
+  }
+
+  /**
+   * @public
+   *
+   * Gets a string representation of the GraphQL subscription.
+   */
+  getQueryString(): string {
+    let printedQuery = this._printedQuery;
+    if (!printedQuery) {
+      printedQuery = printRelayQuery(this._subscription);
+      this._printedQuery = printedQuery;
+    }
+    return printedQuery.text;
+  }
+
+  /**
+   * @public
+   *
+   * Called when new event data is received for the subscription.
+   */
+  onNext(result: SubscriptionResult): void {
+    this._observer.onNext(result);
+  }
+
+  /**
+   * @public
+   *
+   * Called when there is an error with the subscription.  Ends the
+   * subscription.
+   */
+  onError(err: any): void {
+    this._observer.onError(err);
+  }
+
+  /**
+   * @public
+   *
+   * Called when no more data will be provided to the subscriptions.  Ends
+   * the subscription.
+   */
+  onCompleted(): void {
+    this._observer.onCompleted();
+  }
+
+  /**
+   * @public
+   * @unstable
+   */
+  getSubscription(): RelayQuery.Subscription {
+    return this._subscription;
+  }
+
+}
+
+module.exports = RelaySubscriptionRequest;

--- a/src/network/__mocks__/RelaySubscriptionRequest.js
+++ b/src/network/__mocks__/RelaySubscriptionRequest.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = require.requireActual('RelaySubscriptionRequest');

--- a/src/network/__tests__/RelaySubscriptionRequest-test.js
+++ b/src/network/__tests__/RelaySubscriptionRequest-test.js
@@ -1,0 +1,396 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+const RelaySubscriptionRequest = require('RelaySubscriptionRequest');
+const RelayTestUtils = require('RelayTestUtils');
+
+describe('RelaySubscriptionRequest', () => {
+  var disposable;
+  var request;
+
+  beforeEach(() => {
+    jest.resetModuleRegistry();
+    jasmine.addMatchers(RelayTestUtils.matchers);
+
+    var subscription = {};
+    request = new RelaySubscriptionRequest(subscription);
+    disposable = {
+      dispose: jest.genMockFunction(),
+    };
+    request.setDisposable(disposable);
+  });
+
+  describe('subscribe', () => {
+    it('returns a subscription', () => {
+      const subscriber = {};
+
+      const subscription = request.subscribe(subscriber);
+      expect(typeof subscription.dispose).toBe('function');
+    });
+
+    it('throws if the request has been disposed', () => {
+      request.dispose();
+
+      const subscriber = {};
+
+      expect(() => {
+        request.subscribe(subscriber);
+      }).toFailInvariant('RelaySubscriptionRequest: Cannot subscribe to disposed subscription.');
+    });
+  });
+
+  describe('subscriptions', () => {
+    it('can only be diposed once', () => {
+      const subscriber = {};
+
+      const subscription = request.subscribe(subscriber);
+      subscription.dispose();
+      expect(() => {
+        subscription.dispose();
+      }).toFailInvariant('RelaySubscriptionRequest: Subscriptions may only be disposed once.');
+    });
+
+    it('disposes the request when the last subscription unsubscribes', () => {
+      const subscriberA = {};
+      const subscriberB = {};
+
+      const subscriptionA = request.subscribe(subscriberA);
+      const subscriptionB = request.subscribe(subscriberB);
+      subscriptionA.dispose();
+      expect(disposable.dispose).not.toBeCalled();
+      subscriptionB.dispose();
+      expect(disposable.dispose).toBeCalled();
+    });
+  });
+
+  describe('onNext', () => {
+    it('calls onNext of each subscriber', () => {
+      const subscriberA = {
+        onNext: jest.genMockFunction(),
+      };
+      const subscriberB = {
+        onNext: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriberA);
+      request.subscribe(subscriberB);
+
+      const data = {response: {}};
+      request.onNext(data);
+
+      expect(subscriberA.onNext).toBeCalledWith(data);
+      expect(subscriberB.onNext).toBeCalledWith(data);
+    });
+
+    it('handles a subscriber without an onNext', () => {
+      const subscriber = {};
+      request.subscribe(subscriber);
+
+      request.onNext({response: {}});
+    });
+
+    it('does not call onNext of a subscriber who has unsubscribed', () => {
+      const subscriberA = {
+        onNext: jest.genMockFunction(),
+      };
+      const subscriberB = {
+        onNext: jest.genMockFunction(),
+      };
+
+      const subscriptionA = request.subscribe(subscriberA);
+      request.subscribe(subscriberB);
+
+      const dataOne = {response: 1};
+      request.onNext(dataOne);
+
+      expect(subscriberA.onNext).toBeCalledWith(dataOne);
+      expect(subscriberB.onNext).toBeCalledWith(dataOne);
+
+      subscriptionA.dispose();
+
+      const dataTwo = {response: 2};
+      request.onNext(dataTwo);
+
+      expect(subscriberA.onNext).not.toBeCalledWith(dataTwo);
+      expect(subscriberB.onNext).toBeCalledWith(dataTwo);
+    });
+
+    it('does not call onNext of subscribers if the request has errored', () => {
+      const subscriber = {
+        onNext: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriber);
+      request.onError('error');
+
+      request.onNext({response: {}});
+
+      expect(subscriber.onNext).not.toBeCalled();
+    });
+
+    it('does not call onNext of subscribers if the request is completed', () => {
+      const subscriber = {
+        onNext: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriber);
+      request.onCompleted();
+
+      request.onNext({response: {}});
+
+      expect(subscriber.onNext).not.toBeCalled();
+    });
+
+    it('does not call onNext of subscribers if the request is disposed', () => {
+      const subscriber = {
+        onNext: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriber);
+      request.dispose();
+
+      request.onNext({response: {}});
+
+      expect(subscriber.onNext).not.toBeCalled();
+    });
+
+    it('disposes the request if onNext throws', () => {
+      const subscriber = {
+        onNext: (data) => { throw Error('subscriber error'); },
+      };
+
+      request.subscribe(subscriber);
+
+      const data = {response: {}};
+      expect(() => request.onNext(data)).toThrowError('subscriber error');
+
+      expect(disposable.dispose).toBeCalled();
+    });
+  });
+
+  describe('onError', () => {
+    it('calls onError of each subscriber', () => {
+      const subscriberA = {
+        onError: jest.genMockFunction(),
+      };
+      const subscriberB = {
+        onError: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriberA);
+      request.subscribe(subscriberB);
+
+      const error = 'an error';
+      request.onError(error);
+
+      expect(subscriberA.onError).toBeCalledWith(error);
+      expect(subscriberB.onError).toBeCalledWith(error);
+    });
+
+    it('handles a subscriber without an onError', () => {
+      const subscriber = {};
+      request.subscribe(subscriber);
+
+      request.onError('an error');
+    });
+
+    it('does not call onError of a subscriber who has unsubscribed', () => {
+      const subscriberA = {
+        onError: jest.genMockFunction(),
+      };
+      const subscriberB = {
+        onError: jest.genMockFunction(),
+      };
+
+      const subscriptionA = request.subscribe(subscriberA);
+      request.subscribe(subscriberB);
+
+      subscriptionA.dispose();
+
+      const error = 'error';
+      request.onError(error);
+
+      expect(subscriberA.onError).not.toBeCalledWith(error);
+      expect(subscriberB.onError).toBeCalledWith(error);
+    });
+
+    it('does not call onError of subscribers if the request has already errored', () => {
+      const subscriber = {
+        onError: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriber);
+      request.onError('error 1');
+      expect(subscriber.onError).toBeCalledWith('error 1');
+
+      request.onError('error 2');
+      expect(subscriber.onError).not.toBeCalledWith('error 2');
+    });
+
+    it('does not call onError of subscribers if the request is completed', () => {
+      const subscriber = {
+        onError: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriber);
+      request.onCompleted();
+
+      request.onError('error');
+
+      expect(subscriber.onError).not.toBeCalled();
+    });
+
+    it('does not call onError of subscribers if the request is disposed', () => {
+      const subscriber = {
+        onError: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriber);
+      request.dispose();
+
+      request.onError('error');
+
+      expect(subscriber.onError).not.toBeCalled();
+    });
+
+    it('disposes the request if onError throws', () => {
+      const subscriber = {
+        onError: (data) => { throw Error('subscriber error'); },
+      };
+
+      request.subscribe(subscriber);
+
+      expect(() => request.onError('error')).toThrowError('subscriber error');
+
+      expect(disposable.dispose).toBeCalled();
+    });
+  });
+
+  describe('onCompleted', () => {
+    it('calls onCompleted of each subscriber', () => {
+      const subscriberA = {
+        onCompleted: jest.genMockFunction(),
+      };
+      const subscriberB = {
+        onCompleted: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriberA);
+      request.subscribe(subscriberB);
+
+      request.onCompleted();
+
+      expect(subscriberA.onCompleted).toBeCalled();
+      expect(subscriberB.onCompleted).toBeCalled();
+    });
+
+    it('handles a subscriber without an onCompleted', () => {
+      const subscriber = {};
+      request.subscribe(subscriber);
+
+      request.onCompleted();
+    });
+
+    it('does not call onCompleted of a subscriber who has unsubscribed', () => {
+      const subscriberA = {
+        onCompleted: jest.genMockFunction(),
+      };
+      const subscriberB = {
+        onCompleted: jest.genMockFunction(),
+      };
+
+      const subscriptionA = request.subscribe(subscriberA);
+      request.subscribe(subscriberB);
+
+      subscriptionA.dispose();
+
+      request.onCompleted();
+
+      expect(subscriberA.onCompleted).not.toBeCalledWith();
+      expect(subscriberB.onCompleted).toBeCalledWith();
+    });
+
+    it('does not call onCompleted of subscribers if the request has already errored', () => {
+      const subscriber = {
+        onCompleted: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriber);
+      request.onError('error');
+
+      request.onCompleted();
+      expect(subscriber.onCompleted).not.toBeCalled();
+    });
+
+    it('does not call onCompleted of subscribers if the request is completed', () => {
+      const subscriber = {
+        onCompleted: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriber);
+      request.onCompleted();
+
+      request.onCompleted();
+
+      expect(subscriber.onCompleted.mock.calls.length).toBe(1);
+    });
+
+    it('does not call onCompleted of subscribers if the request is disposed', () => {
+      const subscriber = {
+        onCompleted: jest.genMockFunction(),
+      };
+
+      request.subscribe(subscriber);
+      request.dispose();
+
+      request.onCompleted();
+
+      expect(subscriber.onCompleted).not.toBeCalled();
+    });
+
+    it('disposes the request if onCompleted throws', () => {
+      const subscriber = {
+        onCompleted: () => { throw Error('subscriber error'); },
+      };
+
+      request.subscribe(subscriber);
+
+      expect(() => request.onCompleted()).toThrowError('subscriber error');
+
+      expect(disposable.dispose).toBeCalled();
+    });
+  });
+
+  describe('setDisposable', () => {
+    it('should call the disposable when the request is disposed', () => {
+      request.dispose();
+      expect(disposable.dispose).toBeCalled();
+    });
+
+    it('should call the disposable if the request is already disposed', () => {
+      request = new RelaySubscriptionRequest({});
+      request.dispose();
+
+      expect(disposable.dispose).not.toBeCalled();
+      request.setDisposable(disposable);
+      expect(disposable.dispose).toBeCalled();
+    });
+
+    it('throws when setting the disposable more than once', () => {
+      expect(() => {
+        request.setDisposable(disposable);
+      }).toFailInvariant('RelaySubscriptionRequest: attempting to set disposable more than once');
+    });
+  });
+
+});

--- a/src/tools/RelayTypes.js
+++ b/src/tools/RelayTypes.js
@@ -217,6 +217,9 @@ export type QueryResult = {
   ref_params?: ?{[name: string]: mixed};
   response: Object;
 };
+export type SubscriptionResult = {
+  response: Object;
+};
 
 // Utility
 export type Abortable = {

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -761,6 +761,70 @@ describe('printRelayOSSQuery', () => {
     });
   });
 
+  it('prints a subscription', () => {
+    const inputValue = {
+      clientSubscriptionId: '123',
+      feedbackId: '456',
+    };
+    const subscription = getNode(Relay.QL`
+      subscription {
+        commentCreateSubscribe(input:$input) {
+          clientSubscriptionId,
+          feedback {
+            id,
+            topLevelComments {
+              count,
+            },
+          },
+          feedbackCommentEdge {
+            cursor,
+            node {
+              id,
+              body {
+                text,
+              },
+            },
+            source {
+              id,
+            },
+          },
+        }
+      }
+    `, {input: inputValue});
+
+    const {text, variables} = printRelayOSSQuery(subscription);
+    expect(text).toEqualPrintedQuery(`
+      subscription PrintRelayOSSQuery(
+        $input_0: CommentCreateSubscribeInput
+      ) {
+        commentCreateSubscribe(input: $input_0) {
+          clientSubscriptionId,
+          feedback {
+            id,
+            topLevelComments {
+              count
+            }
+          },
+          feedbackCommentEdge {
+            cursor,
+            node {
+              id,
+              body {
+                text
+              }
+            },
+            source {
+              id
+            }
+          }
+        }
+      }
+    `);
+    expect(variables).toEqual({
+      input_0: inputValue,
+    });
+  });
+
   it('prints directives', () => {
     const params = {cond: true};
     const nestedFragment = Relay.QL`

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -775,6 +775,9 @@ describe('printRelayOSSQuery', () => {
             topLevelComments {
               count,
             },
+            profilePicture(preset: SMALL) {
+              uri
+            },
           },
           feedbackCommentEdge {
             cursor,
@@ -792,10 +795,12 @@ describe('printRelayOSSQuery', () => {
       }
     `, {input: inputValue});
 
+    const alias = generateRQLFieldAlias('profilePicture.preset(SMALL)');
     const {text, variables} = printRelayOSSQuery(subscription);
     expect(text).toEqualPrintedQuery(`
       subscription PrintRelayOSSQuery(
-        $input_0: CommentCreateSubscribeInput
+        $input_0: CommentCreateSubscribeInput,
+        $preset_1: PhotoSize
       ) {
         commentCreateSubscribe(input: $input_0) {
           clientSubscriptionId,
@@ -803,6 +808,9 @@ describe('printRelayOSSQuery', () => {
             id,
             topLevelComments {
               count
+            },
+            ${alias}: profilePicture(preset: $preset_1) {
+              uri
             }
           },
           feedbackCommentEdge {
@@ -822,6 +830,7 @@ describe('printRelayOSSQuery', () => {
     `);
     expect(variables).toEqual({
       input_0: inputValue,
+      preset_1: 'SMALL',
     });
   });
 

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1041,7 +1041,7 @@ describe('writePayload()', () => {
           node: {
             id: nextNodeID,
             body: {
-              text: messageText,
+              text: input.message.text,
             },
           },
           source: {
@@ -1219,7 +1219,7 @@ describe('writePayload()', () => {
       expect(store.getField(nextNodeID, 'id')).toBe(nextNodeID);
       expect(store.getType(nextNodeID)).toBe('Comment');
       expect(store.getLinkedRecordID(nextNodeID, 'body')).toBe(bodyID);
-      expect(store.getField(bodyID, 'text')).toBe(messageText);
+      expect(store.getField(bodyID, 'text')).toBe(input.message.text);
       expect(store.getRangeMetadata(
         connectionID,
         [{name: 'first', value: '2'}]
@@ -1232,8 +1232,8 @@ describe('writePayload()', () => {
     it('non-optimistically prepends comments for subscriptions', () => {
       // create the subscription and payload
       var input = {
-        feedbackId: feedbackID,
         [RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID]: '0',
+        feedbackId: feedbackID,
       };
 
       var subscription = getNode(Relay.QL`
@@ -1288,7 +1288,7 @@ describe('writePayload()', () => {
           node: {
             id: nextNodeID,
             body: {
-              text: input.message.text,
+              text: messageText,
             },
           },
           source: {
@@ -1302,6 +1302,7 @@ describe('writePayload()', () => {
       var queryTracker = new RelayQueryTracker();
       var writer = new RelayQueryWriter(
         store,
+        writer,
         queryTracker,
         changeTracker
       );
@@ -1334,7 +1335,7 @@ describe('writePayload()', () => {
       expect(store.getField(nextNodeID, 'id')).toBe(nextNodeID);
       expect(store.getType(nextNodeID)).toBe('Comment');
       expect(store.getLinkedRecordID(nextNodeID, 'body')).toBe(bodyID);
-      expect(store.getField(bodyID, 'text')).toBe(input.message.text);
+      expect(store.getField(bodyID, 'text')).toBe(messageText);
       expect(store.getRangeMetadata(
         connectionID,
         [{name: 'first', value: '2'}]

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1228,5 +1228,121 @@ describe('writePayload()', () => {
         edgeID,
       ]);
     });
+
+    it('non-optimistically prepends comments without a client mutation ID', () => {
+      // create the mutation and payload
+      var input = {
+        actor_id: 'actor:123',
+        feedback_id: feedbackID,
+        message: {
+          text: 'Hello!',
+          ranges: [],
+        },
+      };
+
+      var mutation = getNode(Relay.QL`
+        mutation {
+          commentCreate(input:$input) {
+            feedback {
+              id,
+              topLevelComments {
+                count,
+              },
+            },
+            feedbackCommentEdge {
+              cursor,
+              node {
+                id,
+                body {
+                  text,
+                },
+              },
+              source {
+                id,
+              },
+            },
+          }
+        }
+      `, {
+        input: JSON.stringify(input),
+      });
+      var configs = [{
+        type: RelayMutationType.RANGE_ADD,
+        connectionName: 'topLevelComments',
+        edgeName: 'feedbackCommentEdge',
+        rangeBehaviors: {'': GraphQLMutatorConstants.PREPEND},
+      }];
+
+      var nextCursor = 'comment789:cursor';
+      var nextNodeID = 'comment789';
+      var bodyID = 'client:2';
+      var nextEdgeID = generateClientEdgeID(connectionID, nextNodeID);
+      var payload = {
+        feedback: {
+          id: feedbackID,
+          topLevelComments: {
+            count: 2,
+          },
+        },
+        feedbackCommentEdge: {
+          cursor: nextCursor,
+          node: {
+            id: nextNodeID,
+            body: {
+              text: input.message.text,
+            },
+          },
+          source: {
+            id: feedbackID,
+          },
+        },
+      };
+
+      // write to base store
+      var changeTracker = new RelayChangeTracker();
+      var queryTracker = new RelayQueryTracker();
+      var writer = new RelayQueryWriter(
+        store,
+        queryTracker,
+        changeTracker
+      );
+
+      writeRelayUpdatePayload(
+        writer,
+        mutation,
+        payload,
+        {configs, isOptimisticUpdate: false}
+      );
+
+      expect(changeTracker.getChangeSet()).toEqual({
+        created: {
+          [nextNodeID]: true, // node added
+          [nextEdgeID]: true, // edge added
+          [bodyID]: true, // `body` subfield
+        },
+        updated: {
+          [connectionID]: true, // range item added & count changed
+        },
+      });
+
+      // base records are updated: edge/node added
+      expect(store.getField(connectionID, 'count')).toBe(2);
+      expect(store.getLinkedRecordID(nextEdgeID, 'source')).toBe(
+        feedbackID
+      );
+      expect(store.getField(nextEdgeID, 'cursor')).toBe(nextCursor);
+      expect(store.getLinkedRecordID(nextEdgeID, 'node')).toBe(nextNodeID);
+      expect(store.getField(nextNodeID, 'id')).toBe(nextNodeID);
+      expect(store.getType(nextNodeID)).toBe('Comment');
+      expect(store.getLinkedRecordID(nextNodeID, 'body')).toBe(bodyID);
+      expect(store.getField(bodyID, 'text')).toBe(input.message.text);
+      expect(store.getRangeMetadata(
+        connectionID,
+        [{name: 'first', value: '2'}]
+      ).filteredEdges.map(edge => edge.edgeID)).toEqual([
+        nextEdgeID,
+        edgeID,
+      ]);
+    });
   });
 });

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1238,7 +1238,7 @@ describe('writePayload()', () => {
 
       var subscription = getNode(Relay.QL`
         subscription {
-          commentCreate(input:$input) {
+          commentCreateSubscribe(input:$input) {
             feedback {
               id,
               topLevelComments {

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1236,7 +1236,7 @@ describe('writePayload()', () => {
         [RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID]: '0',
       };
 
-      var mutation = getNode(Relay.QL`
+      var subscription = getNode(Relay.QL`
         subscription {
           commentCreate(input:$input) {
             feedback {
@@ -1308,7 +1308,7 @@ describe('writePayload()', () => {
 
       writeRelayUpdatePayload(
         writer,
-        mutation,
+        subscription,
         payload,
         {configs, isOptimisticUpdate: false}
       );

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1300,7 +1300,7 @@ describe('writePayload()', () => {
       // write to base store
       var changeTracker = new RelayChangeTracker();
       var queryTracker = new RelayQueryTracker();
-      var writer = new RelayQueryWriter(
+      var queryWriter = new RelayQueryWriter(
         store,
         writer,
         queryTracker,
@@ -1308,7 +1308,7 @@ describe('writePayload()', () => {
       );
 
       writeRelayUpdatePayload(
-        writer,
+        queryWriter,
         subscription,
         payload,
         {configs, isOptimisticUpdate: false}

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -1041,7 +1041,7 @@ describe('writePayload()', () => {
           node: {
             id: nextNodeID,
             body: {
-              text: input.message.text,
+              text: messageText,
             },
           },
           source: {
@@ -1219,7 +1219,7 @@ describe('writePayload()', () => {
       expect(store.getField(nextNodeID, 'id')).toBe(nextNodeID);
       expect(store.getType(nextNodeID)).toBe('Comment');
       expect(store.getLinkedRecordID(nextNodeID, 'body')).toBe(bodyID);
-      expect(store.getField(bodyID, 'text')).toBe(input.message.text);
+      expect(store.getField(bodyID, 'text')).toBe(messageText);
       expect(store.getRangeMetadata(
         connectionID,
         [{name: 'first', value: '2'}]
@@ -1229,19 +1229,15 @@ describe('writePayload()', () => {
       ]);
     });
 
-    it('non-optimistically prepends comments without a client mutation ID', () => {
-      // create the mutation and payload
+    it('non-optimistically prepends comments for subscriptions', () => {
+      // create the subscription and payload
       var input = {
-        actor_id: 'actor:123',
-        feedback_id: feedbackID,
-        message: {
-          text: 'Hello!',
-          ranges: [],
-        },
+        feedbackId: feedbackID,
+        [RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID]: '0',
       };
 
       var mutation = getNode(Relay.QL`
-        mutation {
+        subscription {
           commentCreate(input:$input) {
             feedback {
               id,
@@ -1273,11 +1269,14 @@ describe('writePayload()', () => {
         rangeBehaviors: {'': GraphQLMutatorConstants.PREPEND},
       }];
 
+      var messageText = 'Hello!';
       var nextCursor = 'comment789:cursor';
       var nextNodeID = 'comment789';
       var bodyID = 'client:2';
       var nextEdgeID = generateClientEdgeID(connectionID, nextNodeID);
       var payload = {
+        [RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID]:
+          input[RelayConnectionInterface.CLIENT_SUBSCRIPTION_ID],
         feedback: {
           id: feedbackID,
           topLevelComments: {

--- a/src/traversal/printRelayOSSQuery.js
+++ b/src/traversal/printRelayOSSQuery.js
@@ -57,6 +57,8 @@ function printRelayOSSQuery(node: RelayQuery.Node): PrintedQuery {
     queryText = printRoot(node, printerState);
   } else if (node instanceof RelayQuery.Mutation) {
     queryText = printMutation(node, printerState);
+  } else if (node instanceof RelayQuery.Subscription) {
+    queryText = printSubscription(node, printerState);
   } else if (node instanceof RelayQuery.Fragment) {
     queryText = printFragment(node, printerState);
   }
@@ -114,6 +116,21 @@ function printMutation(
   node: RelayQuery.Mutation,
   printerState: PrinterState
 ): string {
+  return printOperation('mutation', node, printerState);
+}
+
+function printSubscription(
+  node: RelayQuery.Subscription,
+  printerState: PrinterState
+): string {
+  return printOperation('subscription', node, printerState);
+}
+
+function printOperation(
+  operationName: string,
+  node: RelayQuery.Operation,
+  printerState: PrinterState
+): string {
   const call = node.getCall();
   const inputString = printArgument(
     node.getCallVariableName(),
@@ -123,17 +140,18 @@ function printMutation(
   );
   invariant(
     inputString,
-    'printRelayOSSQuery(): Expected mutation `%s` to have a value for `%s`.',
+    'printRelayOSSQuery(): Expected %s `%s` to have a value for `%s`.',
+    operationName,
     node.getName(),
     node.getCallVariableName()
   );
   // Note: children must be traversed before printing variable definitions
   const children = printChildren(node, printerState);
-  const mutationString =
+  const operationString =
     node.getName() + printVariableDefinitions(printerState);
   const fieldName = call.name + '(' + inputString + ')';
 
-  return 'mutation ' + mutationString + '{' + fieldName + children + '}';
+  return operationName + ' ' + operationString + '{' + fieldName + children + '}';
 }
 
 function printVariableDefinitions({variableMap}: PrinterState): string {

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -390,9 +390,15 @@ function handleRangeAdd(
     ));
   }
 
-  const clientMutationID = getString(payload, CLIENT_MUTATION_ID);
-  // subscriptions won't have a clientMutationID so never optimistically add
-  if (clientMutationID) {
+  if (operation instanceof RelayQuery.Mutation) {
+    const clientMutationID = getString(payload, CLIENT_MUTATION_ID);
+    invariant(
+      clientMutationID,
+      'writeRelayUpdatePayload(): Expected operation `%s` to have a `%s`.',
+      operation.getName(),
+      CLIENT_MUTATION_ID
+    );
+
     if (isOptimisticUpdate) {
       // optimistic updates need to record the generated client ID for
       // a to-be-created node

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -334,13 +334,6 @@ function handleRangeAdd(
   config: OperationConfig,
   isOptimisticUpdate: boolean
 ): void {
-  const clientMutationID = getString(payload, CLIENT_MUTATION_ID);
-  invariant(
-    clientMutationID,
-    'writeRelayUpdatePayload(): Expected operation `%s` to have a `%s`.',
-    operation.getName(),
-    CLIENT_MUTATION_ID
-  );
   const store = writer.getRecordStore();
 
   // Extracts the new edge from the payload
@@ -397,25 +390,29 @@ function handleRangeAdd(
     ));
   }
 
-  if (isOptimisticUpdate) {
-    // optimistic updates need to record the generated client ID for
-    // a to-be-created node
-    RelayMutationTracker.putClientIDForMutation(
-      nodeID,
-      clientMutationID
-    );
-  } else {
-    // non-optimistic updates check for the existence of a generated client
-    // ID (from the above `if` clause) and link the client ID to the actual
-    // server ID.
-    const clientNodeID =
-      RelayMutationTracker.getClientIDForMutation(clientMutationID);
-    if (clientNodeID) {
-      RelayMutationTracker.updateClientServerIDMap(
-        clientNodeID,
-        nodeID
+  const clientMutationID = getString(payload, CLIENT_MUTATION_ID);
+  // subscriptions won't have a clientMutationID so never optimistically add
+  if (clientMutationID) {
+    if (isOptimisticUpdate) {
+      // optimistic updates need to record the generated client ID for
+      // a to-be-created node
+      RelayMutationTracker.putClientIDForMutation(
+        nodeID,
+        clientMutationID
       );
-      RelayMutationTracker.deleteClientIDForMutation(clientMutationID);
+    } else {
+      // non-optimistic updates check for the existence of a generated client
+      // ID (from the above `if` clause) and link the client ID to the actual
+      // server ID.
+      const clientNodeID =
+        RelayMutationTracker.getClientIDForMutation(clientMutationID);
+      if (clientNodeID) {
+        RelayMutationTracker.updateClientServerIDMap(
+          clientNodeID,
+          nodeID
+        );
+        RelayMutationTracker.deleteClientIDForMutation(clientMutationID);
+      }
     }
   }
 }


### PR DESCRIPTION
This adds support to the network layer for subscriptions.  And by support I mean properly throwing errors -- so not much really!

This builds off of https://github.com/facebook/relay/pull/736 purely for having schema support for subscriptions during tests.  It doesn't depend on the code change to `writeRelayUpdatePayload`.  So really the only diff should be the last commit: https://github.com/facebook/relay/commit/690da4d9e14bfb9a18ed5ebbe153aaccb786708d

I'm going to try adding some sweet, sweet github code comments for areas I have questions with!