### PR TITLE
allow rangeBehaviors to be defined as a function

### DIFF
--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -329,9 +329,36 @@ Given a parent, a connection, and the name of the newly created edge in the resp
 
   The field name in the response that represents the newly created edge
 
-- `rangeBehaviors: {[call: string]: GraphQLMutatorConstants.RANGE_OPERATIONS}`
+- `rangeBehaviors: {[call: string]: GraphQLMutatorConstants.RANGE_OPERATIONS} | (connectionArgs: {[argName: string]: string}) => $Enum<GraphQLMutatorConstants.RANGE_OPERATIONS>`
 
-  A map between printed, dot-separated GraphQL calls *in alphabetical order*, and the behavior we want Relay to exhibit when adding the new edge to connections under the influence of those calls. Behaviors can be one of `'append'`, `'ignore'`, `'prepend'`, `'refetch'`, or `'remove'`.
+  A map between printed, dot-separated GraphQL calls *in alphabetical order* and the behavior we want Relay to exhibit when adding the new edge to connections under the influence of those calls or a function accepting an array of connection arguments, returning that behavior.
+
+For example, `rangeBehaviors` could be written this way:
+
+```
+const rangeBehaviors = {
+  // When the ships connection is not under the influence
+  // of any call, append the ship to the end of the connection
+  '': 'append',
+  // Prepend the ship, wherever the connection is sorted by age
+  'orderby(newest)': 'prepend',
+};
+```
+
+Or this way, with the same results:
+
+```
+const rangeBehaviors = ({orderby}) => {
+  if (orderby === 'newest') {
+    return 'prepend';
+  } else {
+    return 'append';
+  }
+};
+
+```
+
+Behaviors can be one of `'append'`, `'ignore'`, `'prepend'`, `'refetch'`, or `'remove'`.
 
 #### Example
 

--- a/examples/todo/js/mutations/AddTodoMutation.js
+++ b/examples/todo/js/mutations/AddTodoMutation.js
@@ -42,11 +42,12 @@ export default class AddTodoMutation extends Relay.Mutation {
       parentID: this.props.viewer.id,
       connectionName: 'todos',
       edgeName: 'todoEdge',
-      rangeBehaviors: {
-        '': 'append',
-        'status(any)': 'append',
-        'status(active)': 'append',
-        'status(completed)': 'ignore',
+      rangeBehaviors: ({status}) => {
+        if (status === 'completed') {
+          return 'ignore';
+        } else {
+          return 'append';
+        }
       },
     }];
   }

--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -27,6 +27,7 @@ const {REFETCH} = require('GraphQLMutatorConstants');
 
 const flattenRelayQuery = require('flattenRelayQuery');
 const forEachObject = require('forEachObject');
+const getRangeBehavior = require('getRangeBehavior');
 const nullthrows = require('nullthrows');
 const inferRelayFieldsFromData = require('inferRelayFieldsFromData');
 const intersectRelayQuery = require('intersectRelayQuery');
@@ -222,9 +223,11 @@ const RelayMutationQuery = {
           return;
         }
 
