### PR TITLE
Add deprecation pathway for mutation config fields

### DIFF
--- a/src/mutation/validateMutationConfig.js
+++ b/src/mutation/validateMutationConfig.js
@@ -18,14 +18,38 @@ import type {RelayMutationConfig} from 'RelayTypes';
 const invariant = require('invariant');
 const sprintf = require('sprintf');
 const testEditDistance = require('testEditDistance');
+const warning = require('warning');
 
 type PropertyDescription = {
-  [name: string]: boolean;
+  [name: string]: Validator;
+};
+type Validator = {
+  assert: Function;
+  message: string;
+  type: 'DEPRECATED' | 'OPTIONAL' | 'REQUIRED';
 };
 
 const FUZZY_THRESHOLD = 3;
-const OPTIONAL = false;
-const REQUIRED = true;
+
+const DEPRECATED = Object.freeze({
+  assert: warning,
+  message: 'has deprecated property',
+  type: 'DEPRECATED',
+});
+
+const OPTIONAL = Object.freeze({
+  // These first two properties are not needed, but including them is easier
+  // than getting Flow to accept a disjoint union.
+  assert: () => {},
+  message: '',
+  type: 'OPTIONAL',
+});
+
+const REQUIRED = {
+  assert: invariant,
+  message: 'must have property',
+  type: 'REQUIRED',
+};
 
 function validateMutationConfig(
   config: RelayMutationConfig,
@@ -59,16 +83,23 @@ function validateMutationConfig(
       }
     });
 
-    // Check for missing properties.
+    // Check for deprecated and missing properties.
     Object.keys(properties).forEach(property => {
-      const isRequired = properties[property];
-      if (isRequired && !config[property]) {
-        invariant(
+      const validator = properties[property];
+      const isRequired = validator.type === 'REQUIRED';
+      const isDeprecated = validator.type === 'DEPRECATED';
+      const present = config.hasOwnProperty(property);
+      if (
+        isRequired && !present ||
+        isDeprecated && present
+      ) {
+        validator.assert(
           false,
-          'validateMutationConfig: `%s` config on `%s` must have property ' +
+          'validateMutationConfig: `%s` config on `%s` %s ' +
           '`%s`.',
           config.type,
           name,
+          validator.message,
           property
         );
       }


### PR DESCRIPTION
This should be a behavioral no-op, but I'm preparing for the ability to mark mutation config fields as deprecated. I tested this manually by temporarily marking one of the existing fields as deprecated (`s/REQUIRED/DEPRECATED/`) and then using an assertion like this:

```
it('warns about deprecated keys', () => {
  validateMutationConfig({
    ...config,
    connectionName: 'todos',
  }, 'MyMutation');
  expect([
    'validateMutationConfig: `%s` config on `%s` %s `%s`.',
    'NODE_DELETE',
    'MyMutation',
    'has deprecated property',
    'connectionName'
  ]).toBeWarnedNTimes(1);
});
```

Once we have a mutation config that actually has a deprecated attribute then I can commit a test, and it will look pretty much like that.

Making the deprecation message customizable would be a trivial extension of this (for example, if we rename a key, which is actually what led me to start looking at this, we can point to the new name for the key in the deprecation message).