### PR TITLE
Non string identifying argument values

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-isftDgu2uVYHE61WqmtgLAW/fxE=
+Bymfx+W0wVxiTT8S4zaiyJVbRhM=

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -456,7 +456,7 @@ module.exports = function (t, options) {
         }
         return codify({
           kind: t.valueToNode('CallValue'),
-          callValue: t.valueToNode(value)
+          callValue: printLiteralValue(value)
         });
       }
     }, {
@@ -615,6 +615,27 @@ module.exports = function (t, options) {
 
   function property(name, value) {
     return t.objectProperty(t.identifier(name), value);
+  }
+
+  function printLiteralValue(value) {
+    if (value == null) {
+      return NULL;
+    } else if (Array.isArray(value)) {
+      return t.arrayExpression(value.map(printLiteralValue));
+    } else if (typeof value === 'object' && value != null) {
+      var _ret2 = (function () {
+        var objectValue = value;
+        return {
+          v: t.objectExpression(Object.keys(objectValue).map(function (key) {
+            return property(key, printLiteralValue(objectValue[key]));
+          }))
+        };
+      })();
+
+      if (typeof _ret2 === 'object') return _ret2.v;
+    } else {
+      return t.valueToNode(value);
+    }
   }
 
   function shallowFlatten(arr) {

--- a/scripts/babel-relay-plugin/src/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/src/RelayQLAST.js
@@ -33,6 +33,7 @@ import type {
   FragmentSpread as GraphQLFragmentSpread,
   InlineFragment as GraphQLInlineFragment,
   OperationDefinition as GraphQLOperationDefinition,
+  Value as GraphQLValue,
 } from 'GraphQLAST';
 
 // TODO: Import types from `graphql`.
@@ -379,25 +380,17 @@ class RelayQLArgument {
       'Cannot get value of an argument variable.'
     );
     const value = this.ast.value;
-    switch (value.kind) {
-      case 'IntValue':
-        return parseInt(value.value, 10);
-      case 'FloatValue':
-        return parseFloat(value.value);
-      case 'StringValue':
-      case 'BooleanValue':
-      case 'EnumValue':
-        return value.value;
-      case 'ListValue':
-        return value.values.map(
-          value => new RelayQLArgument(
-            this.context,
-            {...this.ast, value},
-            this.type.ofType()
-          )
-        );
+    if (value.kind === 'ListValue') {
+      return value.values.map(
+        value => new RelayQLArgument(
+          this.context,
+          {...this.ast, value},
+          this.type.ofType()
+        )
+      );
+    } else {
+      return getLiteralValue(value);
     }
-    invariant(false, 'Unexpected argument kind: %s', value.kind);
   }
 }
 
@@ -765,6 +758,41 @@ function stripMarkerTypes(schemaModifiedType: GraphQLSchemaType): {
     schemaUnmodifiedType = schemaUnmodifiedType.ofType;
   }
   return {isListType, isNonNullType, schemaUnmodifiedType};
+}
+
+function getLiteralValue(value: GraphQLValue): mixed {
+  switch (value.kind) {
+    case 'IntValue':
+      return parseInt(value.value, 10);
+    case 'FloatValue':
+      return parseFloat(value.value);
+    case 'StringValue':
+    case 'BooleanValue':
+    case 'EnumValue':
+      return value.value;
+    case 'ListValue':
+      return value.values.map(getLiteralValue);
+    case 'ObjectValue':
+      const object = {};
+      value.fields.forEach(field => {
+        object[field.name.value] = getLiteralValue(field.value);
+      });
+      return object;
+    case 'Variable':
+      invariant(
+        false,
+        'Unexpected nested variable `%s`; variables are supported as top-' +
+        'level arguments - `node(id: $id)` - or directly within lists - ' +
+        '`nodes(ids: [$id])`.',
+        value.name.value
+      );
+    default:
+      invariant(
+        false,
+        'Unexpected value kind: %s',
+        value.kind
+      );
+  }
 }
 
 module.exports = {

--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -537,7 +537,7 @@ module.exports = function(t: any, options: PrinterOptions): Function {
       }
       return codify({
         kind: t.valueToNode('CallValue'),
-        callValue: t.valueToNode(value),
+        callValue: printLiteralValue(value),
       });
     }
 
@@ -793,6 +793,21 @@ module.exports = function(t: any, options: PrinterOptions): Function {
 
   function property(name: string, value: mixed): Printable {
     return t.objectProperty(t.identifier(name), value);
+  }
+
+  function printLiteralValue(value: mixed): Printable {
+    if (value == null) {
+      return NULL;
+    } else if (Array.isArray(value)) {
+      return t.arrayExpression(value.map(printLiteralValue));
+    } else if (typeof value === 'object' && value != null) {
+      const objectValue = value;
+      return t.objectExpression(Object.keys(objectValue).map(key =>
+        property(key, printLiteralValue(objectValue[key]))
+      ));
+    } else {
+      return t.valueToNode(value);
+    }
   }
 
   function shallowFlatten(arr: mixed) {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('Relay');
 var q = Relay.QL`
   query {
-    search(query: $query) {
+    searchAll(queries: [$query]) {
       title,
     },
   }
@@ -15,13 +15,13 @@ var q = (function () {
     calls: [{
       kind: 'Call',
       metadata: {
-        type: 'SearchInput!'
+        type: '[SearchInput!]!'
       },
-      name: 'query',
-      value: {
+      name: 'queries',
+      value: [{
         kind: 'CallVariable',
         callVariableName: 'query'
-      }
+      }]
     }],
     children: [{
       fieldName: 'title',
@@ -29,14 +29,14 @@ var q = (function () {
       metadata: {},
       type: 'String'
     }],
-    fieldName: 'search',
+    fieldName: 'searchAll',
     kind: 'Query',
     metadata: {
       isPlural: true,
-      identifyingArgName: 'query',
-      identifyingArgType: 'SearchInput!'
+      identifyingArgName: 'queries',
+      identifyingArgType: '[SearchInput!]!'
     },
-    name: 'QueryWithObjectArg',
+    name: 'QueryWithArrayObjectArg',
     type: 'SearchResult'
   };
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
@@ -1,0 +1,15 @@
+Input:
+var Relay = require('Relay');
+var q = Relay.QL`
+  query {
+    searchAll(queries: [{queryText: $query}]) {
+      title,
+    },
+  }
+`;
+
+Output:
+var Relay = require('Relay');
+var q = (function () {
+  throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithArrayObjectNestedVariable.fixture`.');
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('Relay');
 var q = Relay.QL`
   query {
-    search(query: $query) {
+    searchAll(queries: [{queryText: "Relay"}]) {
       title,
     },
   }
@@ -15,13 +15,15 @@ var q = (function () {
     calls: [{
       kind: 'Call',
       metadata: {
-        type: 'SearchInput!'
+        type: '[SearchInput!]!'
       },
-      name: 'query',
-      value: {
-        kind: 'CallVariable',
-        callVariableName: 'query'
-      }
+      name: 'queries',
+      value: [{
+        kind: 'CallValue',
+        callValue: {
+          queryText: 'Relay'
+        }
+      }]
     }],
     children: [{
       fieldName: 'title',
@@ -29,14 +31,14 @@ var q = (function () {
       metadata: {},
       type: 'String'
     }],
-    fieldName: 'search',
+    fieldName: 'searchAll',
     kind: 'Query',
     metadata: {
       isPlural: true,
-      identifyingArgName: 'query',
-      identifyingArgType: 'SearchInput!'
+      identifyingArgName: 'queries',
+      identifyingArgType: '[SearchInput!]!'
     },
-    name: 'QueryWithObjectArg',
+    name: 'QueryWithArrayObjectValue',
     type: 'SearchResult'
   };
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
@@ -1,0 +1,15 @@
+Input:
+var Relay = require('Relay');
+var q = Relay.QL`
+  query {
+    search(query: {queryText: $query}) {
+      title,
+    },
+  }
+`;
+
+Output:
+var Relay = require('Relay');
+var q = (function () {
+  throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithObjectArgNestedVariable.fixture`.');
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('Relay');
 var q = Relay.QL`
   query {
-    search(query: $query) {
+    search(query: {queryText: "Relay"}) {
       title,
     },
   }
@@ -19,8 +19,10 @@ var q = (function () {
       },
       name: 'query',
       value: {
-        kind: 'CallVariable',
-        callVariableName: 'query'
+        kind: 'CallValue',
+        callValue: {
+          queryText: 'Relay'
+        }
       }
     }],
     children: [{
@@ -36,7 +38,7 @@ var q = (function () {
       identifyingArgName: 'query',
       identifyingArgType: 'SearchInput!'
     },
-    name: 'QueryWithObjectArg',
+    name: 'QueryWithObjectArgValue',
     type: 'SearchResult'
   };
 })();

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -3,7 +3,8 @@ type Root {
   nodes(ids: [Int]): [Node]
   media(id: Int): Media
   viewer: Viewer
-  search(query: [SearchInput!]): [SearchResult]
+  search(query: SearchInput!): [SearchResult]
+  searchAll(queries: [SearchInput!]!): [SearchResult]
   _invalid: InvalidType
   actor: Actor
 }
@@ -21,7 +22,7 @@ type SearchResult {
 }
 
 input SearchInput {
-  query: String
+  queryText: String
 }
 
 type Mutation {

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -113,15 +113,49 @@
                   "name": "query",
                   "description": null,
                   "type": {
-                    "kind": "LIST",
+                    "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "NON_NULL",
+                      "kind": "INPUT_OBJECT",
+                      "name": "SearchInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SearchResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "searchAll",
+              "description": null,
+              "args": [
+                {
+                  "name": "queries",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
                       "name": null,
                       "ofType": {
-                        "kind": "INPUT_OBJECT",
-                        "name": "SearchInput",
-                        "ofType": null
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "SearchInput"
+                        }
                       }
                     }
                   },
@@ -173,7 +207,7 @@
         {
           "kind": "SCALAR",
           "name": "Int",
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^53 - 1) and 2^53 - 1 since represented in JSON as double-precision floating point numbers specifiedby [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -1343,7 +1377,7 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "query",
+              "name": "queryText",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -1,15 +1,36 @@
 type Root {
   checkinSearchQuery(query: CheckinSearchInput): CheckinSearchResult
   defaultSettings: Settings,
-  settings(environment: Environment): Settings
+  route(waypoints: [WayPoint!]!): Route
   me: User
-  story: Story
   node(id: ID): Node
   nodes(ids: [ID!]): [Node]
+  settings(environment: Environment): Settings
+  story: Story
+  task(number: Int): Task
   username(name: String!): Actor
   usernames(names: [String!]!): [Actor]
   viewer: Viewer
   _mutation: Mutation
+}
+
+type Task {
+  title: String
+}
+
+input WayPoint {
+  lat: String
+  lon: String
+}
+
+type Route {
+  steps: [RouteStep]
+}
+
+type RouteStep {
+  lat: String
+  lon: String
+  note: String
 }
 
 type Mutation {

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -50,23 +50,34 @@
               "deprecationReason": null
             },
             {
-              "name": "settings",
+              "name": "route",
               "description": null,
               "args": [
                 {
-                  "name": "environment",
+                  "name": "waypoints",
                   "description": null,
                   "type": {
-                    "kind": "ENUM",
-                    "name": "Environment",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "WayPoint"
+                        }
+                      }
+                    }
                   },
                   "defaultValue": null
                 }
               ],
               "type": {
                 "kind": "OBJECT",
-                "name": "Settings",
+                "name": "Route",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -79,18 +90,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "User",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "story",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Story",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -150,6 +149,64 @@
                   "name": "Node",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "settings",
+              "description": null,
+              "args": [
+                {
+                  "name": "environment",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "Environment",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Settings",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "story",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Story",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "task",
+              "description": null,
+              "args": [
+                {
+                  "name": "number",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Task",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -380,6 +437,111 @@
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "WayPoint",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "lat",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lon",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Route",
+          "description": null,
+          "fields": [
+            {
+              "name": "steps",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RouteStep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RouteStep",
+          "description": null,
+          "fields": [
+            {
+              "name": "lat",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lon",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "note",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         },
         {
@@ -6734,6 +6896,29 @@
             }
           ],
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Task",
+          "description": null,
+          "fields": [
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/src/container/__tests__/RelayRenderer_renderArgs-test.js
+++ b/src/container/__tests__/RelayRenderer_renderArgs-test.js
@@ -21,6 +21,7 @@ const Relay = require('Relay');
 const RelayQueryConfig = require('RelayQueryConfig');
 const RelayRenderer = require('RelayRenderer');
 const RelayStore = require('RelayStore');
+const RelayTestUtils = require('RelayTestUtils');
 
 describe('RelayRenderer.renderArgs', () => {
   let MockComponent;
@@ -50,6 +51,7 @@ describe('RelayRenderer.renderArgs', () => {
       />,
       container
     );
+    jasmine.addMatchers(RelayTestUtils.matchers);
     jasmine.addMatchers({
       toRenderWithArgs() {
         return {
@@ -202,8 +204,8 @@ describe('RelayRenderer.renderArgs', () => {
 
     const {retry} = render.mock.calls[1][0];
     expect(typeof retry).toBe('function');
-    expect(() => retry()).toThrowError(
-      'Invariant Violation: RelayRenderer: You tried to call `retry`, but the last request did ' +
+    expect(() => retry()).toFailInvariant(
+      'RelayRenderer: You tried to call `retry`, but the last request did ' +
       'not fail. You can only call this when the last request has failed.'
     );
   });

--- a/src/interface/RelayOSSNodeInterface.js
+++ b/src/interface/RelayOSSNodeInterface.js
@@ -29,7 +29,7 @@ type PayloadResult = {
 
 type RootCallInfo = {
   storageKey: string;
-  identifyingArgValue: ?string;
+  identifyingArgKey: ?string;
 }
 
 /**
@@ -80,9 +80,9 @@ var RelayOSSNodeInterface = {
       var records = getPayloadRecords(query, payload);
       var ii = 0;
       const storageKey = query.getStorageKey();
-      forEachRootCallArg(query, identifyingArgValue => {
+      forEachRootCallArg(query, ({identifyingArgKey}) => {
         var result = records[ii++];
-        var dataID = store.getDataID(storageKey, identifyingArgValue);
+        var dataID = store.getDataID(storageKey, identifyingArgKey);
         if (dataID == null) {
           var payloadID = typeof result === 'object' && result ?
             result[RelayOSSNodeInterface.ID] :
@@ -96,7 +96,7 @@ var RelayOSSNodeInterface = {
         results.push({
           dataID,
           result,
-          rootCallInfo: {storageKey, identifyingArgValue},
+          rootCallInfo: {storageKey, identifyingArgKey},
         });
       });
     }
@@ -111,23 +111,23 @@ function getPayloadRecords(
 ): Array<mixed> {
   var fieldName = query.getFieldName();
   const identifyingArg = query.getIdentifyingArg();
-  const identifyingArgValue = (identifyingArg && identifyingArg.value) || null;
+  const identifyingArgKey = (identifyingArg && identifyingArg.value) || null;
   var records = payload[fieldName];
   if (!query.getBatchCall()) {
-    if (Array.isArray(identifyingArgValue)) {
+    if (Array.isArray(identifyingArgKey)) {
       invariant(
         Array.isArray(records),
         'RelayOSSNodeInterface: Expected payload for root field `%s` to be ' +
         'an array with %s results, instead received a single non-array result.',
         fieldName,
-        identifyingArgValue.length
+        identifyingArgKey.length
       );
       invariant(
-        records.length === identifyingArgValue.length,
+        records.length === identifyingArgKey.length,
         'RelayOSSNodeInterface: Expected payload for root field `%s` to be ' +
         'an array with %s results, instead received an array with %s results.',
         fieldName,
-        identifyingArgValue.length,
+        identifyingArgKey.length,
         records.length
       );
     } else if (Array.isArray(records)) {

--- a/src/mutation/__tests__/RelayMutationQueue-test.js
+++ b/src/mutation/__tests__/RelayMutationQueue-test.js
@@ -165,8 +165,8 @@ describe('RelayMutationQueue', () => {
     it('throws if commit is called more than once', () => {
       var transaction = mutationQueue.createTransaction(mockMutation1);
       transaction.commit();
-      expect(() => transaction.commit()).toThrowError(
-        'Invariant Violation: RelayMutationTransaction: Only transactions with status ' +
+      expect(() => transaction.commit()).toFailInvariant(
+        'RelayMutationTransaction: Only transactions with status ' +
         '`UNCOMMITTED` can be comitted.'
       );
     });
@@ -321,8 +321,8 @@ describe('RelayMutationQueue', () => {
 
       expect(failureCallback1).toBeCalled();
       expect(failureCallback2).toBeCalled();
-      expect(() => transaction1.getStatus()).toThrowError(
-        'Invariant Violation: RelayMutationQueue: `0` is not a valid pending transaction ID.'
+      expect(() => transaction1.getStatus()).toFailInvariant(
+        'RelayMutationQueue: `0` is not a valid pending transaction ID.'
       );
       expect(transaction2.getStatus()).toBe(
         RelayMutationTransactionStatus.COLLISION_COMMIT_FAILED
@@ -426,8 +426,8 @@ describe('RelayMutationQueue', () => {
       expect(transaction1.getStatus()).toBe(
         RelayMutationTransactionStatus.COMMIT_FAILED
       );
-      expect(() => transaction2.getStatus()).toThrowError(
-        'Invariant Violation: RelayMutationQueue: `1` is not a valid pending transaction ID.'
+      expect(() => transaction2.getStatus()).toFailInvariant(
+        'RelayMutationQueue: `1` is not a valid pending transaction ID.'
       );
       expect(transaction3.getStatus()).toBe(
         RelayMutationTransactionStatus.COLLISION_COMMIT_FAILED

--- a/src/query/__tests__/RelayQL-test.js
+++ b/src/query/__tests__/RelayQL-test.js
@@ -97,8 +97,8 @@ describe('RelayQL', () => {
           }
         }
       `;
-    }).toThrowError(
-      'Invariant Violation: RelayQL: Invalid argument `size` supplied via template substitution. ' +
+    }).toFailInvariant(
+      'RelayQL: Invalid argument `size` supplied via template substitution. ' +
       'Instead, use an inline variable (e.g. `comments(count: $count)`).'
     );
   });

