### PR TITLE
Remove dependency on graphql from main package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-react": "^3.3.1",
     "fbjs-scripts": "^0.5.0",
     "flow-bin": "0.22.0",
-    "graphql": "0.4.13",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-derequire": "^2.1.0",


### PR DESCRIPTION
I couldn't find a place where we depend on `graphql` directly from the main repo. The only requires I saw were inside the plugin.