### PR TITLE
Added missing docs for prepareParams to Relay.Route.

### DIFF
--- a/docs/APIReference-Route.md
+++ b/docs/APIReference-Route.md
@@ -125,7 +125,7 @@ const Container = Relay.createContainer(({viewer}) => (
   }
 });
 ```
-In this example query parameters are being passed down to the `Child` component: One comes from the `ProfileRoute` via `prepareParams` and given `ProfileRoute` and `Container` are both being passed into `Relay.Renderer`, it automatically passed it down. The `Container` then passes two different `limit` variables down to the `Child` one from the `Route` and one from within.
+In this example `prepareParams` overrides any `limit` variables the route gets initialised with. Given `ProfileRoute` and `Container` are both being passed into `Relay.Renderer`, that limit variable will automatically be passed down to `Container`.
 
 ### queries (static property)
 

--- a/docs/APIReference-Route.md
+++ b/docs/APIReference-Route.md
@@ -92,38 +92,19 @@ class ProfileRoute extends Relay.Route {
     viewer: () => Relay.QL`query { viewer }`
   };
   static prepareParams = (prevParams) => {
-    // Make sure any params that ProfileRoute gets initialised with will still be passed down.
     return {
+      // Ensure any params that ProfileRoute gets initialised with will still be passed down.
       ...prevParams,
+      //  Override the `limit` variable in the top level container.
       limit: 10
     }
   }
   // ...
 }
 
-const Child = Relay.createContainer((props) => ..., {
-  initialVariables: {
-    limit: null
-  },
-  fragments: {
-    viewer: ({limit}) => Relay.QL`
-      fragment on User {
-        friends(first: $limit) {
-          edges {
-            node {
-              name
-            }
-          }
-        }
-      }
-    `
-  }
-});
-
-const Container = Relay.createContainer((props) => (
+const Container = Relay.createContainer(({viewer}) => (
   <View>
-    <Child viewer={viewer} limit={this.props.relay.variables.limit} />
-    <Child viewer={viewer} limit={20} />
+    {viewer.edges.map((node) => <div>node.name</div>)}
   </View>
   ), {
   initialVariables: {
@@ -131,10 +112,14 @@ const Container = Relay.createContainer((props) => (
   },
   fragments: {
     viewer: ({limit}) => Relay.QL`
-      fragment on User {
-        name
-        ${Child.getFragment('viewer', {limit})}
-        ${Child.getFragment('viewer', {limit: 20})}
+      fragment on Viewer {
+        friends(first: $limit) {
+          edges {
+            node {
+              name
+            }
+          }
+        }
       }
     `
   }
@@ -163,6 +148,7 @@ class ProfileRoute extends Relay.Route {
   // ...
 }
 ```
+In this example the Route should be initialised with an `userID` which gets passed on to the query. That `userID` variable will automatically be passed down to the top-level container and can be used there if needed. Further the top-level RelayContainer is expected to have a `user` fragment with the fields to be queried.
 
 ### routeName (static property)
 

--- a/docs/APIReference-Route.md
+++ b/docs/APIReference-Route.md
@@ -140,7 +140,7 @@ const Container = Relay.createContainer((props) => (
   }
 });
 ```
-In this example query parameters are being passed down to the `Child` component: One comes from the `ProfileRoute` at the top via `prepareParams`, which automatically passes them down, given `ProfileRoute` and `Container` are both being passed into `Relay.Renderer`. The `Container` then passes two different `limit` variables down to the `Child` one from the `Route` and one from within.
+In this example query parameters are being passed down to the `Child` component: One comes from the `ProfileRoute` via `prepareParams` and given `ProfileRoute` and `Container` are both being passed into `Relay.Renderer`, it automatically passed it down. The `Container` then passes two different `limit` variables down to the `Child` one from the `Route` and one from within.
 
 ### queries (static property)
 

--- a/docs/APIReference-Route.md
+++ b/docs/APIReference-Route.md
@@ -120,7 +120,12 @@ const Child = Relay.createContainer((props) => ..., {
   }
 });
 
-const Container = Relay.createContainer((props) => <Child viewer={viewer} limit={this.props.relay.variables.limit}, {
+const Container = Relay.createContainer((props) => (
+  <View>
+    <Child viewer={viewer} limit={this.props.relay.variables.limit} />
+    <Child viewer={viewer} limit={20} />
+  </View>
+  ), {
   initialVariables: {
     limit: null
   },
@@ -129,12 +134,13 @@ const Container = Relay.createContainer((props) => <Child viewer={viewer} limit=
       fragment on User {
         name
         ${Child.getFragment('viewer', {limit})}
+        ${Child.getFragment('viewer', {limit: 20})}
       }
     `
   }
 });
 ```
-In this example query parameters are being passed down to a child component. `prepareParams` is being used to create the params and given that the `ProfileRoute` and the `Container` are both being passed into `Relay.Renderer` the `Container` will set the `limit` variable in `Child`.
+In this example query parameters are being passed down to the `Child` component: One comes from the `ProfileRoute` at the top via `prepareParams`, which automatically passes them down, given `ProfileRoute` and `Container` are both being passed into `Relay.Renderer`. The `Container` then passes two different `limit` variables down to the `Child` one from the `Route` and one from within.
 
 ### queries (static property)
 

--- a/docs/APIReference-Route.md
+++ b/docs/APIReference-Route.md
@@ -111,7 +111,7 @@ const Container = Relay.createContainer(({viewer}) => (
     limit: null
   },
   fragments: {
-    viewer: ({limit}) => Relay.QL`
+    viewer: () => Relay.QL`
       fragment on Viewer {
         friends(first: $limit) {
           edges {

--- a/docs/APIReference-Route.md
+++ b/docs/APIReference-Route.md
@@ -104,7 +104,7 @@ class ProfileRoute extends Relay.Route {
 
 const Container = Relay.createContainer(({viewer}) => (
   <View>
-    {viewer.edges.map((node) => <div>node.name</div>)}
+    {viewer.edges.map((edge) => <div>edge.node.name</div>)}
   </View>
   ), {
   initialVariables: {


### PR DESCRIPTION
Given the issue https://github.com/facebook/relay/issues/1101 and that there are no docs for `prepareParams` yet I thought I could do both at once.

I haven't actually tested this example out as such, but assuming that `prepareParams` in `react-router-relay` (https://github.com/relay-tools/react-router-relay/tree/6c36030e8bdfba7ca2e344a6436135610b6e2256#additional-parameters) do behave exactly the same as stated.