### PR TITLE
Update plugin to Babel 6

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-GPY6hTnGbVf8uNlttPaNVTbTI8o=
+ZwPi8UplWk9YbMNtG+bQ0Q6ii48=

--- a/scripts/babel-relay-plugin/lib/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLAST.js
@@ -11,33 +11,33 @@
  * @fullSyntaxTransform
  */
 
-// TODO: Import types from `graphql`.
 'use strict';
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var _require = require('./GraphQL');
 
 var types = _require.type;
-var _require$type_introspection = _require.type_introspection;
-var SchemaMetaFieldDef = _require$type_introspection.SchemaMetaFieldDef;
-var TypeMetaFieldDef = _require$type_introspection.TypeMetaFieldDef;
-var TypeNameMetaFieldDef = _require$type_introspection.TypeNameMetaFieldDef;
+var _require$type_introsp = _require.type_introspection;
+var SchemaMetaFieldDef = _require$type_introsp.SchemaMetaFieldDef;
+var TypeMetaFieldDef = _require$type_introsp.TypeMetaFieldDef;
+var TypeNameMetaFieldDef = _require$type_introsp.TypeNameMetaFieldDef;
 
 var GraphQLRelayDirective = require('./GraphQLRelayDirective');
 
 var find = require('./find');
 var invariant = require('./invariant');
 
