### PR TITLE
Fix most warnings in jest tests

### DIFF
--- a/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
@@ -320,12 +320,14 @@ describe('GraphQLStoreQueryResolver', () => {
       const payload = {
         viewer: {
           actor: {
+            __typename: 'User',
             id: '123',
           },
           newsFeed: {
             edges: [
               {
                 node: {
+                  __typename: 'Story',
                   id: '456',
                 },
               },

--- a/src/store/__tests__/RelayStoreData_cacheManager-test.js
+++ b/src/store/__tests__/RelayStoreData_cacheManager-test.js
@@ -110,18 +110,24 @@ describe('RelayStoreData', function() {
 
   it('caches node metadata', () => {
     var query = getNode(Relay.QL`query{node(id:"123"){id}}`);
-    var response = {node: {id: '123'}};
+    var response = {
+      node: {
+        __typename: 'User',
+        id: '123',
+      },
+    };
     storeData.handleQueryPayload(query, response);
     var {queryWriter} = cacheManager.mocks;
 
     expect(queryWriter).toContainCalledMethods({
       writeNode: 0,
-      writeField: 2,
+      writeField: 3,
       writeRootCall: 0,
     });
     expect(queryWriter.writeField).toBeCalledWithNodeFields({
       '123': {
         __dataID__: '123',
+        __typename: 'User',
         id: '123',
       },
     });
@@ -129,13 +135,18 @@ describe('RelayStoreData', function() {
 
   it('caches custom root calls', () => {
     var query = getNode(Relay.QL`query{username(name:"yuzhi"){id}}`);
-    var response = {username: {id: '123'}};
+    var response = {
+      username: {
+        __typename: 'User',
+        id: '123'
+      }
+    };
     storeData.handleQueryPayload(query, response);
     var {queryWriter} = cacheManager.mocks;
 
     expect(queryWriter).toContainCalledMethods({
       writeNode: 0,
-      writeField: 2,
+      writeField: 3,
       writeRootCall: 1,
     });
     expect(queryWriter.writeRootCall).toBeCalledWith(
@@ -146,6 +157,7 @@ describe('RelayStoreData', function() {
     expect(queryWriter.writeField).toBeCalledWithNodeFields({
       '123': {
         __dataID__: '123',
+        __typename: 'User',
         id: '123',
       },
     });
@@ -153,7 +165,12 @@ describe('RelayStoreData', function() {
 
   it('caches nodes with client IDs', () => {
     var query = getNode(Relay.QL`query{viewer{isFbEmployee}}`);
-    var response = {viewer: {isFbEmployee: true}};
+    var response = {
+      viewer: {
+        __typename: 'User',
+        isFbEmployee: true,
+      },
+    };
     storeData.handleQueryPayload(query, response);
     var {queryWriter} = cacheManager.mocks;
 
@@ -184,8 +201,10 @@ describe('RelayStoreData', function() {
     `);
     var response = {
       node: {
+        __typename: 'User',
         id: '123',
         hometown: {
+          __typename: 'Page',
           id: '456',
           url: 'http://...',
         },
@@ -196,7 +215,7 @@ describe('RelayStoreData', function() {
 
     expect(queryWriter).toContainCalledMethods({
       writeNode: 0,
-      writeField: 6,
+      writeField: 7,
       writeRootCall: 0,
     });
     expect(queryWriter.writeField).toBeCalledWithNodeFields({
@@ -226,6 +245,7 @@ describe('RelayStoreData', function() {
     `);
     var response = {
       node: {
+        __typename: 'User',
         id: '123',
         screennames: [
           {service: 'GTALK'},
@@ -239,12 +259,13 @@ describe('RelayStoreData', function() {
     expect(getPathToRecord('client:1')).toEqual(getPathToRecord('client:2'));
     expect(queryWriter).toContainCalledMethods({
       writeNode: 0,
-      writeField: 7,
+      writeField: 8,
       writeRootCall: 0,
     });
     expect(queryWriter.writeField).toBeCalledWithNodeFields({
       '123': {
         __dataID__: '123',
+        __typename: 'User',
         id: '123',
         screennames: [
           {__dataID__: 'client:1'},
@@ -284,17 +305,20 @@ describe('RelayStoreData', function() {
     `);
     var response = transformRelayQueryPayload(query, {
       node: {
+        __typename: 'User',
         id: '123',
         friends: {
           edges: [
             {
               node: {
+                __typename: 'User',
                 id: '1',
               },
               cursor: '1',
             },
             {
               node: {
+                __typename: 'User',
                 id: '2',
               },
               cursor: '2',
@@ -312,7 +336,7 @@ describe('RelayStoreData', function() {
 
     expect(queryWriter).toContainCalledMethods({
       writeNode: 0,
-      writeField: 18,
+      writeField: 19,
       writeRootCall: 0,
     });
     expect(queryWriter.writeField).toBeCalledWithNodeFields({
@@ -370,6 +394,7 @@ describe('RelayStoreData', function() {
     `);
     var response = transformRelayQueryPayload(query, {
       node: {
+        __typename: 'User',
         id: '123',
         friends: {
           edges: [],
@@ -385,7 +410,7 @@ describe('RelayStoreData', function() {
 
     expect(queryWriter).toContainCalledMethods({
       writeNode: 0,
-      writeField: 8,
+      writeField: 9,
       writeRootCall: 0,
     });
     expect(queryWriter.writeField).toBeCalledWithNodeFields({
@@ -405,7 +430,13 @@ describe('RelayStoreData', function() {
 
   it('caches simple mutations', () => {
     var query = getNode(Relay.QL`query{node(id:"123"){id,doesViewerLike}}`);
-    var response = {node: {id: '123', doesViewerLike: false}};
+    var response = {
+      node: {
+        __typename: 'User',
+        id: '123',
+        doesViewerLike: false,
+      }
+    };
     storeData.handleQueryPayload(query, response);
     var {mutationWriter} = cacheManager.mocks;
 
@@ -468,6 +499,7 @@ describe('RelayStoreData', function() {
     `);
     var response = transformRelayQueryPayload(query, {
       node: {
+        __typename: 'Story',
         id: '123',
         comments: {
           count: 2,
@@ -484,7 +516,6 @@ describe('RelayStoreData', function() {
             [HAS_NEXT_PAGE]: true,
           },
         },
-        __typename: 'Story',
       },
     });
     storeData.handleQueryPayload(query, response);
@@ -528,6 +559,7 @@ describe('RelayStoreData', function() {
         id: '123',
       },
       feedbackCommentEdge: {
+        __typename: 'User',
         node: {
           id: '2',
         },
@@ -589,6 +621,7 @@ describe('RelayStoreData', function() {
     `);
     var response = transformRelayQueryPayload(query, {
       node: {
+        __typename: 'Story',
         id: '123',
         comments: {
           count: 2,
@@ -605,7 +638,6 @@ describe('RelayStoreData', function() {
             [HAS_NEXT_PAGE]: true,
           },
         },
-        __typename: 'Story',
       },
     });
     storeData.handleQueryPayload(query, response);

--- a/src/traversal/__tests__/diffRelayQuery-test.js
+++ b/src/traversal/__tests__/diffRelayQuery-test.js
@@ -1753,6 +1753,7 @@ describe('diffRelayQuery', () => {
     var records = {
       '4': {
         __dataID__: '4',
+        __typename: 'User',
         id: '4',
         name: 'Mark Zuckerberg',
         friends: {__dataID__: 'client:1'},
@@ -1800,18 +1801,20 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         nodes(ids:"4") {
-          id,
-          __typename,
-          friends(find:"4808495") {
-            edges {
-              cursor,
-              node {
-                id,
-                __typename, # not strictly required here
-              },
-              source {
-                id,
-                firstName
+          ... on User {
+            id,
+            __typename,
+            friends(find:"4808495") {
+              edges {
+                cursor,
+                node {
+                  id,
+                  __typename, # not strictly required here
+                },
+                source {
+                  id,
+                  firstName
+                }
               }
             }
           }

--- a/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
@@ -195,6 +195,7 @@ describe('writePayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           allPhones: [phone],
         },
@@ -240,6 +241,7 @@ describe('writePayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           friends: {
             edges: [
@@ -446,6 +448,7 @@ describe('writePayload()', () => {
       };
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           allPhones: [phone],
         },
@@ -489,6 +492,7 @@ describe('writePayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           friends: {
             edges: [
@@ -549,6 +553,7 @@ describe('writePayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           friends: {
             edges: [

--- a/src/traversal/__tests__/writeRelayQueryPayload_pluralLinkedField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_pluralLinkedField-test.js
@@ -57,6 +57,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           allPhones: [],
         },
@@ -103,6 +104,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           allPhones: [phone],
         },
@@ -142,6 +144,7 @@ describe('writeRelayQueryPayload()', () => {
       var records = {
         '123': {
           __dataID__: '123',
+          __typename: 'User',
           id: '123',
           allPhones: [
             {__dataID__: 'client:1'},
@@ -183,6 +186,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           allPhones: [newPhone],
         },
@@ -213,6 +217,7 @@ describe('writeRelayQueryPayload()', () => {
       var records = {
         '123': {
           __dataID__: '123',
+          __typename: 'User',
           id: '123',
           allPhones: [
             {__dataID__: 'client:1'},
@@ -246,6 +251,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           allPhones: [{
             displayNumber: '1-800-555-1212',
@@ -275,6 +281,7 @@ describe('writeRelayQueryPayload()', () => {
       var records = {
         '123': {
           __dataID__: '123',
+          __typename: 'User',
           id: '123',
           allPhones: [
             {__dataID__: 'client:1'},
@@ -309,6 +316,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           allPhones: [phone],
         },
@@ -336,6 +344,7 @@ describe('writeRelayQueryPayload()', () => {
       var records = {
         '123': {
           __dataID__: '123',
+          __typename: 'User',
           id: '123',
           allPhones: [],
         },
@@ -356,6 +365,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           allPhones: [],
         },
@@ -377,8 +387,8 @@ describe('writeRelayQueryPayload()', () => {
         query {
           node(id: "1") {
             actors {
-              id,
               __typename
+              id
             }
           }
         }
@@ -387,8 +397,8 @@ describe('writeRelayQueryPayload()', () => {
         node: {
           id: '1',
           actors: [{
-            id: '123',
             __typename: 'User',
+            id: '123',
           }],
           __typename: 'Story',
         },

--- a/src/traversal/__tests__/writeRelayQueryPayload_pluralScalarField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_pluralScalarField-test.js
@@ -39,6 +39,7 @@ describe('writeRelayQueryPayload()', () => {
       var records = {
         '123': {
           __dataID__: '123',
+          __typename: 'User',
           id: '123',
           emailAddresses: [email],
         },
@@ -55,6 +56,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           emailAddresses: [newEmail],
         },
@@ -74,6 +76,7 @@ describe('writeRelayQueryPayload()', () => {
       var records = {
         '123': {
           __dataID__: '123',
+          __typename: 'User',
           id: '123',
           emailAddresses: [email],
         },
@@ -90,6 +93,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           emailAddresses: [newEmail, email],
         },
@@ -110,6 +114,7 @@ describe('writeRelayQueryPayload()', () => {
       var records = {
         '123': {
           __dataID__: '123',
+          __typename: 'User',
           id: '123',
           emailAddresses: [email],
         },
@@ -126,6 +131,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           emailAddresses: [email, newEmail],
         },
@@ -146,6 +152,7 @@ describe('writeRelayQueryPayload()', () => {
       var records = {
         '123': {
           __dataID__: '123',
+          __typename: 'User',
           id: '123',
           emailAddresses: [email],
         },
@@ -162,6 +169,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           emailAddresses: [email],
         },

--- a/src/traversal/__tests__/writeRelayQueryPayload_scalarField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_scalarField-test.js
@@ -49,9 +49,9 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           name: null,
-          __typename: 'User',
         },
       };
       var results = writePayload(store, writer, query, payload);
@@ -82,6 +82,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           name: null,
         },
@@ -115,6 +116,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           name: null,
         },
@@ -170,6 +172,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           name: undefined,
         },
@@ -198,6 +201,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           name: undefined,
         },
@@ -225,6 +229,7 @@ describe('writeRelayQueryPayload()', () => {
       `);
       var payload = {
         node: {
+          __typename: 'User',
           id: '123',
           name: 'Joseph',
         },


### PR DESCRIPTION
For the most part this adds missing `__typename` fields in the payloads which
triggered a warning and spammed full test runs.