### PR TITLE
Remove excess semicolon after `export` statement

### DIFF
--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -58,7 +58,7 @@ export function checkHidingSpotForTreasure(id) {
   turnsRemaining--;
   var hidingSpot = getHidingSpot(id);
   hidingSpot.hasBeenChecked = true;
-};
+}
 export function getHidingSpot(id) {
   return hidingSpots.find(hs => hs.id === id)
 }


### PR DESCRIPTION
Very minor and trivial change, but the excess semicolon shouldn't be there for an export statement. Might confuse the less experienced! :)