### PR TITLE
Update Jest to work with npm3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-flatten": "^0.1.0",
     "gulp-header": "^1.2.2",
     "gulp-util": "^3.0.6",
-    "jest-cli": "^0.9.0-fb1",
+    "jest-cli": "^0.9.0-fb3",
     "object-assign": "^3.0.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -27,7 +27,7 @@
     "eslint": "^1.3.1",
     "flow-bin": "0.21.0",
     "glob": "^5.0.15",
-    "jest-cli": "0.9.0-fb1",
+    "jest-cli": "0.9.0-fb3",
     "minimist": "^1.1.3",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.1"

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -63,13 +63,6 @@ module.exports = {
   getCacheKey: createCacheKeyFunction([
     __filename,
     SCHEMA_PATH,
-    path.join(
-      __dirname,
-      '..',
-      '..',
-      'node_modules',
-      'babel-relay-plugin',
-      'package.json'
-    ),
+    path.join(__dirname, '..', 'babel-relay-plugin', 'package.json'),
   ]),
 };


### PR DESCRIPTION
0.9.0-fb3 comes with all those sweet npm3 fixes. Also see #840 and #832.

Tests are passing for me on node4 both with npm2 and npm3.

See https://github.com/facebook/jest/commit/7b44ca0ab0270fe453a3c84cb1799fcac20993e9 and https://github.com/facebook/jest/commit/2d10421baf79081ce698791023360144fb595a27

cc @jkassens @raineroviir
