### PR TITLE
RelayFragmentResolver - implement new resolver 1/n

### DIFF
--- a/src/store/RelayFragmentResolver.js
+++ b/src/store/RelayFragmentResolver.js
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule RelayFragmentResolver
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+import type {ChangeSubscription} from 'GraphQLStoreChangeEmitter';
+import type {DataID} from 'RelayInternalTypes';
+import type RelayQuery from 'RelayQuery';
+import type RelayQueryTracker from 'RelayQueryTracker';
+import type RelayStoreData from 'RelayStoreData';
+import type {
+  StoreReaderData,
+  Subscription,
+  SubscriptionCallbacks,
+} from 'RelayTypes';
+
+const filterExclusiveKeys = require('filterExclusiveKeys');
+const invariant = require('invariant');
+const readRelayQueryData = require('readRelayQueryData');
+const recycleNodesInto = require('recycleNodesInto');
+const resolveImmediate = require('resolveImmediate');
+
+type DataIDSet = {[dataID: DataID]: any};
+
+/**
+ * An Rx Observable representing the results of a fragment in the local cache.
+ * Subscribers are notified as follows:
+ *
+ * `onNext`: Called when the result of the fragment change. Results may be
+ * `null` if the data was marked as deleted or `undefined` if the fragment was
+ * either not fetched or evicted from the cache. Note that required fields may
+ * be missing if the fragment was not fetched with `Relay.Store.primeCache` or
+ * `Relay.Store.forceFetch` before creating a subscription.
+ *
+ * `onError`: Currently not called. In the future this may be used to indicate
+ * that required data for the fragment has not been fetched or was evicted
+ * from the cache.
+ *
+ * `onCompleted`: Not called.
+ *
+ * @see http://reactivex.io/documentation/observable.html
+ */
+class RelayFragmentResolver {
+  _changeSubscription: ?ChangeSubscription;
+  _data: ?StoreReaderData;
+  _dataID: DataID;
+  _fragment: RelayQuery.Fragment;
+  _storeData: RelayStoreData;
+  _subscriptions: Array<SubscriptionCallbacks>;
+  _subscribedIDs: DataIDSet;
+
+  constructor(
+    storeData: RelayStoreData,
+    fragment: RelayQuery.Fragment,
+    dataID: DataID,
+    prevData?: ?StoreReaderData
+  ) {
+    this._changeSubscription = null;
+    this._data = prevData;
+    this._dataID = dataID;
+    this._fragment = fragment;
+    this._storeData = storeData;
+    this._subscriptions = [];
+    this._subscribedIDs = {};
+  }
+
+  subscribe(callbacks: SubscriptionCallbacks): Subscription {
+    const subscription = {
+      dispose: () => {
+        this._subscriptions = this._subscriptions.filter(c => c !== callbacks);
+        resolveImmediate(() =>{
+          if (!this._subscriptions.length) {
+            this._unobserve();
+          }
+        });
+      },
+    };
+    this._subscriptions.push(callbacks);
+    if (!this._changeSubscription) {
+      this._observe();
+    } else {
+      callbacks.onNext(this._data);
+    }
+    return subscription;
+  }
+
+  _observe(): void {
+    const prevChangeSubscription = this._changeSubscription;
+    const prevData = this._data;
+    const prevIDs = this._subscribedIDs;
+    let nextChangeSubscription;
+
+    const {data, dataIDs} = readRelayQueryData(
+      this._storeData,
+      this._fragment,
+      this._dataID
+    );
+    const nextData = recycleNodesInto(
+      prevData,
+      data
+    );
+
+    if (nextData !== prevData || !prevChangeSubscription) {
+      dataIDs[this._dataID] = true;
+      prevChangeSubscription && prevChangeSubscription.remove();
+      this._updateGarbageCollectorSubscriptionCount(prevIDs, dataIDs);
+      const changeEmitter = this._storeData.getChangeEmitter();
+      nextChangeSubscription = changeEmitter.addListenerForIDs(
+        Object.keys(dataIDs),
+        () => this._observe()
+      );
+    }
+    this._changeSubscription = nextChangeSubscription;
+    this._data = data;
+    this._subscribedIDs = dataIDs;
+
+    this._subscriptions.forEach(callbacks => callbacks.onNext(data));
+  }
+
+  _unobserve(): void {
+    if (this._changeSubscription) {
+      this._changeSubscription.remove();
+      this._updateGarbageCollectorSubscriptionCount(this._subscribedIDs, {});
+
+      this._changeSubscription = null;
+      this._data = undefined;
+      this._subscribedIDs = {};
+    }
+  }
+
+  _updateGarbageCollectorSubscriptionCount(
+    prevIDs: DataIDSet,
+    nextIDs: DataIDSet
+  ): void {
+    const gc = this._storeData.getGarbageCollector();
+    if (gc) {
+      Object.keys(prevIDs).forEach(id => gc.decrementReferenceCount(id));
+      Object.keys(nextIDs).forEach(id => gc.incrementReferenceCount(id));
+    }
+  }
+}
+
+module.exports = RelayFragmentResolver;

