### PR TITLE
Small fix for Flow v0.21.0

### DIFF
--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -43,7 +43,7 @@ type PrinterOptions = {
 
 module.exports = function(t: any, options: PrinterOptions): Function {
   const formatFields = options.snakeCase ?
-    fields => {
+    function<T: Object>(fields: T): {[keys: $Keys<T>]: string} {
       const formatted = {};
       Object.keys(fields).forEach(name => {
         formatted[name] =
@@ -51,7 +51,7 @@ module.exports = function(t: any, options: PrinterOptions): Function {
       });
       return formatted;
     } :
-    fields => fields;
+    function<T>(fields: T): T { return fields };
 
   const FIELDS = formatFields({
     __typename: '__typename',
@@ -320,9 +320,9 @@ module.exports = function(t: any, options: PrinterOptions): Function {
         });
       }
       const printedFields = this.printFields(
-        fields, 
-        parent, 
-        requisiteFields, 
+        fields,
+        parent,
+        requisiteFields,
         isGeneratedQuery
       );
       const selections = [...printedFields, ...printedFragments];
@@ -353,10 +353,10 @@ module.exports = function(t: any, options: PrinterOptions): Function {
         delete generatedFields[field.getName()];
         printedFields.push(
           this.printField(
-            field, 
-            parent, 
-            requisiteFields, 
-            generatedFields, 
+            field,
+            parent,
+            requisiteFields,
+            generatedFields,
             isGeneratedQuery
           )
         );


### PR DESCRIPTION
Flow doesn't infer generics yet, so we need to annotate these
functions in order for Flow to understand what's going on.

Without this change, Flow didn't understand the type of `FIELDS`

Test Plan: Ran Flow v0.21.0 and v0.20.1