### PR TITLE
Update jest to v12.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp-flatten": "^0.1.0",
     "gulp-header": "^1.2.2",
     "gulp-util": "^3.0.6",
-    "jest-cli": "^11.0.2",
+    "jest-cli": "^12.0.1",
     "object-assign": "^3.0.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -25,7 +25,7 @@
     "babel-cli": "^6.7.5",
     "babel-core": "^6.6.4",
     "babel-eslint": "^4.1.1",
-    "babel-jest": "^11.0.2",
+    "babel-jest": "^12.0.1",
     "babel-plugin-syntax-flow": "^6.5.0",
     "babel-plugin-syntax-object-rest-spread": "^6.5.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
@@ -36,7 +36,7 @@
     "eslint": "^1.3.1",
     "flow-bin": "0.23.0",
     "glob": "^7.0.3",
-    "jest-cli": "^11.0.2",
+    "jest-cli": "^12.0.1",
     "minimist": "^1.1.3",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5"


### PR DESCRIPTION
This jest release is compatible with node 6 and will help with adding node 6 to
our test matrix (PR #1091).