### PR TITLE
Don't extend Object in todo example

### DIFF
--- a/examples/todo/data/database.js
+++ b/examples/todo/data/database.js
@@ -10,8 +10,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-export class Todo extends Object {}
-export class User extends Object {}
+export class Todo {}
+export class User {}
 
 // Mock authenticated ID
 const VIEWER_ID = 'me';


### PR DESCRIPTION
Extending object currently breaks `instanceof` checks which breaks the check in
the GraphQL `node` implementation of the `todo` example. This just removes
`Object` as the superclass.

Fixes #873

Test Plan:
1. Run the todo example
2. Go to http://localhost:3000/#/active
3. Mark all todos as done
4. Reload (still on `/active`), notice it correctly displays no more active todos
5. Switch to the completed tab and notice it displays the completed todos
   (before this diff, it wouldn't dislpay anything.