### PR TITLE
Support null-prototype mutation payload objects

### DIFF
--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -187,7 +187,7 @@ function handleMerge(
   //
   // TODO #7167718: more efficient mutation/subscription writes
   for (const fieldName in payload) {
-    if (!payload.hasOwnProperty(fieldName)) {
+    if (!Object.prototype.hasOwnProperty.call(payload, fieldName)) {
       continue;
     }
     const payloadData = (payload[fieldName]: $FlowIssue); // #9357395


### PR DESCRIPTION
This came to my attention via https://github.com/relay-tools/relay-local-schema/pull/15. Recent versions of graphql-js use `null`-prototype objects for maps, which leads to the `payload.hasOwnProperty` call below failing when directly feeding the output of in-process graphql-js into Relay (e.g. with relay-local-schema).

I felt that it was trivial enough to just make this little patch here.