### PR TITLE
Set branch on travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Relay](https://facebook.github.io/relay/) [![Build Status](https://travis-ci.org/facebook/relay.svg)](https://travis-ci.org/facebook/relay) [![npm version](https://badge.fury.io/js/react-relay.svg)](http://badge.fury.io/js/react-relay)
+# [Relay](https://facebook.github.io/relay/) [![Build Status](https://travis-ci.org/facebook/relay.svg?branch=master)](https://travis-ci.org/facebook/relay) [![npm version](https://badge.fury.io/js/react-relay.svg)](http://badge.fury.io/js/react-relay)
 
 Relay is a JavaScript framework for building data-driven React applications.
 


### PR DESCRIPTION
In case we have a feature branch on the main repo, we should still show the build status from master instead of the most recent build.