### PR TITLE
Fix RelayContainer-test

### DIFF
--- a/src/container/__tests__/RelayContainer-test.js
+++ b/src/container/__tests__/RelayContainer-test.js
@@ -68,7 +68,7 @@ describe('RelayContainer', function() {
     mockFooPointer = getPointer('42', mockFooFragment);
     const mockBarFragment =
       getNode(MockContainer.getFragment('bar').getFragment());
-    mockBarPointer = getPointer(['42'], mockBarFragment);
+    mockBarPointer = getPointer('42', mockBarFragment);
 
     RelayTestRenderer = RelayTestUtils.createRenderer();
 


### PR DESCRIPTION
The argument should always be a `DataID` and never an array.