### PR TITLE
Account for duplicate variables in printRelayQuery

### DIFF
--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -195,21 +195,20 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query FooQuery {
           defaultSettings {
-            web: notifications(environment: WEB),
+            web: notifications(environment: WEB)
             foo: notifications(environment: $env)
           }
         }
       `, {
         env: enumValue,
       });
-      const alias1 = query.getChildren()[0].getSerializationKey();
-      const alias2 = query.getChildren()[1].getSerializationKey();
+      const alias = generateRQLFieldAlias('notifications.environment(WEB)');
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
         query FooQuery($environment_0:Environment) {
           defaultSettings {
-            ${alias1}: notifications(environment:$environment_0),
-            ${alias2}: notifications(environment:$environment_0)
+            ${alias}: notifications(environment:$environment_0),
+            ${alias}: notifications(environment:$environment_0)
           }
         }
       `);

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -190,6 +190,34 @@ describe('printRelayOSSQuery', () => {
       });
     });
 
+    it('dedupes arguments', () => {
+      const enumValue = 'WEB';
+      const query = getNode(Relay.QL`
+        query FooQuery {
+          defaultSettings {
+            web: notifications(environment: WEB),
+            foo: notifications(environment: $env)
+          }
+        }
+      `, {
+        env: enumValue,
+      });
+      const alias1 = query.getChildren()[0].getSerializationKey();
+      const alias2 = query.getChildren()[1].getSerializationKey();
+      const {text, variables} = printRelayOSSQuery(query);
+      expect(text).toEqualPrintedQuery(`
+        query FooQuery($environment_0:Environment) {
+          defaultSettings {
+            ${alias1}: notifications(environment:$environment_0),
+            ${alias2}: notifications(environment:$environment_0)
+          }
+        }
+      `);
+      expect(variables).toEqual({
+        environment_0: enumValue,
+      });
+    });
+
     it('throws for ref queries', () => {
       const query = RelayQuery.Root.build(
         'RefQueryName',

--- a/src/traversal/printRelayOSSQuery.js
+++ b/src/traversal/printRelayOSSQuery.js
@@ -62,9 +62,13 @@ function printRelayOSSQuery(node: RelayQuery.Node): PrintedQuery {
     queryText,
     'printRelayOSSQuery(): Unsupported node type.'
   );
+  const variables = {};
+  for (const [key, value] of variableMap) {
+    variables[value.variableID] = key;
+  }
   return {
     text: [queryText, ...fragmentTexts].join(' '),
-    variables: variableMap.keys(),
+    variables,
   };
 }
 

--- a/src/traversal/printRelayOSSQuery.js
+++ b/src/traversal/printRelayOSSQuery.js
@@ -301,6 +301,14 @@ function createVariable(
   type: string,
   printerState: PrinterState
 ): string {
+  const existingIds = Object.keys(printerState.variableMap);
+  for (let i = 0; i < existingIds.length; i++) {
+    const existingId = existingIds[i];
+    const existingVariable = printerState.variableMap[existingId];
+    if (existingVariable.type === type && Object.is(existingVariable.value, value)) {
+      return existingId;
+    }
+  }
   const variableID = name + '_' + base62(printerState.variableCount++);
   printerState.variableMap[variableID] = {
     type,

--- a/src/traversal/printRelayOSSQuery.js
+++ b/src/traversal/printRelayOSSQuery.js
@@ -300,9 +300,9 @@ function createVariable(
   type: string,
   printerState: PrinterState
 ): string {
-  const {variableMap} = printerState;
-  if (variableMap.has(value)) {
-    return variableMap.get(value).variableID;
+  const existingVariable = printerState.variableMap.get(value);
+  if (existingVariable) {
+    return existingVariable.variableID;
   } else {
     const variableID = name + '_' + base62(printerState.variableCount++);
     printerState.variableMap.set(value, {


### PR DESCRIPTION
This pull request relates to #784. I've adjusted the `createVariable` function, within `src\traversal\printRelayOSSQuery.js`, so that it first checks the existing variables before creating a new variable. This is to assist Relay when printing queries that contain overlapping arguments. (If the variable type and value is the same, do we need to continue creating variables with the same type and value? This PR adds the logic that answers that with a *no*.)

Without knowing what existing code is at my disposal within all of the FB libraries, I went ahead and just use a simple for loop over the existing keys, since the return state needs the key anyway.

I also created a test case that, prior to adjusting `createVariable`, failed. After adjusting `createVariable` the test passes, and no other existing tests seem to fail. Yay?