--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -342,6 +342,65 @@ describe('RelayQueryRoot', () => {
     expect(meIdentifyingArg).toBeUndefined();
   });
 
+  it('returns numeric identifying arguments', () => {
+   var query = getNode(Relay.QL`
+     query {
+       task(number: 5) {
+         title
+       }
+     }
+   `);
+   const nodeIdentifyingArg = query.getIdentifyingArg();
+   expect(nodeIdentifyingArg).toEqual({
+     name: 'number',
+     value: 5,
+   });
+ });
+
+ it('returns input-object identifying arguments', () => {
+   var query = getNode(Relay.QL`
+     query {
+       checkinSearchQuery(query: {query: "Facebook"}) {
+         query,
+       }
+     }
+   `);
+   const nodeIdentifyingArg = query.getIdentifyingArg();
+   expect(nodeIdentifyingArg).toEqual({
+     name: 'query',
+     type: 'CheckinSearchInput',
+     value: {
+       query: 'Facebook',
+     },
+   });
+ });
+
+ it('returns array identifying arguments', () => {
+   var query = getNode(Relay.QL`
+     query {
+       route(waypoints: [
+         {lat: "0.0", lon: "0.0"},
+         {lat: "1.1", lon: "1.1"}
+       ]) {
+         steps {
+           note
+         }
+       }
+     }
+   `);
+   const nodeIdentifyingArg = query.getIdentifyingArg();
+   expect(nodeIdentifyingArg).toEqual(
+     {
+       name: 'waypoints',
+       value: [
+         {lat: '0.0', lon: '0.0'},
+         {lat: '1.1', lon: '1.1'}
+       ],
+       type: '[WayPoint!]!',
+     }
+   );
+ });
+
   it('creates nodes', () => {
     var query = getNode(Relay.QL`
       query {

--- a/src/query/callsFromGraphQL.js
+++ b/src/query/callsFromGraphQL.js
@@ -59,20 +59,36 @@ function callsFromGraphQL(
 }
 
 function getCallValue(
-  value: ConcreteCallValue | ConcreteCallVariable,
+  concreteValue: ConcreteCallValue | ConcreteCallVariable,
   variables: Variables
 ): ?CallValue {
-  if (value.kind === 'CallValue') {
-    return value.callValue;
+  let callValue;
+  if (concreteValue.kind === 'CallValue') {
+    callValue = concreteValue.callValue;
   } else {
-    var variableName = value.callVariableName;
+    var variableName = concreteValue.callVariableName;
     invariant(
       variables.hasOwnProperty(variableName),
       'callsFromGraphQL(): Expected a declared value for variable, `$%s`.',
       variableName
     );
-    return variables[variableName];
+    callValue = variables[variableName];
   }
+  const valueType = typeof callValue;
+  // Perform a shallow check to ensure the value conforms to `CallValue` type:
+  // skip testing recursive array/object values.
+  invariant (
+    callValue == null ||
+    valueType === 'boolean' ||
+    valueType === 'number' ||
+    valueType === 'string' ||
+    valueType === 'object' ||
+    Array.isArray(valueType),
+    'callsFromGraphQL(): Expected value to be null, a boolean, string, ' +
+    'or an array/object of the same, but got `%s`.',
+    JSON.stringify(callValue)
+  );
+  return (callValue: any);
 }
 
 module.exports = callsFromGraphQL;

--- a/src/store/RelayContext.js
+++ b/src/store/RelayContext.js
@@ -173,9 +173,9 @@ class RelayContext {
     const queuedStore = this._storeData.getQueuedStore();
     const storageKey = root.getStorageKey();
     var results = [];
-    forEachRootCallArg(root, identifyingArgValue => {
+    forEachRootCallArg(root, ({identifyingArgKey}) => {
       let data;
-      const dataID = queuedStore.getDataID(storageKey, identifyingArgValue);
+      const dataID = queuedStore.getDataID(storageKey, identifyingArgKey);
       if (dataID != null) {
         data = this.read(root, dataID, options);
       }

--- a/src/store/RelayDiskCacheReader.js
+++ b/src/store/RelayDiskCacheReader.js
@@ -163,12 +163,12 @@ class RelayCacheReader {
       }
       if (query) {
         const storageKey = query.getStorageKey();
-        forEachRootCallArg(query, identifyingArgValue => {
+        forEachRootCallArg(query, ({identifyingArgKey}) => {
           if (this._state === 'COMPLETED') {
             return;
           }
-          identifyingArgValue = identifyingArgValue || '';
-          this.visitRoot(storageKey, identifyingArgValue, query);
+          identifyingArgKey = identifyingArgKey || '';
+          this.visitRoot(storageKey, identifyingArgKey, query);
         });
       }
     });
@@ -204,20 +204,20 @@ class RelayCacheReader {
 
   visitRoot(
     storageKey: string,
-    identifyingArgValue: string,
+    identifyingArgKey: string,
     query: RelayQuery.Root
   ): void {
-    var dataID = this._store.getDataID(storageKey, identifyingArgValue);
+    var dataID = this._store.getDataID(storageKey, identifyingArgKey);
     if (dataID == null) {
       if (this._cachedRootCallMap.hasOwnProperty(storageKey) &&
           this._cachedRootCallMap[storageKey].hasOwnProperty(
-            identifyingArgValue
+            identifyingArgKey
           )
       ) {
         // Already attempted to read this root from cache.
         this._handleFailed();
       } else {
-        this.queueRoot(storageKey, identifyingArgValue, query);
+        this.queueRoot(storageKey, identifyingArgKey, query);
       }
     } else {
       this.visitNode(
@@ -233,17 +233,17 @@ class RelayCacheReader {
 
   queueRoot(
     storageKey: string,
-    identifyingArgValue: string,
+    identifyingArgKey: string,
     query: RelayQuery.Root
   ) {
-    var rootKey = storageKey + '*' + identifyingArgValue;
+    var rootKey = storageKey + '*' + identifyingArgKey;
     if (this._pendingRoots.hasOwnProperty(rootKey)) {
       this._pendingRoots[rootKey].push(query);
     } else {
       this._pendingRoots[rootKey] = [query];
       this._cacheManager.readRootCall(
         storageKey,
-        identifyingArgValue,
+        identifyingArgKey,
         (error, value) => {
           if (this._state === 'COMPLETED') {
             return;
@@ -257,8 +257,8 @@ class RelayCacheReader {
 
           this._cachedRootCallMap[storageKey] =
             this._cachedRootCallMap[storageKey] || {};
-          this._cachedRootCallMap[storageKey][identifyingArgValue] = value;
-          if (this._cachedRootCallMap[storageKey][identifyingArgValue] ==
+          this._cachedRootCallMap[storageKey][identifyingArgKey] = value;
+          if (this._cachedRootCallMap[storageKey][identifyingArgKey] ==
               null) {
             // Read from cache and we still don't have valid `dataID`.
             this._handleFailed();

--- a/src/store/__tests__/RelayRecordWriter-test.js
+++ b/src/store/__tests__/RelayRecordWriter-test.js
@@ -171,8 +171,8 @@ describe('RelayRecordWriter', () => {
       const store = new RelayRecordWriter({}, {}, false);
       expect(() => {
         store.deleteField('1', 'name', null);
-      }).toThrowError(
-        'Invariant Violation: RelayRecordWriter.deleteField(): Expected record `1` to exist ' +
+      }).toFailInvariant(
+        'RelayRecordWriter.deleteField(): Expected record `1` to exist ' +
         'before deleting field `name`.'
       );
     });

--- a/src/store/__tests__/readRelayQueryData-test.js
+++ b/src/store/__tests__/readRelayQueryData-test.js
@@ -599,7 +599,7 @@ describe('readRelayQueryData', () => {
     `);
     expect(
       () => readData(getStoreData({records}), query, 'story_id')
-    ).toThrowError('Invariant Violation: ' + error);
+    ).toFailInvariant(error);
 
     // Note that `pageInfo` also triggers the error...
     const pageInfoFragment = Relay.QL`
@@ -620,7 +620,7 @@ describe('readRelayQueryData', () => {
     `);
     expect(
       () => readData(getStoreData({records}), query, 'story_id')
-    ).toThrowError('Invariant Violation: ' + error);
+    ).toFailInvariant(error);
 
     // ...but not `count`:
     query = getNode(Relay.QL`fragment on Story{feedback{likers{count}}}`);