--- a/src/store/__mocks__/RelayFragmentResolver.js
+++ b/src/store/__mocks__/RelayFragmentResolver.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = require.requireActual('RelayFragmentResolver');

--- a/src/store/__tests__/RelayFragmentResolver-test.js
+++ b/src/store/__tests__/RelayFragmentResolver-test.js
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+jest.dontMock('GraphQLStoreChangeEmitter');
+
+const Relay = require('Relay');
+const RelayFragmentResolver = require('RelayFragmentResolver');
+const RelayStoreData = require('RelayStoreData');
+const RelayTestUtils = require('RelayTestUtils');
+
+const readRelayQueryData = require('readRelayQueryData');
+
+describe('RelayFragmentResolver', () => {
+  let fragment;
+  let results;
+  let store;
+  let storeData;
+  let writer;
+
+  // helper functions
+  const {getNode, writePayload} = RelayTestUtils;
+
+  function genMockSubscriber() {
+    const onCompleted = jest.genMockFunction();
+    const onError = jest.genMockFunction();
+    const onNext = jest.genMockFunction();
+    const mockClear = () => {
+      [onCompleted, onError, onNext].forEach(fn => fn.mockClear());
+    };
+    return {
+      onCompleted,
+      onError,
+      onNext,
+      mockClear,
+    };
+  }
+
+  function createFragmentResolver(dataID) {
+    return new RelayFragmentResolver(
+      storeData,
+      fragment,
+      dataID
+    );
+  }
+
+  beforeEach(() => {
+    jest.resetModuleRegistry();
+    const concreteFragment = Relay.QL`fragment on Node{id,address{country}}`;
+    const query = getNode(Relay.QL`
+      query {
+        node(id: "123") {
+          ${concreteFragment},
+        }
+      }
+    `);
+    results = {
+      __dataID__: '123',
+      id: '123',
+      address: {
+        __dataID__: 'client:1',
+        country: 'US',
+      },
+    };
+    fragment = getNode(concreteFragment);
+    storeData = new RelayStoreData();
+    storeData.initializeGarbageCollector();
+    store = storeData.getRecordStore();
+    writer = storeData.getRecordWriter();
+    writePayload(store, writer, query, {node: results});
+
+    jest.addMatchers(RelayTestUtils.matchers);
+  });
+
+  describe('subscribe()', () => {
+    it('subscription `dispose` is idempotent', () => {
+      const resolver = createFragmentResolver('123');
+      const subscriber = genMockSubscriber();
+      const subscription = resolver.subscribe(subscriber);
+      subscription.dispose();
+      subscription.dispose();
+    });
+
+    it('immediately calls onNext of the first subscriber', () => {
+      const resolver = createFragmentResolver('123');
+      const subscriber = genMockSubscriber();
+      resolver.subscribe(subscriber);
+
+      expect(readRelayQueryData).toBeCalledWith(
+        storeData,
+        fragment,
+        '123'
+      );
+      expect(subscriber.onCompleted).not.toBeCalled();
+      expect(subscriber.onError).not.toBeCalled();
+      expect(subscriber.onNext).toBeCalledWith(results);
+    });
+
+    it('immediately calls onNext of subsequent subscribers', () => {
+      const resolver = createFragmentResolver('123');
+      const firstSubscriber = genMockSubscriber();
+      resolver.subscribe(firstSubscriber);
+      readRelayQueryData.mockClear();
+      firstSubscriber.mockClear();
+
+      const secondSubscriber = genMockSubscriber();
+      resolver.subscribe(secondSubscriber);
+      expect(readRelayQueryData).not.toBeCalled();
+      expect(firstSubscriber.onNext).not.toBeCalled();
+      expect(secondSubscriber.onCompleted).not.toBeCalled();
+      expect(secondSubscriber.onNext).toBeCalledWith(results);
+      expect(secondSubscriber.onError).not.toBeCalled();
+    });
+
+    it('updates all subscribers when data changes', () => {
+      const resolver = createFragmentResolver('123');
+      const subscribers = [
+        genMockSubscriber(),
+        genMockSubscriber(),
+      ];
+      subscribers.forEach(subscriber => {
+        resolver.subscribe(subscriber);
+        subscriber.mockClear();
+      });
+
+      // Change the data to ensure that `onNext` is called
+      writer.putField('client:1', 'country', 'JP');
+      results.address.country = 'JP';
+      storeData.getChangeEmitter().broadcastChangeForID('123');
+      jest.runAllTimers();
+
+      subscribers.forEach(subscriber => {
+        expect(subscriber.onCompleted).not.toBeCalled();
+        expect(subscriber.onError).not.toBeCalled();
+        expect(subscriber.onNext).toBeCalledWith(results);
+      });
+    });
+
+    it('does not call callbacks after a subscription is disposed', () => {
+      const resolver = createFragmentResolver('123');
+      const subscriber = genMockSubscriber();
+      const subscription = resolver.subscribe(subscriber);
+      subscriber.mockClear();
+      subscription.dispose();
+
+      // Change the data to ensure that `onNext` would be called
+      writer.putField('client:1', 'country', 'JP');
+      storeData.getChangeEmitter().broadcastChangeForID('123');
+      jest.runAllTimers();
+
+      expect(subscriber.onCompleted).not.toBeCalled();
+      expect(subscriber.onError).not.toBeCalled();
+      expect(subscriber.onNext).not.toBeCalled();
+    });
+
+    it('calls onNext if the record is deleted', () => {
+      const resolver = createFragmentResolver('123');
+      const subscriber = genMockSubscriber();
+      resolver.subscribe(subscriber);
+      subscriber.mockClear();
+
+      // deleting the record calls onNext
+      writer.deleteRecord('123');
+      storeData.getChangeEmitter().broadcastChangeForID('123');
+      jest.runAllTimers();
+      expect(subscriber.onCompleted).not.toBeCalled();
+      expect(subscriber.onError).not.toBeCalled();
+      expect(subscriber.onNext).toBeCalledWith(null);
+      subscriber.mockClear();
+
+      // restoring the record calls onNext
+      writer.putRecord('123');
+      storeData.getChangeEmitter().broadcastChangeForID('123');
+      jest.runAllTimers();
+      expect(subscriber.onCompleted).not.toBeCalled();
+      expect(subscriber.onError).not.toBeCalled();
+      expect(subscriber.onNext).toBeCalledWith({
+        __dataID__: '123',
+        __status__: 4,
+      });
+    });
+
+    it('calls onNext if the record is evicted from the store', () => {
+      const resolver = createFragmentResolver('123');
+      const subscriber = genMockSubscriber();
+      resolver.subscribe(subscriber);
+      subscriber.mockClear();
+
+      // evicting the record calls onNext
+      store.removeRecord('123');
+      storeData.getChangeEmitter().broadcastChangeForID('123');
+      jest.runAllTimers();
+      expect(subscriber.onCompleted).not.toBeCalled();
+      expect(subscriber.onError).not.toBeCalled();
+      expect(subscriber.onNext).toBeCalledWith(undefined);
+      subscriber.mockClear();
+
+      // restoring the record calls onNext
+      writer.putRecord('123');
+      storeData.getChangeEmitter().broadcastChangeForID('123');
+      jest.runAllTimers();
+      expect(subscriber.onCompleted).not.toBeCalled();
+      expect(subscriber.onError).not.toBeCalled();
+      expect(subscriber.onNext).toBeCalledWith({
+        __dataID__: '123',
+        __status__: 4,
+      });
+    });
+  });
+
+  describe('Garbage Collection', () => {
+    let gc;
+
+    beforeEach(() => {
+      const RelayGarbageCollector =
+        jest.genMockFromModule('RelayGarbageCollector');
+      gc = new RelayGarbageCollector();
+      storeData.getGarbageCollector = () => gc;
+    });
+
+    it('increments reference counts on subscribe()', () => {
+      const resolver = createFragmentResolver('123');
+      resolver.subscribe(genMockSubscriber());
+      expect(gc.incrementReferenceCount).toBeCalledWith('123');
+      expect(gc.incrementReferenceCount).toBeCalledWith('client:1');
+    });
+
+    it('decrements reference counts on final dispose()', () => {
+      const resolver = createFragmentResolver('123');
+      const {dispose} = resolver.subscribe(genMockSubscriber());
+
+      // Records are not dereferenced after a setImmediate
+      dispose();
+      expect(gc.decrementReferenceCount).not.toBeCalledWith('123');
+      expect(gc.decrementReferenceCount).not.toBeCalledWith('client:1');
+
+      jest.runAllTimers();
+      expect(gc.incrementReferenceCount).toBeCalledWith('123');
+      expect(gc.incrementReferenceCount).toBeCalledWith('client:1');
+    });
+  });
+});


### PR DESCRIPTION
Picking this up again as it relates to work on mutations by @wincent and diffing by @kassens - the goal is to have a single `RelayFragmentResolver` instance for every combination of runtime fragment & dataID, such that we know what fragments are actively subscribed on what ids. This is just the resolver implementation, a follow-up will replace GraphQLStoreQueryResolver with this.