### PR TITLE
Fix printing of idential values of different types

### DIFF
--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -596,6 +596,7 @@ type User implements Node Actor {
   message: Text
   name: String
   storySearch(query: StorySearchInput): [Story]
+  storyCommentSearch(query: StoryCommentSearchInput): [Comment]
   profilePicture(size: [String], preset: PhotoSize): Image
   segments(first: String): Segments
   screennames: [Screenname]
@@ -610,6 +611,12 @@ type User implements Node Actor {
 }
 
 input StorySearchInput {
+  text: String
+  limit: Int
+  offset: Int
+}
+
+input StoryCommentSearchInput {
   text: String
   limit: Int
   offset: Int

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -1019,6 +1019,33 @@
               "deprecationReason": null
             },
             {
+              "name": "storyCommentSearch",
+              "description": null,
+              "args": [
+                {
+                  "name": "query",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "StoryCommentSearchInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Comment",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "profilePicture",
               "description": null,
               "args": [
@@ -6861,6 +6888,47 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "StorySearchInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "text",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "limit",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "offset",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "StoryCommentSearchInput",
           "description": null,
           "fields": null,
           "inputFields": [


### PR DESCRIPTION
Fixes a bug where the printer creates only a single variable for any given value, even if that value is used at places in the query that accept values of different types. The printer currently de-dupes variables only by value; this change causes it to only de-duplicate values of the same (non-null) type.

Fixes #1011.