### PR TITLE
Be more explicit about trackers

### DIFF
--- a/src/tools/__mocks__/RelayTestUtils.js
+++ b/src/tools/__mocks__/RelayTestUtils.js
@@ -548,7 +548,15 @@ const RelayTestUtils = {
    * writing; property keys are rewritten from application names into
    * serialization keys matching the fields in the query.
    */
-  writePayload(store, writer, query, payload, tracker, fragmentTracker, options) {
+  writePayload(
+    store,
+    writer,
+    query,
+    payload,
+    queryTracker,
+    fragmentTracker,
+    options
+  ) {
     const transformRelayQueryPayload = require('transformRelayQueryPayload');
 
     return RelayTestUtils.writeVerbatimPayload(
@@ -556,7 +564,7 @@ const RelayTestUtils = {
       writer,
       query,
       transformRelayQueryPayload(query, payload),
-      tracker,
+      queryTracker,
       fragmentTracker,
       options
     );
@@ -571,7 +579,7 @@ const RelayTestUtils = {
     writer,
     query,
     payload,
-    tracker,
+    queryTracker,
     fragmentTracker,
     options,
   ) {
@@ -581,14 +589,14 @@ const RelayTestUtils = {
     const RelayQueryWriter = require('RelayQueryWriter');
     const writeRelayQueryPayload = require('writeRelayQueryPayload');
 
-    tracker = tracker || new RelayQueryTracker();
+    queryTracker = queryTracker || new RelayQueryTracker();
     fragmentTracker = fragmentTracker || new RelayFragmentTracker();
     options = options || {};
     const changeTracker = new RelayChangeTracker();
     const queryWriter = new RelayQueryWriter(
       store,
       writer,
-      tracker,
+      queryTracker,
       changeTracker,
       fragmentTracker,
       options

--- a/src/traversal/__tests__/diffRelayQuery_fragments-test.js
+++ b/src/traversal/__tests__/diffRelayQuery_fragments-test.js
@@ -378,7 +378,7 @@ describe('diffRelayQuery - fragments', () => {
   describe('fragments inside connections', () => {
     let store;
     let writer;
-    let tracker;
+    let queryTracker;
     let fragmentTracker;
 
     function writeEdgesForQuery(edges, query) {
@@ -393,14 +393,21 @@ describe('diffRelayQuery - fragments', () => {
           },
         },
       };
-      writePayload(store, writer, query, payload, tracker, fragmentTracker);
+      writePayload(
+        store,
+        writer,
+        query,
+        payload,
+        queryTracker,
+        fragmentTracker
+      );
     }
 
     beforeEach(() => {
       const records = {};
       store = new RelayRecordStore({records}, {rootCallMap});
       writer = new RelayRecordWriter(records, rootCallMap, false);
-      tracker = new RelayQueryTracker();
+      queryTracker = new RelayQueryTracker();
       fragmentTracker = new RelayFragmentTracker();
 
       // Load 2 stories without message
@@ -467,7 +474,7 @@ describe('diffRelayQuery - fragments', () => {
       const diffQueries = diffRelayQuery(
         getNode(feedQuery, {count: 3, after: null}),
         store,
-        tracker,
+        queryTracker,
         fragmentTracker,
       );
       expect(diffQueries.length).toBe(2);
@@ -527,7 +534,7 @@ describe('diffRelayQuery - fragments', () => {
       const diffQueries = diffRelayQuery(
         getNode(feedQuery, {count: 3, after: null}),
         store,
-        tracker,
+        queryTracker,
         fragmentTracker,
       );
       expect(diffQueries.length).toBe(1);

--- a/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
@@ -701,25 +701,45 @@ describe('writePayload()', () => {
         },
       };
       // populate the store and record the original tracked queries
-      let tracker = new RelayQueryTracker();
+      let queryTracker = new RelayQueryTracker();
 
-      writePayload(store, writer, query, payload, tracker, fragmentTracker);
-      const prevTracked = tracker.trackNodeForID.mock.calls.slice();
+      writePayload(
+        store,
+        writer,
+        query,
+        payload,
+        queryTracker,
+        fragmentTracker
+      );
+      const prevTracked = queryTracker.trackNodeForID.mock.calls.slice();
       expect(prevTracked.length).toBe(6);
 
       // rewriting the same payload by default does not track anything
-      tracker = new RelayQueryTracker();
-      tracker.trackNodeForID.mockClear();
-      writePayload(store, writer, query, payload, tracker, fragmentTracker);
-      expect(tracker.trackNodeForID.mock.calls.length).toBe(0);
+      queryTracker = new RelayQueryTracker();
+      queryTracker.trackNodeForID.mockClear();
+      writePayload(
+        store,
+        writer,
+        query,
+        payload,
+        queryTracker,
+        fragmentTracker
+      );
+      expect(queryTracker.trackNodeForID.mock.calls.length).toBe(0);
 
       // force-tracking should track the original nodes again
-      tracker = new RelayQueryTracker();
-      tracker.trackNodeForID.mockClear();
-      writePayload(store, writer, query, payload, tracker, fragmentTracker, {
-        updateTrackedQueries: true,
-      });
-      const nextTracked = tracker.trackNodeForID.mock.calls;
+      queryTracker = new RelayQueryTracker();
+      queryTracker.trackNodeForID.mockClear();
+      writePayload(
+        store,
+        writer,
+        query,
+        payload,
+        queryTracker,
+        fragmentTracker,
+        {updateTrackedQueries: true}
+      );
+      const nextTracked = queryTracker.trackNodeForID.mock.calls;
       expect(nextTracked.length).toBe(prevTracked.length);
       nextTracked.forEach((tracked, ii) => {
         expect(tracked[1]).toBe(prevTracked[ii][1]); // dataID

--- a/src/traversal/diffRelayQuery.js
+++ b/src/traversal/diffRelayQuery.js
@@ -78,13 +78,17 @@ type DiffOutput = {
 function diffRelayQuery(
   root: RelayQuery.Root,
   store: RelayRecordStore,
-  tracker: RelayQueryTracker,
+  queryTracker: RelayQueryTracker,
   fragmentTracker: RelayFragmentTracker,
 ): Array<RelayQuery.Root> {
   const path = RelayQueryPath.create(root);
   const queries = [];
 
-  const visitor = new RelayDiffQueryBuilder(store, tracker, fragmentTracker);
+  const visitor = new RelayDiffQueryBuilder(
+    store,
+    queryTracker,
+    fragmentTracker
+  );
   const rootIdentifyingArg = root.getIdentifyingArg();
   const rootIdentifyingArgValue =
     (rootIdentifyingArg && rootIdentifyingArg.value) || null;
@@ -162,24 +166,24 @@ function diffRelayQuery(
  *   - `diffNode`: subset of the input that could not diffed out
  *   - `trackedNode`: subset of the input that must be tracked
  *
- * The provided `tracker` is updated whenever the traversal of a node results
- * in a `trackedNode` being created. New top-level queries are not returned
- * up the tree, and instead are available via `getSplitQueries()`.
+ * The provided `queryTracker` is updated whenever the traversal of a node
+ * results in a `trackedNode` being created. New top-level queries are not
+ * returned up the tree, and instead are available via `getSplitQueries()`.
  */
 class RelayDiffQueryBuilder {
   _store: RelayRecordStore;
   _splitQueries: Array<RelayQuery.Root>;
-  _tracker: RelayQueryTracker;
+  _queryTracker: RelayQueryTracker;
   _fragmentTracker: RelayFragmentTracker;
 
   constructor(
     store: RelayRecordStore,
-    tracker: RelayQueryTracker,
+    queryTracker: RelayQueryTracker,
     fragmentTracker: RelayFragmentTracker,
   ) {
     this._store = store;
     this._splitQueries = [];
-    this._tracker = tracker;
+    this._queryTracker = queryTracker;
     this._fragmentTracker = fragmentTracker;
   }
 
@@ -381,7 +385,7 @@ class RelayDiffQueryBuilder {
     // always be composed into, and therefore tracked by, their nearest
     // non-fragment parent.
     if (trackedNode && !(trackedNode instanceof RelayQuery.Fragment)) {
-      this._tracker.trackNodeForID(trackedNode, scope.dataID, path);
+      this._queryTracker.trackNodeForID(trackedNode, scope.dataID, path);
     }
 
     return {


### PR DESCRIPTION
In these files we have change trackers, query trackers, and now fragment trackers. This can be confusing.

This commit makes sure that whenever we have more than one tracker in a local area, we use explicit names:

- `_tracker` becomes `_queryTracker`
- `tracker` becomes `queryTracker`

And so on. Even if we simplify things in the future to involve fewer trackers I still think this is a worthwhile change (another one is probably tackling the code smell of `writePayload` and the `RelayQueryWriter` constructor taking seven and six parameters respectively, but that is beyond the scope of this commit).