### PR TITLE
Use async function for async test

### DIFF
--- a/src/mutation/__tests__/RelayGraphQLMutation-test.js
+++ b/src/mutation/__tests__/RelayGraphQLMutation-test.js
@@ -294,7 +294,7 @@ describe('RelayGraphQLMutation', () => {
     });
 
     describe('updating an existing node', () => {
-      it('can toggle a boolean', () => {
+      pit('can toggle a boolean', async () => {
         writePayload(
           getNode(Relay.QL`
             query {
@@ -400,8 +400,7 @@ describe('RelayGraphQLMutation', () => {
             },
           },
         };
-        request.resolve(result);
-        jest.runAllTimers();
+        await request.resolve(result);
 
         // Item is removed from queue.
         expect(() => queue.getStatus(id))


### PR DESCRIPTION
This is a followup on 581d87a to try out if async functions are supported on our
different targets to make some code more readable.