### PR TITLE
Pass RelayRootContainer environment prop to RelayRenderer

### DIFF
--- a/src/container/RelayRootContainer.js
+++ b/src/container/RelayRootContainer.js
@@ -35,6 +35,7 @@ type RootContainerProps = {
   ) => React$Element;
   renderLoading?: ?() => React$Element;
   route: RelayQueryConfigInterface;
+  environment: RelayStore;
 };
 
 const {PropTypes} = React;
@@ -103,6 +104,7 @@ function RelayRootContainer({
   renderFetched,
   renderLoading,
   route,
+  environment,
 }: RootContainerProps): React$Element {
   return (
     <RelayRenderer
@@ -110,7 +112,7 @@ function RelayRootContainer({
       forceFetch={forceFetch}
       onReadyStateChange={onReadyStateChange}
       queryConfig={route}
-      environment={RelayStore}
+      environment={environment || RelayStore}
       render={({done, error, props, retry, stale}) => {
         if (error) {
           if (renderFailure) {
@@ -141,6 +143,7 @@ RelayRootContainer.propTypes = {
   renderFetched: PropTypes.func,
   renderLoading: PropTypes.func,
   route: RelayPropTypes.QueryConfig.isRequired,
+  environment: PropTypes.Environment,
 };
 
 RelayRootContainer.childContextTypes = {

--- a/src/container/RelayRootContainer.js
+++ b/src/container/RelayRootContainer.js
@@ -35,7 +35,6 @@ type RootContainerProps = {
   ) => React$Element;
   renderLoading?: ?() => React$Element;
   route: RelayQueryConfigInterface;
-  environment: RelayStore;
 };
 
 const {PropTypes} = React;
@@ -143,7 +142,6 @@ RelayRootContainer.propTypes = {
   renderFetched: PropTypes.func,
   renderLoading: PropTypes.func,
   route: RelayPropTypes.QueryConfig.isRequired,
-  environment: PropTypes.Environment,
 };
 
 RelayRootContainer.childContextTypes = {

--- a/src/container/RelayRootContainer.js
+++ b/src/container/RelayRootContainer.js
@@ -142,6 +142,7 @@ RelayRootContainer.propTypes = {
   renderFetched: PropTypes.func,
   renderLoading: PropTypes.func,
   route: RelayPropTypes.QueryConfig.isRequired,
+  environment: PropTypes.object,
 };
 
 RelayRootContainer.childContextTypes = {


### PR DESCRIPTION
Pass RelayRootContainer environment prop to RelayRenderer

I'm not 100% sure on the type checking `(type RootContainerProps... environment: RelayStore)` and the propTypes `(environment: PropTypes.Environment) `

But I needed to add line 107 and line 115 `(environment={environment || RelayStore}` in order to pass the environment prop down to RelayRenderer. All of my screens (using relay with React Native) use Relay.RootContainer and pass in the environment prop.

I know environment is still very new to the Public API  (only 1 week old) so if this method is incorrect please let me know. 

Thanks,