### PR TITLE
Update TodoMVC .babelrc for production builds of RN

### DIFF
--- a/examples/TodoMVC/.babelrc
+++ b/examples/TodoMVC/.babelrc
@@ -11,6 +11,17 @@
         "react-native"
       ]
     },
+    "production": {
+      "passPerPreset": true,
+      "presets": [
+        {
+          "plugins": [
+            "./plugins/babelRelayPlugin"
+          ]
+        },
+        "react-native"
+      ]
+    },
     "server": {
       "plugins": [
         "./plugins/babelRelayPlugin"


### PR DESCRIPTION
It seems the presence of a `.babelrc` file in the react-native project is messing up the packager.
I'm not sure why but the bundling process was failing when hitting flow definitions.

Since the `.babelrc` configuration is needed when using relay with RN it can't be deleted.

I added an identical configuration for `production` builds and it seems to have solved the issue.

Update .babelrc to cover production builds.