### PR TITLE
Use injectDefaultNetworkLayer in `Relay` module

### DIFF
--- a/src/__forks__/Relay.js
+++ b/src/__forks__/Relay.js
@@ -27,7 +27,8 @@ if (__DEV__) {
 }
 
 // By default, assume that GraphQL is served at `/graphql` on the same domain.
-RelayStore.injectNetworkLayer(new RelayDefaultNetworkLayer('/graphql'));
+// To override, use `Relay.injectNetworkLayer`.
+RelayStore.injectDefaultNetworkLayer(new RelayDefaultNetworkLayer('/graphql'));
 
 module.exports = {
   ...RelayPublic,


### PR DESCRIPTION
Thanks to @mailaneel for reporting this, which I missed in ed8d28ee706b31936.

Fixes https://github.com/facebook/relay/issues/1099