### PR TITLE
RelayContainer: pass empty arrays through for plural fragments

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -573,6 +573,11 @@ function createContainerComponent(
             fragmentName,
             componentName
           );
+          if (!propValue.length) {
+            // Nothing to observe: pass the empty array through
+            fragmentPointers[fragmentName] = null;
+            return;
+          }
           let dataIDs = null;
           propValue.forEach((item, ii) => {
             if (typeof item === 'object' && item != null) {

--- a/src/container/__tests__/RelayContainer-test.js
+++ b/src/container/__tests__/RelayContainer-test.js
@@ -726,6 +726,17 @@ describe('RelayContainer', function() {
     );
   });
 
+  it('passes through empty arrays for plural fragments', () => {
+    RelayTestRenderer.render(
+      () => <MockContainer bar={[]} />,
+      relayContext,
+      mockRoute
+    );
+    expect(MockContainer.mock.render.mock.calls.length).toBe(1);
+    expect(MockContainer.mock.render.mock.calls[0].props.bar).toEqual([]);
+    expect(relayContext.getFragmentResolver).not.toBeCalled();
+  });
+
   it('does not re-render if props resolve to the same object', () => {
     var mockData = {__dataID__: '42', id: '42', name: 'Tim'};
 


### PR DESCRIPTION
Fixes an issue where passing an empty array as a prop corresponding to a plural fragment would warn about mock data. The empty array is now passed through to the component as-is.