### PR TITLE
Refactor RelayRenderer

### DIFF
--- a/src/container/RelayRenderer.js
+++ b/src/container/RelayRenderer.js
@@ -33,6 +33,9 @@ const getRelayQueries = require('getRelayQueries');
 const invariant = require('invariant');
 const mapObject = require('mapObject');
 
+type RelayContainerProps = {
+  [propName: string]: mixed;
+};
 type RelayRendererProps = {
   Container: RelayContainer;
   forceFetch?: ?boolean;
@@ -54,7 +57,7 @@ export type RelayRendererRenderCallback =
 type RelayRendererRenderArgs = {
   done: boolean;
   error: ?Error;
-  props: ?{[propName: string]: mixed};
+  props: ?RelayContainerProps;
   retry: ?Function;
   stale: boolean;
 };
@@ -80,7 +83,7 @@ const {PropTypes} = React;
  *
  * The `render` callback is called with an object with the following properties:
  *
- *   props: ?{[propName: string]: mixed}
+ *   props: ?RelayContainerProps
  *     If present, sufficient data is ready to render the container. This object
  *     must be spread into the container using the spread attribute operator. If
  *     absent, there is insufficient data to render the container.
@@ -125,7 +128,7 @@ const {PropTypes} = React;
  *
  */
 class RelayRenderer extends React.Component {
-  containerProps: ?{[propName: string]: mixed};
+  containerProps: ?RelayContainerProps;
   gcHold: ?GarbageCollectionHold;
   mounted: boolean;
   pendingRequest: ?Abortable;
@@ -284,7 +287,7 @@ class RelayRenderer extends React.Component {
   /**
    * @private
    */
-  _resolveContainerProps(): {[propName: string]: mixed} {
+  _resolveContainerProps(): RelayContainerProps {
     if (!this.containerProps) {
       const {environment, queryConfig} = this.props;
       this.containerProps = {

--- a/src/container/RelayRenderer.js
+++ b/src/container/RelayRenderer.js
@@ -303,21 +303,23 @@ class RelayRenderer extends React.Component {
    */
   _calculateRenderArgs(): RelayRendererRenderArgs {
     const {readyState} = this.state;
-    return readyState ?
-      {
+    if (readyState) {
+      return {
         done: readyState.done,
         error: readyState.error,
         props: readyState.ready ? this._resolveContainerProps() : null,
         retry: this._retry.bind(this),
         stale: readyState.stale,
-      } :
-      {
+      };
+    } else {
+      return {
         done: false,
         error: null,
         props: null,
         retry: this._retry.bind(this),
         stale: false,
       };
+    }
   }
 
   render(): ?React$Element {

--- a/src/container/RelayRenderer.js
+++ b/src/container/RelayRenderer.js
@@ -54,7 +54,7 @@ export type RelayRendererRenderCallback =
 type RelayRendererRenderArgs = {
   done: boolean;
   error: ?Error;
-  props: ?Object;
+  props: ?{[propName: string]: mixed};
   retry: ?Function;
   stale: boolean;
 };
@@ -80,7 +80,7 @@ const {PropTypes} = React;
  *
  * The `render` callback is called with an object with the following properties:
  *
- *   props: ?Object
+ *   props: ?{[propName: string]: mixed}
  *     If present, sufficient data is ready to render the container. This object
  *     must be spread into the container using the spread attribute operator. If
  *     absent, there is insufficient data to render the container.
@@ -125,7 +125,7 @@ const {PropTypes} = React;
  *
  */
 class RelayRenderer extends React.Component {
-  containerProps: ?Object;
+  containerProps: ?{[propName: string]: mixed};
   gcHold: ?GarbageCollectionHold;
   mounted: boolean;
   pendingRequest: ?Abortable;
@@ -284,7 +284,7 @@ class RelayRenderer extends React.Component {
   /**
    * @private
    */
-  _resolveContainerProps(): Object {
+  _resolveContainerProps(): {[propName: string]: mixed} {
     if (!this.containerProps) {
       const {environment, queryConfig} = this.props;
       this.containerProps = {

--- a/src/container/RelayRenderer.js
+++ b/src/container/RelayRenderer.js
@@ -59,11 +59,8 @@ type RelayRendererRenderArgs = {
   stale: boolean;
 };
 type RelayRendererState = {
-  activeContainer: ?RelayContainer;
-  activeEnvironment: ?RelayEnvironmentInterface;
-  activeQueryConfig: ?RelayQueryConfigSpec;
+  active: boolean;
   readyState: ?ComponentReadyState;
-  renderArgs: RelayRendererRenderArgs;
 };
 
 const {PropTypes} = React;
@@ -128,45 +125,24 @@ const {PropTypes} = React;
  *
  */
 class RelayRenderer extends React.Component {
+  containerProps: ?Object;
   gcHold: ?GarbageCollectionHold;
   mounted: boolean;
   pendingRequest: ?Abortable;
   props: RelayRendererProps;
+  querySet: ?RelayQuerySet;
   state: RelayRendererState;
 
   constructor(props: RelayRendererProps, context: any) {
     super(props, context);
+    this.containerProps = null;
     const garbageCollector =
       this.props.environment.getStoreData().getGarbageCollector();
     this.gcHold = garbageCollector && garbageCollector.acquireHold();
     this.mounted = true;
     this.pendingRequest = null;
-    this.state = this._buildState(null, null, null, null, null);
-  }
-
-  /**
-   * @private
-   */
-  _buildState(
-    activeContainer: ?RelayContainer,
-    activeEnvironment: ?RelayEnvironmentInterface,
-    activeQueryConfig: ?RelayQueryConfigSpec,
-    readyState: ?ReadyState,
-    props: ?Object
-  ): RelayRendererState {
-    return {
-      activeContainer,
-      activeEnvironment,
-      activeQueryConfig,
-      readyState: readyState && {...readyState, mounted: true},
-      renderArgs: {
-        done: !!readyState && readyState.done,
-        error: readyState && readyState.error,
-        props,
-        retry: () => this._retry(),
-        stale: !!readyState && readyState.stale,
-      },
-    };
+    this.querySet = null;
+    this.state = {active: false, readyState: null};
   }
 
   getChildContext(): Object {
@@ -193,7 +169,6 @@ class RelayRenderer extends React.Component {
       environment,
     }: RelayRendererProps
   ): void {
-    const querySet = getRelayQueries(Container, queryConfig);
     const onReadyStateChange = readyState => {
       if (!this.mounted) {
         this._handleReadyStateChange({...readyState, mounted: false});
@@ -206,41 +181,25 @@ class RelayRenderer extends React.Component {
       if (readyState.aborted || readyState.done || readyState.error) {
         this.pendingRequest = null;
       }
-      let {props} = this.state.renderArgs;
-      if (readyState.ready && !props) {
-        props = {
-          ...queryConfig.params,
-          ...mapObject(
-            querySet,
-            query => createFragmentPointerForRoot(environment, query)
-          ),
-        };
-      }
-      this.setState(
-        this._buildState(
-          Container,
-          environment,
-          queryConfig,
-          readyState,
-          props
-        )
-      );
+      this.setState({active: true, readyState: {...readyState, mounted: true}});
     };
 
     if (this.pendingRequest) {
       this.pendingRequest.abort();
     }
 
+    this.containerProps = null;
+    this.querySet = getRelayQueries(Container, queryConfig);
     const request = this.pendingRequest = forceFetch ?
       (
         onForceFetch ?
-          onForceFetch(querySet, onReadyStateChange) :
-          environment.forceFetch(querySet, onReadyStateChange)
+          onForceFetch(this.querySet, onReadyStateChange) :
+          environment.forceFetch(this.querySet, onReadyStateChange)
       ) :
       (
         onPrimeCache ?
-          onPrimeCache(querySet, onReadyStateChange) :
-          environment.primeCache(querySet, onReadyStateChange)
+          onPrimeCache(this.querySet, onReadyStateChange) :
+          environment.primeCache(this.querySet, onReadyStateChange)
       );
   }
 
@@ -253,29 +212,7 @@ class RelayRenderer extends React.Component {
    * @private
    */
   _shouldUpdate(): boolean {
-    const {activeContainer, activeEnvironment, activeQueryConfig} = this.state;
-    const {Container, queryConfig, environment} = this.props;
-    return (
-      (!activeContainer || Container === activeContainer) &&
-      (!activeEnvironment || environment === activeEnvironment) &&
-      (!activeQueryConfig || queryConfig === activeQueryConfig)
-    );
-  }
-
-  /**
-   * @private
-   */
-  _runQueriesAndSetState(props: RelayRendererProps): void {
-    this._runQueries(props);
-    this.setState(
-      this._buildState(
-        this.state.activeContainer,
-        this.state.activeEnvironment,
-        this.state.activeQueryConfig,
-        null,
-        null
-      )
-    );
+    return !!this.state.readyState || !this.state.active;
   }
 
   /**
@@ -288,7 +225,8 @@ class RelayRenderer extends React.Component {
       'RelayRenderer: You tried to call `retry`, but the last request did ' +
       'not fail. You can only call this when the last request has failed.'
     );
-    this._runQueriesAndSetState(this.props);
+    this._runQueries(this.props);
+    this.setState({readyState: null});
   }
 
   componentWillReceiveProps(nextProps: RelayRendererProps): void {
@@ -304,7 +242,8 @@ class RelayRenderer extends React.Component {
           nextProps.environment.getStoreData().getGarbageCollector();
         this.gcHold = garbageCollector && garbageCollector.acquireHold();
       }
-      this._runQueriesAndSetState(nextProps);
+      this._runQueries(nextProps);
+      this.setState({readyState: null});
     }
   }
 
@@ -342,12 +281,51 @@ class RelayRenderer extends React.Component {
     this.mounted = false;
   }
 
+  /**
+   * @private
+   */
+  _resolveContainerProps(): Object {
+    if (!this.containerProps) {
+      const {environment, queryConfig} = this.props;
+      this.containerProps = {
+        ...queryConfig.params,
+        ...mapObject(
+          this.querySet,
+          query => createFragmentPointerForRoot(environment, query)
+        ),
+      };
+    }
+    return this.containerProps;
+  }
+
+  /**
+   * @private
+   */
+  _calculateRenderArgs(): RelayRendererRenderArgs {
+    const {readyState} = this.state;
+    return readyState ?
+      {
+        done: readyState.done,
+        error: readyState.error,
+        props: readyState.ready ? this._resolveContainerProps() : null,
+        retry: this._retry.bind(this),
+        stale: readyState.stale,
+      } :
+      {
+        done: false,
+        error: null,
+        props: null,
+        retry: this._retry.bind(this),
+        stale: false,
+      };
+  }
+
   render(): ?React$Element {
     let children;
     let shouldUpdate = this._shouldUpdate();
     if (shouldUpdate) {
       const {Container, render} = this.props;
-      const {renderArgs} = this.state;
+      const renderArgs = this._calculateRenderArgs();
       if (render) {
         children = render(renderArgs);
       } else if (renderArgs.props) {


### PR DESCRIPTION
This simplifies state handling in `RelayRenderer`, but does not change external behaviour and API. It follows principles described in section "[Thinking in React: Identify the minimal (but complete) representation of UI state](https://facebook.github.io/react/docs/thinking-in-react.html#step-3-identify-the-minimal-but-complete-representation-of-ui-state)". I identified that only two things actually determine internal state of `RelayRenderer`:
- the most recent ready state (the `readyState` state param),
- and whether we received a ready state at least once (the new `active` state param).

The `active` param means that we made a render while having a ready state at least once, and next time we will rerender only if we also have a ready state (we might have reseted the ready state to `null` after sending new queries).

Previously other state params were either redundant or derivable from `readyState` and `active`.

After this refactoring it will probably be easy for `RelayRenderer` to make use of `RelayRedayStateRenderer` [proposed](https://github.com/facebook/relay/pull/921#issuecomment-194392149) by @yungsters.

But originally it was submitted as a part of #921 to simplify implementation of isomorphic rendering for `RelayRenderer`.