### PR TITLE
[WIP] Fix query constructions from paths in OSS (thin interfaces)

### DIFF
--- a/src/query/__tests__/RelayQueryPath-test.js
+++ b/src/query/__tests__/RelayQueryPath-test.js
@@ -15,13 +15,17 @@ require('configureForRelayOSS');
 
 const Relay = require('Relay');
 const RelayQueryPath = require('RelayQueryPath');
+const RelayRecordStore = require('RelayRecordStore');
 const RelayTestUtils = require('RelayTestUtils');
 
 describe('RelayQueryPath', () => {
   var {getNode} = RelayTestUtils;
+  let store;
 
   beforeEach(() => {
     jest.resetModuleRegistry();
+
+    store = new RelayRecordStore({record: {}});
 
     jasmine.addMatchers(RelayTestUtils.matchers);
   });
@@ -43,7 +47,7 @@ describe('RelayQueryPath', () => {
     var path = new RelayQueryPath(query);
     expect(path.getName()).toBe(query.getName());
 
-    var pathQuery = path.getQuery(getNode(fragment));
+    var pathQuery = path.getQuery(store, getNode(fragment));
     expect(pathQuery).toEqualQueryRoot(getNode(Relay.QL`
       query {
         node(id:"123") {
@@ -69,7 +73,8 @@ describe('RelayQueryPath', () => {
       }
     `;
     var path = new RelayQueryPath(query);
-    expect(path.getQuery(getNode(fragment))).toEqualQueryRoot(getNode(Relay.QL`
+    var pathQuery = path.getQuery(store, getNode(fragment));
+    expect(pathQuery).toEqualQueryRoot(getNode(Relay.QL`
       query {
         me {
           id
@@ -98,7 +103,8 @@ describe('RelayQueryPath', () => {
       }
     `;
     var path = new RelayQueryPath(query);
-    expect(path.getQuery(getNode(fragment))).toEqualQueryRoot(getNode(Relay.QL`
+    var pathQuery = path.getQuery(store, getNode(fragment));
+    expect(pathQuery).toEqualQueryRoot(getNode(Relay.QL`
       query {
         viewer {
           ${fragment}
@@ -132,7 +138,7 @@ describe('RelayQueryPath', () => {
     // address is not refetchable, has client ID
     var root = new RelayQueryPath(query);
     var path = root.getPath(address, 'client:1');
-    var pathQuery = path.getQuery(city);
+    var pathQuery = path.getQuery(store, city);
     expect(pathQuery).toEqualQueryRoot(getNode(Relay.QL`
       query {
         node(id:"123") {
@@ -169,7 +175,8 @@ describe('RelayQueryPath', () => {
     // actor has an ID and is refetchable
     var root = new RelayQueryPath(query);
     var path = root.getPath(actor, '123');
-    expect(path.getQuery(getNode(fragment))).toEqualQueryRoot(getNode(Relay.QL`
+    var pathQuery = path.getQuery(store, getNode(fragment));
+    expect(pathQuery).toEqualQueryRoot(getNode(Relay.QL`
       query {
         node(id:"123") {
           id

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -398,7 +398,7 @@ class RelayStoreData {
         'record `%s` without a path.',
         dataID
       );
-      return path.getQuery(fragment);
+      return path.getQuery(this._cachedStore, fragment);
     }
     // Fragment fields cannot be spread directly into the root because they
     // may not exist on the `Node` type.

--- a/src/store/__tests__/RelayStoreData-test.js
+++ b/src/store/__tests__/RelayStoreData-test.js
@@ -358,19 +358,21 @@ describe('RelayStoreData', () => {
         }
       `);
       var query = storeData.buildFragmentQueryForDataID(fragment, 'client:1');
-      expect(query).toEqualQueryRoot(getNode(Relay.QL`
-        query {
-          node(id: "123") {
-            id,
-            __typename,
-            address {
-              ... on StreetAddress {
-                city,
+      expect(query).toEqualQueryRoot(getVerbatimNode(Relay.QL`
+        query RelayStoreData($id_0: ID!) {
+          node(id: $id_0) {
+            ... on User {
+              id,
+              __typename,
+              address {
+                ... on StreetAddress {
+                  city,
+                },
               },
-            },
+            }
           },
         }
-      `));
+      `, {id_0: '123'}));
       expect(query.getName()).toBe(node.getName());
       expect(query.isAbstract()).toBe(true);
     });

--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -469,8 +469,14 @@ var RelayTestUtils = {
             RelayMetaRoute.get('$RelayTestUtils'),
             {}
           );
-          var actualQuery = actual.getQuery(fragment);
-          var expectedQuery = expected.getQuery(fragment);
+          const mockStore = {
+            getType() {
+              return 'RelayTestUtils';
+            },
+          };
+
+          var actualQuery = actual.getQuery(mockStore, fragment);
+          var expectedQuery = expected.getQuery(mockStore, fragment);
 
           if (!actualQuery.equals(expectedQuery)) {
             return {

--- a/src/traversal/diffRelayQuery.js
+++ b/src/traversal/diffRelayQuery.js
@@ -674,7 +674,9 @@ class RelayDiffQueryBuilder {
               hasSplitQueries = true;
               // current path has `parent`, `connection`, `edges`; pop to parent
               var connectionParent = path.getParent().getParent();
-              this.splitQuery(connectionParent.getQuery(connectionFind));
+              var connectionQuery =
+                connectionParent.getQuery(this._store, connectionFind);
+              this.splitQuery(connectionQuery);
             }
           } else {
             warning(


### PR DESCRIPTION
Fix for #861. Copying my description there:

In this case, what's happening is that you're fetching some record:

```
query {
  viewer { # concrete type, id '123'
    # ... fields
    session { # concrete type, no id
      # ... fields
     }
  }
}
```

Because everything is a concrete type it's okay to query fields directly w/o conditioning on type (i.e. you don't need to do `viewer { ... on SomeType { session } }`). However when Relay tries to refetch `session`, it doesn't have an id, so it looks up the "path" to session from the nearest node that does have an id, in this case the `viewer` record. It constructs a query:

```
node(id: "123") { ... }
```

And fills in everything that was on the path from node 123 down to session:

```
node(id: "123") {
  session {
    # ...
  }
}
```

But this is invalid: while in the original query `session` was a direct field of a concrete type (so no need to condition), now it's a direct field on a different type, `Node`, which doesn't have a `session` field. Relay should use its knowledge of the type of record 123 to construct the conditioning fragment and generate the correct:


```
node(id: "123") {
  ... on Viewer {
    session {
      # ...
    }
  }
}
```