### PR TITLE
Update Relay to jest 0.9.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-flatten": "^0.1.0",
     "gulp-header": "^1.2.2",
     "gulp-util": "^3.0.6",
-    "jest-cli": "^0.8.1",
+    "jest-cli": "^0.9.0-fb1",
     "object-assign": "^3.0.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
@@ -80,6 +80,7 @@
     ],
     "testPathDirs": [
       "<rootDir>/node_modules/fbjs/lib/",
+      "<rootDir>/node_modules/fbjs-scripts/jest",
       "<rootDir>/node_modules/react/lib/",
       "<rootDir>/node_modules/react-static-container/lib/",
       "<rootDir>/src/"

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -24,7 +24,7 @@
     "babel-jest": "^5.3.0",
     "flow-bin": "0.21.0",
     "glob": "^5.0.15",
-    "jest-cli": "^0.8.2",
+    "jest-cli": "0.9.0-fb1",
     "minimist": "^1.1.3",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.1"


### PR DESCRIPTION
The babel-relay-plugin is failing right now but it seems unrelated to the Jest update.