### PR TITLE
Restore ability to pass filter to `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jest": "NODE_ENV=test jest $@",
     "lint": "eslint .",
     "prepublish": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && npm run build",
-    "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; npm run jest || EXIT=$?; exit $EXIT; }; f",
+    "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; npm run jest \"$@\" || EXIT=$?; exit $EXIT; }; f",
     "typecheck": "flow check src/",
     "update-schema": "babel-node ./scripts/jest/updateSchema.js"
   },


### PR DESCRIPTION
Prior to 8c386dc7130f9fb7e you could pass a "filter" pattern to `npm test` to limit the scope of the test run (eg. `npm test RelayMutationQuery` to run just the `RelayMutationQuery` tests).

While you can still pass a filter to `npm jest`, we shouldn't break things for people who might be used to running `npm test`. This commit restores that ability.

Manually tested `npm test` with and without a filter.