-        const rangeBehaviorKey = trackedConnection.getRangeBehaviorKey();
-        const rangeBehaviorValue = rangeBehaviors[rangeBehaviorKey];
-        if (rangeBehaviorKey in rangeBehaviors && rangeBehaviorValue !== REFETCH) {
+        const callsWithValues = trackedConnection.getRangeBehaviorCalls();
+        const rangeBehavior = 
+          getRangeBehavior(rangeBehaviors, callsWithValues);
+
+        if (rangeBehavior && rangeBehavior !== REFETCH) {
           // Include edges from all connections that exist in `rangeBehaviors`.
           // This may add duplicates, but they will eventually be flattened.
           trackedEdges.forEach(trackedEdge => {
@@ -234,7 +237,7 @@ const RelayMutationQuery = {
           // If the connection is not in `rangeBehaviors` or we have explicitly
           // set the behavior to `refetch`, re-fetch it.
           warning(
-            rangeBehaviorValue === REFETCH,
+            rangeBehavior === REFETCH,
             'RelayMutation: The connection `%s` on the mutation field `%s` ' +
             'that corresponds to the ID `%s` did not match any of the ' +
             '`rangeBehaviors` specified in your RANGE_ADD config. This means ' +
@@ -533,6 +536,12 @@ function sanitizeRangeBehaviors(
   // Prior to 0.4.1 you would have to specify the args in your range behaviors
   // in the same order they appeared in your query. From 0.4.1 onward, args in a
   // range behavior key must be in alphabetical order.
+
+  // No need to sanitize if defined as a function
+  if (typeof rangeBehaviors === 'function') {
+    return rangeBehaviors;
+  }
+
   let unsortedKeys;
   forEachObject(rangeBehaviors, (value, key) => {
     if (key !== '') {

--- a/src/mutation/__tests__/getRangeBehavior-test.js
+++ b/src/mutation/__tests__/getRangeBehavior-test.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+jest.dontMock('getRangeBehavior');
+const RelayTestUtils = require('RelayTestUtils');
+const getRangeBehavior = require('getRangeBehavior');
+
+describe('getRangeBehavior()', () => {
+  describe('when rangeBehaviors are defined as a function', () => {
+    const rangeBehaviors = ({status}) => {
+      if (status === 'any') {
+        return 'append';
+      } else {
+        return 'refetch';
+      }
+    }
+
+    it('returns the rangeBehavior to use with the connectionArgs', () => {
+      const calls = [{name: 'status', value: 'any'}];
+      const rangeBehavior = getRangeBehavior(rangeBehaviors, calls);
+      expect(rangeBehavior).toBe('append');
+    }); 
+  });
+
+  describe('when rangeBehaviors are a plain object', () => {
+    const rangeBehaviors = {
+      'status(any)': 'append',
+      '': 'prepend',
+    };
+
+    it('returns the rangeBehavior associated with the rangeBehaviorKey', () => {
+      const calls = [{name: 'status', value: 'any'}];
+      const rangeBehavior = getRangeBehavior(rangeBehaviors, calls);
+      expect(rangeBehavior).toBe('append');
+    });
+  });
+});
+ 

--- a/src/mutation/__tests__/getRangeBehavior-test.js
+++ b/src/mutation/__tests__/getRangeBehavior-test.js
@@ -43,6 +43,12 @@ describe('getRangeBehavior()', () => {
       const rangeBehavior = getRangeBehavior(rangeBehaviors, calls);
       expect(rangeBehavior).toBe('append');
     });
+
+    it('returns null when no rangeBehavior is associated with the rangeBehaviorKey', () => {
+      const calls = [{name: 'status', value: 'recent'}];
+      const rangeBehavior = getRangeBehavior(rangeBehaviors, calls);
+      expect(rangeBehavior).toBe(null);
+    });
   });
 });
  

--- a/src/mutation/getRangeBehavior.js
+++ b/src/mutation/getRangeBehavior.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getRangeBehavior
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+import type {
+  Call,
+  RangeBehaviors,
+} from 'RelayInternalTypes';
+
+const serializeRelayQueryCall = require('serializeRelayQueryCall');
+
+/**
+ * Return the action (prepend/append) to use when adding an item to
+ * the range with the specified calls.
+ *
+ * Ex:
+ * rangeBehaviors: `{'orderby(recent)': 'append'}`
+ * calls: `[{name: 'orderby', value: 'recent'}]`
+ *
+ * Returns `'append'`
+ */
+function getRangeBehavior(
+  rangeBehaviors: RangeBehaviors,
+  calls: Array<Call>
+): ?string {
+  if (typeof rangeBehaviors === 'function') {
+    const rangeFilterCalls = getObjectFromCalls(calls);
+    return rangeBehaviors(rangeFilterCalls); 
+  } else {
+    const rangeBehaviorKey = 
+      calls.map(serializeRelayQueryCall).sort().join('').slice(1);
+    return rangeBehaviors[rangeBehaviorKey] || null;
+  }
+}
+
+/**
+ * Returns an object representation of the rangeFilterCalls that
+ * will be passed to config.rangeBehaviors
+ * 
+ * Example:
+ * calls: `[{name: 'orderby', value: 'recent'}]`
+ *
+ * Returns:
+ * `{orderby: 'recent'}`
+*/
+function getObjectFromCalls(
+  calls: Array<Call>
+): {[argName: string]: string} {
+  return calls.reduce((rangeFilterCalls, call) => {
+    rangeFilterCalls[call.name] = call.value;
+    return rangeFilterCalls;
+  },{})
+}
+
+module.exports = getRangeBehavior;

--- a/src/query/RelayQuery.js
+++ b/src/query/RelayQuery.js
@@ -1085,33 +1085,21 @@ class RelayQueryField extends RelayQueryNode {
   }
 
   /**
-   * A string representing the range behavior eligible arguments associated with
-   * this field. Arguments will be sorted.
-   *
-   * Non-core arguments (like connection and identifying arguments) are dropped.
-   *   `field(first: 10, foo: "bar", baz: "bat")` => `'baz(bat).foo(bar)'`
-   *   `username(name: "steve")`                  => `''`
-   */
-  getRangeBehaviorKey(): string {
+   * An array of calls excluding Core args to use with rangeBehavior
+   * functions. 
+  */ 
+  getRangeBehaviorCalls(): Array<Call> {
     invariant(
       this.isConnection(),
       'RelayQueryField: Range behavior keys are associated exclusively with ' +
-      'connection fields. `getRangeBehaviorKey()` was called on the ' +
+      'connection fields. `getRangeBehaviorCalls()` was called on the ' +
       'non-connection field `%s`.',
       this.getSchemaName()
     );
-    let rangeBehaviorKey = this.__rangeBehaviorKey__;
-    if (rangeBehaviorKey == null) {
-      const printedCoreArgs = [];
-      this.getCallsWithValues().forEach(arg => {
-        if (this._isCoreArg(arg)) {
-          printedCoreArgs.push(serializeRelayQueryCall(arg));
-        }
-      });
-      rangeBehaviorKey = printedCoreArgs.sort().join('').slice(1);
-      this.__rangeBehaviorKey__ = rangeBehaviorKey;
-    }
-    return rangeBehaviorKey;
+
+    return this.getCallsWithValues().filter(arg => {
+      return this._isCoreArg(arg);
+    }); 
   }
 
   /**

--- a/src/query/RelayQuery.js
+++ b/src/query/RelayQuery.js
@@ -947,7 +947,7 @@ class RelayQueryFragment extends RelayQueryNode {
 class RelayQueryField extends RelayQueryNode {
   __debugName__: ?string;
   __isRefQueryDependency__: boolean;
-  __rangeBehaviorKey__: ?string;
+  __rangeBehaviorCalls__: ?Array<Call>;
   __shallowHash__: ?string;
 
   static create(
@@ -1015,7 +1015,7 @@ class RelayQueryField extends RelayQueryNode {
     super(concreteNode, route, variables);
     this.__debugName__ = undefined;
     this.__isRefQueryDependency__ = false;
-    this.__rangeBehaviorKey__ = undefined;
+    this.__rangeBehaviorCalls__ = undefined;
     this.__shallowHash__ = undefined;
   }
 
@@ -1085,9 +1085,12 @@ class RelayQueryField extends RelayQueryNode {
   }
 
   /**
-   * An array of calls excluding Core args to use with rangeBehavior
-   * functions. 
-  */ 
+  * An Array of Calls to be used with rangeBehavior config functions.
+  *
+  * Non-core arguments (like connection and identifying arguments) are dropped.
+  *   `field(first: 10, foo: "bar", baz: "bat")` => `'baz(bat).foo(bar)'`
+  *   `username(name: "steve")`                  => `''`
+  */
   getRangeBehaviorCalls(): Array<Call> {
     invariant(
       this.isConnection(),
@@ -1096,11 +1099,16 @@ class RelayQueryField extends RelayQueryNode {
       'non-connection field `%s`.',
       this.getSchemaName()
     );
-
-    return this.getCallsWithValues().filter(arg => {
-      return this._isCoreArg(arg);
-    }); 
-  }
+    
+    let rangeBehaviorCalls = this.__rangeBehaviorCalls__;
+    if (!rangeBehaviorCalls) {
+      rangeBehaviorCalls = this.getCallsWithValues().filter(arg => {
+        return this._isCoreArg(arg);
+      }); 
+      this.__rangeBehaviorCalls__ = rangeBehaviorCalls; 
+    }
+    return rangeBehaviorCalls;
+ }
 
   /**
    * The name for the field when serializing the query or interpreting query

--- a/src/store/__tests__/RelayStoreData_cacheManager-test.js
+++ b/src/store/__tests__/RelayStoreData_cacheManager-test.js
@@ -15,6 +15,7 @@ require('configureForRelayOSS');
 
 jest
   .dontMock('GraphQLRange')
+  .dontMock('getRangeBehavior')
   .dontMock('GraphQLSegment');
 
 const GraphQLMutatorConstants = require('GraphQLMutatorConstants');

--- a/src/tools/RelayInternalTypes.js
+++ b/src/tools/RelayInternalTypes.js
@@ -80,9 +80,13 @@ export type UpdateOptions = {
   isOptimisticUpdate: boolean;
 };
 
-export type RangeBehaviors = {
+type RangeBehaviorsFunction = (connectionArgs: {[argName: string]: string}) => $Keys<GraphQLMutatorConstants.RANGE_OPERATIONS>;
+
+type RangeBehaviorsObject = {
   [key: string]: $Keys<GraphQLMutatorConstants.RANGE_OPERATIONS>;
 };
+
+export type RangeBehaviors = RangeBehaviorsFunction | RangeBehaviorsObject;
 
 type AfterConnectionArgumentMap = {
   after: string;
@@ -114,3 +118,4 @@ export type ConnectionArgumentsMap = (
   InitialTailConnectionArgumentMap |
   TailConnectionArgumentMap
 );
+

--- a/src/tools/RelayTypes.js
+++ b/src/tools/RelayTypes.js
@@ -20,6 +20,7 @@ import type URI from 'URI';
 import type {
   DataID,
   FieldValue,
+  RangeBehaviors,
 } from 'RelayInternalTypes';
 import type RelayFragmentReference from 'RelayFragmentReference';
 import type RelayMutationRequest from 'RelayMutationRequest';
@@ -106,8 +107,7 @@ export type RelayMutationConfig = {
   parentID?: string,
   connectionName: string,
   edgeName: string,
-  // from GraphQLMutatorConstants.RANGE_OPERATIONS
-  rangeBehaviors: {[call: string]: 'append' | 'prepend' | 'remove'},
+  rangeBehaviors: RangeBehaviors,
 } | {
   type: 'NODE_DELETE',
   parentName: string;

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -16,6 +16,7 @@ require('configureForRelayOSS');
 jest
   .dontMock('GraphQLRange')
   .dontMock('GraphQLSegment')
+  .dontMock('getRangeBehavior')
   .mock('warning');
 
 const GraphQLMutatorConstants = require('GraphQLMutatorConstants');

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -18,7 +18,6 @@ const RelayConnectionInterface = require('RelayConnectionInterface');
 import type {
   Call,
   DataID,
-  RangeBehaviors,
   UpdateOptions,
 } from 'RelayInternalTypes';
 const RelayMutationTracker = require('RelayMutationTracker');
@@ -33,8 +32,8 @@ import type RelayRecordStore from 'RelayRecordStore';
 
 const generateClientEdgeID = require('generateClientEdgeID');
 const generateClientID = require('generateClientID');
+const getRangeBehavior = require('getRangeBehavior');
 const invariant = require('invariant');
-const serializeRelayQueryCall = require('serializeRelayQueryCall');
 const warning = require('warning');
 
 // TODO: Replace with enumeration for possible config types.
@@ -541,24 +540,6 @@ function deleteRangeEdge(
 
   deleteRecord(writer, edgeID);
   writer.recordUpdate(connectionID);
-}
-
-/**
- * Return the action (prepend/append) to use when adding an item to
- * the range with the specified calls.
- *
- * Ex:
- * rangeBehaviors: `{'orderby(recent)': 'append'}`
- * calls: `[{name: 'orderby', value: 'recent'}]`
- *
- * Returns `'append'`
- */
-function getRangeBehavior(
-  rangeBehaviors: RangeBehaviors,
-  calls: Array<Call>
-): ?string {
-  const call = calls.map(serializeRelayQueryCall).sort().join('').slice(1);
-  return rangeBehaviors[call] || null;
 }
 
 /**


### PR DESCRIPTION
New PR for #639
Fix for #615, proposed in #538

Allows `rangeBehaviors` to be defined as a function that receives the connection arguments and returns one of `GraphQLMutatorConstants.RANGE_OPERATIONS`.

changes summary:
  - added a `getRangeBehavior` module that will return a `rangeBehavior` depdending on `rangeBehaviors` config and `calls` passed by argument.
  - changed `RelayQuery`'s `getRangeBehaviorKey` to `getRangeBehaviorCalls` so it can be reused by a function or plain object `rangeBehaviors` config.
  - Added some documentation on using a function as `rangeBehaviors` config.
  - Modified `todo` example to use a function.