### PR TITLE
Make plugin build checker independent of Babel version

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-JvWvngBaHPV3GjrJ036AjM/JyKE=
+PlWc6fXw/ncFDKKqFnYPZdcICHI=

--- a/scripts/babel-relay-plugin/scripts/build-lib
+++ b/scripts/babel-relay-plugin/scripts/build-lib
@@ -15,8 +15,7 @@ const src = path.join(root, 'src');
 // Blow away prior build artifacts.
 rimraf.sync(lib);
 
-// Accumulate a hash that can be used as a cache breaker.
-const hash = crypto.createHash('sha1');
+const sources = [];
 
 // Get the files to transform
 const files = glob.sync('**/*.js', {
@@ -32,10 +31,19 @@ files.forEach(file => {
   mkdirp.sync(path.dirname(libFile));
   const result = babel.transformFileSync(srcFile);
 
+  sources.push(fs.readFileSync(srcFile, 'utf8'));
+
   // Prepend @generated annotation
   const code = '// @generated\n' + result.code;
   fs.writeFile(libFile, code, 'utf8');
-  hash.update(code);
+});
+
+// Hash sources to be used as a cache breaker and to verify we've build the
+// latest sources.
+const hash = crypto.createHash('sha1');
+sources.sort();
+sources.forEach((source) => {
+  hash.update(source);
 });
 
 const hashFile = path.resolve(lib, 'HASH');


### PR DESCRIPTION
Currently, the build checker test is tied to the exact output of the transform.
This means if people run different minor versions of babel, the test fails.

This change makes the test more resilient. Everytime the build is run, the
`SRC_HASH` is updated. The test hashes the source files again and makes sure the
hash matches. This makes sure we ran the build after modifying some sources.