### PR TITLE
Clean up some context -> environment cruft

### DIFF
--- a/src/mutation/RelayMutation.js
+++ b/src/mutation/RelayMutation.js
@@ -52,7 +52,7 @@ class RelayMutation<Tp: Object> {
   ) => Variables;
 
   props: Tp;
-  _context: RelayEnvironmentInterface;
+  _environment: RelayEnvironmentInterface;
   _didShowFakeDataWarning: boolean;
   _unresolvedProps: Tp;
 
@@ -64,14 +64,14 @@ class RelayMutation<Tp: Object> {
   /**
    * @internal
    */
-  bindContext(context: RelayEnvironmentInterface): void {
-    if (!this._context) {
-      this._context = context;
+  bindEnvironment(environment: RelayEnvironmentInterface): void {
+    if (!this._environment) {
+      this._environment = environment;
       this._resolveProps();
     } else {
       invariant(
-        context === this._context,
-        '%s: Mutation instance cannot be used in different Relay contexts.',
+        environment === this._environment,
+        '%s: Mutation instance cannot be used in different Relay environments.',
         this.constructor.name
       );
     }
@@ -326,7 +326,7 @@ class RelayMutation<Tp: Object> {
         });
 
         resolvedProps[fragmentName] = dataIDs.map(
-          dataID => this._context.read(fragment, dataID)
+          dataID => this._environment.read(fragment, dataID)
         );
       } else {
         invariant(
@@ -338,7 +338,10 @@ class RelayMutation<Tp: Object> {
         );
         const dataID = RelayFragmentPointer.getDataID(propValue, fragment);
         if (dataID) {
-          resolvedProps[fragmentName] = this._context.read(fragment, dataID);
+          resolvedProps[fragmentName] = this._environment.read(
+            fragment,
+            dataID
+          );
         } else {
           if (__DEV__) {
             if (!this._didShowFakeDataWarning) {

--- a/src/mutation/__tests__/RelayMutation-test.js
+++ b/src/mutation/__tests__/RelayMutation-test.js
@@ -87,43 +87,43 @@ describe('RelayMutation', function() {
     jasmine.addMatchers(RelayTestUtils.matchers);
   });
 
-  it('throws if used in different Relay contexts', () => {
-    mockMutation.bindContext(environment);
+  it('throws if used in different Relay environments', () => {
+    mockMutation.bindEnvironment(environment);
     expect(() => {
-      mockMutation.bindContext(new RelayEnvironment());
+      mockMutation.bindEnvironment(new RelayEnvironment());
     }).toFailInvariant(
       'MockMutationClass: Mutation instance cannot be used ' +
-      'in different Relay contexts.'
+      'in different Relay environments.'
     );
   });
 
-  it('can be reused in the same Relay context', () => {
-    mockMutation.bindContext(environment);
+  it('can be reused in the same Relay environment', () => {
+    mockMutation.bindEnvironment(environment);
     expect(() => {
-      mockMutation.bindContext(environment);
+      mockMutation.bindEnvironment(environment);
     }).not.toThrow();
   });
 
-  it('does not resolve props before binding Relay context', () => {
+  it('does not resolve props before binding Relay environment', () => {
     expect(mockMutation.props).toBeUndefined();
   });
 
   it('resolves props only once', () => {
-    mockMutation.bindContext(environment);
-    mockMutation.bindContext(environment);
+    mockMutation.bindEnvironment(environment);
+    mockMutation.bindEnvironment(environment);
     expect(environment.read.mock.calls).toEqual([
       [/* fragment */mockFooFragment, /* dataID */'foo'],
       [/* fragment */mockBarFragment, /* dataID */'bar'],
     ]);
   });
 
-  it('resolves props after binding Relay context', () => {
+  it('resolves props after binding Relay environment', () => {
     const resolvedProps = {
       bar: {},
       foo: {},
     };
     environment.read.mockImplementation((_, dataID) => resolvedProps[dataID]);
-    mockMutation.bindContext(environment);
+    mockMutation.bindEnvironment(environment);
     expect(environment.read.mock.calls).toEqual([
       [/* fragment */mockFooFragment, /* dataID */'foo'],
       [/* fragment */mockBarFragment, /* dataID */'bar'],

--- a/src/store/RelayEnvironment.js
+++ b/src/store/RelayEnvironment.js
@@ -216,7 +216,7 @@ class RelayEnvironment {
     mutation: RelayMutation,
     callbacks?: RelayMutationTransactionCommitCallbacks
   ): RelayMutationTransaction {
-    mutation.bindContext(this);
+    mutation.bindEnvironment(this);
     return this._storeData.getMutationQueue().createTransaction(
       mutation,
       callbacks

--- a/src/store/__tests__/RelayContext-test.js
+++ b/src/store/__tests__/RelayContext-test.js
@@ -181,13 +181,13 @@ describe('RelayEnvironment', () => {
     });
 
     describe('applyUpdate', () => {
-      it('binds context to mutation before creating transaction', () => {
-        mockMutation.bindContext.mockImplementation(() => {
+      it('binds environment to mutation before creating transaction', () => {
+        mockMutation.bindEnvironment.mockImplementation(() => {
           expect(createTransactionMock).not.toBeCalled();
         });
         environment.applyUpdate(mockMutation);
-        expect(mockMutation.bindContext).toBeCalled();
-        expect(mockMutation.bindContext.mock.calls[0][0]).toBe(environment);
+        expect(mockMutation.bindEnvironment).toBeCalled();
+        expect(mockMutation.bindEnvironment.mock.calls[0][0]).toBe(environment);
       });
 
       it('creates a new RelayMutationTransaction without committing it', () => {
@@ -203,13 +203,13 @@ describe('RelayEnvironment', () => {
     });
 
     describe('commitUpdate', () => {
-      it('binds context to mutation before creating transaction', () => {
-        mockMutation.bindContext.mockImplementation(() => {
+      it('binds environment to mutation before creating transaction', () => {
+        mockMutation.bindEnvironment.mockImplementation(() => {
           expect(createTransactionMock).not.toBeCalled();
         });
         environment.commitUpdate(mockMutation);
-        expect(mockMutation.bindContext).toBeCalled();
-        expect(mockMutation.bindContext.mock.calls[0][0]).toBe(environment);
+        expect(mockMutation.bindEnvironment).toBeCalled();
+        expect(mockMutation.bindEnvironment.mock.calls[0][0]).toBe(environment);
       });
 
       it('creates a new RelayMutationTransaction and commits it', () => {

--- a/src/store/__tests__/isRelayEnvironment-test.js
+++ b/src/store/__tests__/isRelayEnvironment-test.js
@@ -23,23 +23,23 @@ describe('isRelayEnvironment()', () => {
   });
 
   it('returns true for objects that conform to the interface', () => {
-    const context = {
+    const environment = {
       forceFetch: () => null,
       getFragmentResolver: () => null,
       getStoreData: () => null,
       primeCache: () => null,
     };
-    expect(isRelayEnvironment(context)).toBe(true);
+    expect(isRelayEnvironment(environment)).toBe(true);
   });
 
   it('returns false for objects that do not conform to the interface', () => {
-    const fakeContext = {
+    const fakeEnvironment = {
       forceFetch: true,
       getFragmentResolver: true,
       getStoreData: true,
       primeCache: true,
     };
-    expect(isRelayEnvironment(fakeContext)).toBe(false);
+    expect(isRelayEnvironment(fakeEnvironment)).toBe(false);
   });
 
   it('returns false for non-objects', () => {

--- a/src/store/isRelayEnvironment.js
+++ b/src/store/isRelayEnvironment.js
@@ -17,14 +17,14 @@
  * Determine if a given value is an object that implements the `RelayEnvironment`
  * interface.
  */
-function isRelayEnvironment(context: mixed): boolean {
+function isRelayEnvironment(environment: mixed): boolean {
   return (
-    typeof context === 'object' &&
-    context !== null &&
-    typeof context.forceFetch === 'function' &&
-    typeof context.getFragmentResolver === 'function' &&
-    typeof context.getStoreData === 'function' &&
-    typeof context.primeCache === 'function'
+    typeof environment === 'object' &&
+    environment !== null &&
+    typeof environment.forceFetch === 'function' &&
+    typeof environment.getFragmentResolver === 'function' &&
+    typeof environment.getStoreData === 'function' &&
+    typeof environment.primeCache === 'function'
   );
 }
 


### PR DESCRIPTION
For consistency, and to eliminate potential confusion, let's make sure we always refer to the `RelayEnvironment` as an environment and not a context.