### PR TITLE
Remove an unnecessary guard

### DIFF
--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -597,12 +597,10 @@ function getConnectionAndValidate(
   parentName: string,
   connectionName: string,
 ): void {
-  if (parentField) {
-    const connections = findDescendantFields(parentField, connectionName);
-    if (connections.length) {
-      // If the first instance of the connection passes validation, all will.
-      validateConnection(parentName, connectionName, connections[0]);
-    }
+  const connections = findDescendantFields(parentField, connectionName);
+  if (connections.length) {
+    // If the first instance of the connection passes validation, all will.
+    validateConnection(parentName, connectionName, connections[0]);
   }
 }
 


### PR DESCRIPTION
In code review for D3136035 @yungsters suggested hoisting a guard up to the callsites. Turns out the callsites already have guards (either due to prior `invariant` calls or an explicit `if`), so the guard isn't needed at all (in fact, was in there as a remnant of an intermediate state I had while preparing that diff).

So, let's just remove the guard.