### PR TITLE
Update Jest to 0.9.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-flatten": "^0.1.0",
     "gulp-header": "^1.2.2",
     "gulp-util": "^3.0.6",
-    "jest-cli": "^0.9.0-fb3",
+    "jest-cli": "^0.9.0",
     "object-assign": "^3.0.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
@@ -66,7 +66,6 @@
   },
   "jest": {
     "rootDir": "",
-    "testRunner": "<rootDir>/node_modules/jest-cli/src/testRunners/jasmine/jasmine2.js",
     "scriptPreprocessor": "scripts/jest/preprocessor.js",
     "setupEnvScriptFile": "node_modules/fbjs-scripts/jest/environment.js",
     "persistModuleRegistryBetweenSpecs": true,


### PR DESCRIPTION
This puts Jest back from the pre-release track on to `0.9.x`. Apparently npm doesn't automatically go from `0.9.0-fb3` to above or equal `0.9.0`.