### PR TITLE
Reorder installs based on which one's more likely to fail

### DIFF
--- a/examples/TodoMVC/README.md
+++ b/examples/TodoMVC/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```
-npm install && npm install -g react-native-cli
+npm install -g react-native-cli && npm install
 ```
 
 ## Running


### PR DESCRIPTION
`npm install -g react-native-cli ` is less likely to fail than `npm install`, so let's encourage people to run that one first when installing the React Native / Relay example app.