### PR TITLE
babel plugin: always annotate argument types (including scalars)

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-PlWc6fXw/ncFDKKqFnYPZdcICHI=
+GPY6hTnGbVf8uNlttPaNVTbTI8o=

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -141,14 +141,16 @@ module.exports = function (t, options) {
           // a 1-1 correspondence with a Relay record, or null) has a formal type,
           // assume that the lone arg in a root field's call is the identifying one.
           var identifyingArg = rootFieldArgs[0];
-          metadata.identifyingArgName = identifyingArg.getName();
-          metadata.identifyingArgType = this.printArgumentTypeForMetadata(identifyingArg.getType());
+          var identifyingArgName = identifyingArg.getName();
+          var identifyingArgType = identifyingArg.getType().getName({ modifiers: true });
+          metadata.identifyingArgName = identifyingArgName;
+          metadata.identifyingArgType = identifyingArgType;
           calls = t.arrayExpression([codify({
             kind: t.valueToNode('Call'),
             metadata: objectify({
-              type: this.printArgumentTypeForMetadata(identifyingArg.getType())
+              type: identifyingArgType
             }),
-            name: t.valueToNode(identifyingArg.getName()),
+            name: t.valueToNode(identifyingArgName),
             value: this.printArgumentValue(identifyingArg)
           })]);
         }

