### PR TITLE
Fix formatErrors when offset is negative

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -190,7 +190,7 @@ function formatRequestErrors(
         const offset = Math.min(column - 1, CONTEXT_BEFORE);
         return [
           queryLine.substr(column - 1 - offset, CONTEXT_LENGTH),
-          ' '.repeat(offset) + '^^^',
+          ' '.repeat(Math.max(0, offset)) + '^^^',
         ].map(messageLine => indent + messageLine).join('\n');
       }).join('\n')) :
       '';

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -174,6 +174,34 @@ describe('RelayDefaultNetworkLayer', () => {
       expect(error.source).toEqual(response);
     });
 
+    it('handles errors with column 0', () => {
+      const response = {
+        errors: [{
+          message: 'Something went wrong.',
+          locations: [{
+            column: 0,
+            line: 1,
+          }],
+        }],
+      };
+
+      fetch.mock.deferreds[0].resolve(genResponse(response));
+      jest.runAllTimers();
+
+      expect(rejectCallback.mock.calls.length).toBe(1);
+      const error = rejectCallback.mock.calls[0][0];
+      expect(error instanceof Error).toBe(true);
+      expect(error.message).toEqual([
+        'Server request for mutation \`FeedbackLikeMutation\` failed for the ' +
+          'following reasons:',
+        '',
+        '1. Something went wrong.',
+        '   ' + request.getQueryString().substr(0, 60),
+        '   ^^^',
+      ].join('\n'));
+      expect(error.source).toEqual(response);
+    });
+
     it('handles custom errors', () => {
       const response = {
         errors: [{


### PR DESCRIPTION
I was looking at this stackoverflow question: https://stackoverflow.com/questions/36948277/relay-js-error-repeat-argument-must-be-greater-than-or-equal-to-0-and-not-be

It seems like if your server returns errors with column `0`, offset would be `-1`, and `repeat` would 💥  because `.repeat` takes a count argument which is
> An integer between 0 and +∞.

This fix is just `Math.max(0, offset)`.

I was looking for the spec for errors, I'm not totally sure if `0` is an accepted value for column in the first place so I might be missing context.