### PR TITLE
Fix flow error in getRelayQueries

### DIFF
--- a/src/container/getRelayQueries.js
+++ b/src/container/getRelayQueries.js
@@ -38,14 +38,12 @@ function getRelayQueries(
   Component: RelayLazyContainer,
   route: RelayQueryConfigSpec
 ): RelayQuerySet {
-  if (!queryCache.has(Component)) {
-    queryCache.set(Component, {});
+  let cache = queryCache.get(Component);
+  if (!cache) {
+    cache = {};
+    queryCache.set(Component, cache);
   }
   const cacheKey = route.name + ':' + stableStringify(route.params);
-  /* $FlowFixMe: Error discovered while adding Flow types
-   * to Map and Set. This is often because .get() can return null.
-   */
-  const cache = queryCache.get(Component);
   if (cache.hasOwnProperty(cacheKey)) {
     return cache[cacheKey];
   }


### PR DESCRIPTION
The return value of `Map.prototype.get` is nullable, but the standard flow type
currently doesn't match that yet. Internally, we have the return value as
nullable which is why the `@FlowFixMe` annotation was added.