### PR TITLE
Strip trailing commas from fixtures

### DIFF
--- a/scripts/babel-relay-plugin/src/__fixtures__/argsInvalidValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsInvalidValues.fixture
@@ -4,20 +4,20 @@ var foo = Relay.QL`
     node(id: 123) {
       ... on User {
         friends(
-          first: "10",
-          orderby: Name,
-          find: cursor1,
-          isViewerFriend: "true",
-          gender: "MALE",
+          first: "10"
+          orderby: Name
+          find: cursor1
+          isViewerFriend: "true"
+          gender: "MALE"
         ) {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsSubstitution.fixture
@@ -2,8 +2,8 @@ Input:
 var foo = Relay.QL`
   query Args {
     node(id: ${userID}) {
-      id,
-    },
+      id
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsValues.fixture
@@ -4,21 +4,21 @@ var foo = Relay.QL`
     node(id: 123) {
       ... on User {
         friends(
-          first: 10,
-          orderby: "Name",
-          find: "cursor1",
-          isViewerFriend: true,
-          gender: MALE,
+          first: 10
+          orderby: "Name"
+          find: "cursor1"
+          isViewerFriend: true
+          gender: MALE
         ) {
           edges {
             node {
-              id,
-              firstName(if: true, unless: false),
-            },
-          },
-        },
-      },
-    },
+              id
+              firstName(if: true, unless: false)
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsVariablesList.fixture
@@ -2,8 +2,8 @@ Input:
 var foo = Relay.QL`
   query Args {
     nodes(ids: [$one, $two, 3]) {
-      id,
-    },
+      id
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionPattern.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionPattern.fixture
@@ -5,10 +5,10 @@ var x = Relay.QL`
     friends {
       edges {
         node {
-          id,
-        },
-      },
-    },
+          id
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgs.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends(last: 3, after: "foo") {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgsWithInlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgsWithInlineFragment.fixture
@@ -8,13 +8,13 @@ var x = Relay.QL`
           ... on UserConnection {
             edges {
               node {
-                id,
-              },
-            },
-          },
-        },
-      },
-    },
+                id
+              }
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastOneVariableArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastOneVariableArgs.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends(last: $last, after: "foo") {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastVariableArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastVariableArgs.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends(after: $after, last: $last) {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstArgs.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends(first: 3, before: "foo") {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithFirstLastArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithFirstLastArgs.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends(first: 3, last: 3) {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithFirstLastVariableArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithFirstLastVariableArgs.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends(first: $first, last: $last) {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
@@ -6,11 +6,11 @@ var x = Relay.QL`
       ... on User {
         friends(first: 3) {
           nodes {
-            id,
-          },
-        },
-      },
-    },
+            id
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoAlias.fixture
@@ -7,15 +7,15 @@ var x = Relay.QL`
         friends(first: 3) {
           edges {
             node {
-              name,
-            },
-          },
+              name
+            }
+          }
           myPageInfo: pageInfo {
-            hasPreviousPage,
-          },
-        },
-      },
-    },
+            hasPreviousPage
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithPageInfoSubfields.fixture
@@ -7,13 +7,13 @@ var x = Relay.QL`
         friends(first: 3) {
           edges {
             node {
-              name,
-            },
-          },
-          pageInfo,
-        },
-      },
-    },
+              name
+            }
+          }
+          pageInfo
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgs.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgsWithInlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgsWithInlineFragment.fixture
@@ -8,13 +8,13 @@ var x = Relay.QL`
           ... on UserConnection {
             edges {
               node {
-                id,
-              },
-            },
-          },
-        },
-      },
-    },
+                id
+              }
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeField.fixture
@@ -6,11 +6,11 @@ var x = Relay.QL`
       ... on User {
         friends(first: 3) {
           edges {
-            cursor,
-          },
-        },
-      },
-    },
+            cursor
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutNodeID.fixture
@@ -6,11 +6,11 @@ var x = Relay.QL`
       ... on User {
         friends(first: 3) @relay(isConnectionWithoutNodeID: true) {
           edges {
-            cursor,
-          },
-        },
-      },
-    },
+            cursor
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldForEnum.fixture
@@ -4,9 +4,9 @@ var x = Relay.QL`
   query {
     node(id: 123) {
       ... on User {
-        gender,
-      },
-    },
+        gender
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAlias.fixture
@@ -4,9 +4,9 @@ var x = Relay.QL`
   query {
     node(id: 123) {
       ... on User {
-        realName: name,
-      },
-    },
+        realName: name
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithAliasAndArgs.fixture
@@ -5,10 +5,10 @@ var x = Relay.QL`
     node(id: 123) {
       ... on User {
         mugShot: profilePicture(size: 100) {
-          uri,
-        },
-      },
-    },
+          uri
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithArgs.fixture
@@ -5,10 +5,10 @@ var x = Relay.QL`
     node(id: 123) {
       ... on User {
         profilePicture(size: 100) {
-          uri,
-        },
-      },
-    },
+          uri
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEmptyArrayArg.fixture
@@ -3,8 +3,8 @@ var Relay = require('react-relay');
 var x = Relay.QL`
   fragment on User {
     friends(isViewerFriend: false) {
-      count,
-    },
+      count
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumArg.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends(first: 5, gender: MALE) {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithEnumQueryArg.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends(first: 5, gender: $gender_0) {
           edges {
             node {
-              id,
-            },
-          },
-        },
-      },
-    },
+              id
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithFakeConnection.fixture
@@ -5,10 +5,10 @@ var foo = Relay.QL`
     fakeConnection {
       edges {
         node {
-          id,
-        },
-      },
-    },
+          id
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fieldWithParams.fixture
@@ -5,10 +5,10 @@ var x = Relay.QL`
     node(id: 123) {
       ... on User {
         profilePicture(size: $size) {
-          uri,
-        },
-      },
-    },
+          uri
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/inlineFragment.fixture
@@ -3,8 +3,8 @@ var Relay = require('react-relay');
 var x = Relay.QL`
   fragment on Node {
     ... on User {
-      userOnlyField,
-    },
+      userOnlyField
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/inlineFragmentWithoutType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/inlineFragmentWithoutType.fixture
@@ -6,8 +6,8 @@ TODO: Upgrade to graphql@0.4.7 and uncomment this.
 var x = Relay.QL`
   fragment on Node {
     ... {
-      id,
-    },
+      id
+    }
   }
 `;
 */
@@ -22,8 +22,8 @@ TODO: Upgrade to graphql@0.4.7 and uncomment this.
 var x = Relay.QL`
   fragment on Node {
     ... {
-      id,
-    },
+      id
+    }
   }
 `;
 */

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForSchema.fixture
@@ -3,9 +3,9 @@ var foo = Relay.QL`
   query IntrospectionQueryForSchema {
     __schema {
       types {
-        name,
-      },
-    },
+        name
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/introspectionQueryForType.fixture
@@ -2,8 +2,8 @@ Input:
 var foo = Relay.QL`
   query IntrospectionQueryForType {
     __type(name: "Root") {
-      name,
-    },
+      name
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnection.fixture
@@ -7,12 +7,12 @@ var x = Relay.QL`
         friends(first: 3) {
           edges {
             node {
-              name,
-            },
-          },
-        },
-      },
-    },
+              name
+            }
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
@@ -6,11 +6,11 @@ var x = Relay.QL`
       __configs__ {
         edges {
           node {
-            name,
-          },
-        },
-      },
-    },
+            name
+          }
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataDynamic.fixture
@@ -4,12 +4,12 @@ var x = Relay.QL`
   fragment on NewsFeedConnection {
     edges {
       node {
-        id,
+        id
         ... on Story {
-          attachments,
+          attachments
         }
-      },
-    },
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataNonFindable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataNonFindable.fixture
@@ -4,9 +4,9 @@ var x = Relay.QL`
   query {
     viewer {
       pendingPosts {
-        count,
-      },
-    },
+        count
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataPlural.fixture
@@ -4,9 +4,9 @@ var x = Relay.QL`
   query {
     node(id: 123) {
       ... on User {
-        websites,
-      },
-    },
+        websites
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataVarArgs.fixture
@@ -3,8 +3,8 @@ var Relay = require('react-relay');
 var x = Relay.QL`
   fragment on User {
     friends(orderby: $order) {
-      count,
-    },
+      count
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
@@ -4,9 +4,9 @@ var x = Relay.QL`
   mutation {
     actorSubscribe(input: $input) {
       actor {
-        profilePicture,
-      },
-    },
+        profilePicture
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaMissingArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaMissingArgs.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('react-relay');
 var x = Relay.QL`
   mutation {
-    mutationMissingArg,
+    mutationMissingArg
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaWrongArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaWrongArgs.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('react-relay');
 var x = Relay.QL`
   mutation {
-    mutationWrongArgs,
+    mutationWrongArgs
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithExtraArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithExtraArgs.fixture
@@ -3,8 +3,8 @@ var Relay = require('react-relay');
 var x = Relay.QL`
   mutation MutationNameHere {
     actorSubscribe(input: $input, extra: $extra) {
-      ${reference},
-    },
+      ${reference}
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
@@ -3,8 +3,8 @@ var Relay = require('react-relay');
 var x = Relay.QL`
   mutation MutationNameHere {
     actorSubscribe(input: $input) {
-      ${reference},
-    },
+      ${reference}
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('react-relay');
 var x = Relay.QL`
   mutation {
-    actorSubscribe,
+    actorSubscribe
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/nonExistentMutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/nonExistentMutation.fixture
@@ -4,9 +4,9 @@ var x = Relay.QL`
   mutation {
     fakeMutation(input: $input) {
       actor {
-        profilePicture,
-      },
-    },
+        profilePicture
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/pluralField.fixture
@@ -5,11 +5,11 @@ var x = Relay.QL`
     node(id: 456) {
       ... on Story {
         actors {
-          id,
-          __typename,
-        },
-      },
-    },
+          id
+          __typename
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectArg.fixture
@@ -3,8 +3,8 @@ var Relay = require('Relay');
 var q = Relay.QL`
   query {
     searchAll(queries: [$query]) {
-      title,
-    },
+      title
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
@@ -3,8 +3,8 @@ var Relay = require('Relay');
 var q = Relay.QL`
   query {
     searchAll(queries: [{queryText: $query}]) {
-      title,
-    },
+      title
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectValue.fixture
@@ -3,8 +3,8 @@ var Relay = require('Relay');
 var q = Relay.QL`
   query {
     searchAll(queries: [{queryText: "Relay"}]) {
-      title,
-    },
+      title
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithFields.fixture
@@ -4,9 +4,9 @@ var x = Relay.QL`
   query {
     node(id: 123) {
       ... on User {
-        name,
-      },
-    },
+        name
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithName.fixture
@@ -5,10 +5,10 @@ var x = Relay.QL`
     node(id: 123) {
       ... on User {
         profilePicture {
-          uri,
-        },
-      },
-    },
+          uri
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFields.fixture
@@ -5,10 +5,10 @@ var x = Relay.QL`
     node(id: 123) {
       ... on User {
         profilePicture {
-          uri,
-        },
-      },
-    },
+          uri
+        }
+      }
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithNestedFragments.fixture
@@ -3,24 +3,24 @@ var Relay = require('react-relay');
 var x = Relay.QL`
   query {
     node(id: 123) {
-      ${frag1},
-      ${frag2},
-      ${frag3},
-      ${frag4},
+      ${frag1}
+      ${frag2}
+      ${frag3}
+      ${frag4}
       ... on User {
         profilePicture {
-          uri,
-          ${frag5},
-          ${frag6},
-          ${frag7},
-          ${frag8},
-        },
-      },
-      ${frag9},
-      ${frag10},
-      ${frag11},
-      ${frag12},
-    },
+          uri
+          ${frag5}
+          ${frag6}
+          ${frag7}
+          ${frag8}
+        }
+      }
+      ${frag9}
+      ${frag10}
+      ${frag11}
+      ${frag12}
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArg.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArg.fixture
@@ -3,8 +3,8 @@ var Relay = require('Relay');
 var q = Relay.QL`
   query {
     search(query: $query) {
-      title,
-    },
+      title
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
@@ -3,8 +3,8 @@ var Relay = require('Relay');
 var q = Relay.QL`
   query {
     search(query: {queryText: $query}) {
-      title,
-    },
+      title
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgValue.fixture
@@ -3,8 +3,8 @@ var Relay = require('Relay');
 var q = Relay.QL`
   query {
     search(query: {queryText: "Relay"}) {
-      title,
-    },
+      title
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithVarArgs.fixture
@@ -3,8 +3,8 @@ var Relay = require('react-relay');
 var x = Relay.QL`
   query {
     nodes(ids: [123,456]) {
-      id,
-    },
+      id
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/subscription.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/subscription.fixture
@@ -3,8 +3,8 @@ var Relay = require('react-relay');
 var x = Relay.QL`
   subscription {
     likeStory(input: $input) {
-      ${reference},
-    },
+      ${reference}
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/tagRelayQL.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/tagRelayQL.fixture
@@ -3,8 +3,8 @@ var RelayQL = require('react-relay/RelayQL');
 var x = RelayQL`
   query {
     node(id: 123) {
-      id,
-    },
+      id
+    }
   }
 `;
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/unionWithTypename.fixture
@@ -2,8 +2,8 @@ Input:
 var foo = Relay.QL`
   query UnionWithTypename {
     media(id: 123) {
-      __typename,
-    },
+      __typename
+    }
   }
 `;
 


### PR DESCRIPTION
Commas are considered whitespace in GraphQL and we can just skip them. They're
nice inline, but at end of lines they're useless.

Done using [remove_commas.py](https://gist.github.com/kassens/6449143a9d1adb31b1a9):

```
find scripts/babel-relay-plugin/src/__fixtures__ -type f | xargs -n1 python remove_commas.py
```