### PR TITLE
Wrap $@ in quotes as recommended by shellcheck linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "repository": "facebook/relay",
   "scripts": {
     "build": "gulp",
-    "jest": "NODE_ENV=test jest $@",
+    "jest": "NODE_ENV=test jest \"$@\"",
     "lint": "eslint .",
     "prepublish": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && npm run build",
     "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; npm run jest \"$@\" || EXIT=$?; exit $EXIT; }; f",


### PR DESCRIPTION
We discussed this in respect to e5843c496075c08ac (D3103860).

The shellcheck linter recommends:

>  SC2068: Double quote array expansions to avoid re-splitting elements.

So let's apply the same change here. From `man bash`:

```
*     Expands  to the positional parameters, starting from one.  When the
      expansion occurs within double quotes, it expands to a single  word
      with  the  value of each parameter separated by the first character
      of the IFS special  variable.   That  is,  "$*"  is  equivalent  to
      "$1c$2c...", where c is the first character of the value of the IFS
      variable.  If IFS is unset, the parameters are separated by spaces.
      If IFS is null, the parameters are joined without intervening sepa-
      rators.
@     Expands to the positional parameters, starting from one.  When  the
      expansion  occurs within double quotes, each parameter expands to a
      separate word.  That is, "$@" is equivalent to "$1"  "$2"  ...   If
      the  double-quoted expansion occurs within a word, the expansion of
      the first parameter is joined with the beginning part of the origi-
      nal  word,  and  the expansion of the last parameter is joined with
      the last part of the original word.  When there are  no  positional
      parameters, "$@" and $@ expand to nothing (i.e., they are removed).
```