### PR TITLE
babel-relay-plugin: reset static fragment id counter per fragment

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-N9UszfRa4qupicRnB6KXkwSOf7A=
+isftDgu2uVYHE61WqmtgLAW/fxE=

--- a/scripts/babel-relay-plugin/lib/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLAST.js
@@ -37,8 +37,6 @@ var GraphQLRelayDirective = require('./GraphQLRelayDirective');
 var find = require('./find');
 var invariant = require('./invariant');
 
-var _nextFragmentID = 0;
-
 var RelayQLNode = (function () {
   function RelayQLNode(context, ast) {
     _classCallCheck(this, RelayQLNode);
@@ -156,7 +154,7 @@ var RelayQLFragment = (function (_RelayQLDefinition) {
     key: 'getFragmentID',
     value: function getFragmentID() {
       if (this.fragmentID == null) {
-        var suffix = (_nextFragmentID++).toString(32);
+        var suffix = this.context.generateID();
         // The fragmentLocationID is the same for all inline/nested fragments
         // within each Relay.QL tagged template expression; the auto-incrementing
         // suffix distinguishes these fragments from each other.

--- a/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
@@ -148,7 +148,7 @@ var RelayQLTransformer = (function () {
       var context = {
         definitionName: capitalize(documentName),
         isPattern: false,
-        nodeIndex: 0,
+        generateID: createIDGenerator(),
         schema: this.schema,
         fragmentLocationID: fragmentLocationID
       };
@@ -203,6 +203,16 @@ var RelayQLTransformer = (function () {
 
 function capitalize(string) {
   return string[0].toUpperCase() + string.slice(1);
+}
+
+/**
+ * Utility to generate locally scoped auto-incrementing IDs.
+ */
+function createIDGenerator() {
+  var _id = 0;
+  return function () {
+    return (_id++).toString(32);
+  };
 }
 
 module.exports = RelayQLTransformer;

--- a/scripts/babel-relay-plugin/src/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/src/RelayQLAST.js
@@ -44,6 +44,7 @@ type GraphQLSchemaType = Object;
 type RelayQLContext = {
   definitionName: string;
   fragmentLocationID: string;
+  generateID: () => string;
   isPattern: boolean;
   schema: GraphQLSchema;
 };
@@ -51,8 +52,6 @@ type RelayQLSelection =
   RelayQLField |
   RelayQLFragmentSpread |
   RelayQLInlineFragment;
-
-let _nextFragmentID = 0;
 
 class RelayQLNode<T> {
   ast: T;
@@ -151,7 +150,7 @@ class RelayQLFragment extends RelayQLDefinition<
 
   getFragmentID(): string {
     if (this.fragmentID == null) {
-      let suffix = (_nextFragmentID++).toString(32);
+      let suffix = this.context.generateID();
       // The fragmentLocationID is the same for all inline/nested fragments
       // within each Relay.QL tagged template expression; the auto-incrementing
       // suffix distinguishes these fragments from each other.

--- a/scripts/babel-relay-plugin/src/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/src/RelayQLTransformer.js
@@ -203,7 +203,7 @@ class RelayQLTransformer {
     const context = {
       definitionName: capitalize(documentName),
       isPattern: false,
-      nodeIndex: 0,
+      generateID: createIDGenerator(),
       schema: this.schema,
       fragmentLocationID,
     };
@@ -291,6 +291,14 @@ class RelayQLTransformer {
 
 function capitalize(string: string): string {
   return string[0].toUpperCase() + string.slice(1);
+}
+
+/**
+ * Utility to generate locally scoped auto-incrementing IDs.
+ */
+function createIDGenerator(): () => string {
+  let _id = 0;
+  return () => (_id++).toString(32);
 }
 
 module.exports = RelayQLTransformer;

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionPattern.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionPattern.fixture
@@ -96,7 +96,7 @@ var x = (function () {
       },
       type: 'String'
     }],
-    id: 'k317qPCVHPHq:1',
+    id: 'k317qPCVHPHq:0',
     kind: 'Fragment',
     metadata: {
       pattern: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
@@ -143,7 +143,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'ptGsI0gOvEjC:2',
+      id: 'ptGsI0gOvEjC:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
@@ -141,7 +141,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'LK+x4YTqVFKq:3',
+      id: 'LK+x4YTqVFKq:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
@@ -134,7 +134,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: '54G3LPw7xxFD:4',
+      id: '54G3LPw7xxFD:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
@@ -135,7 +135,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: '3D6pywLnanwh:5',
+      id: '3D6pywLnanwh:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
@@ -31,7 +31,7 @@ Relay.createContainer(Component, {
             },
             type: 'User'
           }],
-          id: 'okH/bEm+BsZO:6',
+          id: 'okH/bEm+BsZO:0',
           kind: 'Fragment',
           metadata: {},
           name: 'ContainerRelayQL',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
@@ -54,7 +54,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'TYmaoL9mHssN:7',
+      id: 'TYmaoL9mHssN:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
@@ -55,7 +55,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'w2tdpppwZpAc:8',
+      id: 'w2tdpppwZpAc:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
@@ -74,7 +74,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'zIlVHlBwD1Nv:9',
+      id: 'zIlVHlBwD1Nv:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
@@ -73,7 +73,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'JB7byebaJzeI:a',
+      id: 'JB7byebaJzeI:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
@@ -45,7 +45,7 @@ var x = (function () {
       },
       type: 'String'
     }],
-    id: 'RAqyiHXQIf4h:b',
+    id: 'RAqyiHXQIf4h:0',
     kind: 'Fragment',
     metadata: {},
     name: 'FieldWithEmptyArrayArgRelayQL',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -145,7 +145,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'dRRUtCt6aHlk:c',
+      id: 'dRRUtCt6aHlk:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
@@ -145,7 +145,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'QMqt+yyYMWEg:d',
+      id: 'QMqt+yyYMWEg:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
@@ -68,7 +68,7 @@ var foo = (function () {
       },
       type: 'String'
     }],
-    id: 'LUWdmGzrlfjf:e',
+    id: 'LUWdmGzrlfjf:0',
     kind: 'Fragment',
     metadata: {},
     name: 'FieldWithFakeConnectionRelayQL',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
@@ -73,7 +73,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'eryiJuqVSufS:f',
+      id: 'eryiJuqVSufS:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragment.fixture
@@ -22,7 +22,7 @@ var x = (function () {
       },
       type: 'String'
     }],
-    id: 'xNupCo5yp7aB:g',
+    id: 'xNupCo5yp7aB:0',
     kind: 'Fragment',
     metadata: {
       isAbstract: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentDirectives.fixture
@@ -22,7 +22,7 @@ var x = (function () {
       },
       type: 'String'
     }],
-    id: 'ozBVuIInxLw9:h',
+    id: 'ozBVuIInxLw9:0',
     kind: 'Fragment',
     metadata: {
       plural: true,

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithModuleName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithModuleName.fixture
@@ -25,7 +25,7 @@ var x = (function () {
       },
       type: 'String'
     }],
-    id: '8eAZa3uRn4XK:i',
+    id: '8eAZa3uRn4XK:0',
     kind: 'Fragment',
     metadata: {
       isAbstract: true
@@ -52,7 +52,7 @@ var y = (function () {
       },
       type: 'String'
     }],
-    id: 'i8LCtT+AsLwr:j',
+    id: 'i8LCtT+AsLwr:0',
     kind: 'Fragment',
     metadata: {
       isAbstract: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithName.fixture
@@ -22,7 +22,7 @@ var x = (function () {
       },
       type: 'String'
     }],
-    id: 'lO6582eWhl9f:k',
+    id: 'lO6582eWhl9f:0',
     kind: 'Fragment',
     metadata: {
       isAbstract: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithPossibleId.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithPossibleId.fixture
@@ -33,7 +33,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'dNUZm2RVoXq0:l',
+      id: 'dNUZm2RVoXq0:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',
@@ -55,7 +55,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'dNUZm2RVoXq0:m',
+      id: 'dNUZm2RVoXq0:1',
       kind: 'Fragment',
       metadata: {
         isAbstract: true
@@ -63,7 +63,7 @@ var x = (function () {
       name: 'IdFragment',
       type: 'Node'
     }],
-    id: 'dNUZm2RVoXq0:n',
+    id: 'dNUZm2RVoXq0:2',
     kind: 'Fragment',
     metadata: {
       isAbstract: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithReference.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithReference.fixture
@@ -23,7 +23,7 @@ var x = (function (RQL_0) {
       },
       type: 'String'
     }, Relay.QL.__frag(RQL_0)]),
-    id: 'x5Mj5WnGskUj:o',
+    id: 'x5Mj5WnGskUj:0',
     kind: 'Fragment',
     metadata: {
       isAbstract: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithoutCommas.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithoutCommas.fixture
@@ -27,7 +27,7 @@ var x = (function (RQL_0) {
       },
       type: 'String'
     }, Relay.QL.__frag(RQL_0)]),
-    id: 'sSd9IuTSjyA+:p',
+    id: 'sSd9IuTSjyA+:0',
     kind: 'Fragment',
     metadata: {
       isAbstract: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
@@ -43,13 +43,13 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'dDCJUnpyqMbd:q',
+      id: 'dDCJUnpyqMbd:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',
       type: 'User'
     }],
-    id: 'dDCJUnpyqMbd:r',
+    id: 'dDCJUnpyqMbd:1',
     kind: 'Fragment',
     metadata: {
       isAbstract: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
@@ -141,7 +141,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'C+6HBasJOQFL:s',
+      id: 'C+6HBasJOQFL:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
@@ -72,7 +72,7 @@ var x = (function () {
             },
             type: 'String'
           }],
-          id: 'B8asXVuHwFNu:t',
+          id: 'B8asXVuHwFNu:0',
           kind: 'Fragment',
           metadata: {},
           name: 'Story',
@@ -131,7 +131,7 @@ var x = (function () {
       },
       type: 'PageInfo'
     }],
-    id: 'B8asXVuHwFNu:u',
+    id: 'B8asXVuHwFNu:1',
     kind: 'Fragment',
     metadata: {},
     name: 'MetadataDynamicRelayQL',

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
@@ -56,7 +56,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'iN4febuik46I:v',
+      id: 'iN4febuik46I:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataRequisite.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataRequisite.fixture
@@ -22,7 +22,7 @@ var x = (function () {
       },
       type: 'String'
     }],
-    id: 'xNupCo5yp7aB:10',
+    id: 'xNupCo5yp7aB:0',
     kind: 'Fragment',
     metadata: {
       isAbstract: true

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
@@ -45,7 +45,7 @@ var x = (function () {
       },
       type: 'String'
     }],
-    id: 'YJwz6CUUv4c8:11',
+    id: 'YJwz6CUUv4c8:0',
     kind: 'Fragment',
     metadata: {},
     name: 'MetadataVarArgsRelayQL',

--- a/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
@@ -75,7 +75,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'PNWj2QeO3q0w:12',
+      id: 'PNWj2QeO3q0w:0',
       kind: 'Fragment',
       metadata: {},
       name: 'Story',

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
@@ -76,7 +76,7 @@ var x = (function () {
           }
         }]
       }],
-      id: 'OucjrEJhDOCC:13',
+      id: 'OucjrEJhDOCC:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
@@ -54,7 +54,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'yHbKa6x/4o/n:14',
+      id: 'yHbKa6x/4o/n:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
@@ -64,7 +64,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'cSIk6Q0D+5c+:15',
+      id: 'cSIk6Q0D+5c+:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
@@ -64,7 +64,7 @@ var x = (function () {
         },
         type: 'String'
       }],
-      id: 'tBKaPqKgOrD0:16',
+      id: 'tBKaPqKgOrD0:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
@@ -76,7 +76,7 @@ var x = (function (RQL_0, RQL_1, RQL_2, RQL_3, RQL_4, RQL_5, RQL_6, RQL_7, RQL_8
         },
         type: 'String'
       }],
-      id: 'bOWENMIatxpZ:17',
+      id: 'bOWENMIatxpZ:0',
       kind: 'Fragment',
       metadata: {},
       name: 'User',


### PR DESCRIPTION
We currently use a global auto-incrementing id to distinguish nested fragments with the same hash. This can cause issues where two build passes look at fragments in a different order or traverse a different total number of fragments. This diff changes this auto-incrementing suffix to be local to each root Relay.QL expression and therefore consistent regardless of how the expression is transformed.