### PR TITLE
Update fixtures for plugin test

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-zNoASUzkucFsu7t+oglTVN2N3OU=
+htIpWb3sh76WlvZCJ3y3wzath28=

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -22,6 +22,7 @@
     "lib/"
   ],
   "devDependencies": {
+    "babel-cli": "^6.7.5",
     "babel-core": "^6.6.4",
     "babel-eslint": "^4.1.1",
     "babel-jest": "^10.0.1",

--- a/scripts/babel-relay-plugin/src/__fixtures__/argsInvalidValues.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/argsInvalidValues.fixture
@@ -25,5 +25,5 @@ Output:
 "use strict";
 
 var foo = function () {
-  throw new Error("GraphQL validation/transform error ``Argument \"first\" has invalid value \"10\".\nExpected type \"Int\", found \"10\". Argument \"orderby\" has invalid value Name.\nExpected type \"String\", found Name. Argument \"find\" has invalid value cursor1.\nExpected type \"String\", found cursor1. Argument \"isViewerFriend\" has invalid value \"true\".\nExpected type \"Boolean\", found \"true\". Argument \"gender\" has invalid value \"MALE\".\nExpected type \"Gender\", found \"MALE\".`` in file `argsInvalidValues.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.");
+  throw new Error("GraphQL validation error ``Argument \"first\" has invalid value \"10\".\nExpected type \"Int\", found \"10\". Argument \"orderby\" has invalid value Name.\nExpected type \"String\", found Name. Argument \"find\" has invalid value cursor1.\nExpected type \"String\", found cursor1. Argument \"isViewerFriend\" has invalid value \"true\".\nExpected type \"Boolean\", found \"true\". Argument \"gender\" has invalid value \"MALE\".\nExpected type \"Gender\", found \"MALE\".`` in file `argsInvalidValues.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.");
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgs.fixture
@@ -21,5 +21,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported unless both are variables. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, `(after: <cursor>, first: <count>)`, or `(after: $<var>, last: $<var>)`.`` in file `connectionWithAfterLastArgs.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported unless both are variables. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, `(after: <cursor>, first: <count>)`, or `(after: $<var>, last: $<var>)`.`` in file `connectionWithAfterLastArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgsWithInlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastArgsWithInlineFragment.fixture
@@ -23,5 +23,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported unless both are variables. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, `(after: <cursor>, first: <count>)`, or `(after: $<var>, last: $<var>)`.`` in file `connectionWithAfterLastArgsWithInlineFragment.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported unless both are variables. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, `(after: <cursor>, first: <count>)`, or `(after: $<var>, last: $<var>)`.`` in file `connectionWithAfterLastArgsWithInlineFragment.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastOneVariableArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithAfterLastOneVariableArgs.fixture
@@ -21,5 +21,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported unless both are variables. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, `(after: <cursor>, first: <count>)`, or `(after: $<var>, last: $<var>)`.`` in file `connectionWithAfterLastOneVariableArgs.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``Connection arguments `friends(after: <cursor>, last: <count>)` are not supported unless both are variables. Use `(last: <count>)`, `(before: <cursor>, last: <count>)`, `(after: <cursor>, first: <count>)`, or `(after: $<var>, last: $<var>)`.`` in file `connectionWithAfterLastOneVariableArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithBeforeFirstArgs.fixture
@@ -21,5 +21,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Connection arguments `friends(before: <cursor>, first: <count>)` are not supported unless both are variables. Use `(first: <count>)`, `(after: <cursor>, first: <count>)`, `(before: <cursor>, last: <count>)`, or `(before: $<var>, first: $<var>)`.`` in file `connectionWithBeforeFirstArgs.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``Connection arguments `friends(before: <cursor>, first: <count>)` are not supported unless both are variables. Use `(first: <count>)`, `(after: <cursor>, first: <count>)`, `(before: <cursor>, last: <count>)`, or `(before: $<var>, first: $<var>)`.`` in file `connectionWithBeforeFirstArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithFirstLastArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithFirstLastArgs.fixture
@@ -21,5 +21,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Connection arguments `friends(first: <count>, last: <count>)` are not supported unless both are variables. Use `(first: <count>)`, `(last: <count>)`, or `(first: $<var>, last: $<var>)`.`` in file `connectionWithFirstLastArgs.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``Connection arguments `friends(first: <count>, last: <count>)` are not supported unless both are variables. Use `(first: <count>)`, `(last: <count>)`, or `(first: $<var>, last: $<var>)`.`` in file `connectionWithFirstLastArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithNodesField.fixture
@@ -19,5 +19,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``You supplied a field named `nodes` on a connection named `friends`, but pagination is not supported on connections without using `edges`. Use `friends{edges{node{...}}}` instead.`` in file `connectionWithNodesField.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``You supplied a field named `nodes` on a connection named `friends`, but pagination is not supported on connections without using `edges`. Use `friends{edges{node{...}}}` instead.`` in file `connectionWithNodesField.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgs.fixture
@@ -21,5 +21,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``You supplied the `edges` field on a connection named `friends`, but you did not supply an argument necessary to do so. Use either the `find`, `first`, or `last` argument.`` in file `connectionWithoutArgs.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``You supplied the `edges` field on a connection named `friends`, but you did not supply an argument necessary to do so. Use either the `find`, `first`, or `last` argument.`` in file `connectionWithoutArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgsWithInlineFragment.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/connectionWithoutArgsWithInlineFragment.fixture
@@ -23,5 +23,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``You supplied the `edges` field on a connection named `friends`, but you did not supply an argument necessary to do so. Use either the `find`, `first`, or `last` argument.`` in file `connectionWithoutArgsWithInlineFragment.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``You supplied the `edges` field on a connection named `friends`, but you did not supply an argument necessary to do so. Use either the `find`, `first`, or `last` argument.`` in file `connectionWithoutArgsWithInlineFragment.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentOnBadType.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentOnBadType.fixture
@@ -7,5 +7,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Unknown type "NotAType".`` in file `fragmentOnBadType.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('GraphQL validation error ``Unknown type "NotAType".`` in file `fragmentOnBadType.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaMissingArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaMissingArgs.fixture
@@ -11,5 +11,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Your schema defines a mutation field `mutationMissingArg` that takes 0 arguments, but mutation fields must have exactly one argument named `input`.`` in file `mutationBadSchemaMissingArgs.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``Your schema defines a mutation field `mutationMissingArg` that takes 0 arguments, but mutation fields must have exactly one argument named `input`.`` in file `mutationBadSchemaMissingArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaWrongArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationBadSchemaWrongArgs.fixture
@@ -11,5 +11,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Your schema defines a mutation field `mutationWrongArgs` that takes an argument named `foo`, but mutation fields must have exactly one argument named `input`.`` in file `mutationBadSchemaWrongArgs.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``Your schema defines a mutation field `mutationWrongArgs` that takes an argument named `foo`, but mutation fields must have exactly one argument named `input`.`` in file `mutationBadSchemaWrongArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithExtraArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithExtraArgs.fixture
@@ -13,5 +13,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Unknown argument "extra" on field "actorSubscribe" of type "Mutation".`` in file `mutationWithExtraArgs.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('GraphQL validation error ``Unknown argument "extra" on field "actorSubscribe" of type "Mutation".`` in file `mutationWithExtraArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/nonExistentMutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/nonExistentMutation.fixture
@@ -15,5 +15,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``Cannot query field "fakeMutation" on type "Mutation".`` in file `nonExistentMutation.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('GraphQL validation error ``Cannot query field "fakeMutation" on type "Mutation".`` in file `nonExistentMutation.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/nonRootNodeField.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/nonRootNodeField.fixture
@@ -15,5 +15,5 @@ Output:
 
 var Relay = require('Relay');
 var fragment = function () {
-  throw new Error('GraphQL validation/transform error ``You defined a `node(id: Int)` field on type `InvalidType`, but Relay requires the `node` field to be defined on the root type. See the Object Identification Guide: \nhttp://facebook.github.io/relay/docs/graphql-object-identification.html`` in file `nonRootNodeField.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``You defined a `node(id: Int)` field on type `InvalidType`, but Relay requires the `node` field to be defined on the root type. See the Object Identification Guide: \nhttp://facebook.github.io/relay/docs/graphql-object-identification.html`` in file `nonRootNodeField.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithArrayObjectNestedVariable.fixture
@@ -13,5 +13,5 @@ Output:
 
 var Relay = require('Relay');
 var q = function () {
-  throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithArrayObjectNestedVariable.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithArrayObjectNestedVariable.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirective.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirective.fixture
@@ -13,5 +13,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``You supplied a directive named `bad`, but no such directive exists.`` in file `queryWithBadDirective.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``You supplied a directive named `bad`, but no such directive exists.`` in file `queryWithBadDirective.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirectiveArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithBadDirectiveArgs.fixture
@@ -13,5 +13,5 @@ Output:
 
 var Relay = require('react-relay');
 var x = function () {
-  throw new Error('GraphQL validation/transform error ``You supplied a directive named `if`, but no such directive exists.`` in file `queryWithBadDirectiveArgs.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``You supplied a directive named `if`, but no such directive exists.`` in file `queryWithBadDirectiveArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/queryWithObjectArgNestedVariable.fixture
@@ -13,5 +13,5 @@ Output:
 
 var Relay = require('Relay');
 var q = function () {
-  throw new Error('GraphQL validation/transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithObjectArgNestedVariable.fixture`. Try updating your GraphQL schema if this argument/field/type is newly added.');
+  throw new Error('Relay transform error ``Unexpected nested variable `query`; variables are supported as top-level arguments - `node(id: $id)` - or directly within lists - `nodes(ids: [$id])`.`` in file `queryWithObjectArgNestedVariable.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();


### PR DESCRIPTION
00de34d32d51ba9e4d17e45280ad6d7e2734c6ed changed the error message slightly.
This update the test fixtures accordincly.

Also adds `babel-cli` since the `update-fixtures` script depends on
`babel-node`.