### PR TITLE
Add `logNode` to `RelayTestUtils`

### DIFF
--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -508,6 +508,35 @@ const RelayTestUtils = {
   },
 
   /**
+   * Prints a textual representation of the query node to the console for
+   * debugging purposes.
+   *
+   * You don't want to commit any code that uses this helper, but it is
+   * useful when developing tests.
+   */
+  logNode(node) {
+    const RelayQuery = require('RelayQuery');
+    const flattenRelayQuery = require('flattenRelayQuery');
+    const printRelayQuery = require('printRelayQuery');
+
+    if (node instanceof RelayQuery.Field) {
+      // Normally can't print fields directly, so wrap it in a fake fragment.
+      node = RelayQuery.Fragment.build(
+        '__PrintableFieldWrapper',
+        '__Phony',
+        [node]
+      );
+    }
+
+    const string = JSON.stringify(
+      printRelayQuery(flattenRelayQuery(node)),
+      null,
+      2
+    );
+    console.log(string);
+  },
+
+  /**
    * Helper to write the result payload of a (root) query into a store,
    * returning created/updated ID sets. The payload is transformed before
    * writing; property keys are rewritten from application names into


### PR DESCRIPTION
Sometimes while working on a test I want to just peek at some node which may or may not be printable. This commit adds `logNode`, which is a convenience wrapper around `flattenRelayQuery` + `printRelayQuery`, and which will wrap otherwise unprintable fields in a phony wrapper.

So, you can do `RelayTestUtils.logNode(node)` and it will print:

```
{
  "text": "fragment __PrintableFieldWrapper on __Phony{feedback{doesViewerLike,id}}",
  "variables": {}
}
```

Compare that with the harder to read result of `console.log(node)`:

```
RelayQueryField {
  __concreteNode__:
   { children: [ [Object], [Object], [Object] ],
     fieldName: 'feedback',
     kind: 'Field',
     metadata:
      { canHaveSubselections: true,
        inferredRootCallName: 'node',
        inferredPrimaryKey: 'id' },
     type: 'Feedback' },
  __route__: RelayMetaRoute { name: '$fromGraphQL' },
  __variables__: {},
  __calls__: [],
  __children__:
   [ RelayQueryField {
       __concreteNode__: [Object],
       __route__: [Object],
       __variables__: {},
       __calls__: [],
       __children__: [],
       __fieldMap__: null,
       __hasDeferredDescendant__: null,
       __hasValidatedConnectionCalls__: null,
       __serializationKey__: null,
       __storageKey__: null,
       __debugName__: undefined,
       __isRefQueryDependency__: false,
       __rangeBehaviorKey__: undefined,
       __shallowHash__: 'comments' },
     RelayQueryField {
       __concreteNode__: [Object],
       __route__: [Object],
       __variables__: {},
       __calls__: [],
       __children__: [],
       __fieldMap__: null,
       __hasDeferredDescendant__: null,
       __hasValidatedConnectionCalls__: null,
       __serializationKey__: null,
       __storageKey__: null,
       __debugName__: undefined,
       __isRefQueryDependency__: false,
       __rangeBehaviorKey__: undefined,
       __shallowHash__: 'topLevelComments' },
     RelayQueryField {
       __concreteNode__: [Object],
       __route__: [Object],
       __variables__: {},
       __calls__: [],
       __children__: [],
       __fieldMap__: null,
       __hasDeferredDescendant__: null,
       __hasValidatedConnectionCalls__: null,
       __serializationKey__: null,
       __storageKey__: null,
       __debugName__: undefined,
       __isRefQueryDependency__: false,
       __rangeBehaviorKey__: undefined,
       __shallowHash__: 'id' } ],
  __fieldMap__: null,
  __hasDeferredDescendant__: null,
  __hasValidatedConnectionCalls__: null,
  __serializationKey__: null,
  __storageKey__: 'feedback',
  __debugName__: undefined,
  __isRefQueryDependency__: false,
  __rangeBehaviorKey__: undefined,
  __shallowHash__: 'feedback' }
```