### PR TITLE
[website] Fix let not working outside 'use strict';

### DIFF
--- a/website/core/DocsSidebar.js
+++ b/website/core/DocsSidebar.js
@@ -7,7 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule DocsSidebar
-*/
+ */
+
+'use strict';
 
 const Metadata = require('Metadata');
 

--- a/website/core/H2.js
+++ b/website/core/H2.js
@@ -7,7 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule H2
-*/
+ */
+
+'use strict';
 
 const React = require('React');
 const Header = require('Header');

--- a/website/core/Header.js
+++ b/website/core/Header.js
@@ -7,7 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule Header
-*/
+ */
+
+'use strict';
 
 const React = require('React');
 

--- a/website/core/HeaderLinks.js
+++ b/website/core/HeaderLinks.js
@@ -7,7 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule HeaderLinks
-*/
+ */
+
+'use strict';
 
 const HeaderLinks = React.createClass({
   links: [

--- a/website/core/Marked.js
+++ b/website/core/Marked.js
@@ -11,7 +11,9 @@
  * https://github.com/chjj/marked
  *
  * @providesModule Marked
-*/
+ */
+
+'use strict';
 
 const React = require('React');
 const Prism = require('Prism');

--- a/website/core/Prism.js
+++ b/website/core/Prism.js
@@ -7,7 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule Prism
-*/
+ */
+
+'use strict';
 
 const React = require('React');
 const unindent = require('unindent');
@@ -22,7 +24,7 @@ const unindent = require('unindent');
 // Private helper vars
 const lang = /\blang(?:uage)?-(?!\*)(\w+)\b/i;
 
-const _ = Prism = {
+const Prism = {
 	util: {
 		encode: function (tokens) {
 			if (tokens instanceof Token) {
@@ -340,6 +342,8 @@ const _ = Prism = {
 	}
 };
 
+const _ = Prism;
+
 var Token = _.Token = function(type, content, alias) {
 	this.type = type;
 	this.content = content;
@@ -498,9 +502,7 @@ if (Prism.languages.markup) {
 			alias: 'language-javascript'
 		}
 	});
-}
-;
-(function(Prism) {
+};
 
 const javascript = Prism.util.clone(Prism.languages.javascript);
 
@@ -520,8 +522,6 @@ Prism.languages.insertBefore('inside', 'attr-value',{
 		'alias': 'language-javascript'
 	}
 }, Prism.languages.jsx.tag);
-
-}(Prism));
 
 const PrismComponent = React.createClass({
   statics: {

--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -7,7 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule Site
-*/
+ */
+
+'use strict';
 
 const React = require('React');
 const HeaderLinks = require('HeaderLinks');

--- a/website/core/SiteData.js
+++ b/website/core/SiteData.js
@@ -9,6 +9,8 @@
  * @providesModule SiteData
  */
 
+'use strict';
+
 module.exports = {
   version: '0.7.3'
 };

--- a/website/core/center.js
+++ b/website/core/center.js
@@ -7,7 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule center
-*/
+ */
+
+'use strict';
 
 const React = require('React');
 

--- a/website/core/unindent.js
+++ b/website/core/unindent.js
@@ -9,6 +9,8 @@
  * @providesModule unindent
  */
 
+'use strict';
+
 // Remove the indentation introduced by JSX
 function unindent(code) {
   const lines = code.split('\n');

--- a/website/layout/DocsLayout.js
+++ b/website/layout/DocsLayout.js
@@ -7,7 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule DocsLayout
-*/
+ */
+
+'use strict';
 
 const React = require('React');
 const Site = require('Site');

--- a/website/layout/PageLayout.js
+++ b/website/layout/PageLayout.js
@@ -7,7 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule PageLayout
-*/
+ */
+
+'use strict';
 
 const React = require('React');
 const Site = require('Site');

--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 const buildGraphQLSpec = require('./buildGraphQLSpec');
 const fs = require('fs-extra');
 const glob = require('glob');

--- a/website/src/relay/index.js
+++ b/website/src/relay/index.js
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 const React = require('React');
 const Site = require('Site');
 const SiteData = require('SiteData');

--- a/website/src/relay/support.js
+++ b/website/src/relay/support.js
@@ -13,6 +13,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 const React = require('React');
 const Site = require('Site');
 const center = require('center');


### PR DESCRIPTION
The awesome codemod to rename var into let broke the website as it wasn't using 'use strict';. Adding it to the files fixes it :)