### PR TITLE
fix gh-pages to display nicely on narrow mobile screens

### DIFF
--- a/website/src/relay/css/relay.css
+++ b/website/src/relay/css/relay.css
@@ -989,10 +989,14 @@ p + .apiIndex {
     float: none;
   }
   .marketing-col {
-    margin-left: 0;
     float: none;
     margin-bottom: 30px;
     text-align: center;
+  }
+  .marketing-col,
+  .marketing-col:first-child {
+    margin-left: auto;
+    margin-right: auto;
   }
   .home-section, .marketing-row {
     margin: 0;
@@ -1033,6 +1037,29 @@ p + .apiIndex {
   }
   ol {
     margin: 0;
+  }
+}
+
+@media only screen and (max-device-width: 460px) {
+  .nav-main {
+    position: static;
+    height: auto;
+    text-align: center;
+  }
+
+  .nav-main .nav-site {
+    float: none;
+    display: table;
+  }
+
+  .nav-main .nav-site li {
+    display: table-cell;
+    width: 1%;
+    white-space: nowrap;
+  }
+
+  .buttons-unit .button {
+    margin-bottom: 10px;
   }
 }
 


### PR DESCRIPTION
Currently the documentation website adapts to mobile screens, but some layout looks broken:

* Navigation items "fall out" from the nav wrapper;
* Marketing columns' text is center-aligned, but columns themselves are not centered;
* Buttons-unit buttons have no space between them when stacked on top of each other.

This commit fixes the issues.
Screenshots to compare:

![relay_compare_1](https://cloud.githubusercontent.com/assets/5347023/13805026/bc17f6f0-eb62-11e5-9452-6cc5894a26cf.png)

![relay_compare_2](https://cloud.githubusercontent.com/assets/5347023/13805030/c3773ae6-eb62-11e5-8067-6b2dd68425c0.png)