-var RelayQLNode = (function () {
+// TODO: Import types from `graphql`.
+
+
+var RelayQLNode = function () {
   function RelayQLNode(context, ast) {
     _classCallCheck(this, RelayQLNode);
 
@@ -45,95 +45,83 @@ var RelayQLNode = (function () {
     this.context = context;
   }
 
-  _createClass(RelayQLNode, [{
-    key: 'getType',
-    value: function getType() {
-      invariant(false, 'Missing Implementation');
-    }
-  }, {
-    key: 'getField',
-    value: function getField(fieldName) {
-      return find(this.getFields(), function (field) {
-        return field.getName() === fieldName;
-      });
-    }
-  }, {
-    key: 'getFields',
-    value: function getFields() {
-      var fields = [];
-      this.getSelections().forEach(function (selection) {
-        if (selection instanceof RelayQLField) {
-          fields.push(selection);
-        }
-      });
-      return fields;
-    }
-  }, {
-    key: 'getSelections',
-    value: function getSelections() {
-      var _this = this;
+  RelayQLNode.prototype.getType = function getType() {
+    invariant(false, 'Missing Implementation');
+  };
 
-      if (!this.ast.selectionSet) {
-        return [];
+  RelayQLNode.prototype.getField = function getField(fieldName) {
+    return find(this.getFields(), function (field) {
+      return field.getName() === fieldName;
+    });
+  };
+
+  RelayQLNode.prototype.getFields = function getFields() {
+    var fields = [];
+    this.getSelections().forEach(function (selection) {
+      if (selection instanceof RelayQLField) {
+        fields.push(selection);
       }
-      return this.ast.selectionSet.selections.map(function (selection) {
-        if (selection.kind === 'Field') {
-          return new RelayQLField(_this.context, selection, _this.getType());
-        } else if (selection.kind === 'FragmentSpread') {
-          return new RelayQLFragmentSpread(_this.context, selection);
-        } else if (selection.kind === 'InlineFragment') {
-          return new RelayQLInlineFragment(_this.context, selection, _this.getType());
-        } else {
-          invariant(false, 'Unexpected selection kind: %s', selection.kind);
-        }
-      });
-    }
-  }, {
-    key: 'getDirectives',
-    value: function getDirectives() {
-      var _this2 = this;
+    });
+    return fields;
+  };
 
-      return (this.ast.directives || []).map(function (directive) {
-        return new RelayQLDirective(_this2.context, directive);
-      });
+  RelayQLNode.prototype.getSelections = function getSelections() {
+    var _this = this;
+
+    if (!this.ast.selectionSet) {
+      return [];
     }
-  }, {
-    key: 'hasDirective',
-    value: function hasDirective(name) {
-      return (this.ast.directives || []).some(function (d) {
-        return d.name.value === name;
-      });
-    }
-  }, {
-    key: 'isPattern',
-    value: function isPattern() {
-      return this.context.isPattern;
-    }
-  }]);
+    return this.ast.selectionSet.selections.map(function (selection) {
+      if (selection.kind === 'Field') {
+        return new RelayQLField(_this.context, selection, _this.getType());
+      } else if (selection.kind === 'FragmentSpread') {
+        return new RelayQLFragmentSpread(_this.context, selection);
+      } else if (selection.kind === 'InlineFragment') {
+        return new RelayQLInlineFragment(_this.context, selection, _this.getType());
+      } else {
+        invariant(false, 'Unexpected selection kind: %s', selection.kind);
+      }
+    });
+  };
+
+  RelayQLNode.prototype.getDirectives = function getDirectives() {
+    var _this2 = this;
+
+    return (this.ast.directives || []).map(function (directive) {
+      return new RelayQLDirective(_this2.context, directive);
+    });
+  };
+
+  RelayQLNode.prototype.hasDirective = function hasDirective(name) {
+    return (this.ast.directives || []).some(function (d) {
+      return d.name.value === name;
+    });
+  };
+
+  RelayQLNode.prototype.isPattern = function isPattern() {
+    return this.context.isPattern;
+  };
 
   return RelayQLNode;
-})();
+}();
 
-var RelayQLDefinition = (function (_RelayQLNode) {
+var RelayQLDefinition = function (_RelayQLNode) {
   _inherits(RelayQLDefinition, _RelayQLNode);
 
   function RelayQLDefinition() {
     _classCallCheck(this, RelayQLDefinition);
 
-    _get(Object.getPrototypeOf(RelayQLDefinition.prototype), 'constructor', this).apply(this, arguments);
+    return _possibleConstructorReturn(this, _RelayQLNode.apply(this, arguments));
   }
 
-  _createClass(RelayQLDefinition, [{
-    key: 'getName',
-    value: function getName() {
-      return this.ast.name ? this.ast.name.value : this.getType().getName({ modifiers: false }); // TODO: this.context.definitionName;
-    }
-  }]);
+  RelayQLDefinition.prototype.getName = function getName() {
+    return this.ast.name ? this.ast.name.value : this.getType().getName({ modifiers: false }); // TODO: this.context.definitionName;
+  };
 
   return RelayQLDefinition;
-})(RelayQLNode);
+}(RelayQLNode);
 
-var RelayQLFragment = (function (_RelayQLDefinition) {
+var RelayQLFragment = function (_RelayQLDefinition) {
   _inherits(RelayQLFragment, _RelayQLDefinition);
 
   function RelayQLFragment(context, ast, parentType) {
@@ -155,219 +143,195 @@ var RelayQLFragment = (function (_RelayQLDefinition) {
     // @relay(isStaticFragment: true)
     var isStaticFragment = relayDirectiveArgs.isStaticFragment && relayDirectiveArgs.isStaticFragment.kind === 'BooleanValue' && relayDirectiveArgs.isStaticFragment.value;
 
-    _get(Object.getPrototypeOf(RelayQLFragment.prototype), 'constructor', this).call(this, _extends({}, context, { isPattern: isPattern }), ast);
-    this.hasStaticFragmentID = isStaticFragment;
-    this.parentType = parentType;
-    this.staticFragmentID = null;
+    var _this4 = _possibleConstructorReturn(this, _RelayQLDefinition.call(this, _extends({}, context, { isPattern: isPattern }), ast));
+
+    _this4.hasStaticFragmentID = isStaticFragment;
+    _this4.parentType = parentType;
+    _this4.staticFragmentID = null;
+    return _this4;
   }
 
-  _createClass(RelayQLFragment, [{
-    key: 'getStaticFragmentID',
-    value: function getStaticFragmentID() {
-      if (this.hasStaticFragmentID && this.staticFragmentID == null) {
-        var suffix = this.context.generateID();
-        // The fragmentLocationID is the same for all inline/nested fragments
-        // within each Relay.QL tagged template expression; the auto-incrementing
-        // suffix distinguishes these fragments from each other.
-        this.staticFragmentID = this.context.fragmentLocationID + ':' + suffix;
-      }
-      return this.staticFragmentID;
+  RelayQLFragment.prototype.getStaticFragmentID = function getStaticFragmentID() {
+    if (this.hasStaticFragmentID && this.staticFragmentID == null) {
+      var suffix = this.context.generateID();
+      // The fragmentLocationID is the same for all inline/nested fragments
+      // within each Relay.QL tagged template expression; the auto-incrementing
+      // suffix distinguishes these fragments from each other.
+      this.staticFragmentID = this.context.fragmentLocationID + ':' + suffix;
     }
-  }, {
-    key: 'getType',
-    value: function getType() {
-      var type = this.ast.typeCondition;
-      if (type) {
-        // Convert `ListType` and `NonNullType` into `NamedType`.
-        while (type.kind !== 'NamedType') {
-          type = type.type;
-        }
-        return new RelayQLType(this.context, this.context.schema.getType(type.name.value));
-      } else if (this.ast.kind === 'InlineFragment') {
-        // Inline fragments without type conditions fall back to parent type.
-        invariant(this.parentType, 'Cannot get type of typeless inline fragment without parent type.');
-        return this.parentType;
-      } else {
-        invariant(false, 'Unexpected fragment kind: %s', this.ast.kind);
+    return this.staticFragmentID;
+  };
+
+  RelayQLFragment.prototype.getType = function getType() {
+    var type = this.ast.typeCondition;
+    if (type) {
+      // Convert `ListType` and `NonNullType` into `NamedType`.
+      while (type.kind !== 'NamedType') {
+        type = type.type;
       }
+      return new RelayQLType(this.context, this.context.schema.getType(type.name.value));
+    } else if (this.ast.kind === 'InlineFragment') {
+      // Inline fragments without type conditions fall back to parent type.
+      invariant(this.parentType, 'Cannot get type of typeless inline fragment without parent type.');
+      return this.parentType;
+    } else {
+      invariant(false, 'Unexpected fragment kind: %s', this.ast.kind);
     }
-  }]);
+  };
 
   return RelayQLFragment;
-})(RelayQLDefinition);
+}(RelayQLDefinition);
 
-var RelayQLMutation = (function (_RelayQLDefinition2) {
+var RelayQLMutation = function (_RelayQLDefinition2) {
   _inherits(RelayQLMutation, _RelayQLDefinition2);
 
   function RelayQLMutation() {
     _classCallCheck(this, RelayQLMutation);
 
-    _get(Object.getPrototypeOf(RelayQLMutation.prototype), 'constructor', this).apply(this, arguments);
+    return _possibleConstructorReturn(this, _RelayQLDefinition2.apply(this, arguments));
   }
 
-  _createClass(RelayQLMutation, [{
-    key: 'getType',
-    value: function getType() {
-      return new RelayQLType(this.context, this.context.schema.getMutationType());
-    }
-  }]);
+  RelayQLMutation.prototype.getType = function getType() {
+    return new RelayQLType(this.context, this.context.schema.getMutationType());
+  };
 
   return RelayQLMutation;
-})(RelayQLDefinition);
+}(RelayQLDefinition);
 
-var RelayQLQuery = (function (_RelayQLDefinition3) {
+var RelayQLQuery = function (_RelayQLDefinition3) {
   _inherits(RelayQLQuery, _RelayQLDefinition3);
 
   function RelayQLQuery() {
     _classCallCheck(this, RelayQLQuery);
 
-    _get(Object.getPrototypeOf(RelayQLQuery.prototype), 'constructor', this).apply(this, arguments);
+    return _possibleConstructorReturn(this, _RelayQLDefinition3.apply(this, arguments));
   }
 
-  _createClass(RelayQLQuery, [{
-    key: 'getType',
-    value: function getType() {
-      return new RelayQLType(this.context, this.context.schema.getQueryType());
-    }
-  }]);
+  RelayQLQuery.prototype.getType = function getType() {
+    return new RelayQLType(this.context, this.context.schema.getQueryType());
+  };
 
   return RelayQLQuery;
-})(RelayQLDefinition);
+}(RelayQLDefinition);
 
-var RelayQLSubscription = (function (_RelayQLDefinition4) {
+var RelayQLSubscription = function (_RelayQLDefinition4) {
   _inherits(RelayQLSubscription, _RelayQLDefinition4);
 
   function RelayQLSubscription() {
     _classCallCheck(this, RelayQLSubscription);
 
-    _get(Object.getPrototypeOf(RelayQLSubscription.prototype), 'constructor', this).apply(this, arguments);
+    return _possibleConstructorReturn(this, _RelayQLDefinition4.apply(this, arguments));
   }
 
-  _createClass(RelayQLSubscription, [{
-    key: 'getType',
-    value: function getType() {
-      return new RelayQLType(this.context, this.context.schema.getSubscriptionType());
-    }
-  }]);
+  RelayQLSubscription.prototype.getType = function getType() {
+    return new RelayQLType(this.context, this.context.schema.getSubscriptionType());
+  };
 
   return RelayQLSubscription;
-})(RelayQLDefinition);
+}(RelayQLDefinition);
 
-var RelayQLField = (function (_RelayQLNode2) {
+var RelayQLField = function (_RelayQLNode2) {
   _inherits(RelayQLField, _RelayQLNode2);
 
   function RelayQLField(context, ast, parentType) {
     _classCallCheck(this, RelayQLField);
 
-    _get(Object.getPrototypeOf(RelayQLField.prototype), 'constructor', this).call(this, context, ast);
-    var fieldName = this.ast.name.value;
+    var _this8 = _possibleConstructorReturn(this, _RelayQLNode2.call(this, context, ast));
+
+    var fieldName = _this8.ast.name.value;
     var fieldDef = parentType.getFieldDefinition(fieldName, ast);
     invariant(fieldDef, 'You supplied a field named `%s` on type `%s`, but no such field ' + 'exists on that type.', fieldName, parentType.getName({ modifiers: false }));
-    this.fieldDef = fieldDef;
+    _this8.fieldDef = fieldDef;
+    return _this8;
   }
 
-  _createClass(RelayQLField, [{
-    key: 'getName',
-    value: function getName() {
-      return this.ast.name.value;
-    }
-  }, {
-    key: 'getAlias',
-    value: function getAlias() {
-      return this.ast.alias ? this.ast.alias.value : null;
-    }
-  }, {
-    key: 'getType',
-    value: function getType() {
-      return this.fieldDef.getType();
-    }
-  }, {
-    key: 'hasArgument',
-    value: function hasArgument(argName) {
-      return this.getArguments().some(function (arg) {
-        return arg.getName() === argName;
-      });
-    }
-  }, {
-    key: 'getArguments',
-    value: function getArguments() {
-      var _this3 = this;
+  RelayQLField.prototype.getName = function getName() {
+    return this.ast.name.value;
+  };
 
-      var argTypes = this.fieldDef.getDeclaredArguments();
-      return (this.ast.arguments || []).map(function (arg) {
-        var argName = arg.name.value;
-        var argType = argTypes[argName];
-        invariant(argType, 'You supplied an argument named `%s` on field `%s`, but no such ' + 'argument exists on that field.', argName, _this3.getName());
-        return new RelayQLArgument(_this3.context, arg, argType);
-      });
-    }
-  }, {
-    key: 'hasDeclaredArgument',
-    value: function hasDeclaredArgument(argName) {
-      return this.fieldDef.getDeclaredArguments().hasOwnProperty(argName);
-    }
-  }, {
-    key: 'getDeclaredArgument',
-    value: function getDeclaredArgument(argName) {
-      return this.fieldDef.getArgument(argName);
-    }
-  }, {
-    key: 'getDeclaredArguments',
-    value: function getDeclaredArguments() {
-      return this.fieldDef.getDeclaredArguments();
-    }
-  }]);
+  RelayQLField.prototype.getAlias = function getAlias() {
+    return this.ast.alias ? this.ast.alias.value : null;
+  };
+
+  RelayQLField.prototype.getType = function getType() {
+    return this.fieldDef.getType();
+  };
+
+  RelayQLField.prototype.hasArgument = function hasArgument(argName) {
+    return this.getArguments().some(function (arg) {
+      return arg.getName() === argName;
+    });
+  };
+
+  RelayQLField.prototype.getArguments = function getArguments() {
+    var _this9 = this;
+
+    var argTypes = this.fieldDef.getDeclaredArguments();
+    return (this.ast.arguments || []).map(function (arg) {
+      var argName = arg.name.value;
+      var argType = argTypes[argName];
+      invariant(argType, 'You supplied an argument named `%s` on field `%s`, but no such ' + 'argument exists on that field.', argName, _this9.getName());
+      return new RelayQLArgument(_this9.context, arg, argType);
+    });
+  };
+
+  RelayQLField.prototype.hasDeclaredArgument = function hasDeclaredArgument(argName) {
+    return this.fieldDef.getDeclaredArguments().hasOwnProperty(argName);
+  };
+
+  RelayQLField.prototype.getDeclaredArgument = function getDeclaredArgument(argName) {
+    return this.fieldDef.getArgument(argName);
+  };
+
+  RelayQLField.prototype.getDeclaredArguments = function getDeclaredArguments() {
+    return this.fieldDef.getDeclaredArguments();
+  };
 
   return RelayQLField;
-})(RelayQLNode);
+}(RelayQLNode);
 
-var RelayQLFragmentSpread = (function (_RelayQLNode3) {
+var RelayQLFragmentSpread = function (_RelayQLNode3) {
   _inherits(RelayQLFragmentSpread, _RelayQLNode3);
 
   function RelayQLFragmentSpread() {
     _classCallCheck(this, RelayQLFragmentSpread);
 
-    _get(Object.getPrototypeOf(RelayQLFragmentSpread.prototype), 'constructor', this).apply(this, arguments);
+    return _possibleConstructorReturn(this, _RelayQLNode3.apply(this, arguments));
   }
 
-  _createClass(RelayQLFragmentSpread, [{
-    key: 'getName',
-    value: function getName() {
-      return this.ast.name.value;
-    }
-  }, {
-    key: 'getSelections',
-    value: function getSelections() {
-      invariant(false, 'Cannot get selection of a fragment spread.');
-    }
-  }]);
+  RelayQLFragmentSpread.prototype.getName = function getName() {
+    return this.ast.name.value;
+  };
+
+  RelayQLFragmentSpread.prototype.getSelections = function getSelections() {
+    invariant(false, 'Cannot get selection of a fragment spread.');
+  };
 
   return RelayQLFragmentSpread;
-})(RelayQLNode);
+}(RelayQLNode);
 
-var RelayQLInlineFragment = (function (_RelayQLNode4) {
+var RelayQLInlineFragment = function (_RelayQLNode4) {
   _inherits(RelayQLInlineFragment, _RelayQLNode4);
 
   function RelayQLInlineFragment(context, ast, parentType) {
     _classCallCheck(this, RelayQLInlineFragment);
 
-    _get(Object.getPrototypeOf(RelayQLInlineFragment.prototype), 'constructor', this).call(this, context, ast);
-    this.parentType = parentType;
+    var _this11 = _possibleConstructorReturn(this, _RelayQLNode4.call(this, context, ast));
+
+    _this11.parentType = parentType;
+    return _this11;
   }
 
-  _createClass(RelayQLInlineFragment, [{
-    key: 'getFragment',
-    value: function getFragment() {
-      return new RelayQLFragment(this.context, this.ast, this.parentType);
-    }
-  }]);
+  RelayQLInlineFragment.prototype.getFragment = function getFragment() {
+    return new RelayQLFragment(this.context, this.ast, this.parentType);
+  };
 
   return RelayQLInlineFragment;
-})(RelayQLNode);
+}(RelayQLNode);
 
-var RelayQLDirective = (function () {
+var RelayQLDirective = function () {
   function RelayQLDirective(context, ast) {
-    var _this4 = this;
+    var _this12 = this;
 
     _classCallCheck(this, RelayQLDirective);
 
@@ -379,33 +343,29 @@ var RelayQLDirective = (function () {
     var schemaDirective = directiveName === GraphQLRelayDirective.name ? GraphQLRelayDirective : context.schema.getDirective(directiveName);
     invariant(schemaDirective, 'You supplied a directive named `%s`, but no such directive exists.', directiveName);
     schemaDirective.args.forEach(function (schemaArg) {
-      _this4.argTypes[schemaArg.name] = new RelayQLArgumentType(schemaArg.type);
+      _this12.argTypes[schemaArg.name] = new RelayQLArgumentType(schemaArg.type);
     });
   }
 
-  _createClass(RelayQLDirective, [{
-    key: 'getName',
-    value: function getName() {
-      return this.ast.name.value;
-    }
-  }, {
-    key: 'getArguments',
-    value: function getArguments() {
-      var _this5 = this;
+  RelayQLDirective.prototype.getName = function getName() {
+    return this.ast.name.value;
+  };
 
-      return (this.ast.arguments || []).map(function (arg) {
-        var argName = arg.name.value;
-        var argType = _this5.argTypes[argName];
-        invariant(argType, 'You supplied an argument named `%s` on directive `%s`, but no ' + 'such argument exists on that directive.', argName, _this5.getName());
-        return new RelayQLArgument(_this5.context, arg, argType);
-      });
-    }
-  }]);
+  RelayQLDirective.prototype.getArguments = function getArguments() {
+    var _this13 = this;
+
+    return (this.ast.arguments || []).map(function (arg) {
+      var argName = arg.name.value;
+      var argType = _this13.argTypes[argName];
+      invariant(argType, 'You supplied an argument named `%s` on directive `%s`, but no ' + 'such argument exists on that directive.', argName, _this13.getName());
+      return new RelayQLArgument(_this13.context, arg, argType);
+    });
+  };
 
   return RelayQLDirective;
-})();
+}();
 
-var RelayQLArgument = (function () {
+var RelayQLArgument = function () {
   function RelayQLArgument(context, ast, type) {
     _classCallCheck(this, RelayQLArgument);
 
@@ -414,48 +374,41 @@ var RelayQLArgument = (function () {
     this.type = type;
   }
 
-  _createClass(RelayQLArgument, [{
-    key: 'getName',
-    value: function getName() {
-      return this.ast.name.value;
-    }
-  }, {
-    key: 'getType',
-    value: function getType() {
-      return this.type;
-    }
-  }, {
-    key: 'isVariable',
-    value: function isVariable() {
-      return this.ast.value.kind === 'Variable';
-    }
-  }, {
-    key: 'getVariableName',
-    value: function getVariableName() {
-      invariant(this.ast.value.kind === 'Variable', 'Cannot get variable name of an argument value.');
-      return this.ast.value.name.value;
-    }
-  }, {
-    key: 'getValue',
-    value: function getValue() {
-      var _this6 = this;
+  RelayQLArgument.prototype.getName = function getName() {
+    return this.ast.name.value;
+  };
 
-      invariant(!this.isVariable(), 'Cannot get value of an argument variable.');
-      var value = this.ast.value;
-      if (value.kind === 'ListValue') {
-        return value.values.map(function (value) {
-          return new RelayQLArgument(_this6.context, _extends({}, _this6.ast, { value: value }), _this6.type.ofType());
-        });
-      } else {
-        return getLiteralValue(value);
-      }
+  RelayQLArgument.prototype.getType = function getType() {
+    return this.type;
+  };
+
+  RelayQLArgument.prototype.isVariable = function isVariable() {
+    return this.ast.value.kind === 'Variable';
+  };
+
+  RelayQLArgument.prototype.getVariableName = function getVariableName() {
+    invariant(this.ast.value.kind === 'Variable', 'Cannot get variable name of an argument value.');
+    return this.ast.value.name.value;
+  };
+
+  RelayQLArgument.prototype.getValue = function getValue() {
+    var _this14 = this;
+
+    invariant(!this.isVariable(), 'Cannot get value of an argument variable.');
+    var value = this.ast.value;
+    if (value.kind === 'ListValue') {
+      return value.values.map(function (value) {
+        return new RelayQLArgument(_this14.context, _extends({}, _this14.ast, { value: value }), _this14.type.ofType());
+      });
+    } else {
+      return getLiteralValue(value);
     }
-  }]);
+  };
 
   return RelayQLArgument;
-})();
+}();
 
-var RelayQLType = (function () {
+var RelayQLType = function () {
   function RelayQLType(context, schemaModifiedType) {
     _classCallCheck(this, RelayQLType);
 
@@ -473,227 +426,207 @@ var RelayQLType = (function () {
     this.schemaModifiedType = schemaModifiedType;
   }
 
-  _createClass(RelayQLType, [{
-    key: 'canHaveSubselections',
-    value: function canHaveSubselections() {
-      return !(this.schemaUnmodifiedType instanceof types.GraphQLScalarType || this.schemaUnmodifiedType instanceof types.GraphQLEnumType);
-    }
-  }, {
-    key: 'getName',
-    value: function getName(_ref) {
-      var modifiers = _ref.modifiers;
-      return (function () {
-        return modifiers ? this.schemaModifiedType.toString() : this.schemaUnmodifiedType.toString();
-      }).apply(this, arguments);
-    }
-  }, {
-    key: 'hasField',
-    value: function hasField(fieldName) {
-      return !!this.getFieldDefinition(fieldName);
-    }
-  }, {
-    key: 'getFieldDefinition',
-    value: function getFieldDefinition(fieldName, fieldAST) {
-      var type = this.schemaUnmodifiedType;
-      var isQueryType = type === this.context.schema.getQueryType();
-      var hasTypeName = type instanceof types.GraphQLObjectType || type instanceof types.GraphQLInterfaceType || type instanceof types.GraphQLUnionType;
-      var hasFields = type instanceof types.GraphQLObjectType || type instanceof types.GraphQLInterfaceType;
+  RelayQLType.prototype.canHaveSubselections = function canHaveSubselections() {
+    return !(this.schemaUnmodifiedType instanceof types.GraphQLScalarType || this.schemaUnmodifiedType instanceof types.GraphQLEnumType);
+  };
 
-      var schemaFieldDef = undefined;
-      if (isQueryType && fieldName === SchemaMetaFieldDef.name) {
-        schemaFieldDef = SchemaMetaFieldDef;
-      } else if (isQueryType && fieldName === TypeMetaFieldDef.name) {
-        schemaFieldDef = TypeMetaFieldDef;
-      } else if (hasTypeName && fieldName === TypeNameMetaFieldDef.name) {
-        schemaFieldDef = TypeNameMetaFieldDef;
-      } else if (hasFields) {
-        schemaFieldDef = type.getFields()[fieldName];
-      }
+  RelayQLType.prototype.getName = function getName(_ref) {
+    var modifiers = _ref.modifiers;
 
-      // Temporary workarounds to support legacy schemas
-      if (!schemaFieldDef) {
-        if (hasTypeName && fieldName === '__type__') {
-          schemaFieldDef = {
-            name: '__type__',
-            type: new types.GraphQLNonNull(this.context.schema.getType('Type')),
-            description: 'The introspected type of this object.',
-            deprecatedReason: 'Use __typename',
-            args: []
-          };
-        } else if (types.isAbstractType(type) && fieldAST && fieldAST.directives && fieldAST.directives.some(function (directive) {
-          return directive.name.value === 'fixme_fat_interface';
-        })) {
-          var possibleTypes = type.getPossibleTypes();
+    return modifiers ? this.schemaModifiedType.toString() : this.schemaUnmodifiedType.toString();
+  };
 
-          var _loop = function (ii) {
-            var possibleField = possibleTypes[ii].getFields()[fieldName];
-            if (possibleField) {
-              // Fat interface fields can have differing arguments. Try to return
-              // a field with matching arguments, but still return a field if the
-              // arguments do not match.
-              schemaFieldDef = possibleField;
-              if (fieldAST && fieldAST.arguments) {
-                var argumentsAllExist = fieldAST.arguments.every(function (argument) {
-                  return find(possibleField.args, function (argDef) {
-                    return argDef.name === argument.name.value;
-                  });
+  RelayQLType.prototype.hasField = function hasField(fieldName) {
+    return !!this.getFieldDefinition(fieldName);
+  };
+
+  RelayQLType.prototype.getFieldDefinition = function getFieldDefinition(fieldName, fieldAST) {
+    var type = this.schemaUnmodifiedType;
+    var isQueryType = type === this.context.schema.getQueryType();
+    var hasTypeName = type instanceof types.GraphQLObjectType || type instanceof types.GraphQLInterfaceType || type instanceof types.GraphQLUnionType;
+    var hasFields = type instanceof types.GraphQLObjectType || type instanceof types.GraphQLInterfaceType;
+
+    var schemaFieldDef = void 0;
+    if (isQueryType && fieldName === SchemaMetaFieldDef.name) {
+      schemaFieldDef = SchemaMetaFieldDef;
+    } else if (isQueryType && fieldName === TypeMetaFieldDef.name) {
+      schemaFieldDef = TypeMetaFieldDef;
+    } else if (hasTypeName && fieldName === TypeNameMetaFieldDef.name) {
+      schemaFieldDef = TypeNameMetaFieldDef;
+    } else if (hasFields) {
+      schemaFieldDef = type.getFields()[fieldName];
+    }
+
+    // Temporary workarounds to support legacy schemas
+    if (!schemaFieldDef) {
+      if (hasTypeName && fieldName === '__type__') {
+        schemaFieldDef = {
+          name: '__type__',
+          type: new types.GraphQLNonNull(this.context.schema.getType('Type')),
+          description: 'The introspected type of this object.',
+          deprecatedReason: 'Use __typename',
+          args: []
+        };
+      } else if (types.isAbstractType(type) && fieldAST && fieldAST.directives && fieldAST.directives.some(function (directive) {
+        return directive.name.value === 'fixme_fat_interface';
+      })) {
+        var possibleTypes = type.getPossibleTypes();
+
+        var _loop = function (ii) {
+          var possibleField = possibleTypes[ii].getFields()[fieldName];
+          if (possibleField) {
+            // Fat interface fields can have differing arguments. Try to return
+            // a field with matching arguments, but still return a field if the
+            // arguments do not match.
+            schemaFieldDef = possibleField;
+            if (fieldAST && fieldAST.arguments) {
+              var argumentsAllExist = fieldAST.arguments.every(function (argument) {
+                return find(possibleField.args, function (argDef) {
+                  return argDef.name === argument.name.value;
                 });
-                if (argumentsAllExist) {
-                  return 'break';
-                }
+              });
+              if (argumentsAllExist) {
+                return 'break';
               }
             }
-          };
-
-          for (var ii = 0; ii < possibleTypes.length; ii++) {
-            var _ret = _loop(ii);
-
-            if (_ret === 'break') break;
           }
+        };
+
+        for (var ii = 0; ii < possibleTypes.length; ii++) {
+          var _ret = _loop(ii);
+
+          if (_ret === 'break') break;
         }
       }
-
-      return schemaFieldDef ? new RelayQLFieldDefinition(this.context, schemaFieldDef) : null;
     }
-  }, {
-    key: 'getInterfaces',
-    value: function getInterfaces() {
-      var _this7 = this;
 
-      if (this.schemaUnmodifiedType instanceof types.GraphQLObjectType) {
-        return this.schemaUnmodifiedType.getInterfaces().map(function (schemaInterface) {
-          return new RelayQLType(_this7.context, schemaInterface);
-        });
-      }
-      return [];
-    }
-  }, {
-    key: 'getConcreteTypes',
-    value: function getConcreteTypes() {
-      var _this8 = this;
+    return schemaFieldDef ? new RelayQLFieldDefinition(this.context, schemaFieldDef) : null;
+  };
 
-      invariant(this.isAbstract(), 'Cannot get concrete types of a concrete type.');
-      return this.schemaUnmodifiedType.getPossibleTypes().map(function (concreteType) {
-        return new RelayQLType(_this8.context, concreteType);
+  RelayQLType.prototype.getInterfaces = function getInterfaces() {
+    var _this15 = this;
+
+    if (this.schemaUnmodifiedType instanceof types.GraphQLObjectType) {
+      return this.schemaUnmodifiedType.getInterfaces().map(function (schemaInterface) {
+        return new RelayQLType(_this15.context, schemaInterface);
       });
     }
-  }, {
-    key: 'getIdentifyingFieldDefinition',
-    value: function getIdentifyingFieldDefinition() {
-      if (this.alwaysImplements('Node')) {
-        return this.getFieldDefinition('id');
+    return [];
+  };
+
+  RelayQLType.prototype.getConcreteTypes = function getConcreteTypes() {
+    var _this16 = this;
+
+    invariant(this.isAbstract(), 'Cannot get concrete types of a concrete type.');
+    return this.schemaUnmodifiedType.getPossibleTypes().map(function (concreteType) {
+      return new RelayQLType(_this16.context, concreteType);
+    });
+  };
+
+  RelayQLType.prototype.getIdentifyingFieldDefinition = function getIdentifyingFieldDefinition() {
+    if (this.alwaysImplements('Node')) {
+      return this.getFieldDefinition('id');
+    }
+    return null;
+  };
+
+  RelayQLType.prototype.isAbstract = function isAbstract() {
+    return types.isAbstractType(this.schemaUnmodifiedType);
+  };
+
+  RelayQLType.prototype.isList = function isList() {
+    return this.isListType;
+  };
+
+  RelayQLType.prototype.isNonNull = function isNonNull() {
+    return this.isNonNullType;
+  };
+
+  RelayQLType.prototype.isConnection = function isConnection() {
+    if (!/Connection$/.test(this.getName({ modifiers: false }))) {
+      return false;
+    }
+    var edges = this.getFieldDefinition('edges');
+    if (!edges || !edges.getType().canHaveSubselections()) {
+      return false;
+    }
+    var node = edges.getType().getFieldDefinition('node');
+    if (!node || !node.getType().canHaveSubselections()) {
+      return false;
+    }
+    var cursor = edges.getType().getFieldDefinition('cursor');
+    if (!cursor || cursor.getType().canHaveSubselections()) {
+      return false;
+    }
+    return true;
+  };
+
+  RelayQLType.prototype.isConnectionEdge = function isConnectionEdge() {
+    return (/Edge$/.test(this.getName({ modifiers: false })) && this.hasField('node') && this.hasField('cursor')
+    );
+  };
+
+  RelayQLType.prototype.isConnectionPageInfo = function isConnectionPageInfo() {
+    return this.getName({ modifiers: false }) === 'PageInfo';
+  };
+
+  RelayQLType.prototype.alwaysImplements = function alwaysImplements(typeName) {
+    return this.getName({ modifiers: false }) === typeName || this.getInterfaces().some(function (type) {
+      return type.getName({ modifiers: false }) === typeName;
+    }) || this.isAbstract() && this.getConcreteTypes().every(function (type) {
+      return type.alwaysImplements(typeName);
+    });
+  };
+
+  RelayQLType.prototype.mayImplement = function mayImplement(typeName) {
+    return this.getName({ modifiers: false }) === typeName || this.getInterfaces().some(function (type) {
+      return type.getName({ modifiers: false }) === typeName;
+    }) || this.isAbstract() && this.getConcreteTypes().some(function (type) {
+      return type.alwaysImplements(typeName);
+    });
+  };
+
+  RelayQLType.prototype.generateField = function generateField(fieldName) {
+    var generatedFieldAST = {
+      kind: 'Field',
+      name: {
+        kind: 'Name',
+        value: fieldName
       }
-      return null;
-    }
-  }, {
-    key: 'isAbstract',
-    value: function isAbstract() {
-      return types.isAbstractType(this.schemaUnmodifiedType);
-    }
-  }, {
-    key: 'isList',
-    value: function isList() {
-      return this.isListType;
-    }
-  }, {
-    key: 'isNonNull',
-    value: function isNonNull() {
-      return this.isNonNullType;
-    }
-  }, {
-    key: 'isConnection',
-    value: function isConnection() {
-      if (!/Connection$/.test(this.getName({ modifiers: false }))) {
-        return false;
-      }
-      var edges = this.getFieldDefinition('edges');
-      if (!edges || !edges.getType().canHaveSubselections()) {
-        return false;
-      }
-      var node = edges.getType().getFieldDefinition('node');
-      if (!node || !node.getType().canHaveSubselections()) {
-        return false;
-      }
-      var cursor = edges.getType().getFieldDefinition('cursor');
-      if (!cursor || cursor.getType().canHaveSubselections()) {
-        return false;
-      }
-      return true;
-    }
-  }, {
-    key: 'isConnectionEdge',
-    value: function isConnectionEdge() {
-      return (/Edge$/.test(this.getName({ modifiers: false })) && this.hasField('node') && this.hasField('cursor')
-      );
-    }
-  }, {
-    key: 'isConnectionPageInfo',
-    value: function isConnectionPageInfo() {
-      return this.getName({ modifiers: false }) === 'PageInfo';
-    }
-  }, {
-    key: 'alwaysImplements',
-    value: function alwaysImplements(typeName) {
-      return this.getName({ modifiers: false }) === typeName || this.getInterfaces().some(function (type) {
-        return type.getName({ modifiers: false }) === typeName;
-      }) || this.isAbstract() && this.getConcreteTypes().every(function (type) {
-        return type.alwaysImplements(typeName);
-      });
-    }
-  }, {
-    key: 'mayImplement',
-    value: function mayImplement(typeName) {
-      return this.getName({ modifiers: false }) === typeName || this.getInterfaces().some(function (type) {
-        return type.getName({ modifiers: false }) === typeName;
-      }) || this.isAbstract() && this.getConcreteTypes().some(function (type) {
-        return type.alwaysImplements(typeName);
-      });
-    }
-  }, {
-    key: 'generateField',
-    value: function generateField(fieldName) {
-      var generatedFieldAST = {
-        kind: 'Field',
+    };
+    return new RelayQLField(this.context, generatedFieldAST, this);
+  };
+
+  RelayQLType.prototype.generateIdFragment = function generateIdFragment() {
+    var generatedFragmentAST = {
+      kind: 'Fragment',
+      name: {
+        kind: 'Name',
+        value: 'IdFragment'
+      },
+      typeCondition: {
+        kind: 'NamedType',
         name: {
-          kind: 'Name',
-          value: fieldName
+          value: 'Node'
         }
-      };
-      return new RelayQLField(this.context, generatedFieldAST, this);
-    }
-  }, {
-    key: 'generateIdFragment',
-    value: function generateIdFragment() {
-      var generatedFragmentAST = {
-        kind: 'Fragment',
-        name: {
-          kind: 'Name',
-          value: 'IdFragment'
-        },
-        typeCondition: {
-          kind: 'NamedType',
+      },
+      selectionSet: {
+        selections: [{
+          kind: 'Field',
           name: {
-            value: 'Node'
+            name: 'Name',
+            value: 'id'
           }
-        },
-        selectionSet: {
-          selections: [{
-            kind: 'Field',
-            name: {
-              name: 'Name',
-              value: 'id'
-            }
-          }]
-        }
-      };
-      return new RelayQLFragment(this.context, generatedFragmentAST, this);
-    }
-  }]);
+        }]
+      }
+    };
+    return new RelayQLFragment(this.context, generatedFragmentAST, this);
+  };
 
   return RelayQLType;
-})();
+}();
 
-var RelayQLFieldDefinition = (function () {
+var RelayQLFieldDefinition = function () {
   function RelayQLFieldDefinition(context, schemaFieldDef) {
     _classCallCheck(this, RelayQLFieldDefinition);
 
@@ -701,47 +634,40 @@ var RelayQLFieldDefinition = (function () {
     this.schemaFieldDef = schemaFieldDef;
   }
 
-  _createClass(RelayQLFieldDefinition, [{
-    key: 'getName',
-    value: function getName() {
-      return this.schemaFieldDef.name;
-    }
-  }, {
-    key: 'getType',
-    value: function getType() {
-      return new RelayQLType(this.context, this.schemaFieldDef.type);
-    }
-  }, {
-    key: 'hasArgument',
-    value: function hasArgument(argName) {
-      return this.schemaFieldDef.args.some(function (schemaArg) {
-        return schemaArg.name === argName;
-      });
-    }
-  }, {
-    key: 'getArgument',
-    value: function getArgument(argName) {
-      var schemaArg = find(this.schemaFieldDef.args, function (schemaArg) {
-        return schemaArg.name === argName;
-      });
-      invariant(schemaArg, 'You tried to get an argument named `%s` on field `%s`, but no such ' + 'argument exists on that field.', argName, this.getName());
-      return new RelayQLArgumentType(schemaArg.type);
-    }
-  }, {
-    key: 'getDeclaredArguments',
-    value: function getDeclaredArguments() {
-      var args = {};
-      this.schemaFieldDef.args.forEach(function (schemaArg) {
-        args[schemaArg.name] = new RelayQLArgumentType(schemaArg.type);
-      });
-      return args;
-    }
-  }]);
+  RelayQLFieldDefinition.prototype.getName = function getName() {
+    return this.schemaFieldDef.name;
+  };
+
+  RelayQLFieldDefinition.prototype.getType = function getType() {
+    return new RelayQLType(this.context, this.schemaFieldDef.type);
+  };
+
+  RelayQLFieldDefinition.prototype.hasArgument = function hasArgument(argName) {
+    return this.schemaFieldDef.args.some(function (schemaArg) {
+      return schemaArg.name === argName;
+    });
+  };
+
+  RelayQLFieldDefinition.prototype.getArgument = function getArgument(argName) {
+    var schemaArg = find(this.schemaFieldDef.args, function (schemaArg) {
+      return schemaArg.name === argName;
+    });
+    invariant(schemaArg, 'You tried to get an argument named `%s` on field `%s`, but no such ' + 'argument exists on that field.', argName, this.getName());
+    return new RelayQLArgumentType(schemaArg.type);
+  };
+
+  RelayQLFieldDefinition.prototype.getDeclaredArguments = function getDeclaredArguments() {
+    var args = {};
+    this.schemaFieldDef.args.forEach(function (schemaArg) {
+      args[schemaArg.name] = new RelayQLArgumentType(schemaArg.type);
+    });
+    return args;
+  };
 
   return RelayQLFieldDefinition;
-})();
+}();
 
-var RelayQLArgumentType = (function () {
+var RelayQLArgumentType = function () {
   function RelayQLArgumentType(schemaModifiedArgType) {
     _classCallCheck(this, RelayQLArgumentType);
 
@@ -757,49 +683,39 @@ var RelayQLArgumentType = (function () {
     this.schemaModifiedArgType = schemaModifiedArgType;
   }
 
-  _createClass(RelayQLArgumentType, [{
-    key: 'getName',
-    value: function getName(_ref2) {
-      var modifiers = _ref2.modifiers;
-      return (function () {
-        return modifiers ? this.schemaModifiedArgType.toString() : this.schemaUnmodifiedArgType.toString();
-      }).apply(this, arguments);
-    }
-  }, {
-    key: 'ofType',
-    value: function ofType() {
-      invariant(this.isList() || this.isNonNull(), 'Can only get type of list or non-null type.');
-      return new RelayQLArgumentType(this.schemaUnmodifiedArgType);
-    }
-  }, {
-    key: 'isEnum',
-    value: function isEnum() {
-      return this.schemaUnmodifiedArgType instanceof types.GraphQLEnumType;
-    }
-  }, {
-    key: 'isList',
-    value: function isList() {
-      return this.isListType;
-    }
-  }, {
-    key: 'isNonNull',
-    value: function isNonNull() {
-      return this.isNonNullType;
-    }
-  }, {
-    key: 'isObject',
-    value: function isObject() {
-      return this.schemaUnmodifiedArgType instanceof types.GraphQLInputObjectType;
-    }
-  }, {
-    key: 'isScalar',
-    value: function isScalar() {
-      return this.schemaUnmodifiedArgType instanceof types.GraphQLScalarType;
-    }
-  }]);
+  RelayQLArgumentType.prototype.getName = function getName(_ref2) {
+    var modifiers = _ref2.modifiers;
+
+    return modifiers ? this.schemaModifiedArgType.toString() : this.schemaUnmodifiedArgType.toString();
+  };
+
+  RelayQLArgumentType.prototype.ofType = function ofType() {
+    invariant(this.isList() || this.isNonNull(), 'Can only get type of list or non-null type.');
+    return new RelayQLArgumentType(this.schemaUnmodifiedArgType);
+  };
+
+  RelayQLArgumentType.prototype.isEnum = function isEnum() {
+    return this.schemaUnmodifiedArgType instanceof types.GraphQLEnumType;
+  };
+
+  RelayQLArgumentType.prototype.isList = function isList() {
+    return this.isListType;
+  };
+
+  RelayQLArgumentType.prototype.isNonNull = function isNonNull() {
+    return this.isNonNullType;
+  };
+
+  RelayQLArgumentType.prototype.isObject = function isObject() {
+    return this.schemaUnmodifiedArgType instanceof types.GraphQLInputObjectType;
+  };
+
+  RelayQLArgumentType.prototype.isScalar = function isScalar() {
+    return this.schemaUnmodifiedArgType instanceof types.GraphQLScalarType;
+  };
 
   return RelayQLArgumentType;
-})();
+}();
 
 function stripMarkerTypes(schemaModifiedType) {
   var isListType = false;

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -13,17 +13,9 @@
 
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var _require = require('./RelayQLAST');
 
@@ -39,6 +31,7 @@ var RelayQLMutation = _require.RelayQLMutation;
 var RelayQLQuery = _require.RelayQLQuery;
 var RelayQLSubscription = _require.RelayQLSubscription;
 var RelayQLType = _require.RelayQLType;
+
 
 var find = require('./find');
 var invariant = require('./invariant');
@@ -72,7 +65,7 @@ module.exports = function (t, options) {
   var INPUT_ARGUMENT_NAME = options.inputArgumentName || 'input';
   var NULL = t.nullLiteral();
 
-  var RelayQLPrinter = (function () {
+  var RelayQLPrinter = function () {
     function RelayQLPrinter(tagName, variableNames) {
       _classCallCheck(this, RelayQLPrinter);
 
@@ -80,464 +73,447 @@ module.exports = function (t, options) {
       this.variableNames = variableNames;
     }
 
-    /**
-     * Determine if a `... on Node { id }` fragment should be generated for a
-     * field/fragment to allow identification of the response record. This
-     * fragment should be added when some/all implementors of the node's type
-     * also implement `Node` but a `Node` fragment is not already present. If it
-     * is present then `id` would be added as a requisite field.
-     */
+    RelayQLPrinter.prototype.print = function print(definition, substitutions) {
+      var printedDocument = void 0;
+      if (definition instanceof RelayQLQuery) {
+        printedDocument = this.printQuery(definition);
+      } else if (definition instanceof RelayQLFragment) {
+        printedDocument = this.printFragment(definition);
+      } else if (definition instanceof RelayQLMutation) {
+        printedDocument = this.printMutation(definition);
+      } else if (definition instanceof RelayQLSubscription) {
+        printedDocument = this.printSubscription(definition);
+      } else {
+        invariant(false, 'Unsupported definition: %s', definition);
+      }
+      return t.callExpression(t.functionExpression(null, substitutions.map(function (substitution) {
+        return t.identifier(substitution.name);
+      }), t.blockStatement([t.returnStatement(printedDocument)])), substitutions.map(function (substitution) {
+        return substitution.value;
+      }));
+    };
 
-    _createClass(RelayQLPrinter, [{
-      key: 'print',
-      value: function print(definition, substitutions) {
-        var printedDocument = undefined;
-        if (definition instanceof RelayQLQuery) {
-          printedDocument = this.printQuery(definition);
-        } else if (definition instanceof RelayQLFragment) {
-          printedDocument = this.printFragment(definition);
-        } else if (definition instanceof RelayQLMutation) {
-          printedDocument = this.printMutation(definition);
-        } else if (definition instanceof RelayQLSubscription) {
-          printedDocument = this.printSubscription(definition);
+    RelayQLPrinter.prototype.printQuery = function printQuery(query) {
+      var rootFields = query.getFields();
+      invariant(rootFields.length === 1, 'There are %d fields supplied to the query named `%s`, but queries ' + 'must have exactly one field.', rootFields.length, query.getName());
+      var rootField = rootFields[0];
+      var rootFieldType = rootField.getType();
+      var rootFieldArgs = rootField.getArguments();
+
+      var requisiteFields = {};
+      var identifyingFieldDef = rootFieldType.getIdentifyingFieldDefinition();
+      if (identifyingFieldDef) {
+        requisiteFields[identifyingFieldDef.getName()] = true;
+      }
+      if (rootFieldType.isAbstract()) {
+        requisiteFields[FIELDS.__typename] = true;
+      }
+      var selections = this.printSelections(rootField, requisiteFields);
+      var metadata = {};
+      if (rootFieldType.isList()) {
+        metadata.isPlural = true;
+      }
+      if (rootFieldType.isAbstract()) {
+        metadata.isAbstract = true;
+      }
+      invariant(rootFieldArgs.length <= 1, 'Invalid root field `%s`; Relay only supports root fields with zero ' + 'or one argument.', rootField.getName());
+      var calls = NULL;
+      if (rootFieldArgs.length === 1) {
+        // Until such time as a root field's 'identifying argument' (one that has
+        // a 1-1 correspondence with a Relay record, or null) has a formal type,
+        // assume that the lone arg in a root field's call is the identifying one.
+        var identifyingArg = rootFieldArgs[0];
+        var identifyingArgName = identifyingArg.getName();
+        var identifyingArgType = identifyingArg.getType().getName({ modifiers: true });
+        metadata.identifyingArgName = identifyingArgName;
+        metadata.identifyingArgType = identifyingArgType;
+        calls = t.arrayExpression([codify({
+          kind: t.valueToNode('Call'),
+          metadata: objectify({
+            type: identifyingArgType
+          }),
+          name: t.valueToNode(identifyingArgName),
+          value: this.printArgumentValue(identifyingArg)
+        })]);
+      }
+
+      return codify({
+        calls: calls,
+        children: selections,
+        directives: this.printDirectives(rootField.getDirectives()),
+        fieldName: t.valueToNode(rootField.getName()),
+        kind: t.valueToNode('Query'),
+        metadata: objectify(metadata),
+        name: t.valueToNode(query.getName()),
+        type: t.valueToNode(rootFieldType.getName({ modifiers: false }))
+      });
+    };
+
+    RelayQLPrinter.prototype.printFragment = function printFragment(fragment) {
+      var fragmentType = fragment.getType();
+
+      var requisiteFields = {};
+      var idFragment = void 0;
+      if (fragmentType.hasField(FIELDS.id)) {
+        requisiteFields.id = true;
+      } else if (shouldGenerateIdFragment(fragment, fragmentType)) {
+        idFragment = fragmentType.generateIdFragment();
+      }
+      if (fragmentType.isAbstract()) {
+        requisiteFields[FIELDS.__typename] = true;
+      }
+      var selections = this.printSelections(fragment, requisiteFields, idFragment ? [idFragment] : null, fragment.hasDirective('generated'));
+      var metadata = this.printRelayDirectiveMetadata(fragment, {
+        isAbstract: fragmentType.isAbstract()
+      });
+
+      return codify({
+        children: selections,
+        directives: this.printDirectives(fragment.getDirectives()),
+        id: this.printFragmentID(fragment),
+        kind: t.valueToNode('Fragment'),
+        metadata: metadata,
+        name: t.valueToNode(fragment.getName()),
+        type: t.valueToNode(fragmentType.getName({ modifiers: false }))
+      });
+    };
+
+    RelayQLPrinter.prototype.printFragmentID = function printFragmentID(fragment) {
+      var staticFragmentID = fragment.getStaticFragmentID();
+      if (staticFragmentID == null) {
+        return t.callExpression(t.memberExpression(identify(this.tagName), t.identifier('__id')), []);
+      } else {
+        return t.valueToNode(staticFragmentID);
+      }
+    };
+
+    RelayQLPrinter.prototype.printMutation = function printMutation(mutation) {
+      var rootFields = mutation.getFields();
+      invariant(rootFields.length === 1, 'There are %d fields supplied to the mutation named `%s`, but ' + 'mutations must have exactly one field.', rootFields.length, mutation.getName());
+      var rootField = rootFields[0];
+      var rootFieldType = rootField.getType();
+      validateMutationField(rootField);
+      var requisiteFields = {};
+      if (rootFieldType.hasField(FIELDS.clientMutationId)) {
+        requisiteFields[FIELDS.clientMutationId] = true;
+      }
+      var selections = this.printSelections(rootField, requisiteFields);
+      var metadata = {
+        inputType: this.printArgumentTypeForMetadata(rootField.getDeclaredArgument(INPUT_ARGUMENT_NAME))
+      };
+
+      return codify({
+        calls: t.arrayExpression([codify({
+          kind: t.valueToNode('Call'),
+          metadata: objectify({}),
+          name: t.valueToNode(rootField.getName()),
+          value: this.printVariable('input')
+        })]),
+        children: selections,
+        directives: this.printDirectives(mutation.getDirectives()),
+        kind: t.valueToNode('Mutation'),
+        metadata: objectify(metadata),
+        name: t.valueToNode(mutation.getName()),
+        responseType: t.valueToNode(rootFieldType.getName({ modifiers: false }))
+      });
+    };
+
+    RelayQLPrinter.prototype.printSubscription = function printSubscription(subscription) {
+      var rootFields = subscription.getFields();
+      invariant(rootFields.length === 1, 'There are %d fields supplied to the subscription named `%s`, but ' + 'subscriptions must have exactly one field.', rootFields.length, subscription.getName());
+      var rootField = rootFields[0];
+      var rootFieldType = rootField.getType();
+      validateMutationField(rootField);
+      var requisiteFields = {};
+      if (rootFieldType.hasField(FIELDS.clientSubscriptionId)) {
+        requisiteFields[FIELDS.clientSubscriptionId] = true;
+      }
+      var selections = this.printSelections(rootField, requisiteFields);
+      var metadata = {
+        inputType: this.printArgumentTypeForMetadata(rootField.getDeclaredArgument(INPUT_ARGUMENT_NAME))
+      };
+
+      return codify({
+        calls: t.arrayExpression([codify({
+          kind: t.valueToNode('Call'),
+          metadata: objectify({}),
+          name: t.valueToNode(rootField.getName()),
+          value: this.printVariable('input')
+        })]),
+        children: selections,
+        directives: this.printDirectives(subscription.getDirectives()),
+        kind: t.valueToNode('Subscription'),
+        metadata: objectify(metadata),
+        name: t.valueToNode(subscription.getName()),
+        responseType: t.valueToNode(rootFieldType.getName({ modifiers: false }))
+      });
+    };
+
+    RelayQLPrinter.prototype.printSelections = function printSelections(parent, requisiteFields, extraFragments) {
+      var _this = this;
+
+      var isGeneratedQuery = arguments.length <= 3 || arguments[3] === undefined ? false : arguments[3];
+
+      var fields = [];
+      var printedFragments = [];
+      var didPrintFragmentReference = false;
+      parent.getSelections().forEach(function (selection) {
+        if (selection instanceof RelayQLFragmentSpread) {
+          // Assume that all spreads exist via template substitution.
+          invariant(selection.getDirectives().length === 0, 'Directives are not yet supported for `${fragment}`-style fragment ' + 'references.');
+          printedFragments.push(_this.printFragmentReference(selection));
+          didPrintFragmentReference = true;
+        } else if (selection instanceof RelayQLInlineFragment) {
+          printedFragments.push(_this.printFragment(selection.getFragment()));
+        } else if (selection instanceof RelayQLField) {
+          fields.push(selection);
         } else {
-          invariant(false, 'Unsupported definition: %s', definition);
+          invariant(false, 'Unsupported selection type `%s`.', selection);
         }
-        return t.callExpression(t.functionExpression(null, substitutions.map(function (substitution) {
-          return t.identifier(substitution.name);
-        }), t.blockStatement([t.returnStatement(printedDocument)])), substitutions.map(function (substitution) {
-          return substitution.value;
+      });
+      if (extraFragments) {
+        extraFragments.forEach(function (fragment) {
+          printedFragments.push(_this.printFragment(fragment));
+        });
+      }
+      var printedFields = this.printFields(fields, parent, requisiteFields, isGeneratedQuery);
+      var selections = [].concat(printedFields, printedFragments);
+
+      if (selections.length) {
+        var arrayExpressionOfSelections = t.arrayExpression(selections);
+        return didPrintFragmentReference ? shallowFlatten(arrayExpressionOfSelections) : arrayExpressionOfSelections;
+      }
+      return NULL;
+    };
+
+    RelayQLPrinter.prototype.printFields = function printFields(fields, parent, requisiteFields) {
+      var _this2 = this;
+
+      var isGeneratedQuery = arguments.length <= 3 || arguments[3] === undefined ? false : arguments[3];
+
+      var parentType = parent.getType();
+      if (parentType.isConnection() && parentType.hasField(FIELDS.pageInfo) && fields.some(function (field) {
+        return field.getName() === FIELDS.edges;
+      })) {
+        requisiteFields[FIELDS.pageInfo] = true;
+      }
+
+      var generatedFields = _extends({}, requisiteFields);
+
+      var printedFields = [];
+      fields.forEach(function (field) {
+        delete generatedFields[field.getName()];
+        printedFields.push(_this2.printField(field, parent, requisiteFields, generatedFields, isGeneratedQuery));
+      });
+
+      Object.keys(generatedFields).forEach(function (fieldName) {
+        var generatedField = parentType.generateField(fieldName);
+        printedFields.push(_this2.printField(generatedField, parent, requisiteFields, generatedFields, isGeneratedQuery));
+      });
+      return printedFields;
+    };
+
+    RelayQLPrinter.prototype.printField = function printField(field, parent, requisiteSiblings, generatedSiblings) {
+      var _this3 = this;
+
+      var isGeneratedQuery = arguments.length <= 4 || arguments[4] === undefined ? false : arguments[4];
+
+      var fieldType = field.getType();
+
+      var metadata = {};
+      var requisiteFields = {};
+      var idFragment = void 0;
+      if (fieldType.hasField(FIELDS.id)) {
+        requisiteFields.id = true;
+      } else if (shouldGenerateIdFragment(field, fieldType)) {
+        idFragment = fieldType.generateIdFragment();
+      }
+
+      if (!isGeneratedQuery) {
+        validateField(field, parent.getType());
+      }
+
+      if (fieldType.canHaveSubselections()) {
+        metadata.canHaveSubselections = true;
+      }
+      // TODO: Generalize to non-`Node` types.
+      if (fieldType.alwaysImplements('Node')) {
+        metadata.inferredRootCallName = 'node';
+        metadata.inferredPrimaryKey = 'id';
+      }
+      if (fieldType.isConnection()) {
+        if (field.hasDeclaredArgument('first') || field.hasDeclaredArgument('last')) {
+          if (!isGeneratedQuery) {
+            validateConnectionField(field);
+          }
+          metadata.isConnection = true;
+          if (field.hasDeclaredArgument('find')) {
+            metadata.isFindable = true;
+          }
+        }
+      } else if (fieldType.isConnectionPageInfo()) {
+        requisiteFields[FIELDS.hasNextPage] = true;
+        requisiteFields[FIELDS.hasPreviousPage] = true;
+      } else if (fieldType.isConnectionEdge()) {
+        requisiteFields[FIELDS.cursor] = true;
+        requisiteFields[FIELDS.node] = true;
+      }
+      if (fieldType.isAbstract()) {
+        metadata.isAbstract = true;
+        requisiteFields[FIELDS.__typename] = true;
+      }
+      if (fieldType.isList()) {
+        metadata.isPlural = true;
+      }
+      if (generatedSiblings.hasOwnProperty(field.getName())) {
+        metadata.isGenerated = true;
+      }
+      if (requisiteSiblings.hasOwnProperty(field.getName())) {
+        metadata.isRequisite = true;
+      }
+
+      var selections = this.printSelections(field, requisiteFields, idFragment ? [idFragment] : null, isGeneratedQuery);
+      var fieldAlias = field.getAlias();
+      var args = field.getArguments();
+      var calls = args.length ? t.arrayExpression(args.map(function (arg) {
+        return _this3.printArgument(arg);
+      })) : NULL;
+
+      return codify({
+        alias: fieldAlias ? t.valueToNode(fieldAlias) : NULL,
+        calls: calls,
+        children: selections,
+        directives: this.printDirectives(field.getDirectives()),
+        fieldName: t.valueToNode(field.getName()),
+        kind: t.valueToNode('Field'),
+        metadata: this.printRelayDirectiveMetadata(field, metadata),
+        type: t.valueToNode(fieldType.getName({ modifiers: false }))
+      });
+    };
+
+    RelayQLPrinter.prototype.printFragmentReference = function printFragmentReference(fragmentReference) {
+      return t.callExpression(t.memberExpression(identify(this.tagName), t.identifier('__frag')), [t.identifier(fragmentReference.getName())]);
+    };
+
+    RelayQLPrinter.prototype.printArgument = function printArgument(arg) {
+      var metadata = {};
+      var inputType = this.printArgumentTypeForMetadata(arg.getType());
+      if (inputType) {
+        metadata.type = inputType;
+      }
+      return codify({
+        kind: t.valueToNode('Call'),
+        metadata: objectify(metadata),
+        name: t.valueToNode(arg.getName()),
+        value: this.printArgumentValue(arg)
+      });
+    };
+
+    RelayQLPrinter.prototype.printArgumentValue = function printArgumentValue(arg) {
+      if (arg.isVariable()) {
+        return this.printVariable(arg.getVariableName());
+      } else {
+        return this.printValue(arg.getValue());
+      }
+    };
+
+    RelayQLPrinter.prototype.printVariable = function printVariable(name) {
+      // Assume that variables named like substitutions are substitutions.
+      if (this.variableNames.hasOwnProperty(name)) {
+        return t.callExpression(t.memberExpression(identify(this.tagName), t.identifier('__var')), [t.identifier(name)]);
+      }
+      return codify({
+        kind: t.valueToNode('CallVariable'),
+        callVariableName: t.valueToNode(name)
+      });
+    };
+
+    RelayQLPrinter.prototype.printValue = function printValue(value) {
+      var _this4 = this;
+
+      if (Array.isArray(value)) {
+        return t.arrayExpression(value.map(function (element) {
+          return _this4.printArgumentValue(element);
         }));
       }
-    }, {
-      key: 'printQuery',
-      value: function printQuery(query) {
-        var rootFields = query.getFields();
-        invariant(rootFields.length === 1, 'There are %d fields supplied to the query named `%s`, but queries ' + 'must have exactly one field.', rootFields.length, query.getName());
-        var rootField = rootFields[0];
-        var rootFieldType = rootField.getType();
-        var rootFieldArgs = rootField.getArguments();
+      return codify({
+        kind: t.valueToNode('CallValue'),
+        callValue: printLiteralValue(value)
+      });
+    };
 
-        var requisiteFields = {};
-        var identifyingFieldDef = rootFieldType.getIdentifyingFieldDefinition();
-        if (identifyingFieldDef) {
-          requisiteFields[identifyingFieldDef.getName()] = true;
-        }
-        if (rootFieldType.isAbstract()) {
-          requisiteFields[FIELDS.__typename] = true;
-        }
-        var selections = this.printSelections(rootField, requisiteFields);
-        var metadata = {};
-        if (rootFieldType.isList()) {
-          metadata.isPlural = true;
-        }
-        if (rootFieldType.isAbstract()) {
-          metadata.isAbstract = true;
-        }
-        invariant(rootFieldArgs.length <= 1, 'Invalid root field `%s`; Relay only supports root fields with zero ' + 'or one argument.', rootField.getName());
-        var calls = NULL;
-        if (rootFieldArgs.length === 1) {
-          // Until such time as a root field's 'identifying argument' (one that has
-          // a 1-1 correspondence with a Relay record, or null) has a formal type,
-          // assume that the lone arg in a root field's call is the identifying one.
-          var identifyingArg = rootFieldArgs[0];
-          var identifyingArgName = identifyingArg.getName();
-          var identifyingArgType = identifyingArg.getType().getName({ modifiers: true });
-          metadata.identifyingArgName = identifyingArgName;
-          metadata.identifyingArgType = identifyingArgType;
-          calls = t.arrayExpression([codify({
-            kind: t.valueToNode('Call'),
-            metadata: objectify({
-              type: identifyingArgType
-            }),
-            name: t.valueToNode(identifyingArgName),
-            value: this.printArgumentValue(identifyingArg)
-          })]);
-        }
+    RelayQLPrinter.prototype.printDirectives = function printDirectives(directives) {
+      var _this5 = this;
 
-        return codify({
-          calls: calls,
-          children: selections,
-          directives: this.printDirectives(rootField.getDirectives()),
-          fieldName: t.valueToNode(rootField.getName()),
-          kind: t.valueToNode('Query'),
-          metadata: objectify(metadata),
-          name: t.valueToNode(query.getName()),
-          type: t.valueToNode(rootFieldType.getName({ modifiers: false }))
-        });
+      var printedDirectives = [];
+      directives.forEach(function (directive) {
+        if (directive.getName() === 'relay') {
+          return;
+        }
+        printedDirectives.push(t.objectExpression([property('kind', t.valueToNode('Directive')), property('name', t.valueToNode(directive.getName())), property('args', t.arrayExpression(directive.getArguments().map(function (arg) {
+          return t.objectExpression([property('name', t.valueToNode(arg.getName())), property('value', _this5.printArgumentValue(arg))]);
+        })))]));
+      });
+      if (printedDirectives.length) {
+        return t.arrayExpression(printedDirectives);
       }
-    }, {
-      key: 'printFragment',
-      value: function printFragment(fragment) {
-        var fragmentType = fragment.getType();
+      return NULL;
+    };
 
-        var requisiteFields = {};
-        var idFragment = undefined;
-        if (fragmentType.hasField(FIELDS.id)) {
-          requisiteFields.id = true;
-        } else if (shouldGenerateIdFragment(fragment, fragmentType)) {
-          idFragment = fragmentType.generateIdFragment();
-        }
-        if (fragmentType.isAbstract()) {
-          requisiteFields[FIELDS.__typename] = true;
-        }
-        var selections = this.printSelections(fragment, requisiteFields, idFragment ? [idFragment] : null, fragment.hasDirective('generated'));
-        var metadata = this.printRelayDirectiveMetadata(fragment, {
-          isAbstract: fragmentType.isAbstract()
-        });
-
-        return codify({
-          children: selections,
-          directives: this.printDirectives(fragment.getDirectives()),
-          id: this.printFragmentID(fragment),
-          kind: t.valueToNode('Fragment'),
-          metadata: metadata,
-          name: t.valueToNode(fragment.getName()),
-          type: t.valueToNode(fragmentType.getName({ modifiers: false }))
-        });
-      }
-    }, {
-      key: 'printFragmentID',
-      value: function printFragmentID(fragment) {
-        var staticFragmentID = fragment.getStaticFragmentID();
-        if (staticFragmentID == null) {
-          return t.callExpression(t.memberExpression(identify(this.tagName), t.identifier('__id')), []);
-        } else {
-          return t.valueToNode(staticFragmentID);
-        }
-      }
-    }, {
-      key: 'printMutation',
-      value: function printMutation(mutation) {
-        var rootFields = mutation.getFields();
-        invariant(rootFields.length === 1, 'There are %d fields supplied to the mutation named `%s`, but ' + 'mutations must have exactly one field.', rootFields.length, mutation.getName());
-        var rootField = rootFields[0];
-        var rootFieldType = rootField.getType();
-        validateMutationField(rootField);
-        var requisiteFields = {};
-        if (rootFieldType.hasField(FIELDS.clientMutationId)) {
-          requisiteFields[FIELDS.clientMutationId] = true;
-        }
-        var selections = this.printSelections(rootField, requisiteFields);
-        var metadata = {
-          inputType: this.printArgumentTypeForMetadata(rootField.getDeclaredArgument(INPUT_ARGUMENT_NAME))
-        };
-
-        return codify({
-          calls: t.arrayExpression([codify({
-            kind: t.valueToNode('Call'),
-            metadata: objectify({}),
-            name: t.valueToNode(rootField.getName()),
-            value: this.printVariable('input')
-          })]),
-          children: selections,
-          directives: this.printDirectives(mutation.getDirectives()),
-          kind: t.valueToNode('Mutation'),
-          metadata: objectify(metadata),
-          name: t.valueToNode(mutation.getName()),
-          responseType: t.valueToNode(rootFieldType.getName({ modifiers: false }))
-        });
-      }
-    }, {
-      key: 'printSubscription',
-      value: function printSubscription(subscription) {
-        var rootFields = subscription.getFields();
-        invariant(rootFields.length === 1, 'There are %d fields supplied to the subscription named `%s`, but ' + 'subscriptions must have exactly one field.', rootFields.length, subscription.getName());
-        var rootField = rootFields[0];
-        var rootFieldType = rootField.getType();
-        validateMutationField(rootField);
-        var requisiteFields = {};
-        if (rootFieldType.hasField(FIELDS.clientSubscriptionId)) {
-          requisiteFields[FIELDS.clientSubscriptionId] = true;
-        }
-        var selections = this.printSelections(rootField, requisiteFields);
-        var metadata = {
-          inputType: this.printArgumentTypeForMetadata(rootField.getDeclaredArgument(INPUT_ARGUMENT_NAME))
-        };
-
-        return codify({
-          calls: t.arrayExpression([codify({
-            kind: t.valueToNode('Call'),
-            metadata: objectify({}),
-            name: t.valueToNode(rootField.getName()),
-            value: this.printVariable('input')
-          })]),
-          children: selections,
-          directives: this.printDirectives(subscription.getDirectives()),
-          kind: t.valueToNode('Subscription'),
-          metadata: objectify(metadata),
-          name: t.valueToNode(subscription.getName()),
-          responseType: t.valueToNode(rootFieldType.getName({ modifiers: false }))
-        });
-      }
-    }, {
-      key: 'printSelections',
-      value: function printSelections(parent, requisiteFields, extraFragments) {
-        var _this = this;
-
-        var isGeneratedQuery = arguments.length <= 3 || arguments[3] === undefined ? false : arguments[3];
-
-        var fields = [];
-        var printedFragments = [];
-        var didPrintFragmentReference = false;
-        parent.getSelections().forEach(function (selection) {
-          if (selection instanceof RelayQLFragmentSpread) {
-            // Assume that all spreads exist via template substitution.
-            invariant(selection.getDirectives().length === 0, 'Directives are not yet supported for `${fragment}`-style fragment ' + 'references.');
-            printedFragments.push(_this.printFragmentReference(selection));
-            didPrintFragmentReference = true;
-          } else if (selection instanceof RelayQLInlineFragment) {
-            printedFragments.push(_this.printFragment(selection.getFragment()));
-          } else if (selection instanceof RelayQLField) {
-            fields.push(selection);
-          } else {
-            invariant(false, 'Unsupported selection type `%s`.', selection);
+    RelayQLPrinter.prototype.printRelayDirectiveMetadata = function printRelayDirectiveMetadata(node, maybeMetadata) {
+      var properties = [];
+      var relayDirective = find(node.getDirectives(), function (directive) {
+        return directive.getName() === 'relay';
+      });
+      if (relayDirective) {
+        relayDirective.getArguments().forEach(function (arg) {
+          if (arg.isVariable()) {
+            invariant(!arg.isVariable(), 'You supplied `$%s` as the `%s` argument to the `@relay` ' + 'directive, but `@relay` require scalar argument values.', arg.getVariableName(), arg.getName());
           }
+          properties.push(property(arg.getName(), t.valueToNode(arg.getValue())));
         });
-        if (extraFragments) {
-          extraFragments.forEach(function (fragment) {
-            printedFragments.push(_this.printFragment(fragment));
+      }
+      if (maybeMetadata) {
+        (function () {
+          var metadata = maybeMetadata;
+          Object.keys(metadata).forEach(function (key) {
+            if (metadata[key]) {
+              properties.push(property(key, t.valueToNode(metadata[key])));
+            }
           });
-        }
-        var printedFields = this.printFields(fields, parent, requisiteFields, isGeneratedQuery);
-        var selections = [].concat(_toConsumableArray(printedFields), printedFragments);
-
-        if (selections.length) {
-          var arrayExpressionOfSelections = t.arrayExpression(selections);
-          return didPrintFragmentReference ? shallowFlatten(arrayExpressionOfSelections) : arrayExpressionOfSelections;
-        }
-        return NULL;
+        })();
       }
-    }, {
-      key: 'printFields',
-      value: function printFields(fields, parent, requisiteFields) {
-        var _this2 = this;
+      return t.objectExpression(properties);
+    };
 
-        var isGeneratedQuery = arguments.length <= 3 || arguments[3] === undefined ? false : arguments[3];
+    /**
+     * Prints the type for arguments that are transmitted via variables.
+     */
 
-        var parentType = parent.getType();
-        if (parentType.isConnection() && parentType.hasField(FIELDS.pageInfo) && fields.some(function (field) {
-          return field.getName() === FIELDS.edges;
-        })) {
-          requisiteFields[FIELDS.pageInfo] = true;
-        }
 
-        var generatedFields = _extends({}, requisiteFields);
-
-        var printedFields = [];
-        fields.forEach(function (field) {
-          delete generatedFields[field.getName()];
-          printedFields.push(_this2.printField(field, parent, requisiteFields, generatedFields, isGeneratedQuery));
-        });
-
-        Object.keys(generatedFields).forEach(function (fieldName) {
-          var generatedField = parentType.generateField(fieldName);
-          printedFields.push(_this2.printField(generatedField, parent, requisiteFields, generatedFields, isGeneratedQuery));
-        });
-        return printedFields;
+    RelayQLPrinter.prototype.printArgumentTypeForMetadata = function printArgumentTypeForMetadata(argType) {
+      // Currently, we always send Enum and Object types as variables.
+      if (argType.isEnum() || argType.isObject()) {
+        return argType.getName({ modifiers: true });
       }
-    }, {
-      key: 'printField',
-      value: function printField(field, parent, requisiteSiblings, generatedSiblings) {
-        var _this3 = this;
-
-        var isGeneratedQuery = arguments.length <= 4 || arguments[4] === undefined ? false : arguments[4];
-
-        var fieldType = field.getType();
-
-        var metadata = {};
-        var requisiteFields = {};
-        var idFragment = undefined;
-        if (fieldType.hasField(FIELDS.id)) {
-          requisiteFields.id = true;
-        } else if (shouldGenerateIdFragment(field, fieldType)) {
-          idFragment = fieldType.generateIdFragment();
-        }
-
-        if (!isGeneratedQuery) {
-          validateField(field, parent.getType());
-        }
-
-        if (fieldType.canHaveSubselections()) {
-          metadata.canHaveSubselections = true;
-        }
-        // TODO: Generalize to non-`Node` types.
-        if (fieldType.alwaysImplements('Node')) {
-          metadata.inferredRootCallName = 'node';
-          metadata.inferredPrimaryKey = 'id';
-        }
-        if (fieldType.isConnection()) {
-          if (field.hasDeclaredArgument('first') || field.hasDeclaredArgument('last')) {
-            if (!isGeneratedQuery) {
-              validateConnectionField(field);
-            }
-            metadata.isConnection = true;
-            if (field.hasDeclaredArgument('find')) {
-              metadata.isFindable = true;
-            }
-          }
-        } else if (fieldType.isConnectionPageInfo()) {
-          requisiteFields[FIELDS.hasNextPage] = true;
-          requisiteFields[FIELDS.hasPreviousPage] = true;
-        } else if (fieldType.isConnectionEdge()) {
-          requisiteFields[FIELDS.cursor] = true;
-          requisiteFields[FIELDS.node] = true;
-        }
-        if (fieldType.isAbstract()) {
-          metadata.isAbstract = true;
-          requisiteFields[FIELDS.__typename] = true;
-        }
-        if (fieldType.isList()) {
-          metadata.isPlural = true;
-        }
-        if (generatedSiblings.hasOwnProperty(field.getName())) {
-          metadata.isGenerated = true;
-        }
-        if (requisiteSiblings.hasOwnProperty(field.getName())) {
-          metadata.isRequisite = true;
-        }
-
-        var selections = this.printSelections(field, requisiteFields, idFragment ? [idFragment] : null, isGeneratedQuery);
-        var fieldAlias = field.getAlias();
-        var args = field.getArguments();
-        var calls = args.length ? t.arrayExpression(args.map(function (arg) {
-          return _this3.printArgument(arg);
-        })) : NULL;
-
-        return codify({
-          alias: fieldAlias ? t.valueToNode(fieldAlias) : NULL,
-          calls: calls,
-          children: selections,
-          directives: this.printDirectives(field.getDirectives()),
-          fieldName: t.valueToNode(field.getName()),
-          kind: t.valueToNode('Field'),
-          metadata: this.printRelayDirectiveMetadata(field, metadata),
-          type: t.valueToNode(fieldType.getName({ modifiers: false }))
-        });
+      // Currently, we always inline scalar types.
+      if (argType.isScalar()) {
+        return null;
       }
-    }, {
-      key: 'printFragmentReference',
-      value: function printFragmentReference(fragmentReference) {
-        return t.callExpression(t.memberExpression(identify(this.tagName), t.identifier('__frag')), [t.identifier(fragmentReference.getName())]);
-      }
-    }, {
-      key: 'printArgument',
-      value: function printArgument(arg) {
-        var metadata = {};
-        var inputType = this.printArgumentTypeForMetadata(arg.getType());
-        if (inputType) {
-          metadata.type = inputType;
-        }
-        return codify({
-          kind: t.valueToNode('Call'),
-          metadata: objectify(metadata),
-          name: t.valueToNode(arg.getName()),
-          value: this.printArgumentValue(arg)
-        });
-      }
-    }, {
-      key: 'printArgumentValue',
-      value: function printArgumentValue(arg) {
-        if (arg.isVariable()) {
-          return this.printVariable(arg.getVariableName());
-        } else {
-          return this.printValue(arg.getValue());
-        }
-      }
-    }, {
-      key: 'printVariable',
-      value: function printVariable(name) {
-        // Assume that variables named like substitutions are substitutions.
-        if (this.variableNames.hasOwnProperty(name)) {
-          return t.callExpression(t.memberExpression(identify(this.tagName), t.identifier('__var')), [t.identifier(name)]);
-        }
-        return codify({
-          kind: t.valueToNode('CallVariable'),
-          callVariableName: t.valueToNode(name)
-        });
-      }
-    }, {
-      key: 'printValue',
-      value: function printValue(value) {
-        var _this4 = this;
-
-        if (Array.isArray(value)) {
-          return t.arrayExpression(value.map(function (element) {
-            return _this4.printArgumentValue(element);
-          }));
-        }
-        return codify({
-          kind: t.valueToNode('CallValue'),
-          callValue: printLiteralValue(value)
-        });
-      }
-    }, {
-      key: 'printDirectives',
-      value: function printDirectives(directives) {
-        var _this5 = this;
-
-        var printedDirectives = [];
-        directives.forEach(function (directive) {
-          if (directive.getName() === 'relay') {
-            return;
-          }
-          printedDirectives.push(t.objectExpression([property('kind', t.valueToNode('Directive')), property('name', t.valueToNode(directive.getName())), property('args', t.arrayExpression(directive.getArguments().map(function (arg) {
-            return t.objectExpression([property('name', t.valueToNode(arg.getName())), property('value', _this5.printArgumentValue(arg))]);
-          })))]));
-        });
-        if (printedDirectives.length) {
-          return t.arrayExpression(printedDirectives);
-        }
-        return NULL;
-      }
-    }, {
-      key: 'printRelayDirectiveMetadata',
-      value: function printRelayDirectiveMetadata(node, maybeMetadata) {
-        var properties = [];
-        var relayDirective = find(node.getDirectives(), function (directive) {
-          return directive.getName() === 'relay';
-        });
-        if (relayDirective) {
-          relayDirective.getArguments().forEach(function (arg) {
-            if (arg.isVariable()) {
-              invariant(!arg.isVariable(), 'You supplied `$%s` as the `%s` argument to the `@relay` ' + 'directive, but `@relay` require scalar argument values.', arg.getVariableName(), arg.getName());
-            }
-            properties.push(property(arg.getName(), t.valueToNode(arg.getValue())));
-          });
-        }
-        if (maybeMetadata) {
-          (function () {
-            var metadata = maybeMetadata;
-            Object.keys(metadata).forEach(function (key) {
-              if (metadata[key]) {
-                properties.push(property(key, t.valueToNode(metadata[key])));
-              }
-            });
-          })();
-        }
-        return t.objectExpression(properties);
-      }
-
-      /**
-       * Prints the type for arguments that are transmitted via variables.
-       */
-    }, {
-      key: 'printArgumentTypeForMetadata',
-      value: function printArgumentTypeForMetadata(argType) {
-        // Currently, we always send Enum and Object types as variables.
-        if (argType.isEnum() || argType.isObject()) {
-          return argType.getName({ modifiers: true });
-        }
-        // Currently, we always inline scalar types.
-        if (argType.isScalar()) {
-          return null;
-        }
-        invariant(false, 'Unsupported input type: %s', argType);
-      }
-    }]);
+      invariant(false, 'Unsupported input type: %s', argType);
+    };
 
     return RelayQLPrinter;
-  })();
+  }();
+
+  /**
+   * Determine if a `... on Node { id }` fragment should be generated for a
+   * field/fragment to allow identification of the response record. This
+   * fragment should be added when some/all implementors of the node's type
+   * also implement `Node` but a `Node` fragment is not already present. If it
+   * is present then `id` would be added as a requisite field.
+   */
+
 
   function shouldGenerateIdFragment(node) {
     return node.getType().mayImplement('Node') && !node.getSelections().some(function (selection) {
@@ -583,7 +559,7 @@ module.exports = function (t, options) {
     invariant(rootFieldArgs.length <= 1, 'There are %d arguments supplied to the mutation field named `%s`, ' + 'but mutation fields must have exactly one `%s` argument.', rootFieldArgs.length, rootField.getName(), INPUT_ARGUMENT_NAME);
   }
 
-  var forEachRecursiveField = function forEachRecursiveField(selection, callback) {
+  var forEachRecursiveField = function (selection, callback) {
     selection.getSelections().forEach(function (selection) {
       if (selection instanceof RelayQLField) {
         callback(selection);
@@ -635,16 +611,16 @@ module.exports = function (t, options) {
     } else if (Array.isArray(value)) {
       return t.arrayExpression(value.map(printLiteralValue));
     } else if (typeof value === 'object' && value != null) {
-      var _ret2 = (function () {
+      var _ret2 = function () {
         var objectValue = value;
         return {
           v: t.objectExpression(Object.keys(objectValue).map(function (key) {
             return property(key, printLiteralValue(objectValue[key]));
           }))
         };
-      })();
+      }();
 
-      if (typeof _ret2 === 'object') return _ret2.v;
+      if (typeof _ret2 === "object") return _ret2.v;
     } else {
       return t.valueToNode(value);
     }

--- a/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
@@ -13,13 +13,7 @@
 
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var GraphQL = require('./GraphQL');
 var formatError = GraphQL.error.formatError;
@@ -45,7 +39,7 @@ var util = require('util');
  * transformed into a Babel AST via RelayQLPrinter.
  */
 
-var RelayQLTransformer = (function () {
+var RelayQLTransformer = function () {
   function RelayQLTransformer(schema, options) {
     _classCallCheck(this, RelayQLTransformer);
 
@@ -53,153 +47,149 @@ var RelayQLTransformer = (function () {
     this.options = options;
   }
 
-  _createClass(RelayQLTransformer, [{
-    key: 'transform',
-    value: function transform(t, // Babel
-    node, options) {
-      var _processTemplateLiteral = this.processTemplateLiteral(node, options.documentName);
+  RelayQLTransformer.prototype.transform = function transform(t, // Babel
+  node, options) {
+    var _processTemplateLiter = this.processTemplateLiteral(node, options.documentName);
 
-      var substitutions = _processTemplateLiteral.substitutions;
-      var templateText = _processTemplateLiteral.templateText;
-      var variableNames = _processTemplateLiteral.variableNames;
+    var substitutions = _processTemplateLiter.substitutions;
+    var templateText = _processTemplateLiter.templateText;
+    var variableNames = _processTemplateLiter.variableNames;
 
-      var documentText = this.processTemplateText(templateText, options);
-      var definition = this.processDocumentText(documentText, options);
+    var documentText = this.processTemplateText(templateText, options);
+    var definition = this.processDocumentText(documentText, options);
 
-      var Printer = RelayQLPrinter(t, this.options);
-      return new Printer(options.tagName, variableNames).print(definition, substitutions);
-    }
+    var Printer = RelayQLPrinter(t, this.options);
+    return new Printer(options.tagName, variableNames).print(definition, substitutions);
+  };
 
-    /**
-     * Convert TemplateLiteral into a single template string with substitution
-     * names, a matching array of substituted values, and a set of substituted
-     * variable names.
-     */
-  }, {
-    key: 'processTemplateLiteral',
-    value: function processTemplateLiteral(node, documentName) {
-      var _this = this;
+  /**
+   * Convert TemplateLiteral into a single template string with substitution
+   * names, a matching array of substituted values, and a set of substituted
+   * variable names.
+   */
 
-      var chunks = [];
-      var variableNames = {};
-      var substitutions = [];
-      node.quasis.forEach(function (element, ii) {
-        var chunk = element.value.cooked;
-        chunks.push(chunk);
-        if (!element.tail) {
-          var _name = 'RQL_' + ii;
-          var _value = node.expressions[ii];
-          substitutions.push({ name: _name, value: _value });
-          if (/:\s*$/.test(chunk)) {
-            invariant(_this.options.substituteVariables, 'You supplied a GraphQL document named `%s` that uses template ' + 'substitution for an argument value, but variable substitution ' + 'has not been enabled.', documentName);
-            chunks.push('$' + _name);
-            variableNames[_name] = undefined;
-          } else {
-            chunks.push('...' + _name);
-          }
-        }
-      });
-      return { substitutions: substitutions, templateText: chunks.join('').trim(), variableNames: variableNames };
-    }
 
-    /**
-     * Converts the template string into a valid GraphQL document string.
-     */
-  }, {
-    key: 'processTemplateText',
-    value: function processTemplateText(templateText, _ref) {
-      var documentName = _ref.documentName;
-      var propName = _ref.propName;
+  RelayQLTransformer.prototype.processTemplateLiteral = function processTemplateLiteral(node, documentName) {
+    var _this = this;
 
-      var pattern = /^(fragment|mutation|query|subscription)\s*(\w*)?([\s\S]*)/;
-      var matches = pattern.exec(templateText);
-      invariant(matches, 'You supplied a GraphQL document named `%s` with invalid syntax. It ' + 'must start with `fragment`, `mutation`, `query`, or `subscription`.', documentName);
-      var type = matches[1];
-      var name = matches[2] || documentName;
-      var rest = matches[3];
-      // Allow `fragment on Type {...}`.
-      if (type === 'fragment' && name === 'on') {
-        name = documentName + (propName ? '_' + capitalize(propName) : '') + 'RelayQL';
-        rest = 'on' + rest;
-      }
-      var definitionName = capitalize(name);
-      return type + ' ' + definitionName + ' ' + rest;
-    }
-
-    /**
-     * Parses the GraphQL document string into a RelayQLDocument.
-     */
-  }, {
-    key: 'processDocumentText',
-    value: function processDocumentText(documentText, _ref2) {
-      var documentName = _ref2.documentName;
-      var fragmentLocationID = _ref2.fragmentLocationID;
-
-      var document = parser.parse(new Source(documentText, documentName));
-      var validationErrors = this.validateDocument(document);
-      if (validationErrors) {
-        var error = new Error(util.format('You supplied a GraphQL document named `%s` with validation errors.', documentName));
-        error.validationErrors = validationErrors;
-        error.sourceText = documentText;
-        throw error;
-      }
-      var definition = document.definitions[0];
-
-      var context = {
-        definitionName: capitalize(documentName),
-        isPattern: false,
-        generateID: createIDGenerator(),
-        schema: this.schema,
-        fragmentLocationID: fragmentLocationID
-      };
-      if (definition.kind === 'FragmentDefinition') {
-        return new RelayQLFragment(context, definition);
-      } else if (definition.kind === 'OperationDefinition') {
-        if (definition.operation === 'mutation') {
-          return new RelayQLMutation(context, definition);
-        } else if (definition.operation === 'query') {
-          return new RelayQLQuery(context, definition);
-        } else if (definition.operation === 'subscription') {
-          return new RelayQLSubscription(context, definition);
+    var chunks = [];
+    var variableNames = {};
+    var substitutions = [];
+    node.quasis.forEach(function (element, ii) {
+      var chunk = element.value.cooked;
+      chunks.push(chunk);
+      if (!element.tail) {
+        var name = 'RQL_' + ii;
+        var _value = node.expressions[ii];
+        substitutions.push({ name: name, value: _value });
+        if (/:\s*$/.test(chunk)) {
+          invariant(_this.options.substituteVariables, 'You supplied a GraphQL document named `%s` that uses template ' + 'substitution for an argument value, but variable substitution ' + 'has not been enabled.', documentName);
+          chunks.push('$' + name);
+          variableNames[name] = undefined;
         } else {
-          invariant(false, 'Unsupported operation: %s', definition.operation);
+          chunks.push('...' + name);
         }
-      } else {
-        invariant(false, 'Unsupported definition kind: %s', definition.kind);
       }
+    });
+    return { substitutions: substitutions, templateText: chunks.join('').trim(), variableNames: variableNames };
+  };
+
+  /**
+   * Converts the template string into a valid GraphQL document string.
+   */
+
+
+  RelayQLTransformer.prototype.processTemplateText = function processTemplateText(templateText, _ref) {
+    var documentName = _ref.documentName;
+    var propName = _ref.propName;
+
+    var pattern = /^(fragment|mutation|query|subscription)\s*(\w*)?([\s\S]*)/;
+    var matches = pattern.exec(templateText);
+    invariant(matches, 'You supplied a GraphQL document named `%s` with invalid syntax. It ' + 'must start with `fragment`, `mutation`, `query`, or `subscription`.', documentName);
+    var type = matches[1];
+    var name = matches[2] || documentName;
+    var rest = matches[3];
+    // Allow `fragment on Type {...}`.
+    if (type === 'fragment' && name === 'on') {
+      name = documentName + (propName ? '_' + capitalize(propName) : '') + 'RelayQL';
+      rest = 'on' + rest;
     }
-  }, {
-    key: 'validateDocument',
-    value: function validateDocument(document) {
-      invariant(document.definitions.length === 1, 'You supplied a GraphQL document named `%s` with %d definitions, but ' + 'it must have exactly one definition.', document.definitions.length);
-      var definition = document.definitions[0];
-      var isMutation = definition.kind === 'OperationDefinition' && definition.operation === 'mutation';
+    var definitionName = capitalize(name);
+    return type + ' ' + definitionName + ' ' + rest;
+  };
 
-      var validator = this.options.validator;
-      var validationErrors = undefined;
-      if (validator) {
-        var _validator = validator(GraphQL);
+  /**
+   * Parses the GraphQL document string into a RelayQLDocument.
+   */
 
-        var _validate = _validator.validate;
 
-        validationErrors = _validate(this.schema, document);
-      } else {
-        var rules = [require('graphql/validation/rules/ArgumentsOfCorrectType').ArgumentsOfCorrectType, require('graphql/validation/rules/DefaultValuesOfCorrectType').DefaultValuesOfCorrectType, require('graphql/validation/rules/FieldsOnCorrectType').FieldsOnCorrectType, require('graphql/validation/rules/FragmentsOnCompositeTypes').FragmentsOnCompositeTypes, require('graphql/validation/rules/KnownArgumentNames').KnownArgumentNames, require('graphql/validation/rules/KnownTypeNames').KnownTypeNames, require('graphql/validation/rules/PossibleFragmentSpreads').PossibleFragmentSpreads, require('graphql/validation/rules/PossibleFragmentSpreads').PossibleFragmentSpreads, require('graphql/validation/rules/VariablesInAllowedPosition').VariablesInAllowedPosition];
-        if (!isMutation) {
-          rules.push(require('graphql/validation/rules/ProvidedNonNullArguments').ProvidedNonNullArguments);
-        }
-        validationErrors = validate(this.schema, document, rules);
-      }
+  RelayQLTransformer.prototype.processDocumentText = function processDocumentText(documentText, _ref2) {
+    var documentName = _ref2.documentName;
+    var fragmentLocationID = _ref2.fragmentLocationID;
 
-      if (validationErrors && validationErrors.length > 0) {
-        return validationErrors.map(formatError);
-      }
-      return null;
+    var document = parser.parse(new Source(documentText, documentName));
+    var validationErrors = this.validateDocument(document);
+    if (validationErrors) {
+      var error = new Error(util.format('You supplied a GraphQL document named `%s` with validation errors.', documentName));
+      error.validationErrors = validationErrors;
+      error.sourceText = documentText;
+      throw error;
     }
-  }]);
+    var definition = document.definitions[0];
+
+    var context = {
+      definitionName: capitalize(documentName),
+      isPattern: false,
+      generateID: createIDGenerator(),
+      schema: this.schema,
+      fragmentLocationID: fragmentLocationID
+    };
+    if (definition.kind === 'FragmentDefinition') {
+      return new RelayQLFragment(context, definition);
+    } else if (definition.kind === 'OperationDefinition') {
+      if (definition.operation === 'mutation') {
+        return new RelayQLMutation(context, definition);
+      } else if (definition.operation === 'query') {
+        return new RelayQLQuery(context, definition);
+      } else if (definition.operation === 'subscription') {
+        return new RelayQLSubscription(context, definition);
+      } else {
+        invariant(false, 'Unsupported operation: %s', definition.operation);
+      }
+    } else {
+      invariant(false, 'Unsupported definition kind: %s', definition.kind);
+    }
+  };
+
+  RelayQLTransformer.prototype.validateDocument = function validateDocument(document) {
+    invariant(document.definitions.length === 1, 'You supplied a GraphQL document named `%s` with %d definitions, but ' + 'it must have exactly one definition.', document.definitions.length);
+    var definition = document.definitions[0];
+    var isMutation = definition.kind === 'OperationDefinition' && definition.operation === 'mutation';
+
+    var validator = this.options.validator;
+    var validationErrors = void 0;
+    if (validator) {
+      var _validator = validator(GraphQL);
+
+      var _validate = _validator.validate;
+
+      validationErrors = _validate(this.schema, document);
+    } else {
+      var rules = [require('graphql/validation/rules/ArgumentsOfCorrectType').ArgumentsOfCorrectType, require('graphql/validation/rules/DefaultValuesOfCorrectType').DefaultValuesOfCorrectType, require('graphql/validation/rules/FieldsOnCorrectType').FieldsOnCorrectType, require('graphql/validation/rules/FragmentsOnCompositeTypes').FragmentsOnCompositeTypes, require('graphql/validation/rules/KnownArgumentNames').KnownArgumentNames, require('graphql/validation/rules/KnownTypeNames').KnownTypeNames, require('graphql/validation/rules/PossibleFragmentSpreads').PossibleFragmentSpreads, require('graphql/validation/rules/PossibleFragmentSpreads').PossibleFragmentSpreads, require('graphql/validation/rules/VariablesInAllowedPosition').VariablesInAllowedPosition];
+      if (!isMutation) {
+        rules.push(require('graphql/validation/rules/ProvidedNonNullArguments').ProvidedNonNullArguments);
+      }
+      validationErrors = validate(this.schema, document, rules);
+    }
+
+    if (validationErrors && validationErrors.length > 0) {
+      return validationErrors.map(formatError);
+    }
+    return null;
+  };
 
   return RelayQLTransformer;
-})();
+}();
 
 function capitalize(string) {
   return string[0].toUpperCase() + string.slice(1);

--- a/scripts/babel-relay-plugin/lib/babelAdapter.js
+++ b/scripts/babel-relay-plugin/lib/babelAdapter.js
@@ -24,13 +24,13 @@ function babelAdapter(Plugin, t, babelVersion, name, visitorsBuilder) {
   }
   // Babel 5.
   var legacyT = _extends({}, t, {
-    nullLiteral: function nullLiteral() {
+    nullLiteral: function () {
       return t.literal(null);
     },
-    valueToNode: function valueToNode(value) {
+    valueToNode: function (value) {
       return t.literal(value);
     },
-    objectProperty: function objectProperty(ident, value) {
+    objectProperty: function (ident, value) {
       return t.property('init', ident, value);
     }
   });
@@ -42,7 +42,7 @@ function babelAdapter(Plugin, t, babelVersion, name, visitorsBuilder) {
       var _this = this;
 
       var compatPath = {
-        get: function get() {
+        get: function () {
           return _this.get.apply(_this, arguments);
         },
         node: node,

--- a/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
@@ -54,17 +54,18 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
           /**
            * Extract the module name from `@providesModule`.
            */
-          Program: function Program(_ref2, state) {
+
+          Program: function (_ref2, state) {
             var parent = _ref2.parent;
 
             if (state.file.opts.documentName) {
               return;
             }
-            var documentName = undefined;
+            var documentName = void 0;
             if (parent.comments && parent.comments.length) {
               var docblock = parent.comments[0].value || '';
               var propertyRegex = /@(\S+) *(\S*)/g;
-              var captures = undefined;
+              var captures = void 0;
               while (captures = propertyRegex.exec(docblock)) {
                 var property = captures[1];
                 var value = captures[2];
@@ -76,19 +77,21 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
             }
             var basename = state.file.opts.basename;
             if (basename && !documentName) {
-              var captures = basename.match(/^[_A-Za-z][_0-9A-Za-z]*/);
-              if (captures) {
-                documentName = captures[0];
+              var _captures = basename.match(/^[_A-Za-z][_0-9A-Za-z]*/);
+              if (_captures) {
+                documentName = _captures[0];
               }
             }
             state.file.opts.documentName = documentName || 'UnknownFile';
           },
 
+
           /**
            * Transform Relay.QL`...`.
            */
-          TaggedTemplateExpression: function TaggedTemplateExpression(path, state) {
+          TaggedTemplateExpression: function (path, state) {
             var node = path.node;
+
 
             var tag = path.get('tag');
             var tagName = tag.matchesPattern('Relay.QL') ? 'Relay.QL' : tag.isIdentifier({ name: 'RelayQL' }) ? 'RelayQL' : null;
@@ -119,7 +122,7 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
               }
             }
 
-            var result = undefined;
+            var result = void 0;
             try {
               result = transformer.transform(t, node.quasi, {
                 documentName: documentName,

--- a/scripts/babel-relay-plugin/lib/tools/generateSchemaJson.js
+++ b/scripts/babel-relay-plugin/lib/tools/generateSchemaJson.js
@@ -1,4 +1,6 @@
 // @generated
+'use strict';
+
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  * All rights reserved.
@@ -13,8 +15,6 @@
 /**
  * Generates `testschema.rfc.json` from `testschema.rfc.graphql`.
  */
-
-'use strict';
 
 var fs = require('fs');
 var path = require('path');

--- a/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
@@ -14,6 +14,7 @@
 
 var babel = require('babel-core');
 var fs = require('fs');
+var getBabelOptions = require('fbjs-scripts/babel-6/default-options');
 var util = require('util');
 
 var getBabelRelayPlugin = require('../getBabelRelayPlugin');
@@ -38,12 +39,14 @@ function transformGraphQL(schemaPath, source, filename) {
     substituteVariables: true,
     suppressWarnings: true
   });
-  return babel.transform(source, {
-    compact: false,
-    filename: filename,
-    plugins: [plugin],
-    blacklist: ['strict']
-  }).code;
+
+  var babelOptions = getBabelOptions({
+    moduleOpts: { prefix: '' }
+  });
+  babelOptions.plugins.unshift(plugin);
+  babelOptions.filename = filename;
+  babelOptions.retainLines = true;
+  return babel.transform(source, babelOptions).code;
 }
 
 module.exports = transformGraphQL;

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -21,13 +21,35 @@
     "lib/"
   ],
   "devDependencies": {
-    "babel-core": "^5.8.35",
+    "babel-core": "^6.6.4",
     "babel-eslint": "^4.1.1",
-    "babel-jest": "^5.3.0",
+    "babel-plugin-check-es2015-constants": "^6.6.4",
+    "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
+    "babel-plugin-transform-class-properties": "^6.6.0",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.5.2",
+    "babel-plugin-transform-es2015-block-scoped-functions": "^6.6.4",
+    "babel-plugin-transform-es2015-block-scoping": "^6.6.4",
+    "babel-plugin-transform-es2015-classes": "^6.6.4",
+    "babel-plugin-transform-es2015-computed-properties": "^6.6.4",
+    "babel-plugin-transform-es2015-destructuring": "^6.6.4",
+    "babel-plugin-transform-es2015-for-of": "^6.6.0",
+    "babel-plugin-transform-es2015-literals": "^6.5.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.6.4",
+    "babel-plugin-transform-es2015-object-super": "^6.6.4",
+    "babel-plugin-transform-es2015-parameters": "^6.6.4",
+    "babel-plugin-transform-es2015-shorthand-properties": "^6.5.0",
+    "babel-plugin-transform-es2015-spread": "^6.6.4",
+    "babel-plugin-transform-es2015-template-literals": "^6.6.4",
+    "babel-plugin-transform-es3-member-expression-literals": "^6.5.0",
+    "babel-plugin-transform-es3-property-literals": "^6.5.0",
+    "babel-plugin-transform-flow-strip-types": "^6.6.4",
+    "babel-plugin-transform-object-rest-spread": "^6.6.4",
+    "babel-preset-jest": "^1.0.0",
     "eslint": "^1.3.1",
+    "fbjs-scripts": "^0.6.0-alpha.3",
     "flow-bin": "0.21.0",
-    "glob": "^5.0.15",
-    "jest-cli": "0.9.0-fb3",
+    "glob": "^7.0.3",
+    "jest-cli": "^0.9.0",
     "minimist": "^1.1.3",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.1"
@@ -36,9 +58,12 @@
     "graphql": "^0.4.18"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
+    "scriptPreprocessor": "<rootDir>/scripts/jest/preprocessor",
     "persistModuleRegistryBetweenSpecs": true,
     "preprocessorIgnorePatterns": [
+      "<rootDir>/node_modules/"
+    ],
+    "modulePathIgnorePatterns": [
       "<rootDir>/node_modules/"
     ],
     "testRunner": "<rootDir>/node_modules/jest-cli/src/testRunners/jasmine/jasmine2.js",

--- a/scripts/babel-relay-plugin/scripts/build-lib
+++ b/scripts/babel-relay-plugin/scripts/build-lib
@@ -12,6 +12,8 @@ const root = path.resolve(__dirname, '..');
 const lib = path.join(root, 'lib');
 const src = path.join(root, 'src');
 
+const getBabelOptions = require('fbjs-scripts/babel-6/default-options');
+
 // Blow away prior build artifacts.
 rimraf.sync(lib);
 
@@ -29,7 +31,9 @@ files.forEach(file => {
 
   // Make sure the full path the destination file exists so we can write to it
   mkdirp.sync(path.dirname(libFile));
-  const result = babel.transformFileSync(srcFile);
+  const result = babel.transformFileSync(srcFile, getBabelOptions({
+    moduleOpts: {prefix: ''},
+  }));
 
   sources.push(fs.readFileSync(srcFile, 'utf8'));
 

--- a/scripts/babel-relay-plugin/scripts/jest/preprocessor.js
+++ b/scripts/babel-relay-plugin/scripts/jest/preprocessor.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+const babel = require('babel-core');
+const getBabelOptions = require('fbjs-scripts/babel-6/default-options');
+const jestPreset = require('babel-preset-jest');
+const path = require('path');
+
+const NODE_MODULES = path.sep + 'node_modules' + path.sep;
+
+module.exports = {
+  process(src, filename) {
+    if (!filename.includes(NODE_MODULES) && babel.util.canCompile(filename)) {
+      const babelOptions = getBabelOptions({
+        moduleOpts: {prefix: ''},
+      });
+      babelOptions.presets = [jestPreset];
+      babelOptions.filename = filename;
+      babelOptions.retainLines = true;
+      return babel.transform(src, babelOptions).code;
+    }
+    return src;
+  },
+};

--- a/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
@@ -10,7 +10,7 @@ Output:
 var Relay = require('react-relay');
 Relay.createContainer(Component, {
   queries: {
-    viewer: function viewer() {
+    viewer: function () {
       return (function () {
         return {
           children: [{
@@ -34,7 +34,7 @@ Relay.createContainer(Component, {
           id: Relay.QL.__id(),
           kind: 'Fragment',
           metadata: {},
-          name: 'ContainerRelayQL',
+          name: 'Container_ViewerRelayQL',
           type: 'Viewer'
         };
       })();

--- a/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
@@ -13,6 +13,7 @@
 
 var babel = require('babel-core');
 var fs = require('fs');
+var getBabelOptions = require('fbjs-scripts/babel-6/default-options');
 var util = require('util');
 
 var getBabelRelayPlugin = require('../getBabelRelayPlugin');
@@ -42,12 +43,14 @@ function transformGraphQL(schemaPath, source, filename) {
     substituteVariables: true,
     suppressWarnings: true,
   });
-  return babel.transform(source, {
-    compact: false,
-    filename: filename,
-    plugins: [plugin],
-    blacklist: ['strict'],
-  }).code;
+
+  const babelOptions = getBabelOptions({
+    moduleOpts: {prefix: ''},
+  });
+  babelOptions.plugins.unshift(plugin);
+  babelOptions.filename = filename;
+  babelOptions.retainLines = true;
+  return babel.transform(source, babelOptions).code;
 }
 
 module.exports = transformGraphQL;


### PR DESCRIPTION
Update the dependencies to the latest Babel version using Facebook's set of plugins from fbjs-scripts since Babel no longer has default plugins.