@@ -662,12 +662,12 @@ describe('readRelayQueryData', () => {
       fragment on Story{feedback{likers{${fragmentReference}}}}
     `);
     expect(() => readData(getStoreData({records}), query, 'story_id'))
-      .toThrowError('Invariant Violation: ' + error);
+      .toFailInvariant(error);
 
     let fragment = Relay.QL`fragment on LikersOfContentConnection{pageInfo}`;
     query = getNode(Relay.QL`fragment on Story{feedback{likers{${fragment}}}}`);
     expect(() => readData(getStoreData({records}), query, 'story_id'))
-      .toThrowError('Invariant Violation: ' + error);
+      .toFailInvariant(error);
 
     fragment = Relay.QL`fragment on LikersOfContentConnection{count}`;
     query = getNode(Relay.QL`fragment on Story{feedback{likers{${fragment}}}}`);

--- a/src/tools/RelayInternalTypes.js
+++ b/src/tools/RelayInternalTypes.js
@@ -27,7 +27,14 @@ export type Call = {
   type?: string;
   value: CallValue;
 };
-export type CallValue = mixed;
+export type CallValue =
+  void |
+  null |
+  boolean |
+  number |
+  string |
+  {[key: string]: CallValue} |
+  Array<CallValue>;
 
 export type ClientMutationID = string;
 

--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -421,7 +421,7 @@ var RelayTestUtils = {
     toFailInvariant() {
       return {
         compare(actual, expected) {
-          expect(actual).toThrowError('Invariant Violation: ' + expected);
+          expect(actual).toThrowError(expected);
           return {
             pass: true,
           };

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -223,6 +223,30 @@ describe('printRelayOSSQuery', () => {
       });
     });
 
+    it('prints literal object call values', () => {
+      const query = getNode(Relay.QL`
+        query {
+          checkinSearchQuery(query: {query: "Menlo Park"}) {
+            query,
+          }
+        }
+      `);
+
+      const {text, variables} = printRelayOSSQuery(query);
+      expect(text).toEqualPrintedQuery(`
+        query PrintRelayOSSQuery($query_0: CheckinSearchInput!) {
+          checkinSearchQuery(query: $query_0) {
+            query
+          }
+        }
+      `);
+      expect(variables).toEqual({
+        query_0: {
+          query: 'Menlo Park',
+        },
+      });
+    });
+
     it('dedupes enum variables', () => {
       const enumValue = 'WEB';
       const query = getNode(Relay.QL`

--- a/src/traversal/checkRelayQueryData.js
+++ b/src/traversal/checkRelayQueryData.js
@@ -86,8 +86,8 @@ class RelayQueryChecker extends RelayQueryVisitor<CheckerState> {
   ): void {
     var nextState;
     const storageKey = root.getStorageKey();
-    forEachRootCallArg(root, identifyingArgValue => {
-      var dataID = this._store.getDataID(storageKey, identifyingArgValue);
+    forEachRootCallArg(root, ({identifyingArgKey}) => {
+      var dataID = this._store.getDataID(storageKey, identifyingArgKey);
       if (dataID == null) {
         state.result = false;
       } else {

--- a/src/traversal/diffRelayQuery.js
+++ b/src/traversal/diffRelayQuery.js
@@ -103,15 +103,9 @@ function diffRelayQuery(
   }
   const fieldName = root.getFieldName();
   const storageKey = root.getStorageKey();
-  forEachRootCallArg(root, identifyingArgValue => {
+  forEachRootCallArg(root, ({identifyingArgValue, identifyingArgKey}) => {
     var nodeRoot;
     if (isPluralCall) {
-      invariant(
-        identifyingArgValue != null,
-        'diffRelayQuery(): Unexpected null or undefined value in root call ' +
-        'argument array for query, `%s(...).',
-        fieldName
-      );
       nodeRoot = RelayQuery.Root.build(
         root.getName(),
         fieldName,
@@ -126,7 +120,7 @@ function diffRelayQuery(
     }
 
     // The whole query must be fetched if the root dataID is unknown.
-    var dataID = store.getDataID(storageKey, identifyingArgValue);
+    var dataID = store.getDataID(storageKey, identifyingArgKey);
     if (dataID == null) {
       queries.push(nodeRoot);
       return;

--- a/src/traversal/inferRelayFieldsFromData.js
+++ b/src/traversal/inferRelayFieldsFromData.js
@@ -113,7 +113,7 @@ function buildField(
         const value = captures[2].split(',');
         return {
           name: captures[1],
-          value: value.length === 1 ? value[0] : value,
+          value: value.length === 1 ? value[0] : (value: any),
         };
       });
     }

--- a/src/traversal/writeRelayQueryPayload.js
+++ b/src/traversal/writeRelayQueryPayload.js
@@ -40,7 +40,7 @@ function writeRelayQueryPayload(
       if (rootCallInfo) {
         recordWriter.putDataID(
           rootCallInfo.storageKey,
-          rootCallInfo.identifyingArgValue,
+          rootCallInfo.identifyingArgKey,
           dataID
         );
       }


### PR DESCRIPTION
Note: this is inspired by and partially based on @iamchenxin's work in #767 and #844. Thanks for the head start!

Relay currently assumes that identifying argument values are strings (numbers _sort_ of work, but not really). This builds on #894 (which added support to the plugin for parsing/printing literal InputObjects) by allowing identifying arguments to be basically anything - boolean, number, string, or array/object of the the same.

Key changes include:
- Change the `CallValue` type from mixed to an explicit list of the supported types
- Change `forEachRootCallArg` to return both the literal JS value of the argument as well as a serialized key
- Change all callers of `forEachRootCallArg` (and some places that manually inspected the identifying arg) to correctly choose between the identifying argument value (i.e. when constructing a query with it) or the identifying argument key (for use with `RelayRecordStore.{putDataID,getDataID}`).
- Added tests that the writer correctly creates root records for queries with non-string identifying arguments.
