### PR TITLE
Drop an unnecessary line from .flowconfig

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -6,7 +6,6 @@
 
 [include]
 ../node_modules/fbjs/lib
-../node_modules/fbjs/node_modules/promise
 ../node_modules/react
 ../node_modules/react-static-container/lib
 


### PR DESCRIPTION
Noticed this diagnostic message when running `npm run typecheck`:

    node_modules/fbjs/node_modules/promise No such file or directory

The directory didn't exist because I had previously used NPM 3, which
flattens the node_modules directory, and stores the "promise" module at
"node_modules/promise".

So, the line had no effect -- we still typecheck with zero errors
without this line, and if I introduce an error I see it reported
correctly -- which means that Flow has probably gotten smart enough
about promises to not need this special case any more.