### PR TITLE
babel plugin: support input object literals

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-isftDgu2uVYHE61WqmtgLAW/fxE=
+Bymfx+W0wVxiTT8S4zaiyJVbRhM=

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -456,7 +456,7 @@ module.exports = function (t, options) {
         }
         return codify({
           kind: t.valueToNode('CallValue'),
-          callValue: t.valueToNode(value)
+          callValue: printLiteralValue(value)
         });
       }
     }, {
@@ -615,6 +615,27 @@ module.exports = function (t, options) {
 
   function property(name, value) {
     return t.objectProperty(t.identifier(name), value);
+  }
+
+  function printLiteralValue(value) {
+    if (value == null) {
+      return NULL;
+    } else if (Array.isArray(value)) {
+      return t.arrayExpression(value.map(printLiteralValue));
+    } else if (typeof value === 'object' && value != null) {
+      var _ret2 = (function () {
+        var objectValue = value;
+        return {
+          v: t.objectExpression(Object.keys(objectValue).map(function (key) {
+            return property(key, printLiteralValue(objectValue[key]));
+          }))
+        };
+      })();
+
+      if (typeof _ret2 === 'object') return _ret2.v;
+    } else {
+      return t.valueToNode(value);
+    }
   }
 
   function shallowFlatten(arr) {

--- a/scripts/babel-relay-plugin/src/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/src/RelayQLAST.js
@@ -33,6 +33,7 @@ import type {
   FragmentSpread as GraphQLFragmentSpread,
   InlineFragment as GraphQLInlineFragment,
   OperationDefinition as GraphQLOperationDefinition,
+  Value as GraphQLValue,
 } from 'GraphQLAST';
 
 // TODO: Import types from `graphql`.
@@ -379,25 +380,17 @@ class RelayQLArgument {
       'Cannot get value of an argument variable.'
     );
     const value = this.ast.value;
-    switch (value.kind) {
-      case 'IntValue':
-        return parseInt(value.value, 10);
-      case 'FloatValue':
-        return parseFloat(value.value);
-      case 'StringValue':
-      case 'BooleanValue':
-      case 'EnumValue':
-        return value.value;
-      case 'ListValue':
-        return value.values.map(
-          value => new RelayQLArgument(
-            this.context,
-            {...this.ast, value},
-            this.type.ofType()
-          )
-        );
+    if (value.kind === 'ListValue') {
+      return value.values.map(
+        value => new RelayQLArgument(
+          this.context,
+          {...this.ast, value},
+          this.type.ofType()
+        )
+      );
+    } else {
+      return getLiteralValue(value);
     }
-    invariant(false, 'Unexpected argument kind: %s', value.kind);
   }
 }
 
@@ -765,6 +758,41 @@ function stripMarkerTypes(schemaModifiedType: GraphQLSchemaType): {
     schemaUnmodifiedType = schemaUnmodifiedType.ofType;
   }
   return {isListType, isNonNullType, schemaUnmodifiedType};
+}
+
+function getLiteralValue(value: GraphQLValue): mixed {
+  switch (value.kind) {
+    case 'IntValue':
+      return parseInt(value.value, 10);
+    case 'FloatValue':
+      return parseFloat(value.value);
+    case 'StringValue':
+    case 'BooleanValue':
+    case 'EnumValue':
+      return value.value;
+    case 'ListValue':
+      return value.values.map(getLiteralValue);
+    case 'ObjectValue':
+      const object = {};
+      value.fields.forEach(field => {
+        object[field.name.value] = getLiteralValue(field.value);
+      });
+      return object;
+    case 'Variable':
+      invariant(
+        false,
+        'Unexpected nested variable `%s`; variables are supported as top-' +
+        'level arguments - `node(id: $id)` - or directly within lists - ' +
+        '`nodes(ids: [$id])`.',
+        value.name.value
+      );
+    default:
+      invariant(
+        false,
+        'Unexpected value kind: %s',
+        value.kind
+      );
+  }
 }
 
 module.exports = {

--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -537,7 +537,7 @@ module.exports = function(t: any, options: PrinterOptions): Function {
       }
       return codify({
         kind: t.valueToNode('CallValue'),
-        callValue: t.valueToNode(value),
+        callValue: printLiteralValue(value),
       });
     }
 
@@ -793,6 +793,21 @@ module.exports = function(t: any, options: PrinterOptions): Function {
 
   function property(name: string, value: mixed): Printable {
     return t.objectProperty(t.identifier(name), value);
+  }
+
+  function printLiteralValue(value: mixed): Printable {
+    if (value == null) {
+      return NULL;
+    } else if (Array.isArray(value)) {
+      return t.arrayExpression(value.map(printLiteralValue));
+    } else if (typeof value === 'object' && value != null) {
+      const objectValue = value;
+      return t.objectExpression(Object.keys(objectValue).map(key =>
+        property(key, printLiteralValue(objectValue[key]))
+      ));
+    } else {
+      return t.valueToNode(value);
+    }
   }
 
   function shallowFlatten(arr: mixed) {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('Relay');
 var q = Relay.QL`
   query {
-    search(query: $query) {
+    searchAll(queries: [$query]) {
       title,
     },
   }
@@ -15,13 +15,13 @@ var q = (function () {
     calls: [{
       kind: 'Call',
       metadata: {
-        type: 'SearchInput!'
+        type: '[SearchInput!]!'
       },
-      name: 'query',
-      value: {
+      name: 'queries',
+      value: [{
         kind: 'CallVariable',
         callVariableName: 'query'
-      }
+      }]
     }],
     children: [{
       fieldName: 'title',
@@ -29,14 +29,14 @@ var q = (function () {
       metadata: {},
       type: 'String'
     }],
-    fieldName: 'search',
+    fieldName: 'searchAll',
     kind: 'Query',
     metadata: {
       isPlural: true,
-      identifyingArgName: 'query',
-      identifyingArgType: 'SearchInput!'
+      identifyingArgName: 'queries',
+      identifyingArgType: '[SearchInput!]!'
     },
-    name: 'QueryWithObjectArg',
+    name: 'QueryWithArrayObjectArg',
     type: 'SearchResult'
   };
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
@@ -1,0 +1,15 @@
+Input:
+var Relay = require('Relay');
+var q = Relay.QL`
+  query {
+    searchAll(queries: [{queryText: $query}]) {
+      title,
+    },
+  }
+`;
+
+Output:
+var Relay = require('Relay');
+var q = (function () {
+  throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithArrayObjectNestedVariable.fixture`.');
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('Relay');
 var q = Relay.QL`
   query {
-    search(query: $query) {
+    searchAll(queries: [{queryText: "Relay"}]) {
       title,
     },
   }
@@ -15,13 +15,15 @@ var q = (function () {
     calls: [{
       kind: 'Call',
       metadata: {
-        type: 'SearchInput!'
+        type: '[SearchInput!]!'
       },
-      name: 'query',
-      value: {
-        kind: 'CallVariable',
-        callVariableName: 'query'
-      }
+      name: 'queries',
+      value: [{
+        kind: 'CallValue',
+        callValue: {
+          queryText: 'Relay'
+        }
+      }]
     }],
     children: [{
       fieldName: 'title',
@@ -29,14 +31,14 @@ var q = (function () {
       metadata: {},
       type: 'String'
     }],
-    fieldName: 'search',
+    fieldName: 'searchAll',
     kind: 'Query',
     metadata: {
       isPlural: true,
-      identifyingArgName: 'query',
-      identifyingArgType: 'SearchInput!'
+      identifyingArgName: 'queries',
+      identifyingArgType: '[SearchInput!]!'
     },
-    name: 'QueryWithObjectArg',
+    name: 'QueryWithArrayObjectValue',
     type: 'SearchResult'
   };
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
@@ -1,0 +1,15 @@
+Input:
+var Relay = require('Relay');
+var q = Relay.QL`
+  query {
+    search(query: {queryText: $query}) {
+      title,
+    },
+  }
+`;
+
+Output:
+var Relay = require('Relay');
+var q = (function () {
+  throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithObjectArgNestedVariable.fixture`.');
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('Relay');
 var q = Relay.QL`
   query {
-    search(query: $query) {
+    search(query: {queryText: "Relay"}) {
       title,
     },
   }
@@ -19,8 +19,10 @@ var q = (function () {
       },
       name: 'query',
       value: {
-        kind: 'CallVariable',
-        callVariableName: 'query'
+        kind: 'CallValue',
+        callValue: {
+          queryText: 'Relay'
+        }
       }
     }],
     children: [{
@@ -36,7 +38,7 @@ var q = (function () {
       identifyingArgName: 'query',
       identifyingArgType: 'SearchInput!'
     },
-    name: 'QueryWithObjectArg',
+    name: 'QueryWithObjectArgValue',
     type: 'SearchResult'
   };
 })();

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -3,7 +3,8 @@ type Root {
   nodes(ids: [Int]): [Node]
   media(id: Int): Media
   viewer: Viewer
-  search(query: [SearchInput!]): [SearchResult]
+  search(query: SearchInput!): [SearchResult]
+  searchAll(queries: [SearchInput!]!): [SearchResult]
   _invalid: InvalidType
   actor: Actor
 }
@@ -21,7 +22,7 @@ type SearchResult {
 }
 
 input SearchInput {
-  query: String
+  queryText: String
 }
 
 type Mutation {

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -113,15 +113,49 @@
                   "name": "query",
                   "description": null,
                   "type": {
-                    "kind": "LIST",
+                    "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "NON_NULL",
+                      "kind": "INPUT_OBJECT",
+                      "name": "SearchInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SearchResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "searchAll",
+              "description": null,
+              "args": [
+                {
+                  "name": "queries",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
                       "name": null,
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
-                        "name": "SearchInput",
-                        "ofType": null
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "SearchInput"
+                        }
                       }
                     }
                   },
@@ -173,7 +207,7 @@
         {
           "kind": "SCALAR",
           "name": "Int",
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^53 - 1) and 2^53 - 1 since represented in JSON as double-precision floating point numbers specifiedby [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -1343,7 +1377,7 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "query",
+              "name": "queryText",
               "description": null,
               "type": {
                 "kind": "SCALAR",


### PR DESCRIPTION
This is an expanded portion of just the plugin changes from #844. Changes:
- Support parsing and printing inline InputObject expressions.
- Clear error message when variables appear nested in ways that the Relay runtime cannot interpret.
- Tests for the above.
