### PR TITLE
Document `REQUIRED_CHILDREN`

### DIFF
--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -431,6 +431,56 @@ class RemoveTagMutation extends Relay.Mutation {
 }
 ```
 
+### `REQUIRED_CHILDREN`
+
+A `REQUIRED_CHILDREN` config is used to append additional children to the mutation query. You may need to use this, for example, to fetch fields on a new object created by the mutation (and which Relay would normally not attempt to fetch because it has not previously fetched anything for that object).
+
+#### Arguments
+
+- `children: Array<RelayQuery.Node>`
+
+#### Example
+
+```
+class CreateCouponMutation extends Relay.Mutation<Props> {
+  getMutation() {
+    return Relay.QL`mutation {
+      create_coupon(data: $input)
+    }`;
+  }
+
+  getFatQuery() {
+    return Relay.QL`
+      // Note the use of `pattern: true` here to show that this
+      // connection field is to be used for pattern-matching only
+      // (to determine what to fetch) and that Relay shouldn't
+      // require the usual connection arguments like (`first` etc)
+      // to be present.
+      fragment on CouponCreatePayload @relay(pattern: true) {
+        coupons
+      }
+    `;
+  }
+
+  getConfigs() {
+    return [{
+      // If we haven't shown the coupons in the UI at the time the
+      // mutation runs, they've never been fetched and the `coupons`
+      // field in the fat query would normally be ignored.
+      // `REQUIRED_CHILDREN` forces it to be retrieved anyway.
+      type: RelayMutationType.REQUIRED_CHILDREN,
+      children: [
+        Relay.QL`
+          fragment on CouponCreatePayload {
+            coupons
+          }
+        `,
+      ],
+    }];
+  }
+}
+```
+
 ## Optimistic updates
 
 All of the mutations we've performed so far have waited on a response from the server before updating the client-side store. Relay offers us a chance to craft an optimistic response of the same shape based on what we expect the server's response to be in the event of a successful mutation.


### PR DESCRIPTION
I made a somewhat artificial example up for this. If anybody wants to suggest a more realistic use case derived from actual practice, please chime in!

Note that I also mentioned `@relay(pattern: true)` to give the technique a little more exposure. Maybe dragging connections into this is complicating the issue unnecessarily...

Also note that I explicitly avoided the "sign-in mutation" example from #166 because until we have `RelayContext` fully rolled out, I don't think we want to encourage the use of session handling too overtly.

Closes: https://github.com/facebook/relay/issues/166