### PR TITLE
Fix test failures in RelayMutationQueue

### DIFF
--- a/src/mutation/__tests__/RelayMutationQueue-test.js
+++ b/src/mutation/__tests__/RelayMutationQueue-test.js
@@ -110,6 +110,7 @@ describe('RelayMutationQueue', () => {
       });
       expect(buildQueryCalls[0][0].mutation).toBe(mutationNode);
       expect(buildQueryCalls[0][0].mutationName).toBe('RelayMutation');
+      expect(buildQueryCalls[0][0].tracker).toBe(storeData.getQueryTracker());
       expect(buildQueryCalls[0][0].fatQuery).toEqualQueryNode(
         flattenRelayQuery(fromGraphQL.Fragment(fatQuery), {
           preserveEmptyNodes: true,

--- a/src/mutation/__tests__/RelayMutationQueue-test.js
+++ b/src/mutation/__tests__/RelayMutationQueue-test.js
@@ -110,7 +110,6 @@ describe('RelayMutationQueue', () => {
       });
       expect(buildQueryCalls[0][0].mutation).toBe(mutationNode);
       expect(buildQueryCalls[0][0].mutationName).toBe('RelayMutation');
-      expect(buildQueryCalls[0][0].tracker).toBe(storeData.getQueryTracker());
       expect(buildQueryCalls[0][0].fatQuery).toEqualQueryNode(
         flattenRelayQuery(fromGraphQL.Fragment(fatQuery), {
           preserveEmptyNodes: true,
@@ -139,7 +138,6 @@ describe('RelayMutationQueue', () => {
       expect(buildQueryCalls[0][0].response).toEqual({
         [RelayConnectionInterface.CLIENT_MUTATION_ID]: '0',
       });
-      expect(buildQueryCalls[0][0].tracker).toBe(storeData.getQueryTracker());
       expect(buildQueryCalls[0][0].fatQuery).toEqualQueryNode(
         flattenRelayQuery(fromGraphQL.Fragment(fatQuery), {
           preserveEmptyNodes: true,


### PR DESCRIPTION
Sample failure run: https://travis-ci.org/facebook/relay/jobs/124994485

These look like harmless failures caused by 5943007d03b (D3210894). We're no longer setting the `tracker` property in our call to `buildQueryForOptimisticUpdate`, so the test shouldn't be including it in its assertions.