### PR TITLE
Relay: Reduce Scope of Tests to Relay Plugin

### DIFF
--- a/scripts/babel-relay-plugin/src/__fixtures__/argsInvalidValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsInvalidValues.fixture
@@ -22,8 +22,6 @@ var foo = Relay.QL`
 `;
 
 Output:
-"use strict";
-
 var foo = function () {
   throw new Error("GraphQL validation/transform error ``Argument \"first\" has invalid value \"10\".\nExpected type \"Int\", found \"10\". Argument \"orderby\" has invalid value Name.\nExpected type \"String\", found Name. Argument \"find\" has invalid value cursor1.\nExpected type \"String\", found cursor1. Argument \"isViewerFriend\" has invalid value \"true\".\nExpected type \"Boolean\", found \"true\". Argument \"gender\" has invalid value \"MALE\".\nExpected type \"Gender\", found \"MALE\".`` in file `argsInvalidValues.fixture`.");
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
@@ -8,8 +8,6 @@ var foo = Relay.QL`
 `;
 
 Output:
-"use strict";
-
 var foo = function (RQL_0) {
   return {
     calls: [{

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
@@ -23,8 +23,6 @@ var foo = Relay.QL`
 `;
 
 Output:
-"use strict";
-
 var foo = function () {
   return {
     calls: [{

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
@@ -8,8 +8,6 @@ var foo = Relay.QL`
 `;
 
 Output:
-"use strict";
-
 var foo = function () {
   return {
     calls: [{

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionPattern.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionPattern.fixture
@@ -13,8 +13,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgs.fixture
@@ -17,8 +17,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, or `(after: <cursor>, first: <count>)`.`` in file `connectionWithAfterLastArgs.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgsWithInlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgsWithInlineFragment.fixture
@@ -19,8 +19,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, or `(after: <cursor>, first: <count>)`.`` in file `connectionWithAfterLastArgsWithInlineFragment.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstArgs.fixture
@@ -17,8 +17,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``Connection arguments `friends(before: <cursor>, first: <count>)` are not supported. Use `(first: <count>)`, `(after: <cursor>, first: <count>)`, or `(before: <cursor>, last: <count>)`.`` in file `connectionWithBeforeFirstArgs.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
@@ -15,8 +15,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied a field named `nodes` on a connection named `friends`, but pagination is not supported on connections without using `edges`. Use `friends{edges{node{...}}}` instead.`` in file `connectionWithNodesField.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
@@ -20,8 +20,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
@@ -18,8 +18,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgs.fixture
@@ -17,8 +17,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied the `edges` field on a connection named `friends`, but you did not supply an argument necessary to do so. Use either the `find`, `first`, or `last` argument.`` in file `connectionWithoutArgs.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgsWithInlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgsWithInlineFragment.fixture
@@ -19,8 +19,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied the `edges` field on a connection named `friends`, but you did not supply an argument necessary to do so. Use either the `find`, `first`, or `last` argument.`` in file `connectionWithoutArgsWithInlineFragment.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
@@ -15,8 +15,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
@@ -15,8 +15,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/container.fixture
@@ -7,39 +7,35 @@ Relay.createContainer(Component, {
 });
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 Relay.createContainer(Component, {
   queries: {
-    viewer: function () {
-      return function () {
-        return {
+    viewer: () => function () {
+      return {
+        children: [{
           children: [{
-            children: [{
-              fieldName: 'id',
-              kind: 'Field',
-              metadata: {
-                isRequisite: true
-              },
-              type: 'String'
-            }],
-            fieldName: 'actor',
+            fieldName: 'id',
             kind: 'Field',
             metadata: {
-              canHaveSubselections: true,
-              inferredRootCallName: 'node',
-              inferredPrimaryKey: 'id'
+              isRequisite: true
             },
-            type: 'User'
+            type: 'String'
           }],
-          id: Relay.QL.__id(),
-          kind: 'Fragment',
-          metadata: {},
-          name: 'Container_ViewerRelayQL',
-          type: 'Viewer'
-        };
-      }();
-    }
+          fieldName: 'actor',
+          kind: 'Field',
+          metadata: {
+            canHaveSubselections: true,
+            inferredRootCallName: 'node',
+            inferredPrimaryKey: 'id'
+          },
+          type: 'User'
+        }],
+        id: Relay.QL.__id(),
+        kind: 'Fragment',
+        metadata: {},
+        name: 'Container_ViewerRelayQL',
+        type: 'Viewer'
+      };
+    }()
   }
 });

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
@@ -11,8 +11,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
@@ -11,8 +11,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
@@ -13,8 +13,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
@@ -13,8 +13,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
@@ -9,8 +9,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -17,8 +17,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
@@ -17,8 +17,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
@@ -13,8 +13,6 @@ var foo = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('Relay');
 var foo = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
@@ -13,8 +13,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragment.fixture
@@ -3,8 +3,6 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on Node { id }`;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentDirectives.fixture
@@ -3,8 +3,6 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on Node @relay(plural: true) { id }`;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentOnBadType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentOnBadType.fixture
@@ -3,8 +3,6 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on NotAType { id }`;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``Unknown type "NotAType".`` in file `fragmentOnBadType.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithModuleName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithModuleName.fixture
@@ -5,8 +5,6 @@ var x = Relay.QL`fragment Foo on Node { id }`;
 var y = Relay.QL`fragment Bar on Node { id }`;
 
 Output:
-'use strict';
-
 /** @providesModule Foo.react */
 var Relay = require('react-relay');
 var x = function () {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithName.fixture
@@ -3,8 +3,6 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment FragmentNameHere on Node { id }`;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithPossibleId.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithPossibleId.fixture
@@ -8,8 +8,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithReference.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithReference.fixture
@@ -3,8 +3,6 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on Node { ${reference} }`;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function (RQL_0) {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithStaticID.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithStaticID.fixture
@@ -7,8 +7,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithoutCommas.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentWithoutCommas.fixture
@@ -8,8 +8,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function (RQL_0) {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
@@ -9,8 +9,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/inlineFragmentWithoutType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/inlineFragmentWithoutType.fixture
@@ -13,8 +13,6 @@ var x = Relay.QL`
 */
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 /*
 TODO: Upgrade to graphql@0.4.7 and uncomment this.

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
@@ -10,8 +10,6 @@ var foo = Relay.QL`
 `;
 
 Output:
-"use strict";
-
 var foo = function () {
   return {
     children: [{

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
@@ -8,8 +8,6 @@ var foo = Relay.QL`
 `;
 
 Output:
-"use strict";
-
 var foo = function () {
   return {
     calls: [{

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
@@ -17,8 +17,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
@@ -15,8 +15,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
@@ -14,8 +14,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataGenerated.fixture
@@ -7,8 +7,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataNonFindable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataNonFindable.fixture
@@ -11,8 +11,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
@@ -11,8 +11,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataRequisite.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataRequisite.fixture
@@ -3,8 +3,6 @@ var Relay = require('react-relay');
 var x = Relay.QL`fragment on Node { id }`;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
@@ -9,8 +9,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
@@ -11,8 +11,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaMissingArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaMissingArgs.fixture
@@ -7,8 +7,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``Your schema defines a mutation field `mutationMissingArg` that takes 0 arguments, but mutation fields must have exactly one argument named `input`.`` in file `mutationBadSchemaMissingArgs.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaWrongArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaWrongArgs.fixture
@@ -7,8 +7,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``Your schema defines a mutation field `mutationWrongArgs` that takes an argument named `foo`, but mutation fields must have exactly one argument named `input`.`` in file `mutationBadSchemaWrongArgs.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithExtraArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithExtraArgs.fixture
@@ -9,8 +9,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``Unknown argument "extra" on field "actorSubscribe" of type "Mutation".`` in file `mutationWithExtraArgs.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
@@ -9,8 +9,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function (RQL_0) {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
@@ -7,8 +7,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/nonExistentMutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/nonExistentMutation.fixture
@@ -11,8 +11,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``Cannot query field "fakeMutation" on type "Mutation".`` in file `nonExistentMutation.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/nonRootNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/nonRootNodeField.fixture
@@ -11,8 +11,6 @@ var fragment = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('Relay');
 var fragment = function () {
   throw new Error('GraphQL validation/transform error ``You defined a `node(id: Int)` field on type `InvalidType`, but Relay requires the `node` field to be defined on the root type. See the Object Identification Guide: \nhttp://facebook.github.io/relay/docs/graphql-object-identification.html`` in file `nonRootNodeField.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
@@ -14,8 +14,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
@@ -9,8 +9,6 @@ var q = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('Relay');
 var q = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
@@ -9,8 +9,6 @@ var q = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('Relay');
 var q = function () {
   throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithArrayObjectNestedVariable.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
@@ -9,8 +9,6 @@ var q = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('Relay');
 var q = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirective.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirective.fixture
@@ -9,8 +9,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied a directive named `bad`, but no such directive exists.`` in file `queryWithBadDirective.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirectiveArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirectiveArgs.fixture
@@ -9,8 +9,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   throw new Error('GraphQL validation/transform error ``You supplied a directive named `if`, but no such directive exists.`` in file `queryWithBadDirectiveArgs.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithDirectives.fixture
@@ -11,8 +11,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
@@ -11,8 +11,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
@@ -13,8 +13,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
@@ -13,8 +13,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
@@ -25,8 +25,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function (RQL_0, RQL_1, RQL_2, RQL_3, RQL_4, RQL_5, RQL_6, RQL_7, RQL_8, RQL_9, RQL_10, RQL_11) {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArg.fixture
@@ -9,8 +9,6 @@ var q = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('Relay');
 var q = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
@@ -9,8 +9,6 @@ var q = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('Relay');
 var q = function () {
   throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithObjectArgNestedVariable.fixture`.');

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
@@ -9,8 +9,6 @@ var q = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('Relay');
 var q = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
@@ -9,8 +9,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithoutFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithoutFields.fixture
@@ -3,8 +3,6 @@ var Relay = require('react-relay');
 var x = Relay.QL`query { viewer }`;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/subscription.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/subscription.fixture
@@ -9,8 +9,6 @@ var x = Relay.QL`
 `;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
 var x = function (RQL_0) {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/tagRelayQL.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/tagRelayQL.fixture
@@ -9,8 +9,6 @@ var x = RelayQL`
 `;
 
 Output:
-'use strict';
-
 var RelayQL = require('react-relay/RelayQL');
 var x = function () {
   return {

--- a/scripts/babel-relay-plugin/src/__fixtures__/templateString.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/templateString.fixture
@@ -3,7 +3,5 @@ var Relay = require('react-relay');
 var x = `Just a template string.`;
 
 Output:
-'use strict';
-
 var Relay = require('react-relay');
-var x = 'Just a template string.';
+var x = `Just a template string.`;

--- a/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
@@ -8,8 +8,6 @@ var foo = Relay.QL`
 `;
 
 Output:
-"use strict";
-
 var foo = function () {
   return {
     calls: [{

--- a/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
@@ -11,20 +11,19 @@
 
 'use strict';
 
-var babel = require('babel-core');
-var fs = require('fs');
-var getBabelOptions = require('fbjs-scripts/babel-6/default-options');
-var util = require('util');
+const babel = require('babel-core');
+const fs = require('fs');
+const util = require('util');
 
-var getBabelRelayPlugin = require('../getBabelRelayPlugin');
+const getBabelRelayPlugin = require('../getBabelRelayPlugin');
 
-var _schemas = {};
+const schemaCache = {};
 function getSchema(schemaPath) {
   try {
-    var schema = _schemas[schemaPath];
+    let schema = schemaCache[schemaPath];
     if (!schema) {
       schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')).data;
-      _schemas[schemaPath] = schema;
+      schemaCache[schemaPath] = schema;
     }
     return schema;
   } catch (e) {
@@ -38,19 +37,16 @@ function getSchema(schemaPath) {
 }
 
 function transformGraphQL(schemaPath, source, filename) {
-  var plugin = getBabelRelayPlugin(getSchema(schemaPath), {
+  const relayPlugin = getBabelRelayPlugin(getSchema(schemaPath), {
     debug: true,
     substituteVariables: true,
     suppressWarnings: true,
   });
-
-  const babelOptions = getBabelOptions({
-    moduleOpts: {prefix: ''},
-  });
-  babelOptions.plugins.unshift(plugin);
-  babelOptions.compact = false;
-  babelOptions.filename = filename;
-  return babel.transform(source, babelOptions).code;
+  return babel.transform(source, {
+    plugins: [relayPlugin],
+    compact: false,
+    filename,
+  }).code;
 }
 
 module.exports = transformGraphQL;


### PR DESCRIPTION
There is some broken integration between the Babel 6 plugins in `fbjs-scripts` and the transform tests in the `babel-relay-plugin`. For now, I am going to reduce the scope of the `babel-relay-plugin` tests until we're fully upgraded to Babel 6. This revision should fix the breaking tests in master.