### PR TITLE
[WIP][RFC] babel plugin: support mixed identifying/non-identifying root calls

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-Bymfx+W0wVxiTT8S4zaiyJVbRhM=
+/Po3acJQ8/fdeEmGegvxERNmZck=

--- a/scripts/babel-relay-plugin/lib/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLAST.js
@@ -766,6 +766,11 @@ var RelayQLArgumentType = (function () {
       return this.schemaUnmodifiedArgType instanceof types.GraphQLEnumType;
     }
   }, {
+    key: 'isID',
+    value: function isID() {
+      return this.isScalar() && this.getName({ modifiers: false }) === 'ID';
+    }
+  }, {
     key: 'isList',
     value: function isList() {
       return this.isListType;

--- a/scripts/babel-relay-plugin/src/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/src/RelayQLAST.js
@@ -722,6 +722,10 @@ class RelayQLArgumentType {
     return this.schemaUnmodifiedArgType instanceof types.GraphQLEnumType;
   }
 
+  isID(): boolean {
+    return this.isScalar() && this.getName({modifiers: false}) === 'ID';
+  }
+
   isList(): boolean {
     return this.isListType;
   }

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
@@ -12,7 +12,9 @@ var foo = (function (RQL_0) {
   return {
     calls: [{
       kind: "Call",
-      metadata: {},
+      metadata: {
+        type: "ID"
+      },
       name: "id",
       value: Relay.QL.__var(RQL_0)
     }],
@@ -36,7 +38,8 @@ var foo = (function (RQL_0) {
     kind: "Query",
     metadata: {
       isAbstract: true,
-      identifyingArgName: "id"
+      identifyingArgName: "id",
+      identifyingArgType: "ID"
     },
     name: "Args",
     type: "Node"

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
@@ -27,7 +27,9 @@ var foo = (function () {
   return {
     calls: [{
       kind: "Call",
-      metadata: {},
+      metadata: {
+        type: "ID"
+      },
       name: "id",
       value: {
         kind: "CallValue",
@@ -206,7 +208,8 @@ var foo = (function () {
     kind: "Query",
     metadata: {
       isAbstract: true,
-      identifyingArgName: "id"
+      identifyingArgName: "id",
+      identifyingArgType: "ID"
     },
     name: "Args",
     type: "Node"

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
@@ -12,7 +12,9 @@ var foo = (function () {
   return {
     calls: [{
       kind: "Call",
-      metadata: {},
+      metadata: {
+        type: "[ID]"
+      },
       name: "ids",
       value: [{
         kind: "CallVariable",
@@ -46,7 +48,8 @@ var foo = (function () {
     metadata: {
       isPlural: true,
       isAbstract: true,
-      identifyingArgName: "ids"
+      identifyingArgName: "ids",
+      identifyingArgType: "[ID]"
     },
     name: "Args",
     type: "Node"

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
@@ -25,7 +25,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -153,7 +155,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'ConnectionWithPageInfoAlias',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
@@ -23,7 +23,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -151,7 +153,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'ConnectionWithPageInfoSubfields',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
@@ -20,7 +20,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -144,7 +146,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'ConnectionWithoutNodeField',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
@@ -20,7 +20,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -145,7 +147,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'ConnectionWithoutNodeID',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -64,7 +66,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'FieldForEnum',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -65,7 +67,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'FieldWithAlias',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -84,7 +86,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'FieldWithAliasAndArgs',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -83,7 +85,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'FieldWithArgs',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -22,7 +22,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -155,7 +157,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'FieldWithEnumArg',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
@@ -22,7 +22,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -155,7 +157,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'FieldWithEnumQueryArg',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -83,7 +85,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'FieldWithParams',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
@@ -27,9 +27,7 @@ var foo = (function () {
     }],
     fieldName: "__type",
     kind: "Query",
-    metadata: {
-      identifyingArgName: "name"
-    },
+    metadata: {},
     name: "IntrospectionQueryForType",
     type: "__Type"
   };

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
@@ -22,7 +22,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -151,7 +153,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'MetadataConnection',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
@@ -12,7 +12,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -40,7 +42,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'MetadataGenerated',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -66,7 +68,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'MetadataPlural',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
@@ -19,7 +19,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -85,7 +87,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'PluralField',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
@@ -32,9 +32,7 @@ var q = (function () {
     fieldName: 'searchAll',
     kind: 'Query',
     metadata: {
-      isPlural: true,
-      identifyingArgName: 'queries',
-      identifyingArgType: '[SearchInput!]!'
+      isPlural: true
     },
     name: 'QueryWithArrayObjectArg',
     type: 'SearchResult'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
@@ -34,9 +34,7 @@ var q = (function () {
     fieldName: 'searchAll',
     kind: 'Query',
     metadata: {
-      isPlural: true,
-      identifyingArgName: 'queries',
-      identifyingArgType: '[SearchInput!]!'
+      isPlural: true
     },
     name: 'QueryWithArrayObjectValue',
     type: 'SearchResult'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -97,7 +99,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'QueryWithDirectives',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -64,7 +66,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'QueryWithFields',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithMixedArgsPlural.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithMixedArgsPlural.fixture
@@ -1,16 +1,16 @@
 Input:
-var Relay = require('react-relay');
-var x = Relay.QL`
+var Relay = require('Relay');
+var q = Relay.QL`
   query {
-    nodes(ids: [123,456]) {
-      id,
-    },
+    filteredNodes(ids: ["1" "3" "5"] filter: "Odd") {
+      id
+    }
   }
 `;
 
 Output:
-var Relay = require('react-relay');
-var x = (function () {
+var Relay = require('Relay');
+var q = (function () {
   return {
     calls: [{
       kind: 'Call',
@@ -20,11 +20,22 @@ var x = (function () {
       name: 'ids',
       value: [{
         kind: 'CallValue',
-        callValue: 123
+        callValue: '1'
       }, {
         kind: 'CallValue',
-        callValue: 456
+        callValue: '3'
+      }, {
+        kind: 'CallValue',
+        callValue: '5'
       }]
+    }, {
+      kind: 'Call',
+      metadata: {},
+      name: 'filter',
+      value: {
+        kind: 'CallValue',
+        callValue: 'Odd'
+      }
     }],
     children: [{
       fieldName: 'id',
@@ -42,7 +53,7 @@ var x = (function () {
       },
       type: 'String'
     }],
-    fieldName: 'nodes',
+    fieldName: 'filteredNodes',
     kind: 'Query',
     metadata: {
       isPlural: true,
@@ -50,7 +61,7 @@ var x = (function () {
       identifyingArgName: 'ids',
       identifyingArgType: '[ID]'
     },
-    name: 'QueryWithVarArgs',
+    name: 'QueryWithMixedArgsPlural',
     type: 'Node'
   };
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithMixedArgsSingular.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithMixedArgsSingular.fixture
@@ -1,16 +1,16 @@
 Input:
-var RelayQL = require('react-relay/RelayQL');
-var x = RelayQL`
+var Relay = require('Relay');
+var q = Relay.QL`
   query {
-    node(id: 123) {
-      id,
-    },
+    filteredNode(id: "4" filter: "Zuck") {
+      id
+    }
   }
 `;
 
 Output:
-var RelayQL = require('react-relay/RelayQL');
-var x = (function () {
+var Relay = require('Relay');
+var q = (function () {
   return {
     calls: [{
       kind: 'Call',
@@ -20,7 +20,15 @@ var x = (function () {
       name: 'id',
       value: {
         kind: 'CallValue',
-        callValue: 123
+        callValue: '4'
+      }
+    }, {
+      kind: 'Call',
+      metadata: {},
+      name: 'filter',
+      value: {
+        kind: 'CallValue',
+        callValue: 'Zuck'
       }
     }],
     children: [{
@@ -39,14 +47,14 @@ var x = (function () {
       },
       type: 'String'
     }],
-    fieldName: 'node',
+    fieldName: 'filteredNode',
     kind: 'Query',
     metadata: {
       isAbstract: true,
       identifyingArgName: 'id',
       identifyingArgType: 'ID'
     },
-    name: 'TagRelayQL',
+    name: 'QueryWithMixedArgsSingular',
     type: 'Node'
   };
 })();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithMultipleIdentifyingArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithMultipleIdentifyingArgs.fixture
@@ -1,0 +1,15 @@
+Input:
+var Relay = require('Relay');
+var q = Relay.QL`
+  query {
+    compare(this: 1 that: 2) {
+      summary
+    }
+  }
+`;
+
+Output:
+var Relay = require('Relay');
+var q = (function () {
+  throw new Error('GraphQL validation/transform error ``Queries may have at most one identifying argument - type `ID!` or `[ID!]` - but field `compare` has 2. Use `ID` only for arguments that correspond 1:1 with objects in the response (ex: `node(id: 4)` (id: ID!) always returns the object with id 4). Use `Int` or `String` for all other arguments.`` in file `queryWithMultipleIdentifyingArgs.fixture`.');
+})();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -74,7 +76,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'QueryNameHere',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -74,7 +76,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'QueryWithNestedFields',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
@@ -30,7 +30,9 @@ var x = (function (RQL_0, RQL_1, RQL_2, RQL_3, RQL_4, RQL_5, RQL_6, RQL_7, RQL_8
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -86,7 +88,8 @@ var x = (function (RQL_0, RQL_1, RQL_2, RQL_3, RQL_4, RQL_5, RQL_6, RQL_7, RQL_8
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID'
     },
     name: 'QueryWithNestedFragments',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArg.fixture
@@ -32,9 +32,7 @@ var q = (function () {
     fieldName: 'search',
     kind: 'Query',
     metadata: {
-      isPlural: true,
-      identifyingArgName: 'query',
-      identifyingArgType: 'SearchInput!'
+      isPlural: true
     },
     name: 'QueryWithObjectArg',
     type: 'SearchResult'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
@@ -34,9 +34,7 @@ var q = (function () {
     fieldName: 'search',
     kind: 'Query',
     metadata: {
-      isPlural: true,
-      identifyingArgName: 'query',
-      identifyingArgType: 'SearchInput!'
+      isPlural: true
     },
     name: 'QueryWithObjectArgValue',
     type: 'SearchResult'

--- a/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
@@ -12,7 +12,9 @@ var foo = (function () {
   return {
     calls: [{
       kind: "Call",
-      metadata: {},
+      metadata: {
+        type: "ID"
+      },
       name: "id",
       value: {
         kind: "CallValue",
@@ -31,7 +33,8 @@ var foo = (function () {
     kind: "Query",
     metadata: {
       isAbstract: true,
-      identifyingArgName: "id"
+      identifyingArgName: "id",
+      identifyingArgType: "ID"
     },
     name: "UnionWithTypename",
     type: "Media"

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -1,12 +1,21 @@
 type Root {
-  node(id: Int): Node
-  nodes(ids: [Int]): [Node]
-  media(id: Int): Media
+  compare(this: ID that: ID): Comparsion
+  filteredNode(id: ID filter: String): Node
+  filteredNodes(ids: [ID] filter: String): [Node]
+  node(id: ID): Node
+  nodes(ids: [ID]): [Node]
+  media(id: ID): Media
   viewer: Viewer
   search(query: SearchInput!): [SearchResult]
   searchAll(queries: [SearchInput!]!): [SearchResult]
   _invalid: InvalidType
   actor: Actor
+}
+
+type Comparsion {
+  this: ID
+  that: ID
+  summary: String
 }
 
 interface Actor {

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -17,6 +17,113 @@
           "description": null,
           "fields": [
             {
+              "name": "compare",
+              "description": null,
+              "args": [
+                {
+                  "name": "this",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "that",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Comparsion",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filteredNode",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Node",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filteredNodes",
+              "description": null,
+              "args": [
+                {
+                  "name": "ids",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Node",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "node",
               "description": null,
               "args": [
@@ -25,7 +132,7 @@
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -51,7 +158,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "SCALAR",
-                      "name": "Int",
+                      "name": "ID",
                       "ofType": null
                     }
                   },
@@ -79,7 +186,7 @@
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null
@@ -206,8 +313,65 @@
         },
         {
           "kind": "SCALAR",
-          "name": "Int",
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Comparsion",
+          "description": null,
+          "fields": [
+            {
+              "name": "this",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "that",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "summary",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -323,16 +487,6 @@
               "ofType": null
             }
           ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "String",
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -647,6 +801,16 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },


### PR DESCRIPTION
This another step toward #112. Here, we use the `ID` type to distinguish between identifying arguments and non-identifying arguments, and allow any combination of root calls *except* multiple arguments of type `ID` or `[ID]` (the whole point is that they are "identifying", but multiple of them makes them non-identifying).

This is *part* of the solution to arbitrary root fields, but it still has some limitations. In addition to the above, this isn't sufficient to support root-level connections. I'm leaning towards changing the query representation itself to be something like:

```
type ConcreteQuery = { 
  kind: 'Query';
  rootField: ConcreteField;
  metadata: {isDeferred: boolean};
  type: string;
};
```

With this approach, root fields whose *only* arguments had type `ID`/`[ID]` would be opted-in to being treated as identifying fields, while everything else would "just work" (as in, we'd have to change everywhere that we process queries to be aware of it having a root field, but at least that could now use the normal field-handling logic).