### PR TITLE
Enforce that connectionName refers to a connection

### DIFF
--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -140,7 +140,11 @@ const RelayMutationQuery = {
       tracker,
     }: EdgeDeletionMutationFragmentBuilderConfig
   ): ?RelayQuery.Node {
-    const fatParent = getFieldFromFatQuery(fatQuery, parentName);
+    const fatParent = getParentAndValidateConnection(
+      parentName,
+      connectionName,
+      fatQuery
+    );
     const mutatedFields = [];
     const trackedParent = fatParent.clone(
       tracker.getTrackedChildrenForID(parentID)
@@ -192,6 +196,14 @@ const RelayMutationQuery = {
       tracker,
     }: EdgeInsertionMutationFragmentBuilderConfig
   ): ?RelayQuery.Node {
+    let fatParent;
+    if (parentName) {
+      fatParent = getParentAndValidateConnection(
+        parentName,
+        connectionName,
+        fatQuery
+      );
+    }
     const trackedChildren = tracker.getTrackedChildrenForID(parentID);
 
     const mutatedFields = [];
@@ -240,8 +252,7 @@ const RelayMutationQuery = {
       }
 
       // TODO: Do this even if there are no tracked connections.
-      if (parentName != null) {
-        const fatParent = getFieldFromFatQuery(fatQuery, parentName);
+      if (fatParent) {
         const trackedParent = fatParent.clone(trackedChildren);
         if (trackedParent) {
           const filterUnterminatedRange = node => (
@@ -545,6 +556,29 @@ function sanitizeRangeBehaviors(
     );
   }
   return rangeBehaviors;
+}
+
+/**
+ * Extracts the parent field identified by `parentName` from the fat query, then
+ * the connection field identified by `connectionName`, and confirms that the
+ * obtained field actually is a connection.
+ *
+ * Returns the parent field on success.
+ */
+function getParentAndValidateConnection(
+  parentName: string,
+  connectionName: string,
+  fatQuery: RelayQuery.Fragment
+): RelayQuery.Field {
+  const parent = getFieldFromFatQuery(fatQuery, parentName);
+  const connection = getFieldFromFatQuery(parent, connectionName);
+  invariant(
+    connection.isConnection(),
+    'RelayMutationQuery: Expected field `%s`%s to be a connection.',
+    connectionName,
+    parentName ? ' on `' + parentName + '`' : ''
+  );
+  return parent;
 }
 
 /**

--- a/src/mutation/__tests__/RelayMutationQuery-test.js
+++ b/src/mutation/__tests__/RelayMutationQuery-test.js
@@ -241,6 +241,42 @@ describe('RelayMutationQuery', () => {
       );
     });
 
+    it('throws for invalid (missing) connection name', () => {
+      expect(() => {
+        RelayMutationQuery.buildFragmentForEdgeDeletion({
+          fatQuery,
+          tracker,
+          connectionName: 'doesViewerLike',
+          parentID: '123',
+          parentName: 'feedback',
+        });
+      }).toFailInvariant(
+        'RelayMutationQuery: Invalid field name on fat query, `doesViewerLike`.'
+      );
+    });
+
+    it('throws for invalid (non-connection) connection name', () => {
+      fatQuery = fromGraphQL.Fragment(Relay.QL`
+        fragment on CommentDeleteResponsePayload {
+          feedback {
+            doesViewerLike
+          }
+        }
+      `);
+      expect(() => {
+        RelayMutationQuery.buildFragmentForEdgeDeletion({
+          fatQuery,
+          tracker,
+          connectionName: 'doesViewerLike',
+          parentID: '123',
+          parentName: 'feedback',
+        });
+      }).toFailInvariant(
+        'RelayMutationQuery: Expected field `doesViewerLike` on ' +
+        '`feedback` to be a connection.'
+      );
+    });
+
     it('creates a fragment for connection metadata', () => {
       tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
         fragment on Feedback {
@@ -592,6 +628,46 @@ describe('RelayMutationQuery', () => {
         });
       }).toFailInvariant(
         'RelayMutationQuery: Invalid field name on fat query, `story`.'
+      );
+    });
+
+    it('throws for invalid (missing) connection name', () => {
+      expect(() => {
+        RelayMutationQuery.buildFragmentForEdgeInsertion({
+          fatQuery,
+          tracker,
+          connectionName: 'doesViewerLike',
+          parentID: '123',
+          edgeName: 'feedbackCommentEdge',
+          parentName: 'feedback',
+          rangeBehaviors,
+        });
+      }).toFailInvariant(
+        'RelayMutationQuery: Invalid field name on fat query, `doesViewerLike`.'
+      );
+    });
+
+    it('throws for invalid (non-connection) connection name', () => {
+      fatQuery = fromGraphQL.Fragment(Relay.QL`
+        fragment on CommentDeleteResponsePayload {
+          feedback {
+            doesViewerLike
+          }
+        }
+      `);
+      expect(() => {
+        RelayMutationQuery.buildFragmentForEdgeInsertion({
+          fatQuery,
+          tracker,
+          connectionName: 'doesViewerLike',
+          parentID: '123',
+          edgeName: 'feedbackCommentEdge',
+          parentName: 'feedback',
+          rangeBehaviors,
+        });
+      }).toFailInvariant(
+        'RelayMutationQuery: Expected field `doesViewerLike` on ' +
+        '`feedback` to be a connection.'
       );
     });
   });


### PR DESCRIPTION
Should help catch issues like this one:

https://github.com/facebook/relay/issues/768

Closes:

https://github.com/facebook/relay/issues/927