### PR TITLE
Print variable definitions as non-nullable

### DIFF
--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -187,8 +187,8 @@ describe('printRelayOSSQuery', () => {
       });
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query FooQuery($environment_0:Environment) {
-          settings(environment:$environment_0) {
+        query FooQuery($environment_0: Environment!) {
+          settings(environment: $environment_0) {
             notificationSounds
           }
         }
@@ -212,8 +212,8 @@ describe('printRelayOSSQuery', () => {
 
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query PrintRelayOSSQuery($query_0:CheckinSearchInput) {
-          checkinSearchQuery(query:$query_0) {
+        query PrintRelayOSSQuery($query_0: CheckinSearchInput!) {
+          checkinSearchQuery(query: $query_0) {
             query
           }
         }
@@ -238,10 +238,10 @@ describe('printRelayOSSQuery', () => {
       const alias = generateRQLFieldAlias('notifications.environment(WEB)');
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query FooQuery($environment_0:Environment) {
+        query FooQuery($environment_0: Environment!) {
           defaultSettings {
-            ${alias}: notifications(environment:$environment_0),
-            ${alias}: notifications(environment:$environment_0)
+            ${alias}: notifications(environment: $environment_0),
+            ${alias}: notifications(environment: $environment_0)
           }
         }
       `);
@@ -273,7 +273,7 @@ describe('printRelayOSSQuery', () => {
       const alias = generateRQLFieldAlias('storySearch.query({"query":"foo"})');
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query FooQuery($query_0: StorySearchInput) {
+        query FooQuery($query_0: StorySearchInput!) {
           node(id: "123") {
             id,
             __typename,
@@ -697,13 +697,13 @@ describe('printRelayOSSQuery', () => {
       const alias = generateRQLFieldAlias('notifications.environment(WEB)');
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query PrintRelayOSSQuery($environment_0:Environment) {
+        query PrintRelayOSSQuery($environment_0: Environment!) {
           defaultSettings {
             ...F0
           }
         }
         fragment F0 on Settings {
-          ${alias}:notifications(environment:$environment_0)
+          ${alias}:notifications(environment: $environment_0)
         }
       `);
       expect(variables).toEqual({
@@ -748,7 +748,7 @@ describe('printRelayOSSQuery', () => {
     };
     const mutation = getNode(Relay.QL`
       mutation {
-        feedbackLike(input:$input) {
+        feedbackLike(input: $input) {
           clientMutationId,
           feedback {
             id,
@@ -768,8 +768,8 @@ describe('printRelayOSSQuery', () => {
     const {text, variables} = printRelayOSSQuery(mutation);
     expect(text).toEqualPrintedQuery(`
       mutation PrintRelayOSSQuery(
-        $input_0: FeedbackLikeInput,
-        $preset_1: PhotoSize
+        $input_0: FeedbackLikeInput!,
+        $preset_1: PhotoSize!
       ) {
         feedbackLike(input: $input_0) {
           clientMutationId,


### PR DESCRIPTION
Fix for #855. https://github.com/facebook/relay/commit/bf7ba6a31f9cc937141c73e55f6a37e46bcc85ce fixed #784 by only printing one variable for each unique variable value (which means that we don't use different variable names for the same serialization key/alias). However, that means that depending on the type of the argument first used to create a variable, the variable's type may be non-null. The fix here is to always print variable definitions using non-nullable types, which is safe since we know a value will be supplied. Note that variables aren't printed if the value is null.