### PR TITLE
Request for feedback: Add eslint-plugin-graphql to example

### DIFF
--- a/examples/TodoMVC/.eslintrc.js
+++ b/examples/TodoMVC/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  'parser': 'babel-eslint',
+  'rules': {
+    'graphql/template-strings': ['error', {
+      schemaJson: require('./data/schema.json'),
+      env: 'relay'
+    }]
+  },
+  plugins: [
+    'graphql'
+  ],
+  root: true
+}

--- a/examples/TodoMVC/package.json
+++ b/examples/TodoMVC/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "BABEL_ENV=server babel-node ./server.js",
     "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install --ignore-scripts && cd scripts/babel-relay-plugin && npm install --ignore-scripts"
+    "preinstall": "cd ../.. && npm install --ignore-scripts && cd scripts/babel-relay-plugin && npm install --ignore-scripts",
+    "lint": "eslint mutations routes containers"
   },
   "dependencies": {
     "babel-preset-es2015": "^6.5.0",
@@ -23,7 +24,10 @@
     "react-relay": "file:../../"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.4"
+    "babel-cli": "^6.6.4",
+    "babel-eslint": "^6.0.4",
+    "eslint": "^2.8.0",
+    "eslint-plugin-graphql": "^0.2.0"
   },
   "engines": {
     "npm": ">=3"


### PR DESCRIPTION
I don't know if you would want to merge this or not, but I'm working on an ESLint plugin for GraphQL validation.

![screenshot 2016-04-25 23 26 25](https://cloud.githubusercontent.com/assets/448783/14808805/40032940-0b3d-11e6-9aa2-f1cea38e0a3e.png)

The benefit over the babel relay plugin is that you can see and fix the errors right in your editor, and there's even a nice underline!

Here's the repo for the linter plugin: https://github.com/apollostack/eslint-plugin-graphql

It's not perfect yet, but I'm curious what you think of this direction, and what improvements you would want to see in such a tool!