### PR TITLE
Update to Jest 11.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp-flatten": "^0.1.0",
     "gulp-header": "^1.2.2",
     "gulp-util": "^3.0.6",
-    "jest-cli": "^0.10.0",
+    "jest-cli": "^11.0.2",
     "object-assign": "^3.0.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",

--- a/src/network/__tests__/RelayNetworkLayer-test.js
+++ b/src/network/__tests__/RelayNetworkLayer-test.js
@@ -233,7 +233,7 @@ describe('RelayNetworkLayer', () => {
       pendingQueries[1].reject(error);
       jest.runAllTimers();
 
-      expect(queryCallback).toBeCalled(2);
+      expect(queryCallback.mock.calls.length).toBe(2);
     });
 
     it('calls subscriber with mutation', () => {
@@ -247,7 +247,7 @@ describe('RelayNetworkLayer', () => {
       pendingMutation.resolve(response);
       jest.runAllTimers();
 
-      expect(mutationCallback).toBeCalled(1);
+      expect(mutationCallback.mock.calls.length).toBe(1);
     });
 
     it('does not call subscriber once it is removed', () => {


### PR DESCRIPTION
Should be backwards compatible. Will land Jest 11 on fbsource next week.