### PR TITLE
Add REFETCH and IGNORE rangeBehaviors

### DIFF
--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -331,7 +331,7 @@ Given a parent, a connection, and the name of the newly created edge in the resp
 
 - `rangeBehaviors: {[call: string]: GraphQLMutatorConstants.RANGE_OPERATIONS}`
 
-  A map between printed, dot-separated GraphQL calls *in alphabetical order*, and the behavior we want Relay to exhibit when adding the new edge to connections under the influence of those calls. Behaviors can be one of `'append'`, `'prepend'`, or `'remove'`.
+  A map between printed, dot-separated GraphQL calls *in alphabetical order*, and the behavior we want Relay to exhibit when adding the new edge to connections under the influence of those calls. Behaviors can be one of `'append'`, `'ignore'`, `'prepend'`, `'refetch'`, or `'remove'`.
 
 #### Example
 

--- a/src/legacy/mutation/GraphQLMutatorConstants.js
+++ b/src/legacy/mutation/GraphQLMutatorConstants.js
@@ -14,7 +14,9 @@
 
 const GraphQLMutatorConstants = {
   APPEND: 'append',
+  IGNORE: 'ignore',
   PREPEND: 'prepend',
+  REFETCH: 'refetch',
   REMOVE: 'remove',
 
   NODE_DELETE_HANDLER: 'node_delete',
@@ -49,7 +51,11 @@ GraphQLMutatorConstants.UPDATE_TYPES
 GraphQLMutatorConstants.RANGE_OPERATIONS
   [GraphQLMutatorConstants.APPEND] = true;
 GraphQLMutatorConstants.RANGE_OPERATIONS
+  [GraphQLMutatorConstants.IGNORE] = true;
+GraphQLMutatorConstants.RANGE_OPERATIONS
   [GraphQLMutatorConstants.PREPEND] = true;
+GraphQLMutatorConstants.RANGE_OPERATIONS
+  [GraphQLMutatorConstants.REFETCH] = true;
 GraphQLMutatorConstants.RANGE_OPERATIONS
   [GraphQLMutatorConstants.REMOVE] = true;
 

--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -23,6 +23,7 @@ const RelayQuery = require('RelayQuery');
 import type RelayQueryTracker from 'RelayQueryTracker';
 const RelayRecord = require('RelayRecord');
 import type {Variables} from 'RelayTypes';
+const {REFETCH} = require('GraphQLMutatorConstants');
 
 const flattenRelayQuery = require('flattenRelayQuery');
 const forEachObject = require('forEachObject');
@@ -210,22 +211,27 @@ const RelayMutationQuery = {
         if (!trackedEdges.length) {
           return;
         }
-        if (trackedConnection.getRangeBehaviorKey() in rangeBehaviors) {
+
+        const rangeBehaviorKey = trackedConnection.getRangeBehaviorKey();
+        const rangeBehaviorValue = rangeBehaviors[rangeBehaviorKey];
+        if (rangeBehaviorKey in rangeBehaviors && rangeBehaviorValue !== REFETCH) {
           // Include edges from all connections that exist in `rangeBehaviors`.
           // This may add duplicates, but they will eventually be flattened.
           trackedEdges.forEach(trackedEdge => {
             mutatedEdgeFields.push(...trackedEdge.getChildren());
           });
         } else {
-          // If the connection is not in `rangeBehaviors`, re-fetch it.
+          // If the connection is not in `rangeBehaviors` or we have explicitly
+          // set the behavior to `refetch`, re-fetch it.
           warning(
-            false,
+            rangeBehaviorValue === REFETCH,
             'RelayMutation: The connection `%s` on the mutation field `%s` ' +
             'that corresponds to the ID `%s` did not match any of the ' +
             '`rangeBehaviors` specified in your RANGE_ADD config. This means ' +
             'that the entire connection will be refetched. Configure a range ' +
             'behavior for this mutation in order to fetch only the new edge ' +
-            'and to enable optimistic mutations.',
+            'and to enable optimistic mutations or use `refetch` to squelch ' +
+            'this warning.',
             trackedConnection.getStorageKey(),
             parentName,
             parentID

--- a/src/mutation/__tests__/RelayMutationQuery-test.js
+++ b/src/mutation/__tests__/RelayMutationQuery-test.js
@@ -305,6 +305,96 @@ describe('RelayMutationQuery', () => {
       };
     });
 
+    it('refetches the whole range when the rangeBehavior is REFETCH', () => {
+      tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
+        fragment on Feedback {
+          comments(orderby:"ranked_threaded",first:"10") {
+            edges {
+              node {
+                body {
+                  text
+                }
+              }
+            }
+          }
+        }
+      `));
+      const node = RelayMutationQuery.buildFragmentForEdgeInsertion({
+        fatQuery,
+        tracker,
+        connectionName: 'comments',
+        parentID: '123',
+        edgeName: 'feedbackCommentEdge',
+        parentName: 'feedback',
+        rangeBehaviors: {
+          'orderby(ranked_threaded)': GraphQLMutatorConstants.REFETCH
+        },
+      });
+      const expected = getNodeWithoutSource(Relay.QL`
+        fragment on CommentCreateResponsePayload {
+          feedback {
+            comments(orderby:"ranked_threaded",first:"10") {
+              edges {
+                node {
+                  body {
+                    text
+                  }
+                }
+              }
+            }
+          }
+        }
+      `);
+      expect(node)
+        .toEqualQueryNode(expected);
+    });
+
+    it('range is not refetched at all when rangeBehavior is IGNORE', () => {
+      tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
+        fragment on Feedback {
+          comments(orderby:"ranked_threaded",first:"10") {
+            edges {
+              node {
+                body {
+                  text
+                }
+              }
+            }
+          }
+        }
+      `));
+      const node = RelayMutationQuery.buildFragmentForEdgeInsertion({
+        fatQuery,
+        tracker,
+        connectionName: 'comments',
+        parentID: '123',
+        edgeName: 'feedbackCommentEdge',
+        parentName: 'feedback',
+        rangeBehaviors: {
+          'orderby(ranked_threaded)': GraphQLMutatorConstants.IGNORE
+        },
+      });
+      const expected = getNodeWithoutSource(Relay.QL`
+        fragment MutationQuery on CommentCreateResponsePayload {
+          feedback {
+            id
+          },
+          feedbackCommentEdge {
+            __typename,
+            cursor,
+            node{
+              body {
+                text
+              },
+              id
+            }
+          }
+        }
+      `);
+      expect(node)
+        .toEqualQueryNode(expected);
+    });
+
     it('includes edge fields for connections with range config', () => {
       tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
         fragment on Feedback {
@@ -493,7 +583,8 @@ describe('RelayMutationQuery', () => {
         '`rangeBehaviors` specified in your RANGE_ADD config. This means ' +
         'that the entire connection will be refetched. Configure a range ' +
         'behavior for this mutation in order to fetch only the new edge ' +
-        'and to enable optimistic mutations.',
+        'and to enable optimistic mutations or use `refetch` to squelch ' +
+        'this warning.',
         'comments{orderby:"ranked_threaded"}',
         'feedback',
         '123'

--- a/src/mutation/__tests__/rangeOperationToMetadataKey-test.js
+++ b/src/mutation/__tests__/rangeOperationToMetadataKey-test.js
@@ -17,7 +17,9 @@ describe('rangeOperationToMetadataKey', () => {
   it('maps from developer-friendly name to internal metadata key name', () => {
     expect(rangeOperationToMetadataKey).toEqual({
       append: '__rangeOperationAppend__',
+      ignore: '__rangeOperationIgnore__',
       prepend: '__rangeOperationPrepend__',
+      refetch: '__rangeOperationRefetch__',
       remove: '__rangeOperationRemove__',
     });
   });

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -15,7 +15,8 @@ require('configureForRelayOSS');
 
 jest
   .dontMock('GraphQLRange')
-  .dontMock('GraphQLSegment');
+  .dontMock('GraphQLSegment')
+  .mock('warning');
 
 const GraphQLMutatorConstants = require('GraphQLMutatorConstants');
 const Relay = require('Relay');
@@ -971,6 +972,194 @@ describe('writePayload()', () => {
         connectionID,
         [{name: 'first', value: '2'}]
       ).filteredEdges.map(edge => edge.edgeID)).toEqual([edgeID]);
+    });
+
+    it('warns when using null as a rangeBehavior value instead of IGNORE', () => {
+      const input = {
+        actor_id: 'actor:123',
+        [RelayConnectionInterface.CLIENT_MUTATION_ID]: '0',
+        feedback_id: feedbackID,
+        message: {
+          text: 'Hello!',
+          ranges: [],
+        },
+      };
+
+      const mutation = getNode(Relay.QL`
+        mutation {
+          commentCreate(input:$input) {
+            feedback {
+              id,
+              topLevelComments {
+                count,
+              },
+            },
+            feedbackCommentEdge {
+              cursor,
+              node {
+                id,
+                body {
+                  text,
+                },
+              },
+              source {
+                id,
+              },
+            },
+          }
+        }
+      `, {
+        input: JSON.stringify(input),
+      });
+      const configs = [{
+        type: RelayMutationType.RANGE_ADD,
+        connectionName: 'topLevelComments',
+        edgeName: 'feedbackCommentEdge',
+        rangeBehaviors: {'': null},
+      }];
+
+      const nextCursor = 'comment789:cursor';
+      const nextNodeID = 'comment789';
+      const bodyID = 'client:2';
+      const nextEdgeID = generateClientEdgeID(connectionID, nextNodeID);
+      const payload = {
+        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
+          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
+        feedback: {
+          id: feedbackID,
+          topLevelComments: {
+            count: 2,
+          },
+        },
+        feedbackCommentEdge: {
+          cursor: nextCursor,
+          node: {
+            id: nextNodeID,
+            body: {
+              text: input.message.text,
+            },
+          },
+          source: {
+            id: feedbackID,
+          },
+        },
+      };
+
+      const changeTracker = new RelayChangeTracker();
+      const queryTracker = new RelayQueryTracker();
+      const queryWriter = new RelayQueryWriter(
+        queueStore,
+        queueWriter,
+        queryTracker,
+        changeTracker
+      );
+
+      writeRelayUpdatePayload(
+        queryWriter,
+        mutation,
+        payload,
+        {configs, isOptimisticUpdate: true}
+      );
+
+      expect([
+        'Using `null` as a rangeBehavior value is deprecated. Use `ignore` to avoid ' +
+        'refetching a range.'
+      ]).toBeWarnedNTimes(1);
+    });
+
+    it('ignores node when rangeBehavior value is IGNORE', () => {
+      const input = {
+        actor_id: 'actor:123',
+        [RelayConnectionInterface.CLIENT_MUTATION_ID]: '0',
+        feedback_id: feedbackID,
+        message: {
+          text: 'Hello!',
+          ranges: [],
+        },
+      };
+
+      const mutation = getNode(Relay.QL`
+        mutation {
+          commentCreate(input:$input) {
+            feedback {
+              id,
+              topLevelComments {
+                count,
+              },
+            },
+            feedbackCommentEdge {
+              cursor,
+              node {
+                id,
+                body {
+                  text,
+                },
+              },
+              source {
+                id,
+              },
+            },
+          }
+        }
+      `, {
+        input: JSON.stringify(input),
+      });
+      const configs = [{
+        type: RelayMutationType.RANGE_ADD,
+        connectionName: 'topLevelComments',
+        edgeName: 'feedbackCommentEdge',
+        rangeBehaviors: {'': GraphQLMutatorConstants.IGNORE},
+      }];
+
+      const nextCursor = 'comment789:cursor';
+      const nextNodeID = 'comment789';
+      const bodyID = 'client:2';
+      const nextEdgeID = generateClientEdgeID(connectionID, nextNodeID);
+      const payload = {
+        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
+          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
+        feedback: {
+          id: feedbackID,
+          topLevelComments: {
+            count: 2,
+          },
+        },
+        feedbackCommentEdge: {
+          cursor: nextCursor,
+          node: {
+            id: nextNodeID,
+            body: {
+              text: input.message.text,
+            },
+          },
+          source: {
+            id: feedbackID,
+          },
+        },
+      };
+
+      const changeTracker = new RelayChangeTracker();
+      const queryTracker = new RelayQueryTracker();
+      const queryWriter = new RelayQueryWriter(
+        queueStore,
+        queueWriter,
+        queryTracker,
+        changeTracker
+      );
+
+      writeRelayUpdatePayload(
+        queryWriter,
+        mutation,
+        payload,
+        {configs, isOptimisticUpdate: true}
+      );
+
+      expect(changeTracker.getChangeSet()).toEqual({
+        created: {}, // No node added 
+        updated: {
+          [connectionID]: true, 
+        },
+      });
     });
 
     it('optimistically prepends comments', () => {

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -50,7 +50,7 @@ type PayloadObject = {[key: string]: Payload};
 
 const {CLIENT_MUTATION_ID, EDGES} = RelayConnectionInterface;
 const {ANY_TYPE, ID, NODE} = RelayNodeInterface;
-const {APPEND, PREPEND, REMOVE} = GraphQLMutatorConstants;
+const {APPEND, IGNORE, PREPEND, REFETCH, REMOVE} = GraphQLMutatorConstants;
 
 const EDGES_FIELD = RelayQuery.Field.build({
   fieldName: EDGES,
@@ -413,7 +413,12 @@ function addRangeNode(
     null;
 
   // no range behavior specified for this combination of filter calls
-  if (!rangeBehavior) {
+  if (!rangeBehavior || rangeBehavior === IGNORE) {
+    warning(
+      rangeBehavior,
+      'Using `null` as a rangeBehavior value is deprecated. Use `ignore` to avoid ' +
+      'refetching a range.'
+    );
     return;
   }
 


### PR DESCRIPTION
 As discussed in #574, #542

Introduce 2 new range behaviors:
  - `REFETCH`: Will refetch the entire connection (to squelch the warning when no `rangeBehavior` matches the tracked connection)
  - `IGNORE`: Replaces using null, means the range should not be refetched at all.

I've deprecated `null`, maybe we don't need to, what do you think ?

@yungsters @steveluscher 

let me what you think! 🍻