### PR TITLE
build-lib script is not generated

### DIFF
--- a/scripts/babel-relay-plugin/scripts/build-lib
+++ b/scripts/babel-relay-plugin/scripts/build-lib
@@ -32,8 +32,8 @@ files.forEach(file => {
   mkdirp.sync(path.dirname(libFile));
   const result = babel.transformFileSync(srcFile);
 
-  // Prepend @generated annotation
-  const code = '// @generated\n' + result.code;
+  // Prepend generated annotation
+  const code = '// @' + 'generated\n' + result.code;
   fs.writeFile(libFile, code, 'utf8');
   hash.update(code);
 });


### PR DESCRIPTION
Breaks up the `@generated` string so the file is not incorrectly classified as generated.