### PR TITLE
Stop relying on clientRequestId in graphql response.

### DIFF
--- a/docs/GraphQL-Mutations.md
+++ b/docs/GraphQL-Mutations.md
@@ -18,13 +18,13 @@ So for our `introduceShip` mutation, we create two types: `IntroduceShipInput` a
 input IntroduceShipInput {
   factionId: ID!
   shipName: String!
-  clientMutationId: String!
+  clientMutationId: String
 }
 
 type IntroduceShipPayload {
   faction: Faction
   ship: Ship
-  clientMutationId: String!
+  clientMutationId: String
 }
 ```
 

--- a/docs/GraphQL-RelaySpecification.md
+++ b/docs/GraphQL-RelaySpecification.md
@@ -71,13 +71,13 @@ type Query {
 input IntroduceShipInput {
   factionId: String!
   shipNamed: String!
-  clientMutationId: String!
+  clientMutationId: String
 }
 
 type IntroduceShipPayload {
   faction: Faction
   ship: Ship
-  clientMutationId: String!
+  clientMutationId: String
 }
 
 type Mutation {

--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-lmbOTQ9brPduHvvU636JVox2Gv8=
+t0fZzNjGjPK8EAN7r7XgB+wjVZ0=

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -65,7 +65,6 @@ module.exports = function (t, options) {
   var EMPTY_ARRAY = t.arrayExpression([]);
   var FIELDS = formatFields({
     __typename: '__typename',
-    clientMutationId: 'clientMutationId',
     clientSubscriptionId: 'clientSubscriptionId',
     cursor: 'cursor',
     edges: 'edges',
@@ -240,11 +239,7 @@ module.exports = function (t, options) {
         var rootField = rootFields[0];
         var rootFieldType = rootField.getType();
         validateMutationField(rootField);
-        var requisiteFields = {};
-        if (rootFieldType.hasField(FIELDS.clientMutationId)) {
-          requisiteFields[FIELDS.clientMutationId] = true;
-        }
-        var selections = this.printSelections(rootField, requisiteFields);
+        var selections = this.printSelections(rootField, {});
         var metadata = {
           inputType: this.printArgumentTypeForMetadata(rootField.getDeclaredArgument(INPUT_ARGUMENT_NAME))
         };

--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -59,7 +59,6 @@ module.exports = function(t: any, options: PrinterOptions): Function {
   const EMPTY_ARRAY = t.arrayExpression([]);
   const FIELDS = formatFields({
     __typename: '__typename',
-    clientMutationId: 'clientMutationId',
     clientSubscriptionId: 'clientSubscriptionId',
     cursor: 'cursor',
     edges: 'edges',
@@ -293,11 +292,7 @@ module.exports = function(t: any, options: PrinterOptions): Function {
       const rootField = rootFields[0];
       const rootFieldType = rootField.getType();
       validateMutationField(rootField);
-      const requisiteFields = {};
-      if (rootFieldType.hasField(FIELDS.clientMutationId)) {
-        requisiteFields[FIELDS.clientMutationId] = true;
-      }
-      const selections = this.printSelections(rootField, requisiteFields);
+      const selections = this.printSelections(rootField, {});
       const metadata = {
         inputType: this.printArgumentTypeForMetadata(
           rootField.getDeclaredArgument(INPUT_ARGUMENT_NAME)

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutation.fixture
@@ -50,14 +50,6 @@ var x = function () {
         inferredPrimaryKey: 'id'
       },
       type: 'User'
-    }, {
-      fieldName: 'clientMutationId',
-      kind: 'Field',
-      metadata: {
-        isGenerated: true,
-        isRequisite: true
-      },
-      type: 'String'
     }],
     kind: 'Mutation',
     metadata: {

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithName.fixture
@@ -23,15 +23,7 @@ var x = function (RQL_0) {
         callVariableName: 'input'
       }
     }],
-    children: [].concat.apply([], [{
-      fieldName: 'clientMutationId',
-      kind: 'Field',
-      metadata: {
-        isGenerated: true,
-        isRequisite: true
-      },
-      type: 'String'
-    }, Relay.QL.__frag(RQL_0)]),
+    children: [].concat.apply([], [Relay.QL.__frag(RQL_0)]),
     kind: 'Mutation',
     metadata: {
       inputType: 'ActorSubscribeInput'

--- a/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/mutationWithoutArgs.fixture
@@ -21,15 +21,6 @@ var x = function () {
         callVariableName: 'input'
       }
     }],
-    children: [{
-      fieldName: 'clientMutationId',
-      kind: 'Field',
-      metadata: {
-        isGenerated: true,
-        isRequisite: true
-      },
-      type: 'String'
-    }],
     kind: 'Mutation',
     metadata: {
       inputType: 'ActorSubscribeInput'

--- a/src/mutation/RelayGraphQLMutation.js
+++ b/src/mutation/RelayGraphQLMutation.js
@@ -101,7 +101,6 @@ class RelayGraphQLMutation {
    *    Relay.QL`
    *      mutation StoryLikeQuery {
    *        likeStory(input: $input) {
-   *          clientMutationId
    *          story {
    *            likeCount
    *            likers {
@@ -126,9 +125,8 @@ class RelayGraphQLMutation {
    *
    * - The mutation should take a single argument named "input".
    * - That input argument should contain a (string) "clientMutationId" property
-   *   for the purposes of reconciling requests and responses (automatically
-   *   added by the RelayGraphQLMutation API).
-   * - The query should request "clientMutationId" as a subselection.
+   *   for backwards compatibility.
+   * - The query may request "clientMutationId" as a subselection.
    *
    * @see http://facebook.github.io/relay/docs/graphql-mutations.html
    * @see http://facebook.github.io/relay/graphql/mutations.htm
@@ -323,10 +321,7 @@ class PendingGraphQLTransaction {
   }
 
   getOptimisticResponse(): ?Object {
-    return {
-      ...this._optimisticResponse,
-      [CLIENT_MUTATION_ID]: this.id,
-    };
+    return this._optimisticResponse;
   }
 
   getQuery(storeData: RelayStoreData): RelayQuery.Mutation {

--- a/src/mutation/RelayMutationQuery.js
+++ b/src/mutation/RelayMutationQuery.js
@@ -73,7 +73,6 @@ type OptimisticUpdateQueryBuilderConfig =
     response: Object,
   };
 
-const {CLIENT_MUTATION_ID} = RelayConnectionInterface;
 const {ANY_TYPE, ID, TYPENAME} = RelayNodeInterface;
 
 /**
@@ -383,13 +382,7 @@ const RelayMutationQuery = {
       tracker: RelayQueryTracker,
     }
   ): RelayQuery.Mutation {
-    let children: Array<?RelayQuery.Node> = [
-      RelayQuery.Field.build({
-        fieldName: CLIENT_MUTATION_ID,
-        type: 'String',
-        metadata: {isRequisite:true},
-      }),
-    ];
+    let children: Array<?RelayQuery.Node> = [];
     /* eslint-disable no-console */
     if (__DEV__ && console.groupCollapsed && console.groupEnd) {
       console.groupCollapsed('Mutation Configs');

--- a/src/mutation/RelayMutationQueue.js
+++ b/src/mutation/RelayMutationQueue.js
@@ -228,6 +228,7 @@ class RelayMutationQueue {
       const configs =
         transaction.getOptimisticConfigs() || transaction.getConfigs();
       this._storeData.handleUpdatePayload(
+        transaction.id,
         optimisticQuery,
         optimisticResponse,
         {
@@ -284,6 +285,7 @@ class RelayMutationQueue {
 
     this._refreshQueuedData();
     this._storeData.handleUpdatePayload(
+      transaction.id,
       transaction.getQuery(this._storeData),
       response[transaction.getCallName()],
       {
@@ -561,11 +563,7 @@ class RelayPendingTransaction {
 
   _getRawOptimisticResponse(): ?Object {
     if (this._rawOptimisticResponse === undefined) {
-      const optimisticResponse = this.mutation.getOptimisticResponse() || null;
-      if (optimisticResponse) {
-        optimisticResponse[CLIENT_MUTATION_ID] = this.id;
-      }
-      this._rawOptimisticResponse = optimisticResponse;
+      this._rawOptimisticResponse = this.mutation.getOptimisticResponse() || null;
     }
     return this._rawOptimisticResponse;
   }

--- a/src/mutation/__tests__/RelayGraphQLMutation-test.js
+++ b/src/mutation/__tests__/RelayGraphQLMutation-test.js
@@ -90,7 +90,6 @@ describe('RelayGraphQLMutation', () => {
     feedbackLikeQuery =
       Relay.QL`mutation FeedbackLikeMutation {
         feedbackLike(input: $input) {
-          clientMutationId
           feedback {
             doesViewerLike
             id
@@ -115,7 +114,6 @@ describe('RelayGraphQLMutation', () => {
     optimisticQuery =
       Relay.QL`mutation FeedbackLikeOptimisticUpdate {
         feedbackLike(input: $input) {
-          clientMutationId
           feedback {
             doesViewerLike
             id

--- a/src/mutation/__tests__/RelayGraphQLMutation-test.js
+++ b/src/mutation/__tests__/RelayGraphQLMutation-test.js
@@ -366,7 +366,6 @@ describe('RelayGraphQLMutation', () => {
         const result = {
           response: {
             feedbackLike: {
-              clientMutationId: id,
               feedback: {
                 id: 'aFeedbackId',
                 doesViewerLike: true,
@@ -527,7 +526,6 @@ describe('RelayGraphQLMutation', () => {
         };
         const query = Relay.QL`mutation CommentAddMutation {
           commentCreate(input: $input) {
-            clientMutationId
             feedbackCommentEdge {
               cursor
               node {
@@ -579,7 +577,6 @@ describe('RelayGraphQLMutation', () => {
         const result = {
           response: {
             commentCreate: {
-              clientMutationId: id,
               feedbackCommentEdge: {
                 __typename: 'CommentsEdge',
                 cursor: 'cursor2',

--- a/src/mutation/__tests__/RelayMutationQuery-test.js
+++ b/src/mutation/__tests__/RelayMutationQuery-test.js
@@ -42,6 +42,11 @@ describe('RelayMutationQuery', () => {
       node => !node.getSchemaName || node.getSchemaName() !== 'source';
     return filterRelayQuery(RelayTestUtils.getNode(...args), filterCallback);
   }
+  function getMutationWithoutClientId(mutation) {
+    return mutation.clone(mutation.getChildren().filter(child =>
+      !child.getSchemaName || child.getSchemaName() !== RelayConnectionInterface.CLIENT_MUTATION_ID
+    ));
+  }
 
   let tracker;
 
@@ -1108,24 +1113,26 @@ describe('RelayMutationQuery', () => {
         mutation,
       });
 
-      const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
-        mutation {
-          commentDelete(input:$input) {
-            ${Relay.QL`
-              fragment on CommentDeleteResponsePayload {
-                feedback {
-                  id
+      const expectedMutationQuery = getMutationWithoutClientId(
+        getNodeWithoutSource(Relay.QL`
+          mutation {
+            commentDelete(input:$input) {
+              ${Relay.QL`
+                fragment on CommentDeleteResponsePayload {
+                  feedback {
+                    id
+                  }
                 }
-              }
-            `},
-            ${Relay.QL`
-              fragment on CommentDeleteResponsePayload {
-                deletedCommentId
-              }
-            `},
-          }
-        }
-      `, variables);
+              `},
+              ${Relay.QL`
+                fragment on CommentDeleteResponsePayload {
+                  deletedCommentId
+                }
+              `},
+            }
+          `, variables
+        )
+      );
 
       expect(query)
         .toEqualQueryNode(expectedMutationQuery);
@@ -1178,24 +1185,26 @@ describe('RelayMutationQuery', () => {
         mutation,
       });
 
-      const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
-        mutation {
-          commentDelete(input:$input) {
-            ${Relay.QL`
-              fragment on CommentDeleteResponsePayload {
-                feedback {
-                  id
+      const expectedMutationQuery = getMutationWithoutClientId(
+        getNodeWithoutSource(Relay.QL`
+          mutation {
+            commentDelete(input:$input) {
+              ${Relay.QL`
+                fragment on CommentDeleteResponsePayload {
+                  feedback {
+                    id
+                  }
                 }
-              }
-            `},
-            ${Relay.QL`
-              fragment on CommentDeleteResponsePayload {
-                deletedCommentId
-              }
-            `},
-          }
-        }
-      `, variables);
+              `},
+              ${Relay.QL`
+                fragment on CommentDeleteResponsePayload {
+                  deletedCommentId
+                }
+              `},
+            }
+          `, variables
+        )
+      );
 
       expect(query)
         .toEqualQueryNode(expectedMutationQuery);
@@ -1263,7 +1272,7 @@ describe('RelayMutationQuery', () => {
         }
       `;
       expect(query).toEqualQueryNode(
-        getNodeWithoutSource(expectedConcreteNode, variables)
+        getMutationWithoutClientId(getNodeWithoutSource(expectedConcreteNode, variables))
       );
     });
 
@@ -1303,20 +1312,22 @@ describe('RelayMutationQuery', () => {
         mutation,
       });
 
-      const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
-        mutation {
-          feedbackLike(input:$input) {
-            ${Relay.QL`
-              fragment on FeedbackLikeResponsePayload {
-                feedback {
-                  id,
-                  likers
+      const expectedMutationQuery = getMutationWithoutClientId(
+        getNodeWithoutSource(Relay.QL`
+          mutation {
+            feedbackLike(input:$input) {
+              ${Relay.QL`
+                fragment on FeedbackLikeResponsePayload {
+                  feedback {
+                    id,
+                    likers
+                  }
                 }
-              }
-            `},
+              `},
+            }
           }
-        }
-      `, variables);
+        `, variables)
+      );
 
       expect(query)
         .toEqualQueryNode(expectedMutationQuery);
@@ -1495,56 +1506,58 @@ describe('RelayMutationQuery', () => {
         mutation,
       });
 
-      const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
-        mutation {
-          commentCreate(input:$input) {
-            ${Relay.QL`
-              fragment on CommentCreateResponsePayload {
-                feedback {
-                  id,
-                  likers,
-                },
-                feedbackCommentEdge {
-                  __typename
-                  cursor,
-                  node {
-                    body {
-                      text
-                    },
-                    id
+      const expectedMutationQuery = getMutationWithoutClientId(
+        getNodeWithoutSource(Relay.QL`
+          mutation {
+            commentCreate(input:$input) {
+              ${Relay.QL`
+                fragment on CommentCreateResponsePayload {
+                  feedback {
+                    id,
+                    likers,
                   },
-                  source {
-                    id
+                  feedbackCommentEdge {
+                    __typename
+                    cursor,
+                    node {
+                      body {
+                        text
+                      },
+                      id
+                    },
+                    source {
+                      id
+                    }
                   }
                 }
-              }
-            `},
-            ${Relay.QL`
-              fragment on CommentCreateResponsePayload {
-                feedback {
-                  comments(first:"10") {
-                    edges {
-                      cursor
-                      node {
-                        body {
-                          text
+              `},
+              ${Relay.QL`
+                fragment on CommentCreateResponsePayload {
+                  feedback {
+                    comments(first:"10") {
+                      edges {
+                        cursor
+                        node {
+                          body {
+                            text
+                          }
+                          id
                         }
-                        id
+                      }
+                      pageInfo {
+                        hasNextPage
+                        hasPreviousPage
                       }
                     }
-                    pageInfo {
-                      hasNextPage
-                      hasPreviousPage
-                    }
+                    id
+                    likers
                   }
-                  id
-                  likers
                 }
-              }
-            `},
+              `},
+            }
           }
-        }
-      `, variables);
+        `, variables)
+      );
 
       expect(query)
         .toEqualQueryNode(expectedMutationQuery);

--- a/src/mutation/__tests__/RelayMutationQuery-test.js
+++ b/src/mutation/__tests__/RelayMutationQuery-test.js
@@ -933,7 +933,6 @@ describe('RelayMutationQuery', () => {
 
       const query = RelayMutationQuery.buildQueryForOptimisticUpdate({
         response: {
-          [RelayConnectionInterface.CLIENT_MUTATION_ID]: '1',
           feedback: {
             doesViewerLike: true,
             id: '1',
@@ -953,7 +952,6 @@ describe('RelayMutationQuery', () => {
             feedbackLike(input:$input) {
               ${Relay.QL`
                 fragment on FeedbackLikeResponsePayload {
-                  clientMutationId,
                   feedback {
                     doesViewerLike,
                     id,
@@ -1034,7 +1032,6 @@ describe('RelayMutationQuery', () => {
         getNodeWithoutSource(Relay.QL`
           mutation {
             commentCreate(input:$input) {
-              clientMutationId
               ... on CommentCreateResponsePayload {
                 feedback {
                   ... on Feedback {
@@ -1114,7 +1111,6 @@ describe('RelayMutationQuery', () => {
       const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
         mutation {
           commentDelete(input:$input) {
-            clientMutationId
             ${Relay.QL`
               fragment on CommentDeleteResponsePayload {
                 feedback {
@@ -1185,7 +1181,6 @@ describe('RelayMutationQuery', () => {
       const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
         mutation {
           commentDelete(input:$input) {
-            clientMutationId
             ${Relay.QL`
               fragment on CommentDeleteResponsePayload {
                 feedback {
@@ -1223,7 +1218,6 @@ describe('RelayMutationQuery', () => {
           actor {
             friends
           }
-          clientMutationId
         }
       `);
       const configs = [
@@ -1251,7 +1245,6 @@ describe('RelayMutationQuery', () => {
       const expectedConcreteNode = Relay.QL`
         mutation {
           unfriend(input: $input) {
-            clientMutationId
             ${Relay.QL`
               fragment on UnfriendResponsePayload {
                 actor {
@@ -1313,7 +1306,6 @@ describe('RelayMutationQuery', () => {
       const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
         mutation {
           feedbackLike(input:$input) {
-            clientMutationId
             ${Relay.QL`
               fragment on FeedbackLikeResponsePayload {
                 feedback {
@@ -1400,7 +1392,6 @@ describe('RelayMutationQuery', () => {
         getNodeWithoutSource(Relay.QL`
           mutation {
             commentCreate(input:$input) {
-              clientMutationId
               ... on CommentCreateResponsePayload {
                 feedback {
                   ... on Feedback {
@@ -1507,7 +1498,6 @@ describe('RelayMutationQuery', () => {
       const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
         mutation {
           commentCreate(input:$input) {
-            clientMutationId
             ${Relay.QL`
               fragment on CommentCreateResponsePayload {
                 feedback {
@@ -1563,7 +1553,7 @@ describe('RelayMutationQuery', () => {
     it('complains about unknown config types', () => {
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on UnfriendResponsePayload {
-          clientMutationId
+          formerFriend { id }
         }
       `);
       const configs = [

--- a/src/mutation/__tests__/RelayMutationQuery-test.js
+++ b/src/mutation/__tests__/RelayMutationQuery-test.js
@@ -42,11 +42,6 @@ describe('RelayMutationQuery', () => {
       node => !node.getSchemaName || node.getSchemaName() !== 'source';
     return filterRelayQuery(RelayTestUtils.getNode(...args), filterCallback);
   }
-  function getMutationWithoutClientId(mutation) {
-    return mutation.clone(mutation.getChildren().filter(child =>
-      !child.getSchemaName || child.getSchemaName() !== RelayConnectionInterface.CLIENT_MUTATION_ID
-    ));
-  }
 
   let tracker;
 
@@ -1113,26 +1108,24 @@ describe('RelayMutationQuery', () => {
         mutation,
       });
 
-      const expectedMutationQuery = getMutationWithoutClientId(
-        getNodeWithoutSource(Relay.QL`
-          mutation {
-            commentDelete(input:$input) {
-              ${Relay.QL`
-                fragment on CommentDeleteResponsePayload {
-                  feedback {
-                    id
-                  }
+      const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
+        mutation {
+          commentDelete(input:$input) {
+            ${Relay.QL`
+              fragment on CommentDeleteResponsePayload {
+                feedback {
+                  id
                 }
-              `},
-              ${Relay.QL`
-                fragment on CommentDeleteResponsePayload {
-                  deletedCommentId
-                }
-              `},
-            }
-          `, variables
-        )
-      );
+              }
+            `},
+            ${Relay.QL`
+              fragment on CommentDeleteResponsePayload {
+                deletedCommentId
+              }
+            `},
+          }
+        }
+      `, variables);
 
       expect(query)
         .toEqualQueryNode(expectedMutationQuery);
@@ -1185,26 +1178,24 @@ describe('RelayMutationQuery', () => {
         mutation,
       });
 
-      const expectedMutationQuery = getMutationWithoutClientId(
-        getNodeWithoutSource(Relay.QL`
-          mutation {
-            commentDelete(input:$input) {
-              ${Relay.QL`
-                fragment on CommentDeleteResponsePayload {
-                  feedback {
-                    id
-                  }
+      const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
+        mutation {
+          commentDelete(input:$input) {
+            ${Relay.QL`
+              fragment on CommentDeleteResponsePayload {
+                feedback {
+                  id
                 }
-              `},
-              ${Relay.QL`
-                fragment on CommentDeleteResponsePayload {
-                  deletedCommentId
-                }
-              `},
-            }
-          `, variables
-        )
-      );
+              }
+            `},
+            ${Relay.QL`
+              fragment on CommentDeleteResponsePayload {
+                deletedCommentId
+              }
+            `},
+          }
+        }
+      `, variables);
 
       expect(query)
         .toEqualQueryNode(expectedMutationQuery);
@@ -1272,7 +1263,7 @@ describe('RelayMutationQuery', () => {
         }
       `;
       expect(query).toEqualQueryNode(
-        getMutationWithoutClientId(getNodeWithoutSource(expectedConcreteNode, variables))
+        getNodeWithoutSource(expectedConcreteNode, variables)
       );
     });
 
@@ -1312,22 +1303,20 @@ describe('RelayMutationQuery', () => {
         mutation,
       });
 
-      const expectedMutationQuery = getMutationWithoutClientId(
-        getNodeWithoutSource(Relay.QL`
-          mutation {
-            feedbackLike(input:$input) {
-              ${Relay.QL`
-                fragment on FeedbackLikeResponsePayload {
-                  feedback {
-                    id,
-                    likers
-                  }
+      const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
+        mutation {
+          feedbackLike(input:$input) {
+            ${Relay.QL`
+              fragment on FeedbackLikeResponsePayload {
+                feedback {
+                  id,
+                  likers
                 }
-              `},
-            }
+              }
+            `},
           }
-        `, variables)
-      );
+        }
+      `, variables);
 
       expect(query)
         .toEqualQueryNode(expectedMutationQuery);
@@ -1506,58 +1495,56 @@ describe('RelayMutationQuery', () => {
         mutation,
       });
 
-      const expectedMutationQuery = getMutationWithoutClientId(
-        getNodeWithoutSource(Relay.QL`
-          mutation {
-            commentCreate(input:$input) {
-              ${Relay.QL`
-                fragment on CommentCreateResponsePayload {
-                  feedback {
-                    id,
-                    likers,
-                  },
-                  feedbackCommentEdge {
-                    __typename
-                    cursor,
-                    node {
-                      body {
-                        text
-                      },
-                      id
+      const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
+        mutation {
+          commentCreate(input:$input) {
+            ${Relay.QL`
+              fragment on CommentCreateResponsePayload {
+                feedback {
+                  id,
+                  likers,
+                },
+                feedbackCommentEdge {
+                  __typename
+                  cursor,
+                  node {
+                    body {
+                      text
                     },
-                    source {
-                      id
-                    }
-                  }
-                }
-              `},
-              ${Relay.QL`
-                fragment on CommentCreateResponsePayload {
-                  feedback {
-                    comments(first:"10") {
-                      edges {
-                        cursor
-                        node {
-                          body {
-                            text
-                          }
-                          id
-                        }
-                      }
-                      pageInfo {
-                        hasNextPage
-                        hasPreviousPage
-                      }
-                    }
                     id
-                    likers
+                  },
+                  source {
+                    id
                   }
                 }
-              `},
-            }
+              }
+            `},
+            ${Relay.QL`
+              fragment on CommentCreateResponsePayload {
+                feedback {
+                  comments(first:"10") {
+                    edges {
+                      cursor
+                      node {
+                        body {
+                          text
+                        }
+                        id
+                      }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      hasPreviousPage
+                    }
+                  }
+                  id
+                  likers
+                }
+              }
+            `},
           }
-        `, variables)
-      );
+        }
+      `, variables);
 
       expect(query)
         .toEqualQueryNode(expectedMutationQuery);

--- a/src/mutation/__tests__/RelayMutationQueue-test.js
+++ b/src/mutation/__tests__/RelayMutationQueue-test.js
@@ -119,8 +119,9 @@ describe('RelayMutationQueue', () => {
         })
       );
       expect(storeData.handleUpdatePayload.mock.calls).toEqual([[
+        '0',
         'optimisticQuery',
-        {[RelayConnectionInterface.CLIENT_MUTATION_ID]: '0'},
+        {},
         {configs: 'optimisticConfigs', isOptimisticUpdate: true},
       ]]);
     });
@@ -137,9 +138,7 @@ describe('RelayMutationQueue', () => {
         RelayMutationQuery.buildQueryForOptimisticUpdate.mock.calls;
       expect(buildQueryCalls.length).toBe(1);
       expect(buildQueryCalls[0][0].mutation).toBe(mutationNode);
-      expect(buildQueryCalls[0][0].response).toEqual({
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]: '0',
-      });
+      expect(buildQueryCalls[0][0].response).toEqual({});
       expect(buildQueryCalls[0][0].fatQuery).toEqualQueryNode(
         flattenRelayQuery(fromGraphQL.Fragment(fatQuery), {
           preserveEmptyNodes: true,
@@ -147,8 +146,9 @@ describe('RelayMutationQueue', () => {
         })
       );
       expect(storeData.handleUpdatePayload.mock.calls).toEqual([[
+        '0',
         'optimisticQuery',
-        {[RelayConnectionInterface.CLIENT_MUTATION_ID]: '0'},
+        {},
         {configs: 'configs', isOptimisticUpdate: true},
       ]]);
     });

--- a/src/query/__tests__/RelayQueryMutation-test.js
+++ b/src/query/__tests__/RelayQueryMutation-test.js
@@ -39,7 +39,6 @@ describe('RelayQueryMutation', () => {
     mutationQuery = getNode(Relay.QL`
       mutation {
         commentCreate(input:$input) {
-          clientMutationId
           feedbackCommentEdge {
             node {id}
             source {id}
@@ -59,12 +58,9 @@ describe('RelayQueryMutation', () => {
       value: input,
     });
     const children = mutationQuery.getChildren();
-    expect(children.length).toBe(2);
-    expect(children[0].getSchemaName()).toBe(
-      RelayConnectionInterface.CLIENT_MUTATION_ID
-    );
-    expect(children[1].getSchemaName()).toBe('feedbackCommentEdge');
-    const edgeChildren = children[1].getChildren();
+    expect(children.length).toBe(1);
+    expect(children[0].getSchemaName()).toBe('feedbackCommentEdge');
+    const edgeChildren = children[0].getChildren();
     expect(edgeChildren.length).toBe(3);
     expect(edgeChildren[0].getSchemaName()).toBe('node');
     expect(edgeChildren[1].getSchemaName()).toBe('source');
@@ -78,11 +74,9 @@ describe('RelayQueryMutation', () => {
     clone = mutationQuery.clone(
       mutationQuery.getChildren().slice(0, 1)
     );
-    expect(clone).not.toBe(mutationQuery);
+    expect(clone).toBe(mutationQuery);
     expect(clone.getChildren().length).toBe(1);
-    expect(clone.getChildren()[0].getSchemaName()).toBe(
-      RelayConnectionInterface.CLIENT_MUTATION_ID
-    );
+    expect(clone.getChildren()[0].getSchemaName()).toBe('feedbackCommentEdge');
 
     clone = mutationQuery.clone([null]);
     expect(clone).toBe(null);
@@ -92,7 +86,6 @@ describe('RelayQueryMutation', () => {
     const equivalentQuery = getNode(Relay.QL`
       mutation {
         commentCreate(input:$input) {
-          clientMutationId
           feedbackCommentEdge {
             node {id}
             source {id}
@@ -103,7 +96,6 @@ describe('RelayQueryMutation', () => {
     const differentQuery = getNode(Relay.QL`
       mutation {
         commentCreate(input:$input) {
-          clientMutationId
           feedbackCommentEdge {
             cursor
             node {id}

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -59,7 +59,6 @@ const warning = require('warning');
 const writeRelayQueryPayload = require('writeRelayQueryPayload');
 const writeRelayUpdatePayload = require('writeRelayUpdatePayload');
 
-const {CLIENT_MUTATION_ID} = RelayConnectionInterface;
 const {ID, ID_TYPE, NODE, NODE_TYPE, TYPENAME} = RelayNodeInterface;
 
 const idField = RelayQuery.Field.build({
@@ -361,6 +360,7 @@ class RelayStoreData {
    * Write the results of an update into the base record store.
    */
   handleUpdatePayload(
+    clientMutationID: ClientMutationID,
     operation: RelayQuery.Operation,
     payload: {[key: string]: mixed},
     {configs, isOptimisticUpdate}: UpdateOptions
@@ -369,13 +369,6 @@ class RelayStoreData {
     const changeTracker = new RelayChangeTracker();
     let recordWriter;
     if (isOptimisticUpdate) {
-      const clientMutationID = payload[CLIENT_MUTATION_ID];
-      invariant(
-        typeof clientMutationID === 'string',
-        'RelayStoreData.handleUpdatePayload(): Expected optimistic payload ' +
-        'to have a valid `%s`.',
-        CLIENT_MUTATION_ID
-      );
       recordWriter =
         this.getRecordWriterForOptimisticMutation(clientMutationID);
     } else {
@@ -394,6 +387,7 @@ class RelayStoreData {
     );
     writeRelayUpdatePayload(
       writer,
+      clientMutationID,
       operation,
       payload,
       {configs, isOptimisticUpdate}

--- a/src/store/__tests__/RelayStoreData-test.js
+++ b/src/store/__tests__/RelayStoreData-test.js
@@ -260,7 +260,6 @@ describe('RelayStoreData', () => {
       const mutationQuery = getNode(Relay.QL`
         mutation {
           feedbackLike(input:$input) {
-            clientMutationId
             feedback {
               id
               doesViewerLike
@@ -272,7 +271,6 @@ describe('RelayStoreData', () => {
         }
       `);
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]: 'abc',
         feedback: {
           id: '123',
           doesViewerLike: false,
@@ -281,7 +279,7 @@ describe('RelayStoreData', () => {
           },
         },
       };
-      storeData.handleUpdatePayload(mutationQuery, payload, {
+      storeData.handleUpdatePayload('mutationID', mutationQuery, payload, {
         configs: [],
         isOptimisticUpdate: false,
       });
@@ -306,7 +304,6 @@ describe('RelayStoreData', () => {
       const mutationQuery = getNode(Relay.QL`
         mutation {
           feedbackLike(input:$input) {
-            clientMutationId
             feedback {
               id
               doesViewerLike
@@ -318,7 +315,6 @@ describe('RelayStoreData', () => {
         }
       `);
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]: 'abc',
         feedback: {
           id: '123',
           doesViewerLike: false,
@@ -327,10 +323,9 @@ describe('RelayStoreData', () => {
           },
         },
       };
-      storeData.handleUpdatePayload(mutationQuery, payload, {
+      storeData.handleUpdatePayload('abc', mutationQuery, payload, {
         configs: [],
         isOptimisticUpdate: true,
-        clientMutationID: 'mutationID',
       });
 
       // results are written to `queuedRecords`
@@ -389,7 +384,6 @@ describe('RelayStoreData', () => {
         const mutationQuery = getNode(Relay.QL`
           mutation {
             feedbackLike(input:$input) {
-              clientMutationId
               feedback {
                 id
                 doesViewerLike
@@ -401,7 +395,6 @@ describe('RelayStoreData', () => {
           }
         `);
         const payload = {
-          [RelayConnectionInterface.CLIENT_MUTATION_ID]: 'abc',
           feedback: {
             id: '123',
             doesViewerLike: false,
@@ -410,10 +403,9 @@ describe('RelayStoreData', () => {
             },
           },
         };
-        storeData.handleUpdatePayload(mutationQuery, payload, {
+        storeData.handleUpdatePayload('mutationID', mutationQuery, payload, {
           configs: [],
           isOptimisticUpdate: true,
-          clientMutationID: 'mutationID',
         });
 
         // simulate a server response with different data

--- a/src/store/__tests__/RelayStoreData_cacheManager-test.js
+++ b/src/store/__tests__/RelayStoreData_cacheManager-test.js
@@ -32,7 +32,7 @@ describe('RelayStoreData', function() {
   let storeData;
 
   const {getNode} = RelayTestUtils;
-  let CLIENT_MUTATION_ID, HAS_NEXT_PAGE, HAS_PREV_PAGE, PAGE_INFO;
+  let HAS_NEXT_PAGE, HAS_PREV_PAGE, PAGE_INFO;
 
   function getPathToRecord(dataID) {
     return storeData.getRecordStore().getPathToRecord(dataID);
@@ -48,7 +48,6 @@ describe('RelayStoreData', function() {
     jest.resetModuleRegistry();
 
     ({
-      CLIENT_MUTATION_ID,
       HAS_NEXT_PAGE,
       HAS_PREV_PAGE,
       PAGE_INFO,
@@ -455,7 +454,6 @@ describe('RelayStoreData', function() {
     const mutationQuery = getNode(Relay.QL`
       mutation {
         feedbackLike(input:$input) {
-          clientMutationId
           feedback {
             id
             doesViewerLike
@@ -464,13 +462,13 @@ describe('RelayStoreData', function() {
       }
     `);
     const payload = {
-      [CLIENT_MUTATION_ID]: 'abc',
       feedback: {
         id: '123',
         doesViewerLike: true,
       },
     };
     storeData.handleUpdatePayload(
+      'abc',
       mutationQuery,
       payload,
       {configs: [], isOptimisticUpdate: false}
@@ -543,7 +541,6 @@ describe('RelayStoreData', function() {
     const mutationQuery = getNode(Relay.QL`
       mutation {
         commentCreate(input:$input) {
-          clientMutationId
           feedback {
             id
             comments {
@@ -563,7 +560,6 @@ describe('RelayStoreData', function() {
       }
     `);
     const payload = {
-      [CLIENT_MUTATION_ID]: 'abc',
       feedback: {
         comments: {
           count: 3,
@@ -582,6 +578,7 @@ describe('RelayStoreData', function() {
       },
     };
     storeData.handleUpdatePayload(
+      'abc',
       mutationQuery,
       payload,
       {configs, isOptimisticUpdate: false}
@@ -664,7 +661,6 @@ describe('RelayStoreData', function() {
     const mutationQuery = getNode(Relay.QL`
       mutation {
         commentDelete(input:$input) {
-          clientMutationId
           deletedCommentId
           feedback {
             id
@@ -676,7 +672,6 @@ describe('RelayStoreData', function() {
       }
     `);
     const payload = {
-      [CLIENT_MUTATION_ID]: 'abc',
       deletedCommentId: '1',
       feedback: {
         id: '123',
@@ -686,6 +681,7 @@ describe('RelayStoreData', function() {
       },
     };
     storeData.handleUpdatePayload(
+      'abc',
       mutationQuery,
       payload,
       {configs, isOptimisticUpdate: false}

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -839,7 +839,6 @@ describe('printRelayOSSQuery', () => {
     const mutation = getNode(Relay.QL`
       mutation {
         feedbackLike(input: $input) {
-          clientMutationId
           feedback {
             id
             actor {
@@ -862,7 +861,6 @@ describe('printRelayOSSQuery', () => {
         $preset_1: PhotoSize!
       ) {
         feedbackLike(input: $input_0) {
-          clientMutationId,
           feedback {
             id,
             actor {
@@ -874,7 +872,8 @@ describe('printRelayOSSQuery', () => {
             },
             likeSentence,
             likers
-          }
+          },
+          clientMutationId
         }
       }
     `);

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -872,8 +872,7 @@ describe('printRelayOSSQuery', () => {
             },
             likeSentence,
             likers
-          },
-          clientMutationId
+          }
         }
       }
     `);

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -146,8 +146,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         feedback: {
           id: 'feedback_id',
           topLevelComments: {},
@@ -167,6 +165,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -317,8 +316,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         deletedCommentId: commentID,
         feedback: {
           id: 'feedback_id',
@@ -341,6 +338,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -402,8 +400,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         deletedCommentId: commentID,
         feedback: {
           id: 'feedback_id',
@@ -425,6 +421,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}
@@ -517,8 +514,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         actor: {
           id: '123',
           __typename: 'User',
@@ -538,6 +533,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}
@@ -927,8 +923,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         deletedCommentId: firstCommentID,
         feedback: {
           id: feedbackID,
@@ -951,6 +945,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1025,8 +1020,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         deletedCommentId: firstCommentID,
         feedback: {
           id: feedbackID,
@@ -1048,6 +1041,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}
@@ -1157,8 +1151,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         deletedRequestIds: [firstRequestID, secondRequestID],
       };
 
@@ -1175,6 +1167,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1223,8 +1216,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         deletedRequestIds: [firstRequestID, secondRequestID],
       };
 
@@ -1240,6 +1231,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}
@@ -1367,8 +1359,6 @@ describe('writeRelayUpdatePayload()', () => {
         rangeBehaviors: {'': GraphQLMutatorConstants.PREPEND},
       }];
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         feedback: {
           id: feedbackID,
           topLevelComments: {
@@ -1390,6 +1380,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1450,8 +1441,6 @@ describe('writeRelayUpdatePayload()', () => {
       const nextCursor = 'comment789:cursor';
       const nextNodeID = 'comment789';
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         feedback: {
           id: feedbackID,
           topLevelComments: {
@@ -1484,6 +1473,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1542,8 +1532,6 @@ describe('writeRelayUpdatePayload()', () => {
       const nextCursor = 'comment789:cursor';
       const nextNodeID = 'comment789';
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         feedback: {
           id: feedbackID,
           topLevelComments: {
@@ -1576,6 +1564,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1639,8 +1628,6 @@ describe('writeRelayUpdatePayload()', () => {
       const bodyID = 'client:2';
       const nextEdgeID = generateClientEdgeID(connectionID, nextNodeID);
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         feedback: {
           id: feedbackID,
           topLevelComments: {
@@ -1675,6 +1662,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1772,8 +1760,6 @@ describe('writeRelayUpdatePayload()', () => {
       const bodyID = 'client:2';
       const nextEdgeID = generateClientEdgeID(connectionID, nextNodeID);
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         feedback: {
           id: feedbackID,
           topLevelComments: {
@@ -1807,6 +1793,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        '0',
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -165,7 +165,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -197,14 +197,12 @@ describe('writeRelayUpdatePayload()', () => {
         deletedCommentId: commentID,
       };
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         feedback: {
           id: null, // Malformed response.
           topLevelComments: {},
         },
       };
-      expect(() => writeRelayUpdatePayload(queryWriter, query, payload, {configs}))
+      expect(() => writeRelayUpdatePayload(queryWriter, '0', query, payload, {configs}))
         .toFailInvariant(
           'writeRelayUpdatePayload(): Expected a record ID in the response ' +
           'payload supplied to update the store for field `feedback`, ' +
@@ -338,7 +336,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -421,7 +419,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}
@@ -533,7 +531,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}
@@ -662,8 +660,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         deletedCommentId: commentIDs,
         feedback: {
           id: 'feedback_id',
@@ -686,6 +682,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -756,8 +753,6 @@ describe('writeRelayUpdatePayload()', () => {
       }];
 
       const payload = {
-        [RelayConnectionInterface.CLIENT_MUTATION_ID]:
-          input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         deletedCommentId: commentIDs,
         feedback: {
           id: 'feedback_id',
@@ -779,6 +774,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}
@@ -945,7 +941,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1041,7 +1037,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}
@@ -1167,7 +1163,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1231,7 +1227,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}
@@ -1380,7 +1376,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1473,7 +1469,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1564,7 +1560,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1662,7 +1658,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: true}
@@ -1793,7 +1789,7 @@ describe('writeRelayUpdatePayload()', () => {
 
       writeRelayUpdatePayload(
         queryWriter,
-        '0',
+        input[RelayConnectionInterface.CLIENT_MUTATION_ID],
         mutation,
         payload,
         {configs, isOptimisticUpdate: false}

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -15,6 +15,7 @@
 const GraphQLMutatorConstants = require('GraphQLMutatorConstants');
 const RelayConnectionInterface = require('RelayConnectionInterface');
 import type {
+  ClientMutationID,
   DataID,
   UpdateOptions,
 } from 'RelayInternalTypes';
@@ -71,6 +72,7 @@ const STUB_CURSOR_ID = 'client:cursor';
  */
 function writeRelayUpdatePayload(
   writer: RelayQueryWriter,
+  clientMutationID: ClientMutationID,
   operation: RelayQuery.Operation,
   payload: PayloadObject,
   {configs, isOptimisticUpdate}: UpdateOptions
@@ -83,6 +85,7 @@ function writeRelayUpdatePayload(
       case RelayMutationType.RANGE_ADD:
         handleRangeAdd(
           writer,
+          clientMutationID,
           payload,
           operation,
           config,
@@ -312,18 +315,12 @@ function mergeField(
  */
 function handleRangeAdd(
   writer: RelayQueryWriter,
+  clientMutationID: ClientMutationID,
   payload: PayloadObject,
   operation: RelayQuery.Operation,
   config: OperationConfig,
   isOptimisticUpdate: boolean
 ): void {
-  const clientMutationID = getString(payload, CLIENT_MUTATION_ID);
-  invariant(
-    clientMutationID,
-    'writeRelayUpdatePayload(): Expected operation `%s` to have a `%s`.',
-    operation.getName(),
-    CLIENT_MUTATION_ID
-  );
   const store = writer.getRecordStore();
 
   // Extracts the new edge from the payload

--- a/website/graphql/Mutations.md
+++ b/website/graphql/Mutations.md
@@ -52,8 +52,8 @@ This section of the spec describes the formal requirements around mutations.
 
 In particular, all mutations must expose exactly one argument, named `input`.
 This argument's type must be a `NON_NULL` wrapper around an `INPUT_OBJECT`. That
-input object type must contain an argument named `clientMutationId`. That
-argument must be a `String`. That argument should be non-null.
+input object type should contain an argument named `clientMutationId`. That
+argument must be a `String`. That argument may be non-null.
 
 Clients may use whatever identifier they see fit for their `clientMutationId`s;
 Version 4 UUIDs are a reasonable choice.
@@ -61,9 +61,10 @@ Version 4 UUIDs are a reasonable choice.
 # Mutation fields
 
 The return type of any mutation field must be an object. That object may
-contain a field named `clientMutationId` which is a `String`, which should
-not be non-null. The value of this field must be the value of the
-`clientMutationId` input argument defined above.
+contain a field named `clientMutationId` which is a `String`. If `input`
+`clientMutationId` is non-null, then mutation `clientMutationId` must also be
+non-null. The value of this field must be the value of the `clientMutationId`
+input argument defined above.
 
 # Introspection
 
@@ -129,6 +130,7 @@ yields
               // May contain more fields here.
               {
                 "name": "clientMutationId",
+                // May also be NON_NULL, must match args
                 "type": {
                   "name": "String",
                   "kind": "SCALAR"
@@ -147,6 +149,7 @@ yields
                     // May contain more fields here
                     {
                       "name": "clientMutationId",
+                      // May also be NON_NULL, must match payload
                       "type": {
                         "name": "String",
                         "kind": "SCALAR"

--- a/website/graphql/Mutations.md
+++ b/website/graphql/Mutations.md
@@ -2,10 +2,11 @@ Relay Input Object Mutations Specification
 ------------------------------------------
 
 Relay's support for mutations relies on the GraphQL server exposing
-mutation fields in a standardized way. These mutations accept and emit a
-identifier string, which allows Relay to track mutations and responses.
+mutation fields in a standardized way. These mutations accept and may emit a
+identifier string, which older versions of Relay use to track mutations and
+responses.
 
-All mutations include in their input a `clientMutationId` string, which is then
+All mutations include in their input a `clientMutationId` string, which may be
 returned as part of the object returned by the mutation field.
 
 An example of this is the following query:
@@ -52,18 +53,17 @@ This section of the spec describes the formal requirements around mutations.
 In particular, all mutations must expose exactly one argument, named `input`.
 This argument's type must be a `NON_NULL` wrapper around an `INPUT_OBJECT`. That
 input object type must contain an argument named `clientMutationId`. That
-argument must be a `String`. That argument may be non-null.
+argument must be a `String`. That argument should be non-null.
 
 Clients may use whatever identifier they see fit for their `clientMutationId`s;
 Version 4 UUIDs are a reasonable choice.
 
 # Mutation fields
 
-The return type of any mutation field must be an object. That object must
-contain a field named `clientMutationId` which is a `String`. If `input`
-`clientMutationId` is non-null, then mutation `clientMutationId` must also be
-non-null. The value of this field must be the value of the `clientMutationId`
-input argument defined above.
+The return type of any mutation field must be an object. That object may
+contain a field named `clientMutationId` which is a `String`, which should
+not be non-null. The value of this field must be the value of the
+`clientMutationId` input argument defined above.
 
 # Introspection
 
@@ -129,7 +129,6 @@ yields
               // May contain more fields here.
               {
                 "name": "clientMutationId",
-                // May also be NON_NULL, must match args
                 "type": {
                   "name": "String",
                   "kind": "SCALAR"
@@ -148,7 +147,6 @@ yields
                     // May contain more fields here
                     {
                       "name": "clientMutationId",
-                      // May also be NON_NULL, must match payload
                       "type": {
                         "name": "String",
                         "kind": "SCALAR"


### PR DESCRIPTION
For issue #825

I would like to fully remove a requirement to have clientMutationId field on mutation input or payload, but currently graphql-relay-js defines these fields as non-null.  This pull request changes the spec to say that the server should make these clientMutationId fields nullable as I have done in https://github.com/graphql/graphql-relay-js/pull/79.

In order to keep compatibility for servers with non-null clientMutationId fields, this pull request continues to send the clientMutationId in the mutation input to avoid validation errors.

However, there is no need to get the clientMutationId value from the server, since the client already has it associated with the pending mutation, so it no longer even requests the clientMutationId for the response.  Instead, the handleUpdatePayload and writeRelayUpdatePayload internal functions have been updated to take the clientMutationId in an additional argument.
## Follow-up

We should stop sending automatically sending clientMutationId in the future, which will be a breaking change.  However, the only change that would be needed to handle this breaking change would be to make the clientMutationId field nullable on the server or to manually specify a clientMutationId field on the client.  At that point we can remove the need to have a clientMutationId field from the relay spec.
