### PR TITLE
Simpler check for plural queries

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-x2plDoafKBiENN03Y8mggKLhqmo=
+iH12VifZFYmG3mnteV0SmiRr6sg=

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -119,7 +119,7 @@ module.exports = function (t, options) {
         }
         var selections = this.printSelections(rootField, requisiteFields);
         var metadata = {};
-        if (rootFieldType.isList()) {
+        if (rootFieldType.isList() || identifyingFieldDef && identifyingFieldDef.getType().isList()) {
           metadata.isPlural = true;
         }
         if (rootFieldType.isAbstract()) {

--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -132,7 +132,10 @@ module.exports = function(t: any, options: PrinterOptions): Function {
       }
       const selections = this.printSelections(rootField, requisiteFields);
       const metadata = {};
-      if (rootFieldType.isList()) {
+      if (
+        rootFieldType.isList() ||
+        (identifyingFieldDef && identifyingFieldDef.getType().isList())
+      ) {
         metadata.isPlural = true;
       }
       if (rootFieldType.isAbstract()) {

--- a/src/query/RelayFragmentPointer.js
+++ b/src/query/RelayFragmentPointer.js
@@ -102,11 +102,7 @@ const RelayFragmentPointer = {
         pointers.push(RelayFragmentPointer.create(dataID, fragment));
       }
     });
-    // Distinguish between singular/plural queries.
-    const identifyingArg = query.getIdentifyingArg();
-    const identifyingArgValue =
-      (identifyingArg && identifyingArg.value) || null;
-    if (Array.isArray(identifyingArgValue)) {
+    if (query.isPlural()) {
       return pointers;
     }
     return pointers[0];

--- a/src/query/__tests__/RelayFragmentPointer-test.js
+++ b/src/query/__tests__/RelayFragmentPointer-test.js
@@ -76,7 +76,7 @@ describe('RelayFragmentPointer', () => {
       recordStore = new RelayRecordStore({records});
     });
 
-    it('creates a wrapped fragment pointer', () => {
+    it('creates singular fragment pointer props', () => {
       const rootFragment = Relay.QL`fragment on Node{id}`;
       const root = getNode(Relay.QL`query{node(id:"123"){${rootFragment}}}`);
 
@@ -87,6 +87,19 @@ describe('RelayFragmentPointer', () => {
           [getNode(rootFragment).getConcreteFragmentID()]: '123',
         },
       });
+    });
+
+    it('creates plural fragment pointer props', () => {
+      const fragment = Relay.QL`fragment on Node{id}`;
+      const root = getNode(Relay.QL`query{nodes(ids:["123"]){${fragment}}}`);
+
+      const result = RelayFragmentPointer.createForRoot(recordStore, root);
+      expect(result).toEqual([{
+        __dataID__: '123',
+        __fragments__: {
+          [getNode(fragment).getConcreteFragmentID()]: '123',
+        },
+      }]);
     });
 
     it('throws if multiple root fragments are present', () => {


### PR DESCRIPTION
Realized that we *have* a method for checking if a query is plural, no need to look at the identifying args.