### PR TITLE
Remove wrong directory from flowconfig

### DIFF
--- a/scripts/babel-relay-plugin/src/.flowconfig
+++ b/scripts/babel-relay-plugin/src/.flowconfig
@@ -5,7 +5,6 @@
 
 [include]
 ../node_modules/
-../../node_modules/
 ../../../node_modules/util/
 
 [libs]


### PR DESCRIPTION
The path pointed at `scripts/node_modules` which doesn't exist and caused the
flow server to crash.

Test Plan:
`flow scripts/babel-relay-plugin/src` now starts a server which doesn't crash.