### PR TITLE
Add `npm run jest` script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   "repository": "facebook/relay",
   "scripts": {
     "build": "gulp",
+    "jest": "NODE_ENV=test jest $@",
     "lint": "eslint .",
     "prepublish": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && npm run build",
-    "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
+    "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; npm run jest || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",
     "update-schema": "babel-node ./scripts/jest/updateSchema.js"
   },

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -7,12 +7,13 @@
   "main": "lib/getBabelRelayPlugin.js",
   "scripts": {
     "build": "node scripts/build-lib",
+    "jest": "NODE_ENV=test jest $@",
     "lint": "eslint .",
     "prepublish": "npm run build",
-    "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; NODE_ENV=test jest $@ || EXIT=$?; exit $EXIT; }; f",
+    "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; npm run jest || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",
-    "update-schema": "babel-node ./src/tools/generateSchemaJson.js",
-    "update-fixtures": "babel-node ./src/tools/regenerateFixtures.js"
+    "update-fixtures": "babel-node ./src/tools/regenerateFixtures.js",
+    "update-schema": "babel-node ./src/tools/generateSchemaJson.js"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
This makes it easier to just run a jest test and skip the flow type checking.

```
npm run jest MyTest
```