### PR TITLE
flow fix: default network layer

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -45,7 +45,7 @@ class RelayDefaultNetworkLayer {
     self.supports = this.supports.bind(this);
   }
 
-  sendMutation(request: RelayMutationRequest): Promise {
+  sendMutation(request: RelayMutationRequest): ?Promise {
     return this._sendMutation(request).then(
       result => result.json()
     ).then(payload => {
@@ -65,7 +65,7 @@ class RelayDefaultNetworkLayer {
     );
   }
 
-  sendQueries(requests: Array<RelayQueryRequest>): Promise {
+  sendQueries(requests: Array<RelayQueryRequest>): ?Promise {
     return Promise.all(requests.map(request => (
       this._sendQuery(request).then(
         result => result.json()


### PR DESCRIPTION
For some reason Flow doesn't like `Promise` being used in a place that accepts `?Promise`. This makes no sense, but it's easiest to just relax the return type and move on.