### PR TITLE
Add re:Culture as user of Relay

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -34,3 +34,4 @@ Using Relay in your production app? If you'd like to add your team to the list, 
 
 - [RelateRocket](https://relaterocket.co/)
 - [Reploy](https://reploy.io)
+- [re:Culture](https://reculture.us)


### PR DESCRIPTION
Add re:Culture as user of relay

re:Culture has been an early user of Relay; we wrote the first Rails/RelayGraphQL article, and contributed the first Rails/Relay starter kit, and also contributed to Relay/GraphQL articles, presentations, videos (not exhaustive list):
* https://github.com/nethsix/relay-on-rails
* https://medium.com/p/relay-facebook-on-rails-8b4af2057152
* https://youtu.be/YFuQlKBXlmA
* http://www.slideshare.net/KhorSoonHin/tokyo-reactjs-3-missing-pages-reactjsfluxgraphqlrelayjs
* http://www.slideshare.net/KhorSoonHin/from-back-to-front-rails-to-react-family