### PR TITLE
Test the version of the specific Babel that was passed into the babel…

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-BygyeiZvGclOAl00KbgUibTdzxs=
+JvWvngBaHPV3GjrJ036AjM/JyKE=

--- a/scripts/babel-relay-plugin/lib/babelAdapter.js
+++ b/scripts/babel-relay-plugin/lib/babelAdapter.js
@@ -15,11 +15,10 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var babel = require('babel-core');
 var path = require('path');
 
-function babelAdapter(Plugin, t, name, visitorsBuilder) {
-  if (Plugin == null || /^6\./.test(babel.version)) {
+function babelAdapter(Plugin, t, babelVersion, name, visitorsBuilder) {
+  if (Plugin == null || /^6\./.test(babelVersion)) {
     // Babel 6.
     return visitorsBuilder(t);
   }

--- a/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
@@ -46,8 +46,9 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
   return function (_ref) {
     var Plugin = _ref.Plugin;
     var types = _ref.types;
+    var version = _ref.version;
 
-    return babelAdapter(Plugin, types, 'relay-query', function (t) {
+    return babelAdapter(Plugin, types, version, 'relay-query', function (t) {
       return {
         visitor: {
           /**

--- a/scripts/babel-relay-plugin/src/babelAdapter.js
+++ b/scripts/babel-relay-plugin/src/babelAdapter.js
@@ -12,12 +12,12 @@
 
 'use strict';
 
-const babel = require('babel-core');
 const path = require('path');
 
 function babelAdapter(
   Plugin: ?Function,
   t: any,
+  babelVersion: string,
   name: string,
   visitorsBuilder: (t: any) => {
     visitor: {
@@ -25,7 +25,7 @@ function babelAdapter(
     };
   }
 ): mixed {
-  if (Plugin == null || /^6\./.test(babel.version)) {
+  if (Plugin == null || /^6\./.test(babelVersion)) {
     // Babel 6.
     return visitorsBuilder(t);
   }

--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -55,8 +55,8 @@ function getBabelRelayPlugin(
     validator: options.validator,
   });
 
-  return function({Plugin, types}) {
-    return babelAdapter(Plugin, types, 'relay-query', t => ({
+  return function({Plugin, types, version}) {
+    return babelAdapter(Plugin, types, version, 'relay-query', t => ({
       visitor: {
         /**
          * Extract the module name from `@providesModule`.


### PR DESCRIPTION
Previously, we were testing that `require('babel-core').version` started with `6.`. This could lead to unexpected results, since the return value of that require might or might not be the version of Babel you're using.