### PR TITLE
Use find helper

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-x2plDoafKBiENN03Y8mggKLhqmo=
+67cv/FJ+K+p0zcmHMXl78y+vPoY=

--- a/scripts/babel-relay-plugin/lib/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLAST.js
@@ -145,7 +145,7 @@ var RelayQLFragment = function (_RelayQLDefinition) {
     _classCallCheck(this, RelayQLFragment);
 
     var relayDirectiveArgs = {};
-    var relayDirective = (ast.directives || []).find(function (directive) {
+    var relayDirective = find(ast.directives || [], function (directive) {
       return directive.name.value === 'relay';
     });
     if (relayDirective) {

--- a/scripts/babel-relay-plugin/src/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/src/RelayQLAST.js
@@ -139,7 +139,7 @@ class RelayQLFragment extends RelayQLDefinition<
     parentType?: RelayQLType
   ) {
     const relayDirectiveArgs = {};
-    const relayDirective = (ast.directives || []).find(
+    const relayDirective = find((ast.directives || []),
       directive => directive.name.value === 'relay'
     );
     if (relayDirective) {


### PR DESCRIPTION
Fixes https://github.com/facebook/relay/issues/968 (maybe..)
I couldn't verify that this fixes it. When I tried it locally I could run the plugin in 0.10 without the patch.

#### Edit
I managed to verify that it is working now.
I used the schema/babel config in the todo example and ran `node node_modules/.bin/babel test.js`
**test.js**
```js
import Relay from 'react-relay';
const q = Relay.QL`
fragment on User @relay(pattern: true) {
  id
}
`;
```
cc @kassens @josephsavona