### PR TITLE
Allow disabling Relay container shouldComponentUpdate

### DIFF
--- a/docs/APIReference-Container.md
+++ b/docs/APIReference-Container.md
@@ -37,6 +37,12 @@ Relay containers are created using `Relay.createContainer`.
       A method to modify the variables based on the runtime environment or previous variable values.
     </a>
   </li>
+  <li>
+    <a href="#pure">
+      <pre>pure</pre>
+      A boolean for disabling shouldComponentUpdate.
+    </a>
+  </li>
 </ul>
 
 *Properties and Methods*
@@ -169,6 +175,23 @@ module.exports = Relay.createContainer(ProfilePicture, {
       size: prevVariables.size * window.devicePixelRatio,
     };
   },
+  // ...
+});
+```
+
+### pure
+
+```
+pure: ?boolean
+```
+
+Relay containers may block updates to components that receive data via context. Setting pure to `false` will override the container's `shouldComponentUpdate` to always return true.
+
+#### Example
+
+```{2}
+module.exports = Relay.createContainer(ProfilePicture, {
+  pure: false,
   // ...
 });
 ```

--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -54,6 +54,7 @@ type FragmentPointer = {
   dataIDs: DataID | Array<DataID>
 };
 export type RelayContainerSpec = {
+  pure?: boolean;
   initialVariables?: Variables;
   prepareVariables?: (
     prevVariables: Variables,
@@ -103,6 +104,7 @@ function createContainerComponent(
   const fragmentNames = Object.keys(fragments);
   const initialVariables = spec.initialVariables || {};
   const prepareVariables = spec.prepareVariables;
+  const pure = spec.pure !== false;
 
   class RelayContainer extends React.Component {
     mounted: boolean;
@@ -691,6 +693,10 @@ function createContainerComponent(
       nextState: any,
       nextContext: any
     ): boolean {
+      if (!pure) {
+        return true;
+      }
+
       // Flag indicating that query data changed since previous render.
       if (this._hasStaleQueryData) {
         this._hasStaleQueryData = false;

--- a/src/container/__tests__/RelayContainer-test.js
+++ b/src/container/__tests__/RelayContainer-test.js
@@ -864,4 +864,45 @@ describe('RelayContainer', function() {
     );
     expect(render.mock.calls.length).toBe(3);
   });
+
+  it('applies `pure` properly', () => {
+    var mockDataSet = {
+      '42': {__dataID__: '42', name: 'Tim'},
+    };
+    var render = jest.genMockFunction().mockImplementation(() => <div />);
+    var shouldComponentUpdate = jest.genMockFunction();
+    shouldComponentUpdate.mockReturnValue(true);
+
+    var MockComponent = React.createClass({render, shouldComponentUpdate});
+
+    var MockImpureContainer = Relay.createContainer(MockComponent, {
+      pure: false,
+      fragments: {
+        foo: jest.genMockFunction().mockImplementation(
+          () => Relay.QL`fragment on Node{id,name}`
+        ),
+      },
+    });
+
+    GraphQLStoreQueryResolver.mockResolveImplementation(0, (_, dataID) => {
+      return mockDataSet[dataID];
+    });
+    mockFooFragment =
+      getNode(MockImpureContainer.getFragment('foo').getFragment({}));
+    var mockPointerA = getPointer('42', mockFooFragment);
+
+    RelayTestRenderer.render(
+      () => <MockImpureContainer foo={mockPointerA} />,
+      environment,
+      mockRoute
+    );
+    expect(render.mock.calls.length).toBe(1);
+
+    RelayTestRenderer.render(
+      () => <MockImpureContainer foo={mockPointerA} />,
+      environment,
+      mockRoute
+    );
+    expect(render.mock.calls.length).toBe(2);
+  });
 });


### PR DESCRIPTION
This PR introduces an optional flag `pure` to `RelayContainer` which overrides `shouldComponentUpdate` to return true.

Closes https://github.com/facebook/relay/issues/674.