### PR TITLE
Use alias when constructing serialization key

### DIFF
--- a/src/query/RelayQuery.js
+++ b/src/query/RelayQuery.js
@@ -1124,13 +1124,16 @@ class RelayQueryField extends RelayQueryNode {
   getSerializationKey(): string {
     let serializationKey = this.__serializationKey__;
     if (!serializationKey) {
-      serializationKey = generateRQLFieldAlias(
-        this.getSchemaName() +
-        this.getCallsWithValues()
-          .map(serializeRelayQueryCall)
-          .sort()
-          .join('')
-      );
+      let key = this.getSchemaName();
+      const alias = (this.__concreteNode__: ConcreteField).alias;
+      if (alias != null) {
+        key += '.' + alias;
+      }
+      key += this.getCallsWithValues()
+        .map(serializeRelayQueryCall)
+        .sort()
+        .join('');
+      serializationKey = generateRQLFieldAlias(key);
       this.__serializationKey__ = serializationKey;
     }
     return serializationKey;

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -260,20 +260,23 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query FooQuery {
           defaultSettings {
+            env: notifications(environment: $env)
             web: notifications(environment: WEB)
-            foo: notifications(environment: $env)
           }
         }
       `, {
         env: enumValue,
       });
-      const alias = generateRQLFieldAlias('notifications.environment(WEB)');
+      const envAlias =
+        generateRQLFieldAlias('notifications.env.environment(WEB)');
+      const webAlias =
+        generateRQLFieldAlias('notifications.web.environment(WEB)');
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
         query FooQuery($environment_0: Environment!) {
           defaultSettings {
-            ${alias}: notifications(environment: $environment_0),
-            ${alias}: notifications(environment: $environment_0)
+            ${envAlias}: notifications(environment: $environment_0),
+            ${webAlias}: notifications(environment: $environment_0)
           }
         }
       `);
@@ -302,7 +305,10 @@ describe('printRelayOSSQuery', () => {
         query1,
         query2,
       });
-      const alias = generateRQLFieldAlias('storySearch.query({"query":"foo"})');
+      const fooAlias =
+        generateRQLFieldAlias('storySearch.foo.query({"query":"foo"})');
+      const barAlias =
+        generateRQLFieldAlias('storySearch.bar.query({"query":"foo"})');
       const {text, variables} = printRelayOSSQuery(query);
       expect(text).toEqualPrintedQuery(`
         query FooQuery($id_0: ID!, $query_1: StorySearchInput!) {
@@ -313,10 +319,10 @@ describe('printRelayOSSQuery', () => {
           }
         }
         fragment F0 on User {
-          ${alias}: storySearch(query: $query_1) {
+          ${fooAlias}: storySearch(query: $query_1) {
             id
           },
-          ${alias}: storySearch(query: $query_1) {
+          ${barAlias}: storySearch(query: $query_1) {
             id
           },
           id


### PR DESCRIPTION
Relay can currently construct invalid GraphQL in the case where two sibling fields end up with the same calls & values. For example in the following, Relay would produce the same serialization key (alias) if $env = WEB:

```graphql
fragment on Foo {
  defaultSettings {
    web: notifications(environment: WEB)
    foo: notifications(environment: $env)
  }
}
```

This PR ensures that unique aliases are produced in this case by using both the canonical schema name *and* the alias (if defined) when constructing the alias (in addition to calls & values).