### PR TITLE
Upgrade Plugin to use `babel-preset-fbjs`

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-fNfgCJRDc73nHs+YJdbdS1IqV+I=
+p3hoT8+mnHP5S+T0/caqPCNnwCo=

--- a/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
@@ -13,8 +13,8 @@
 'use strict';
 
 var babel = require('babel-core');
+var fbjsPreset = require('babel-preset-fbjs');
 var fs = require('fs');
-var getBabelOptions = require('fbjs-scripts/babel-6/default-options');
 var util = require('util');
 
 var getBabelRelayPlugin = require('../getBabelRelayPlugin');
@@ -34,19 +34,19 @@ function getSchema(schemaPath) {
 }
 
 function transformGraphQL(schemaPath, source, filename) {
-  var plugin = getBabelRelayPlugin(getSchema(schemaPath), {
+  var babelPluginRelay = getBabelRelayPlugin(getSchema(schemaPath), {
     debug: true,
     substituteVariables: true,
     suppressWarnings: true
   });
-
-  var babelOptions = getBabelOptions({
-    moduleOpts: { prefix: '' }
-  });
-  babelOptions.plugins.unshift(plugin);
-  babelOptions.filename = filename;
-  babelOptions.retainLines = true;
-  return babel.transform(source, babelOptions).code;
+  var options = {
+    presets: [fbjsPreset],
+    plugins: [babelPluginRelay],
+    compact: false,
+    filename: filename,
+    retainLines: true
+  };
+  return babel.transform(source, options).code;
 }
 
 module.exports = transformGraphQL;

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -11,8 +11,8 @@
     "prepublish": "npm run build",
     "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",
-    "update-schema": "babel-node ./src/tools/generateSchemaJson.js",
-    "update-fixtures": "babel-node ./src/tools/regenerateFixtures.js"
+    "update-schema": "babel-node --presets fbjs ./src/tools/generateSchemaJson.js",
+    "update-fixtures": "babel-node --presets fbjs ./src/tools/regenerateFixtures.js"
   },
   "files": [
     "LICENSE",
@@ -21,38 +21,17 @@
     "lib/"
   ],
   "devDependencies": {
-    "babel-core": "^6.6.4",
-    "babel-eslint": "^4.1.1",
-    "babel-plugin-check-es2015-constants": "^6.6.4",
-    "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
-    "babel-plugin-transform-class-properties": "^6.6.0",
-    "babel-plugin-transform-es2015-arrow-functions": "^6.5.2",
-    "babel-plugin-transform-es2015-block-scoped-functions": "^6.6.4",
-    "babel-plugin-transform-es2015-block-scoping": "^6.6.4",
-    "babel-plugin-transform-es2015-classes": "^6.6.4",
-    "babel-plugin-transform-es2015-computed-properties": "^6.6.4",
-    "babel-plugin-transform-es2015-destructuring": "^6.6.4",
-    "babel-plugin-transform-es2015-for-of": "^6.6.0",
-    "babel-plugin-transform-es2015-literals": "^6.5.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.6.4",
-    "babel-plugin-transform-es2015-object-super": "^6.6.4",
-    "babel-plugin-transform-es2015-parameters": "^6.6.4",
-    "babel-plugin-transform-es2015-shorthand-properties": "^6.5.0",
-    "babel-plugin-transform-es2015-spread": "^6.6.4",
-    "babel-plugin-transform-es2015-template-literals": "^6.6.4",
-    "babel-plugin-transform-es3-member-expression-literals": "^6.5.0",
-    "babel-plugin-transform-es3-property-literals": "^6.5.0",
-    "babel-plugin-transform-flow-strip-types": "^6.6.4",
-    "babel-plugin-transform-object-rest-spread": "^6.6.4",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.2",
+    "babel-eslint": "^5.0.0",
+    "babel-preset-fbjs": "^1.0.0",
     "babel-preset-jest": "^1.0.0",
-    "eslint": "^1.3.1",
-    "fbjs-scripts": "^0.6.0-alpha.3",
-    "flow-bin": "0.22.0",
+    "eslint": "~2.2.0",
+    "flow-bin": "^0.22.1",
     "glob": "^7.0.3",
-    "jest-cli": "^0.9.0",
-    "minimist": "^1.1.3",
+    "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "rimraf": "^2.1"
+    "rimraf": "^2.5.2"
   },
   "dependencies": {
     "graphql": "^0.4.18"

--- a/scripts/babel-relay-plugin/scripts/build-lib
+++ b/scripts/babel-relay-plugin/scripts/build-lib
@@ -12,7 +12,7 @@ const root = path.resolve(__dirname, '..');
 const lib = path.join(root, 'lib');
 const src = path.join(root, 'src');
 
-const getBabelOptions = require('fbjs-scripts/babel-6/default-options');
+const fbjsPreset = require('babel-preset-fbjs');
 
 // Blow away prior build artifacts.
 rimraf.sync(lib);
@@ -31,9 +31,9 @@ files.forEach(file => {
 
   // Make sure the full path the destination file exists so we can write to it
   mkdirp.sync(path.dirname(libFile));
-  const result = babel.transformFileSync(srcFile, getBabelOptions({
-    moduleOpts: {prefix: ''},
-  }));
+  const result = babel.transformFileSync(srcFile, {
+    presets: [fbjsPreset],
+  });
 
   sources.push(fs.readFileSync(srcFile, 'utf8'));
 

--- a/scripts/babel-relay-plugin/scripts/jest/preprocessor.js
+++ b/scripts/babel-relay-plugin/scripts/jest/preprocessor.js
@@ -8,22 +8,24 @@
  */
 
 const babel = require('babel-core');
-const getBabelOptions = require('fbjs-scripts/babel-6/default-options');
+const fbjsPreset = require('babel-preset-fbjs');
 const jestPreset = require('babel-preset-jest');
 const path = require('path');
 
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 
 module.exports = {
-  process(src, filename) {
+  process: function(src, filename) {
     if (!filename.includes(NODE_MODULES) && babel.util.canCompile(filename)) {
-      const babelOptions = getBabelOptions({
-        moduleOpts: {prefix: ''},
-      });
-      babelOptions.presets = [jestPreset];
-      babelOptions.filename = filename;
-      babelOptions.retainLines = true;
-      return babel.transform(src, babelOptions).code;
+      const options = {
+        presets: [
+          fbjsPreset,
+          jestPreset,
+        ],
+        filename: filename,
+        retainLines: true,
+      };
+      return babel.transform(src, options).code;
     }
     return src;
   },

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsInvalidValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsInvalidValues.fixture
@@ -22,6 +22,8 @@ var foo = Relay.QL`
 `;
 
 Output:
-var foo = (function () {
+"use strict";
+
+var foo = function () {
   throw new Error("GraphQL validation/transform error ``Argument \"first\" has invalid value \"10\".\nExpected type \"Int\", found \"10\". Argument \"orderby\" has invalid value Name.\nExpected type \"String\", found Name. Argument \"find\" has invalid value cursor1.\nExpected type \"String\", found cursor1. Argument \"isViewerFriend\" has invalid value \"true\".\nExpected type \"Boolean\", found \"true\". Argument \"gender\" has invalid value \"MALE\".\nExpected type \"Gender\", found \"MALE\".`` in file `argsInvalidValues.fixture`.");
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
@@ -8,7 +8,9 @@ var foo = Relay.QL`
 `;
 
 Output:
-var foo = (function (RQL_0) {
+"use strict";
+
+var foo = function (RQL_0) {
   return {
     calls: [{
       kind: "Call",
@@ -44,4 +46,4 @@ var foo = (function (RQL_0) {
     name: "Args",
     type: "Node"
   };
-})(userID);
+}(userID);

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
@@ -23,7 +23,9 @@ var foo = Relay.QL`
 `;
 
 Output:
-var foo = (function () {
+"use strict";
+
+var foo = function () {
   return {
     calls: [{
       kind: "Call",
@@ -214,4 +216,4 @@ var foo = (function () {
     name: "Args",
     type: "Node"
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
@@ -8,7 +8,9 @@ var foo = Relay.QL`
 `;
 
 Output:
-var foo = (function () {
+"use strict";
+
+var foo = function () {
   return {
     calls: [{
       kind: "Call",
@@ -54,4 +56,4 @@ var foo = (function () {
     name: "Args",
     type: "Node"
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionPattern.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionPattern.fixture
@@ -13,8 +13,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       children: [{
@@ -104,4 +106,4 @@ var x = (function () {
     name: 'ConnectionPatternRelayQL',
     type: 'User'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgs.fixture
@@ -17,7 +17,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, or `(after: <cursor>, first: <count>)`.`` in file `connectionWithAfterLastArgs.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgsWithInlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgsWithInlineFragment.fixture
@@ -19,7 +19,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, or `(after: <cursor>, first: <count>)`.`` in file `connectionWithAfterLastArgsWithInlineFragment.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstArgs.fixture
@@ -17,7 +17,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``Connection arguments `friends(before: <cursor>, first: <count>)` are not supported. Use `(first: <count>)`, `(after: <cursor>, first: <count>)`, or `(before: <cursor>, last: <count>)`.`` in file `connectionWithBeforeFirstArgs.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
@@ -15,7 +15,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied a field named `nodes` on a connection named `friends`, but pagination is not supported on connections without using `edges`. Use `friends{edges{node{...}}}` instead.`` in file `connectionWithNodesField.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
@@ -20,8 +20,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -161,4 +163,4 @@ var x = (function () {
     name: 'ConnectionWithPageInfoAlias',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
@@ -18,8 +18,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -159,4 +161,4 @@ var x = (function () {
     name: 'ConnectionWithPageInfoSubfields',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgs.fixture
@@ -17,7 +17,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied the `edges` field on a connection named `friends`, but you did not supply an argument necessary to do so. Use either the `find`, `first`, or `last` argument.`` in file `connectionWithoutArgs.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgsWithInlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgsWithInlineFragment.fixture
@@ -19,7 +19,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied the `edges` field on a connection named `friends`, but you did not supply an argument necessary to do so. Use either the `find`, `first`, or `last` argument.`` in file `connectionWithoutArgsWithInlineFragment.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
@@ -15,8 +15,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -152,4 +154,4 @@ var x = (function () {
     name: 'ConnectionWithoutNodeField',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
@@ -15,8 +15,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -153,4 +155,4 @@ var x = (function () {
     name: 'ConnectionWithoutNodeID',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
@@ -7,11 +7,13 @@ Relay.createContainer(Component, {
 });
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
 Relay.createContainer(Component, {
   queries: {
     viewer: function () {
-      return (function () {
+      return function () {
         return {
           children: [{
             children: [{
@@ -37,7 +39,7 @@ Relay.createContainer(Component, {
           name: 'Container_ViewerRelayQL',
           type: 'Viewer'
         };
-      })();
+      }();
     }
   }
 });

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
@@ -11,8 +11,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -72,4 +74,4 @@ var x = (function () {
     name: 'FieldForEnum',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
@@ -11,8 +11,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -73,4 +75,4 @@ var x = (function () {
     name: 'FieldWithAlias',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
@@ -13,8 +13,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -92,4 +94,4 @@ var x = (function () {
     name: 'FieldWithAliasAndArgs',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
@@ -13,8 +13,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -91,4 +93,4 @@ var x = (function () {
     name: 'FieldWithArgs',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
@@ -9,8 +9,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       calls: [{
@@ -51,4 +53,4 @@ var x = (function () {
     name: 'FieldWithEmptyArrayArgRelayQL',
     type: 'User'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -17,8 +17,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -163,4 +165,4 @@ var x = (function () {
     name: 'FieldWithEnumArg',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
@@ -17,8 +17,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -163,4 +165,4 @@ var x = (function () {
     name: 'FieldWithEnumQueryArg',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
@@ -13,8 +13,10 @@ var foo = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('Relay');
-var foo = (function () {
+var foo = function () {
   return {
     children: [{
       children: [{
@@ -74,4 +76,4 @@ var foo = (function () {
     name: 'FieldWithFakeConnectionRelayQL',
     type: 'User'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
@@ -13,8 +13,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -91,4 +93,4 @@ var x = (function () {
     name: 'FieldWithParams',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragment.fixture
@@ -3,8 +3,10 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on Node { id }`;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       fieldName: 'id',
@@ -30,4 +32,4 @@ var x = (function () {
     name: 'FragmentRelayQL',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentDirectives.fixture
@@ -3,8 +3,10 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on Node @relay(plural: true) { id }`;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       fieldName: 'id',
@@ -31,4 +33,4 @@ var x = (function () {
     name: 'FragmentDirectivesRelayQL',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentOnBadType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentOnBadType.fixture
@@ -3,7 +3,9 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on NotAType { id }`;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``Unknown type "NotAType".`` in file `fragmentOnBadType.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithModuleName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithModuleName.fixture
@@ -5,9 +5,11 @@ var x = Relay.QL`fragment Foo on Node { id }`;
 var y = Relay.QL`fragment Bar on Node { id }`;
 
 Output:
+'use strict';
+
 /** @providesModule Foo.react */
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       fieldName: 'id',
@@ -33,8 +35,8 @@ var x = (function () {
     name: 'Foo',
     type: 'Node'
   };
-})();
-var y = (function () {
+}();
+var y = function () {
   return {
     children: [{
       fieldName: 'id',
@@ -60,4 +62,4 @@ var y = (function () {
     name: 'Bar',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithName.fixture
@@ -3,8 +3,10 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment FragmentNameHere on Node { id }`;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       fieldName: 'id',
@@ -30,4 +32,4 @@ var x = (function () {
     name: 'FragmentNameHere',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithPossibleId.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithPossibleId.fixture
@@ -8,8 +8,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       fieldName: 'name',
@@ -71,4 +73,4 @@ var x = (function () {
     name: 'FragmentWithPossibleIdRelayQL',
     type: 'Actor'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithReference.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithReference.fixture
@@ -3,8 +3,10 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on Node { ${reference} }`;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function (RQL_0) {
+var x = function (RQL_0) {
   return {
     children: [].concat.apply([], [{
       fieldName: 'id',
@@ -31,4 +33,4 @@ var x = (function (RQL_0) {
     name: 'FragmentWithReferenceRelayQL',
     type: 'Node'
   };
-})(reference);
+}(reference);

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithStaticID.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithStaticID.fixture
@@ -7,8 +7,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       fieldName: 'name',
@@ -57,4 +59,4 @@ var x = (function () {
     name: 'FragmentWithStaticIDRelayQL',
     type: 'Actor'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithoutCommas.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithoutCommas.fixture
@@ -8,8 +8,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function (RQL_0) {
+var x = function (RQL_0) {
   return {
     children: [].concat.apply([], [{
       fieldName: 'id',
@@ -35,4 +37,4 @@ var x = (function (RQL_0) {
     name: 'FragmentWithoutCommasRelayQL',
     type: 'Node'
   };
-})(reference);
+}(reference);

--- a/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
@@ -9,8 +9,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       fieldName: 'id',
@@ -57,4 +59,4 @@ var x = (function () {
     name: 'InlineFragmentRelayQL',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/inlineFragmentWithoutType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/inlineFragmentWithoutType.fixture
@@ -13,6 +13,8 @@ var x = Relay.QL`
 */
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
 /*
 TODO: Upgrade to graphql@0.4.7 and uncomment this.

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
@@ -10,7 +10,9 @@ var foo = Relay.QL`
 `;
 
 Output:
-var foo = (function () {
+"use strict";
+
+var foo = function () {
   return {
     children: [{
       children: [{
@@ -33,4 +35,4 @@ var foo = (function () {
     name: "IntrospectionQueryForSchema",
     type: "__Schema"
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
@@ -8,7 +8,9 @@ var foo = Relay.QL`
 `;
 
 Output:
-var foo = (function () {
+"use strict";
+
+var foo = function () {
   return {
     calls: [{
       kind: "Call",
@@ -36,4 +38,4 @@ var foo = (function () {
     name: "IntrospectionQueryForType",
     type: "__Type"
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
@@ -17,8 +17,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -159,4 +161,4 @@ var x = (function () {
     name: 'MetadataConnection',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
@@ -15,8 +15,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       children: [{
@@ -64,4 +66,4 @@ var x = (function () {
     name: 'MetadataConnectionLimitable',
     type: 'Viewer'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
@@ -14,8 +14,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       children: [{
@@ -137,4 +139,4 @@ var x = (function () {
     name: 'MetadataDynamicRelayQL',
     type: 'NewsFeedConnection'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
@@ -7,8 +7,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -48,4 +50,4 @@ var x = (function () {
     name: 'MetadataGenerated',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataNonFindable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataNonFindable.fixture
@@ -11,8 +11,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       children: [{
@@ -35,4 +37,4 @@ var x = (function () {
     name: 'MetadataNonFindable',
     type: 'Viewer'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
@@ -11,8 +11,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -74,4 +76,4 @@ var x = (function () {
     name: 'MetadataPlural',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataRequisite.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataRequisite.fixture
@@ -3,8 +3,10 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on Node { id }`;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       fieldName: 'id',
@@ -30,4 +32,4 @@ var x = (function () {
     name: 'MetadataRequisiteRelayQL',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
@@ -9,8 +9,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     children: [{
       calls: [{
@@ -51,4 +53,4 @@ var x = (function () {
     name: 'MetadataVarArgsRelayQL',
     type: 'User'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
@@ -11,8 +11,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -64,4 +66,4 @@ var x = (function () {
     name: 'Mutation',
     responseType: 'ActorSubscribeResponsePayload'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaMissingArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaMissingArgs.fixture
@@ -7,7 +7,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``Your schema defines a mutation field `mutationMissingArg` that takes 0 arguments, but mutation fields must have exactly one argument named `input`.`` in file `mutationBadSchemaMissingArgs.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaWrongArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaWrongArgs.fixture
@@ -7,7 +7,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``Your schema defines a mutation field `mutationWrongArgs` that takes an argument named `foo`, but mutation fields must have exactly one argument named `input`.`` in file `mutationBadSchemaWrongArgs.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithExtraArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithExtraArgs.fixture
@@ -9,7 +9,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``Unknown argument "extra" on field "actorSubscribe" of type "Mutation".`` in file `mutationWithExtraArgs.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
@@ -9,8 +9,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function (RQL_0) {
+var x = function (RQL_0) {
   return {
     calls: [{
       kind: 'Call',
@@ -37,4 +39,4 @@ var x = (function (RQL_0) {
     name: 'MutationNameHere',
     responseType: 'ActorSubscribeResponsePayload'
   };
-})(reference);
+}(reference);

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
@@ -7,8 +7,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -35,4 +37,4 @@ var x = (function () {
     name: 'MutationWithoutArgs',
     responseType: 'ActorSubscribeResponsePayload'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/nonExistentMutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/nonExistentMutation.fixture
@@ -11,7 +11,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``Cannot query field "fakeMutation" on type "Mutation".`` in file `nonExistentMutation.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/nonRootNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/nonRootNodeField.fixture
@@ -11,7 +11,9 @@ var fragment = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('Relay');
-var fragment = (function () {
+var fragment = function () {
   throw new Error('GraphQL validation/transform error ``You defined a `node(id: Int)` field on type `InvalidType`, but Relay requires the `node` field to be defined on the root type. See the Object Identification Guide: \nhttp://facebook.github.io/relay/docs/graphql-object-identification.html`` in file `nonRootNodeField.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
@@ -14,8 +14,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -93,4 +95,4 @@ var x = (function () {
     name: 'PluralField',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
@@ -9,8 +9,10 @@ var q = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('Relay');
-var q = (function () {
+var q = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -39,4 +41,4 @@ var q = (function () {
     name: 'QueryWithArrayObjectArg',
     type: 'SearchResult'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
@@ -9,7 +9,9 @@ var q = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('Relay');
-var q = (function () {
+var q = function () {
   throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithArrayObjectNestedVariable.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
@@ -9,8 +9,10 @@ var q = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('Relay');
-var q = (function () {
+var q = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -41,4 +43,4 @@ var q = (function () {
     name: 'QueryWithArrayObjectValue',
     type: 'SearchResult'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirective.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirective.fixture
@@ -9,7 +9,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied a directive named `bad`, but no such directive exists.`` in file `queryWithBadDirective.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirectiveArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirectiveArgs.fixture
@@ -9,7 +9,9 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied a directive named `if`, but no such directive exists.`` in file `queryWithBadDirectiveArgs.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
@@ -11,8 +11,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -105,4 +107,4 @@ var x = (function () {
     name: 'QueryWithDirectives',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
@@ -11,8 +11,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -72,4 +74,4 @@ var x = (function () {
     name: 'QueryWithFields',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
@@ -13,8 +13,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -82,4 +84,4 @@ var x = (function () {
     name: 'QueryNameHere',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
@@ -13,8 +13,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -82,4 +84,4 @@ var x = (function () {
     name: 'QueryWithNestedFields',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
@@ -25,8 +25,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function (RQL_0, RQL_1, RQL_2, RQL_3, RQL_4, RQL_5, RQL_6, RQL_7, RQL_8, RQL_9, RQL_10, RQL_11) {
+var x = function (RQL_0, RQL_1, RQL_2, RQL_3, RQL_4, RQL_5, RQL_6, RQL_7, RQL_8, RQL_9, RQL_10, RQL_11) {
   return {
     calls: [{
       kind: 'Call',
@@ -94,4 +96,4 @@ var x = (function (RQL_0, RQL_1, RQL_2, RQL_3, RQL_4, RQL_5, RQL_6, RQL_7, RQL_8
     name: 'QueryWithNestedFragments',
     type: 'Node'
   };
-})(frag1, frag2, frag3, frag4, frag5, frag6, frag7, frag8, frag9, frag10, frag11, frag12);
+}(frag1, frag2, frag3, frag4, frag5, frag6, frag7, frag8, frag9, frag10, frag11, frag12);

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArg.fixture
@@ -9,8 +9,10 @@ var q = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('Relay');
-var q = (function () {
+var q = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -39,4 +41,4 @@ var q = (function () {
     name: 'QueryWithObjectArg',
     type: 'SearchResult'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
@@ -9,7 +9,9 @@ var q = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('Relay');
-var q = (function () {
+var q = function () {
   throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithObjectArgNestedVariable.fixture`.');
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
@@ -9,8 +9,10 @@ var q = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('Relay');
-var q = (function () {
+var q = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -41,4 +43,4 @@ var q = (function () {
     name: 'QueryWithObjectArgValue',
     type: 'SearchResult'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
@@ -9,8 +9,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -53,4 +55,4 @@ var x = (function () {
     name: 'QueryWithVarArgs',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithoutFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithoutFields.fixture
@@ -3,8 +3,10 @@ var Relay = require('react-relay');
 var x = Relay.QL`query { viewer }`;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function () {
+var x = function () {
   return {
     fieldName: 'viewer',
     kind: 'Query',
@@ -12,4 +14,4 @@ var x = (function () {
     name: 'QueryWithoutFields',
     type: 'Viewer'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/subscription.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/subscription.fixture
@@ -9,8 +9,10 @@ var x = Relay.QL`
 `;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
-var x = (function (RQL_0) {
+var x = function (RQL_0) {
   return {
     calls: [{
       kind: 'Call',
@@ -37,4 +39,4 @@ var x = (function (RQL_0) {
     name: 'Subscription',
     responseType: 'LikeStorySubscriptionPayload'
   };
-})(reference);
+}(reference);

--- a/scripts/babel-relay-plugin/src/__fixtures__/tagRelayQL.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/tagRelayQL.fixture
@@ -9,8 +9,10 @@ var x = RelayQL`
 `;
 
 Output:
+'use strict';
+
 var RelayQL = require('react-relay/RelayQL');
-var x = (function () {
+var x = function () {
   return {
     calls: [{
       kind: 'Call',
@@ -49,4 +51,4 @@ var x = (function () {
     name: 'TagRelayQL',
     type: 'Node'
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/templateString.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/templateString.fixture
@@ -3,5 +3,7 @@ var Relay = require('react-relay');
 var x = `Just a template string.`;
 
 Output:
+'use strict';
+
 var Relay = require('react-relay');
 var x = 'Just a template string.';

--- a/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
@@ -8,7 +8,9 @@ var foo = Relay.QL`
 `;
 
 Output:
-var foo = (function () {
+"use strict";
+
+var foo = function () {
   return {
     calls: [{
       kind: "Call",
@@ -39,4 +41,4 @@ var foo = (function () {
     name: "UnionWithTypename",
     type: "Media"
   };
-})();
+}();

--- a/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-var babel = require('babel-core');
-var fs = require('fs');
-var getBabelOptions = require('fbjs-scripts/babel-6/default-options');
-var util = require('util');
+const babel = require('babel-core');
+const fbjsPreset = require('babel-preset-fbjs');
+const fs = require('fs');
+const util = require('util');
 
-var getBabelRelayPlugin = require('../getBabelRelayPlugin');
+const getBabelRelayPlugin = require('../getBabelRelayPlugin');
 
-var _schemas = {};
+const _schemas = {};
 function getSchema(schemaPath) {
   try {
-    var schema = _schemas[schemaPath];
+    let schema = _schemas[schemaPath];
     if (!schema) {
       schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')).data;
       _schemas[schemaPath] = schema;
@@ -38,19 +38,18 @@ function getSchema(schemaPath) {
 }
 
 function transformGraphQL(schemaPath, source, filename) {
-  var plugin = getBabelRelayPlugin(getSchema(schemaPath), {
+  const babelPluginRelay = getBabelRelayPlugin(getSchema(schemaPath), {
     debug: true,
     substituteVariables: true,
     suppressWarnings: true,
   });
-
-  const babelOptions = getBabelOptions({
-    moduleOpts: {prefix: ''},
-  });
-  babelOptions.plugins.unshift(plugin);
-  babelOptions.filename = filename;
-  babelOptions.retainLines = true;
-  return babel.transform(source, babelOptions).code;
+  const options = {
+    presets: [fbjsPreset],
+    plugins: [babelPluginRelay],
+    compact: false,
+    filename,
+  };
+  return babel.transform(source, options).code;
 }
 
 module.exports = transformGraphQL;


### PR DESCRIPTION
Completely upgrades the `babel-relay-plugin` package to use Babel 6.

Depends on facebook/fbjs#135.

Also, I got rid of all extraneous package dependencies and upgraded the rest.

And for the real reason I even did all of this... `npm run update-fixtures` now preserves pretty printing.