--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -150,15 +150,17 @@ module.exports = function(t: any, options: PrinterOptions): Function {
         // a 1-1 correspondence with a Relay record, or null) has a formal type,
         // assume that the lone arg in a root field's call is the identifying one.
         const identifyingArg = rootFieldArgs[0];
-        metadata.identifyingArgName = identifyingArg.getName();
-        metadata.identifyingArgType =
-          this.printArgumentTypeForMetadata(identifyingArg.getType());
+        const identifyingArgName = identifyingArg.getName();
+        const identifyingArgType =
+          identifyingArg.getType().getName({modifiers: true});
+        metadata.identifyingArgName = identifyingArgName;
+        metadata.identifyingArgType = identifyingArgType;
         calls = t.arrayExpression([codify({
           kind: t.valueToNode('Call'),
           metadata: objectify({
-            type: this.printArgumentTypeForMetadata(identifyingArg.getType()),
+            type: identifyingArgType,
           }),
-          name: t.valueToNode(identifyingArg.getName()),
+          name: t.valueToNode(identifyingArgName),
           value: this.printArgumentValue(identifyingArg),
         })]);
       }

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
@@ -12,7 +12,9 @@ var foo = (function (RQL_0) {
   return {
     calls: [{
       kind: "Call",
-      metadata: {},
+      metadata: {
+        type: "ID!"
+      },
       name: "id",
       value: Relay.QL.__var(RQL_0)
     }],
@@ -36,7 +38,8 @@ var foo = (function (RQL_0) {
     kind: "Query",
     metadata: {
       isAbstract: true,
-      identifyingArgName: "id"
+      identifyingArgName: "id",
+      identifyingArgType: "ID!"
     },
     name: "Args",
     type: "Node"

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
@@ -27,7 +27,9 @@ var foo = (function () {
   return {
     calls: [{
       kind: "Call",
-      metadata: {},
+      metadata: {
+        type: "ID!"
+      },
       name: "id",
       value: {
         kind: "CallValue",
@@ -206,7 +208,8 @@ var foo = (function () {
     kind: "Query",
     metadata: {
       isAbstract: true,
-      identifyingArgName: "id"
+      identifyingArgName: "id",
+      identifyingArgType: "ID!"
     },
     name: "Args",
     type: "Node"

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
@@ -12,7 +12,9 @@ var foo = (function () {
   return {
     calls: [{
       kind: "Call",
-      metadata: {},
+      metadata: {
+        type: "[ID!]"
+      },
       name: "ids",
       value: [{
         kind: "CallVariable",
@@ -46,7 +48,8 @@ var foo = (function () {
     metadata: {
       isPlural: true,
       isAbstract: true,
-      identifyingArgName: "ids"
+      identifyingArgName: "ids",
+      identifyingArgType: "[ID!]"
     },
     name: "Args",
     type: "Node"

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
@@ -25,7 +25,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -153,7 +155,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'ConnectionWithPageInfoAlias',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
@@ -23,7 +23,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -151,7 +153,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'ConnectionWithPageInfoSubfields',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
@@ -20,7 +20,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -144,7 +146,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'ConnectionWithoutNodeField',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
@@ -20,7 +20,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -145,7 +147,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'ConnectionWithoutNodeID',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -64,7 +66,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'FieldForEnum',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -65,7 +67,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'FieldWithAlias',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -84,7 +86,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'FieldWithAliasAndArgs',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -83,7 +85,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'FieldWithArgs',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -22,7 +22,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -155,7 +157,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'FieldWithEnumArg',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
@@ -22,7 +22,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -155,7 +157,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'FieldWithEnumQueryArg',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -83,7 +85,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'FieldWithParams',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
@@ -12,7 +12,9 @@ var foo = (function () {
   return {
     calls: [{
       kind: "Call",
-      metadata: {},
+      metadata: {
+        type: "String!"
+      },
       name: "name",
       value: {
         kind: "CallValue",
@@ -28,7 +30,8 @@ var foo = (function () {
     fieldName: "__type",
     kind: "Query",
     metadata: {
-      identifyingArgName: "name"
+      identifyingArgName: "name",
+      identifyingArgType: "String!"
     },
     name: "IntrospectionQueryForType",
     type: "__Type"

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
@@ -22,7 +22,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -151,7 +153,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'MetadataConnection',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
@@ -12,7 +12,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -40,7 +42,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'MetadataGenerated',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -66,7 +68,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'MetadataPlural',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
@@ -19,7 +19,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -85,7 +87,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'PluralField',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -97,7 +99,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'QueryWithDirectives',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
@@ -16,7 +16,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -64,7 +66,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'QueryWithFields',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -74,7 +76,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'QueryNameHere',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
@@ -18,7 +18,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -74,7 +76,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'QueryWithNestedFields',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
@@ -30,7 +30,9 @@ var x = (function (RQL_0, RQL_1, RQL_2, RQL_3, RQL_4, RQL_5, RQL_6, RQL_7, RQL_8
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -86,7 +88,8 @@ var x = (function (RQL_0, RQL_1, RQL_2, RQL_3, RQL_4, RQL_5, RQL_6, RQL_7, RQL_8
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'QueryWithNestedFragments',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
@@ -14,7 +14,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: '[ID!]'
+      },
       name: 'ids',
       value: [{
         kind: 'CallValue',
@@ -45,7 +47,8 @@ var x = (function () {
     metadata: {
       isPlural: true,
       isAbstract: true,
-      identifyingArgName: 'ids'
+      identifyingArgName: 'ids',
+      identifyingArgType: '[ID!]'
     },
     name: 'QueryWithVarArgs',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/tagRelayQL.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/tagRelayQL.fixture
@@ -14,7 +14,9 @@ var x = (function () {
   return {
     calls: [{
       kind: 'Call',
-      metadata: {},
+      metadata: {
+        type: 'ID!'
+      },
       name: 'id',
       value: {
         kind: 'CallValue',
@@ -41,7 +43,8 @@ var x = (function () {
     kind: 'Query',
     metadata: {
       isAbstract: true,
-      identifyingArgName: 'id'
+      identifyingArgName: 'id',
+      identifyingArgType: 'ID!'
     },
     name: 'TagRelayQL',
     type: 'Node'

--- a/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
@@ -12,7 +12,9 @@ var foo = (function () {
   return {
     calls: [{
       kind: "Call",
-      metadata: {},
+      metadata: {
+        type: "Int"
+      },
       name: "id",
       value: {
         kind: "CallValue",
@@ -31,7 +33,8 @@ var foo = (function () {
     kind: "Query",
     metadata: {
       isAbstract: true,
-      identifyingArgName: "id"
+      identifyingArgName: "id",
+      identifyingArgType: "Int"
     },
     name: "UnionWithTypename",
     type: "Media"

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -1,6 +1,6 @@
 type Root {
-  node(id: Int): Node
-  nodes(ids: [Int]): [Node]
+  node(id: ID!): Node
+  nodes(ids: [ID!]): [Node]
   media(id: Int): Media
   viewer: Viewer
   search(query: SearchInput!): [SearchResult]

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -24,9 +24,13 @@
                   "name": "id",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
                   },
                   "defaultValue": null
                 }
@@ -50,9 +54,13 @@
                     "kind": "LIST",
                     "name": null,
                     "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
                     }
                   },
                   "defaultValue": null
@@ -206,8 +214,8 @@
         },
         {
           "kind": "SCALAR",
-          "name": "Int",
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -647,6 +655,16 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -230,7 +230,9 @@ describe('RelayDefaultNetworkLayer', () => {
       var {body, fetchTimeout, headers, method, retryDelays} = call[1];
       expect(body).toBe(JSON.stringify({
         query: requestA.getQueryString(),
-        variables: queryA.getVariables(),
+        variables: {
+          id_0: '123',
+        },
       }));
       expect(fetchTimeout).toBe(networkConfig.init.fetchTimeout);
       expect(headers).toEqual({

--- a/src/query/QueryBuilder.js
+++ b/src/query/QueryBuilder.js
@@ -71,7 +71,7 @@ const QueryBuilder = {
   createCall(
     name: string,
     value: ?ConcreteValue,
-    type?: string
+    type?: ?string
   ): ConcreteCall {
     return {
       kind: 'Call',
@@ -238,7 +238,8 @@ const QueryBuilder = {
       );
       calls = [QueryBuilder.createCall(
         identifyingArgName,
-        partialQuery.identifyingArgValue
+        partialQuery.identifyingArgValue,
+        metadata.identifyingArgType
       )];
     }
     return {

--- a/src/query/__tests__/RelayQueryField-test.js
+++ b/src/query/__tests__/RelayQueryField-test.js
@@ -607,16 +607,14 @@ describe('RelayQueryField', () => {
   });
 
   it('returns arguments with array values', () => {
-    var variables = {vanities: ['a', 'b', 'c']};
-    var usernamesQuery = getNode(Relay.QL`
-      query {
-        usernames(names:$vanities) {
-          id
-        }
+    var variables = {size: [32, 64]};
+    var profilePicture = getNode(Relay.QL`
+      fragment on User {
+        profilePicture(size: $size)
       }
-    `, variables);
-    expect(usernamesQuery.getIdentifyingArg()).toEqual(
-      {name: 'names', value: ['a', 'b', 'c']}
+    `, variables).getChildren()[0];
+    expect(profilePicture.getCallsWithValues()).toEqual(
+      [{name: 'size', value: [32, 64]}]
     );
   });
 

--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -169,7 +169,11 @@ describe('RelayQueryRoot', () => {
         }
       }
     `).getIdentifyingArg()).toEqual(
-      {name: 'names', value: ['a', 'b', 'c']}
+      {
+        name: 'names',
+        type: '[String!]!',
+        value: ['a', 'b', 'c'],
+      }
     );
   });
 
@@ -353,6 +357,7 @@ describe('RelayQueryRoot', () => {
    const nodeIdentifyingArg = query.getIdentifyingArg();
    expect(nodeIdentifyingArg).toEqual({
      name: 'number',
+     type: 'Int',
      value: 5,
    });
  });

--- a/src/query/__tests__/buildRQL-test.js
+++ b/src/query/__tests__/buildRQL-test.js
@@ -143,6 +143,7 @@ describe('buildRQL', () => {
       expect(query instanceof RelayQuery.Root).toBe(true);
       expect(query.getIdentifyingArg()).toEqual({
         name: 'id',
+        type: 'ID',
         value: '123',
       });
       expect(query.getChildren()[2].equals(
@@ -203,6 +204,7 @@ describe('buildRQL', () => {
       expect(query instanceof RelayQuery.Root).toBe(true);
       expect(query.getIdentifyingArg()).toEqual({
         name: 'id',
+        type: 'ID',
         value: '123',
       });
       expect(query.getChildren()[2].equals(

--- a/src/traversal/__tests__/diffRelayQuery-test.js
+++ b/src/traversal/__tests__/diffRelayQuery-test.js
@@ -682,6 +682,11 @@ describe('diffRelayQuery', () => {
         }
       }
     `));
+    expect(diffQueries[0].getIdentifyingArg()).toEqual({
+      name: 'ids',
+      type: '[ID!]',
+      value: ['4'],
+    });
     expect(diffQueries[1].getName()).toBe(query.getName());
     expect(diffQueries[1]).toEqualQueryRoot(getNode(Relay.QL`
       query {
@@ -692,6 +697,11 @@ describe('diffRelayQuery', () => {
         }
       }
     `));
+    expect(diffQueries[1].getIdentifyingArg()).toEqual({
+      name: 'ids',
+      type: '[ID!]',
+      value: ['4808495'],
+    });
   });
 
   it('splits viewer-rooted queries', () => {

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -96,15 +96,17 @@ describe('printRelayOSSQuery', () => {
       `);
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query PrintRelayOSSQuery {
-          node(id:"123") {
+        query PrintRelayOSSQuery($id_0: ID!) {
+          node(id: $id_0) {
             name,
             id,
             __typename
           }
         }
       `);
-      expect(variables).toEqual({});
+      expect(variables).toEqual({
+        id_0: '123',
+      });
     });
 
     it('prints a query with one root numeric argument', () => {
@@ -118,15 +120,17 @@ describe('printRelayOSSQuery', () => {
       `);
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query FooQuery {
-          node(id:123) {
+        query FooQuery($id_0: ID!) {
+          node(id: $id_0) {
             name,
             id,
             __typename
           }
         }
       `);
-      expect(variables).toEqual({});
+      expect(variables).toEqual({
+        id_0: 123,
+      });
     });
 
     it('prints a query with multiple root arguments', () => {
@@ -140,8 +144,8 @@ describe('printRelayOSSQuery', () => {
       `);
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query PrintRelayOSSQuery {
-          usernames(names:["a","b","c"]) {
+        query PrintRelayOSSQuery($names_0: [String!]!) {
+          usernames(names: $names_0) {
             firstName,
             lastName,
             id,
@@ -149,7 +153,9 @@ describe('printRelayOSSQuery', () => {
           }
         }
       `);
-      expect(variables).toEqual({});
+      expect(variables).toEqual({
+        names_0: ['a', 'b', 'c'],
+      });
     });
 
     it('prints a query with multiple numeric arguments', () => {
@@ -163,15 +169,17 @@ describe('printRelayOSSQuery', () => {
       `);
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query FooQuery {
-          nodes(ids:[123,456]) {
+        query FooQuery($ids_0: [ID!]!) {
+          nodes(ids: $ids_0) {
             name,
             id,
             __typename
           }
         }
       `);
-      expect(variables).toEqual({});
+      expect(variables).toEqual({
+        ids_0: [123,456],
+      });
     });
 
     it('prints enum call values', () => {
@@ -297,25 +305,26 @@ describe('printRelayOSSQuery', () => {
       const alias = generateRQLFieldAlias('storySearch.query({"query":"foo"})');
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
-        query FooQuery($query_0: StorySearchInput!) {
-          node(id: "123") {
+        query FooQuery($id_0: ID!, $query_1: StorySearchInput!) {
+          node(id: $id_0) {
             id,
             __typename,
             ...F0
           }
         }
         fragment F0 on User {
-          ${alias}: storySearch(query: $query_0) {
+          ${alias}: storySearch(query: $query_1) {
             id
           },
-          ${alias}: storySearch(query: $query_0) {
+          ${alias}: storySearch(query: $query_1) {
             id
           },
           id
         }
       `);
       expect(variables).toEqual({
-        query_0: query1,
+        id_0: '123',
+        query_1: query1,
       });
     });
 
@@ -834,8 +843,8 @@ describe('printRelayOSSQuery', () => {
     `, params);
     const {text, variables} = printRelayOSSQuery(query);
     expect(text).toEqualPrintedQuery(`
-      query PrintRelayOSSQuery {
-        node(id: 123) @skip(if: true) {
+      query PrintRelayOSSQuery($id_0: ID!) {
+        node(id: $id_0) @skip(if: true) {
           id,
           __typename,
           ...F0
@@ -845,7 +854,9 @@ describe('printRelayOSSQuery', () => {
         id
       }
     `);
-    expect(variables).toEqual({});
+    expect(variables).toEqual({
+      id_0: 123,
+    });
   });
 
   it('throws for directives with complex values', () => {


### PR DESCRIPTION
This is a tentative fix for #916 - `diffRelayQuery` is generating invalid plural root calls because it assumes that their argument type is `ID`. The most straightforward solution is to annotate all arguments with their type, but this may increase application code size and/or affect performance. I'll benchmark this internally to verify the impact and may reconsider if it affects perf substantially.