### PR TITLE
Treat all fat queries as patterns and preserve their empty nodes

### DIFF
--- a/src/mutation/RelayMutationQueue.js
+++ b/src/mutation/RelayMutationQueue.js
@@ -386,7 +386,19 @@ class PendingTransaction {
       this._fatQuery = nullthrows(flattenRelayQuery(
         fragment,
         {
-          preserveEmptyNodes: fragment.isPattern(),
+          // TODO #10341736
+          // This used to be `preserveEmptyNodes: fragment.isPattern()`. We
+          // discovered that products were not marking their fat queries as
+          // patterns (by adding `@relay(pattern: true)`) which was causing
+          // `preserveEmptyNodes` to be false. This meant that empty fields,
+          // would be stripped instead of being used to produce an intersection
+          // with the tracked query. Products were able to do this because the
+          // Babel Relay plugin doesn't produce validation errors for empty
+          // fields. It should, and we will make it do so, but for now we're
+          // going to set this to `true` always, and make the plugin warn when
+          // it encounters an empty field that supports subselections in a
+          // non-pattern fragment. Revert this when done.
+          preserveEmptyNodes: true,
           shouldRemoveFragments: true,
         }
       ));


### PR DESCRIPTION
So, here's the thing. Currently, the plugin allows you to write an invalid query: a subselection-supporting field that has no subselections:

    fragment on Viewer { todos }

That should fail, unless you've specifically marked the fragment as being a pattern:

    fragment on Viewer @relay(pattern: true) {
      todos
    }

Pattern fragments are those on which certain validations are disabled.

For now, we're going to treat all fat queries as pattern fragments to unbreak products. Next, we're going to start to warn in the Babel Relay plugin when you have a query like the first one above. Lastly, we'll revert this PR and make the Babel Relay plugin throw on a query like the first one above.