### PR TITLE
Add babel package to babel-relay-plugin

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -20,6 +20,7 @@
     "lib/"
   ],
   "devDependencies": {
+    "babel": "^5.8.35",
     "babel-core": "^5.8.35",
     "babel-jest": "^5.3.0",
     "flow-bin": "0.21.0",


### PR DESCRIPTION
It will make `update-schema` and `update-fixtures` work. Currently they produce error on lacking `babel-node`. Also there is version contention in babel-relay-plugin and relay for these packages: 5.8.35 against 5.8.25 respectively.

https://github.com/facebook/relay/blob/master/scripts/babel-relay-plugin/package.json#L23
https://github.com/facebook/relay/blob/master/package.json#L41
