### PR TITLE
Remove trailing commas in GraphQL fragments

### DIFF
--- a/src/container/__tests__/RelayContainer-test.js
+++ b/src/container/__tests__/RelayContainer-test.js
@@ -110,7 +110,7 @@ describe('RelayContainer', function() {
         fragments: {
           viewer: Relay.QL`
             fragment on Viewer {
-              newsFeed,
+              newsFeed
             }
           `,
         },
@@ -182,8 +182,8 @@ describe('RelayContainer', function() {
         fragments: {
           user: () => Relay.QL`
             fragment on Actor {
-              id,
-              name,
+              id
+              name
               ${MockProfileLink.getFragment('user')}
             }
           `,
@@ -193,7 +193,7 @@ describe('RelayContainer', function() {
         fragments: {
           user: () => Relay.QL`
             fragment on Actor {
-              id,
+              id
               url
             }
           `,
@@ -205,9 +205,9 @@ describe('RelayContainer', function() {
       );
       expect(fragment).toEqualQueryNode(getNode(Relay.QL`
         fragment on Actor {
-          id,
-          __typename,
-          name,
+          id
+          __typename
+          name
           ${Relay.QL`
             fragment on Actor {
               id,
@@ -255,7 +255,7 @@ describe('RelayContainer', function() {
         fragments: {
           viewer: variables => Relay.QL`
             fragment on Viewer {
-              ${MockProfile.getFragment('viewer').if(variables.hasSideshow)},
+              ${MockProfile.getFragment('viewer').if(variables.hasSideshow)}
             }
           `,
         },
@@ -295,7 +295,7 @@ describe('RelayContainer', function() {
             fragment on Viewer {
               ${MockProfile
                 .getFragment('viewer')
-                .unless(variables.hasSideshow)},
+                .unless(variables.hasSideshow)}
             }
           `,
         },

--- a/src/container/__tests__/RelayContainer_setVariables-test.js
+++ b/src/container/__tests__/RelayContainer_setVariables-test.js
@@ -672,10 +672,10 @@ describe('RelayContainer.setVariables', function() {
       const MockInnerContainer = Relay.createContainer(MockInnerComponent, {
         fragments: {
           entity: () => Relay.QL`  fragment on Actor {
-                        url(site:$site),
+                        url(site:$site)
                         profilePicture(size:$size) {
-                          uri,
-                        },
+                          uri
+                        }
                       }`,
         },
         initialVariables: {

--- a/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
+++ b/src/legacy/store/__tests__/GraphQLStoreQueryResolver-test.js
@@ -57,8 +57,8 @@ describe('GraphQLStoreQueryResolver', () => {
     mockQueryFragment = getNode(Relay.QL`fragment on Node{id,name}`);
     mockPluralQueryFragment = getNode(Relay.QL`
       fragment on Node @relay(plural:true) {
-        id,
-        name,
+        id
+        name
       }
     `);
 

--- a/src/mutation/__tests__/RelayMutation-test.js
+++ b/src/mutation/__tests__/RelayMutation-test.js
@@ -57,7 +57,7 @@ describe('RelayMutation', function() {
           `,
           bar: () => Relay.QL`
             fragment on Node {
-              id,
+              id
             }
           `,
         };

--- a/src/mutation/__tests__/RelayMutationQuery-test.js
+++ b/src/mutation/__tests__/RelayMutationQuery-test.js
@@ -58,7 +58,7 @@ describe('RelayMutationQuery', () => {
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on ActorSubscribeResponsePayload {
           subscribee {
-            subscribers,
+            subscribers
             subscribeStatus
           }
         }
@@ -80,14 +80,14 @@ describe('RelayMutationQuery', () => {
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on FeedbackLikeResponsePayload {
           feedback {
-            doesViewerLike,
-            likers,
+            doesViewerLike
+            likers
           }
         }
       `);
       tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
         fragment on Feedback {
-          likers,
+          likers
           url
         }
       `));
@@ -124,7 +124,7 @@ describe('RelayMutationQuery', () => {
         fragment on Story {
           message {
             text
-          },
+          }
           seenState
         }
       `));
@@ -169,7 +169,7 @@ describe('RelayMutationQuery', () => {
           fragment on Story {
             actors {
               name
-            },
+            }
             seenState
           }
         `),
@@ -188,18 +188,18 @@ describe('RelayMutationQuery', () => {
       const expected = RelayTestUtils.getVerbatimNode(Relay.QL`
         fragment on Story {
           ... on Story {
-            id,
+            id
             message {
               text
-            },
-          },
+            }
+          }
           ... on Story {
-            id,
+            id
             actors {
-              __typename,
-              id,
+              __typename
+              id
               name
-            },
+            }
             seenState
           }
         }
@@ -220,7 +220,7 @@ describe('RelayMutationQuery', () => {
       fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on CommentDeleteResponsePayload {
           feedback {
-            comments,
+            comments
             topLevelComments
           }
         }
@@ -244,9 +244,9 @@ describe('RelayMutationQuery', () => {
     it('creates a fragment for connection metadata', () => {
       tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
         fragment on Feedback {
-          doesViewerLike,
+          doesViewerLike
           comments(first:"10") {
-            count,
+            count
             edges {
               node {
                 body {
@@ -362,13 +362,13 @@ describe('RelayMutationQuery', () => {
       fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on CommentCreateResponsePayload {
           feedback {
-            comments,
+            comments
             topLevelComments
-          },
-          comment,
+          }
+          comment
           feedbackCommentEdge {
-            cursor,
-            node,
+            cursor
+            node
             source
           }
         }
@@ -452,14 +452,14 @@ describe('RelayMutationQuery', () => {
         fragment MutationQuery on CommentCreateResponsePayload {
           feedback {
             id
-          },
+          }
           feedbackCommentEdge {
-            __typename,
-            cursor,
+            __typename
+            cursor
             node{
               body {
                 text
-              },
+              }
               id
             }
           }
@@ -495,13 +495,13 @@ describe('RelayMutationQuery', () => {
         fragment on CommentCreateResponsePayload {
           feedbackCommentEdge {
             __typename
-            cursor,
+            cursor
             node {
               body {
                 text
-              },
+              }
               id
-            },
+            }
             source {
               id
             }
@@ -547,13 +547,13 @@ describe('RelayMutationQuery', () => {
         fragment on CommentCreateResponsePayload {
           feedbackCommentEdge {
             __typename
-            cursor,
+            cursor
             node {
               body {
                 text
-              },
+              }
               id
-            },
+            }
             source {
               id
             }
@@ -572,7 +572,7 @@ describe('RelayMutationQuery', () => {
       tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
         fragment on Feedback {
           comments(first:"10") {
-            count,
+            count
             edges {
               node {
                 body {
@@ -580,7 +580,7 @@ describe('RelayMutationQuery', () => {
                 }
               }
             }
-          },
+          }
           comments(last:10) {
             edges {
               node {
@@ -604,16 +604,16 @@ describe('RelayMutationQuery', () => {
         fragment on CommentCreateResponsePayload {
           feedbackCommentEdge {
             __typename
-            cursor,
+            cursor
             node {
               author {
                 name
-              },
+              }
               body {
                 text
-              },
+              }
               id
-            },
+            }
             source {
               id
             }
@@ -628,7 +628,7 @@ describe('RelayMutationQuery', () => {
       tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
         fragment on Feedback {
           comments(first:"10") {
-            count,
+            count
             edges {
               node {
                 body {
@@ -636,7 +636,7 @@ describe('RelayMutationQuery', () => {
                 }
               }
             }
-          },
+          }
           comments(orderby:"ranked_threaded",first:"10") {
             edges {
               node {
@@ -660,13 +660,13 @@ describe('RelayMutationQuery', () => {
         fragment on CommentCreateResponsePayload {
           feedbackCommentEdge {
             __typename
-            cursor,
+            cursor
             node {
               body {
                 text
-              },
+              }
               id
-            },
+            }
             source {
               id
             }
@@ -900,7 +900,7 @@ describe('RelayMutationQuery', () => {
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on FeedbackLikeResponsePayload {
           feedback {
-            doesViewerLike,
+            doesViewerLike
             likers
           }
         }
@@ -924,8 +924,8 @@ describe('RelayMutationQuery', () => {
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on FeedbackLikeResponsePayload {
           feedback {
-            doesViewerLike,
-            likers,
+            doesViewerLike
+            likers
           }
         }
       `);
@@ -991,14 +991,14 @@ describe('RelayMutationQuery', () => {
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on CommentCreateResponsePayload {
           feedback {
-            comments,
-          },
-          comment,
+            comments
+          }
+          comment
           feedbackCommentEdge {
-            cursor,
-            node,
-            source,
-          },
+            cursor
+            node
+            source
+          }
         }
       `);
       const parentName = 'feedback';
@@ -1034,7 +1034,7 @@ describe('RelayMutationQuery', () => {
         getNodeWithoutSource(Relay.QL`
           mutation {
             commentCreate(input:$input) {
-              clientMutationId,
+              clientMutationId
               ... on CommentCreateResponsePayload {
                 feedback {
                   ... on Feedback {
@@ -1043,13 +1043,13 @@ describe('RelayMutationQuery', () => {
                 }
                 feedbackCommentEdge {
                   __typename
-                  cursor,
+                  cursor
                   node {
                     body {
                       text
-                    },
+                    }
                     id
-                  },
+                  }
                   source{
                     id
                   }
@@ -1081,7 +1081,7 @@ describe('RelayMutationQuery', () => {
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on CommentDeleteResponsePayload {
           feedback {
-            comments,
+            comments
             topLevelComments
           }
         }
@@ -1114,7 +1114,7 @@ describe('RelayMutationQuery', () => {
       const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
         mutation {
           commentDelete(input:$input) {
-            clientMutationId,
+            clientMutationId
             ${Relay.QL`
               fragment on CommentDeleteResponsePayload {
                 feedback {
@@ -1152,7 +1152,7 @@ describe('RelayMutationQuery', () => {
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on CommentDeleteResponsePayload {
           feedback {
-            comments,
+            comments
             topLevelComments
           }
         }
@@ -1185,7 +1185,7 @@ describe('RelayMutationQuery', () => {
       const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
         mutation {
           commentDelete(input:$input) {
-            clientMutationId,
+            clientMutationId
             ${Relay.QL`
               fragment on CommentDeleteResponsePayload {
                 feedback {
@@ -1251,7 +1251,7 @@ describe('RelayMutationQuery', () => {
       const expectedConcreteNode = Relay.QL`
         mutation {
           unfriend(input: $input) {
-            clientMutationId,
+            clientMutationId
             ${Relay.QL`
               fragment on UnfriendResponsePayload {
                 actor {
@@ -1277,14 +1277,14 @@ describe('RelayMutationQuery', () => {
     it('creates a query for FIELDS_CHANGE', () => {
       tracker.getTrackedChildrenForID.mockReturnValue(getNodeChildren(Relay.QL`
         fragment on Feedback {
-          likers,
+          likers
           url
         }
       `));
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on FeedbackLikeResponsePayload {
           feedback {
-            doesViewerLike,
+            doesViewerLike
             likers
           }
         }
@@ -1313,7 +1313,7 @@ describe('RelayMutationQuery', () => {
       const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
         mutation {
           feedbackLike(input:$input) {
-            clientMutationId,
+            clientMutationId
             ${Relay.QL`
               fragment on FeedbackLikeResponsePayload {
                 feedback {
@@ -1347,14 +1347,14 @@ describe('RelayMutationQuery', () => {
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on CommentCreateResponsePayload {
           feedback {
-            comments,
-          },
-          comment,
+            comments
+          }
+          comment
           feedbackCommentEdge {
-            cursor,
-            node,
-            source,
-          },
+            cursor
+            node
+            source
+          }
         }
       `);
       const parentName = 'feedback';
@@ -1378,8 +1378,8 @@ describe('RelayMutationQuery', () => {
           children: [Relay.QL`
             fragment on CommentCreateResponsePayload {
               feedback {
-                doesViewerLike,
-              },
+                doesViewerLike
+              }
             }
           `],
         },
@@ -1400,7 +1400,7 @@ describe('RelayMutationQuery', () => {
         getNodeWithoutSource(Relay.QL`
           mutation {
             commentCreate(input:$input) {
-              clientMutationId,
+              clientMutationId
               ... on CommentCreateResponsePayload {
                 feedback {
                   ... on Feedback {
@@ -1409,13 +1409,13 @@ describe('RelayMutationQuery', () => {
                 }
                 feedbackCommentEdge {
                   __typename
-                  cursor,
+                  cursor
                   node {
                     body {
                       text
-                    },
+                    }
                     id
-                  },
+                  }
                   source {
                     id
                   }
@@ -1425,7 +1425,7 @@ describe('RelayMutationQuery', () => {
                 feedback {
                   doesViewerLike
                   id
-                },
+                }
               }
             }
           }
@@ -1448,24 +1448,24 @@ describe('RelayMutationQuery', () => {
                 }
               }
             }
-          },
-          likers,
+          }
+          likers
           url
         }
       `));
       const fatQuery = fromGraphQL.Fragment(Relay.QL`
         fragment on CommentCreateResponsePayload {
           feedback {
-            comments,
-            doesViewerLike,
+            comments
+            doesViewerLike
             likers
-          },
-          comment,
+          }
+          comment
           feedbackCommentEdge {
-            cursor,
-            node,
-            source,
-          },
+            cursor
+            node
+            source
+          }
         }
       `);
       const parentName = 'feedback';
@@ -1507,7 +1507,7 @@ describe('RelayMutationQuery', () => {
       const expectedMutationQuery = getNodeWithoutSource(Relay.QL`
         mutation {
           commentCreate(input:$input) {
-            clientMutationId,
+            clientMutationId
             ${Relay.QL`
               fragment on CommentCreateResponsePayload {
                 feedback {
@@ -1534,21 +1534,21 @@ describe('RelayMutationQuery', () => {
                 feedback {
                   comments(first:"10") {
                     edges {
-                      cursor,
+                      cursor
                       node {
                         body {
                           text
-                        },
+                        }
                         id
                       }
-                    },
+                    }
                     pageInfo {
-                      hasNextPage,
+                      hasNextPage
                       hasPreviousPage
                     }
-                  },
-                  id,
-                  likers,
+                  }
+                  id
+                  likers
                 }
               }
             `},

--- a/src/mutation/__tests__/RelayOptimisticMutationUtils-test.js
+++ b/src/mutation/__tests__/RelayOptimisticMutationUtils-test.js
@@ -56,7 +56,7 @@ describe('RelayOptimisticMutationUtils', () => {
       });
       expect(query).toEqualFields(Relay.QL`
         fragment on Actor {
-          id,
+          id
         }
       `);
       expect(query[0].isPlural()).toBe(false);
@@ -68,8 +68,8 @@ describe('RelayOptimisticMutationUtils', () => {
         name: 'Alice',
       })).toEqualFields(Relay.QL`
         fragment on Actor {
-          id,
-          name,
+          id
+          name
         }
       `);
     });
@@ -83,10 +83,10 @@ describe('RelayOptimisticMutationUtils', () => {
       });
       expect(fields).toEqualFields(Relay.QL`
         fragment on Actor {
-          id,
+          id
           address {
-            city,
-          },
+            city
+          }
         }
       `);
       expect(fields[1].canHaveSubselections()).toBe(true);
@@ -119,8 +119,8 @@ describe('RelayOptimisticMutationUtils', () => {
       });
       expect(fields).toEqualFields(Relay.QL`
         fragment on Actor {
-          id,
-          websites,
+          id
+          websites
         }
       `);
       expect(fields[1].isPlural()).toBe(true);
@@ -136,10 +136,10 @@ describe('RelayOptimisticMutationUtils', () => {
       });
       expect(fields).toEqualFields(Relay.QL`
         fragment on Actor {
-          id,
+          id
           screennames {
-            service,
-          },
+            service
+          }
         }
       `);
       expect(fields[1].isPlural()).toBe(true);
@@ -151,8 +151,8 @@ describe('RelayOptimisticMutationUtils', () => {
         websites: [],
       })).toEqualFields(Relay.QL`
         fragment on Actor {
-          id,
-          websites,
+          id
+          websites
         }
       `);
     });
@@ -163,8 +163,8 @@ describe('RelayOptimisticMutationUtils', () => {
         websites: [null],
       })).toEqualFields(Relay.QL`
         fragment on Actor {
-          id,
-          websites,
+          id
+          websites
         }
       `);
     });
@@ -175,8 +175,8 @@ describe('RelayOptimisticMutationUtils', () => {
         'url(site: "www")': 'https://...',
       })).toEqualFields(Relay.QL`
         fragment on Actor {
-          id,
-          url(site: "www"),
+          id
+          url(site: "www")
         }
       `);
     });
@@ -186,7 +186,7 @@ describe('RelayOptimisticMutationUtils', () => {
         'url(relative: true)': '//...',
       })).toEqualFields(Relay.QL`
         fragment on Actor {
-          url(relative: true),
+          url(relative: true)
         }
       `);
     });
@@ -199,7 +199,7 @@ describe('RelayOptimisticMutationUtils', () => {
       })).toEqualFields(Relay.QL`
         fragment on Comment {
           comments(last: 10) {
-            count,
+            count
           }
         }
       `);
@@ -241,20 +241,20 @@ describe('RelayOptimisticMutationUtils', () => {
         },
       })).toEqualFields(Relay.QL`
         fragment on Actor {
-          id,
+          id
           friends(first: "2") {
             edges {
               node {
-                id,
-                name,
-              },
-              cursor,
-            },
+                id
+                name
+              }
+              cursor
+            }
             pageInfo {
-              hasNextPage,
-              hasPreviousPage,
-            },
-          },
+              hasNextPage
+              hasPreviousPage
+            }
+          }
         }
       `);
     });
@@ -268,7 +268,7 @@ describe('RelayOptimisticMutationUtils', () => {
       })).toEqualFields(Relay.QL`
         fragment on NodeSavedStateResponsePayload {
           node {
-            id,
+            id
             name
           }
         }
@@ -284,8 +284,8 @@ describe('RelayOptimisticMutationUtils', () => {
         name: 'Alice',
       })).toEqualFields(Relay.QL`
         fragment on Node {
-          id,
-          name,
+          id
+          name
         }
       `);
     });

--- a/src/query/__tests__/RelayFragmentReference-test.js
+++ b/src/query/__tests__/RelayFragmentReference-test.js
@@ -35,8 +35,8 @@ describe('RelayFragmentReference', () => {
     const node = Relay.QL`
       fragment on User {
         profilePicture(size:$size) {
-          uri,
-        },
+          uri
+        }
       }
     `;
     // equivalent to `getQuery('foo')` without variables
@@ -59,8 +59,8 @@ describe('RelayFragmentReference', () => {
     const node = Relay.QL`
       fragment on User {
         profilePicture(size:$size) {
-          uri,
-        },
+          uri
+        }
       }
     `;
     // equivalent to `getQuery('foo', {size: variables.outerSize})`

--- a/src/query/__tests__/RelayQuery-test.js
+++ b/src/query/__tests__/RelayQuery-test.js
@@ -428,10 +428,10 @@ describe('RelayQuery', () => {
     it('expands fragment references', () => {
       const innerFragment = Relay.QL`
         fragment on User {
-          id,
+          id
           profilePicture(size:$size) {
-            uri,
-          },
+            uri
+          }
         }
       `;
       const reference = new RelayFragmentReference(
@@ -445,8 +445,8 @@ describe('RelayQuery', () => {
       );
       const fragment = getNode(Relay.QL`
         fragment on User {
-          id,
-          ${reference},
+          id
+          ${reference}
         }
       `, {
         outerSize: 'override',

--- a/src/query/__tests__/RelayQueryField-test.js
+++ b/src/query/__tests__/RelayQueryField-test.js
@@ -56,10 +56,10 @@ describe('RelayQueryField', () => {
           friends(first:"1") {
             edges {
               node {
-                special_id: id,
-              },
-            },
-          },
+                special_id: id
+              }
+            }
+          }
         }
       }
     `);
@@ -235,8 +235,8 @@ describe('RelayQueryField', () => {
     const query = getNode(Relay.QL`
       fragment on Story {
         feedback {
-          id,
-          canViewerComment,
+          id
+          canViewerComment
         }
       }
     `).getChildren()[0];

--- a/src/query/__tests__/RelayQueryFragment-test.js
+++ b/src/query/__tests__/RelayQueryFragment-test.js
@@ -74,7 +74,7 @@ describe('RelayQueryFragment', () => {
     `;
     const fragment2 = getNode(Relay.QL`
       fragment on StreetAddress {
-        city,
+        city
         ${subfrag}
       }
     `);
@@ -91,7 +91,7 @@ describe('RelayQueryFragment', () => {
     `;
     const fragment2 = getNode(Relay.QL`
       fragment on StreetAddress {
-        country,
+        country
         ${subfrag}
       }
     `);
@@ -139,8 +139,8 @@ describe('RelayQueryFragment', () => {
   it('clones with updated children', () => {
     const query = getNode(Relay.QL`
       fragment on StreetAddress {
-        country,
-        city,
+        country
+        city
       }
     `);
     const clone = query.clone([query.getChildren()[0]]);

--- a/src/query/__tests__/RelayQueryMutation-test.js
+++ b/src/query/__tests__/RelayQueryMutation-test.js
@@ -39,9 +39,9 @@ describe('RelayQueryMutation', () => {
     mutationQuery = getNode(Relay.QL`
       mutation {
         commentCreate(input:$input) {
-          clientMutationId,
+          clientMutationId
           feedbackCommentEdge {
-            node {id},
+            node {id}
             source {id}
           }
         }
@@ -92,9 +92,9 @@ describe('RelayQueryMutation', () => {
     const equivalentQuery = getNode(Relay.QL`
       mutation {
         commentCreate(input:$input) {
-          clientMutationId,
+          clientMutationId
           feedbackCommentEdge {
-            node {id},
+            node {id}
             source {id}
           }
         }
@@ -103,10 +103,10 @@ describe('RelayQueryMutation', () => {
     const differentQuery = getNode(Relay.QL`
       mutation {
         commentCreate(input:$input) {
-          clientMutationId,
+          clientMutationId
           feedbackCommentEdge {
-            cursor,
-            node {id},
+            cursor
+            node {id}
             source {id}
           }
         }

--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -32,8 +32,8 @@ describe('RelayQueryRoot', () => {
     me = getNode(Relay.QL`
       query {
         me {
-          name1: firstName,
-          name1: lastName,
+          name1: firstName
+          name1: lastName
         }
       }
     `);
@@ -41,7 +41,7 @@ describe('RelayQueryRoot', () => {
     usernames = getNode(Relay.QL`
       query {
         usernames(names:"mroch") {
-          firstName,
+          firstName
         }
       }
     `);
@@ -80,12 +80,12 @@ describe('RelayQueryRoot', () => {
     const query = getNode(Relay.QL`
       query {
         me {
-          id,
-          firstName @skip(if: $true),
-          lastName @include(if: $false),
-          name @skip(if: $true) @include(if: false),
-          emailAddresses @skip(if: $true) @include(if: true),
-          username @skip(if: $false) @include(if: false),
+          id
+          firstName @skip(if: $true)
+          lastName @include(if: $false)
+          name @skip(if: $true) @include(if: false)
+          emailAddresses @skip(if: $true) @include(if: true)
+          username @skip(if: $false) @include(if: false)
         }
       }
     `, {true: true, false: false});
@@ -98,10 +98,10 @@ describe('RelayQueryRoot', () => {
     const query = getNode(Relay.QL`
       query {
         me {
-          id,
-          firstName @skip(if: $false),
-          lastName @include(if: $true),
-          name @skip(if: false) @include(if: $true),
+          id
+          firstName @skip(if: $false)
+          lastName @include(if: $true)
+          name @skip(if: false) @include(if: $true)
         }
       }
     `, {false: false, true: true});
@@ -144,7 +144,7 @@ describe('RelayQueryRoot', () => {
     const query = getNode(Relay.QL`
       query {
         me {
-          firstName,
+          firstName
           lastName
         }
       }
@@ -236,8 +236,8 @@ describe('RelayQueryRoot', () => {
     const me2 = getNode(Relay.QL`
       query {
         me {
-          name1: firstName,
-          name1: lastName,
+          name1: firstName
+          name1: lastName
         }
       }
     `);
@@ -245,7 +245,7 @@ describe('RelayQueryRoot', () => {
     const usernames2 = getNode(Relay.QL`
       query {
         usernames(names:"mroch") {
-          firstName,
+          firstName
         }
       }
     `);
@@ -264,8 +264,8 @@ describe('RelayQueryRoot', () => {
     const me2 = getNode(Relay.QL`
       query {
         me {
-          name1: firstName,
-          lastName,
+          name1: firstName
+          lastName
         }
       }
     `);
@@ -273,7 +273,7 @@ describe('RelayQueryRoot', () => {
     const usernames2 = getNode(Relay.QL`
       query {
         usernames(names:"mroch") {
-          firstName,
+          firstName
           lastName
         }
       }
@@ -366,7 +366,7 @@ describe('RelayQueryRoot', () => {
    const query = getNode(Relay.QL`
      query {
        checkinSearchQuery(query: {query: "Facebook"}) {
-         query,
+         query
        }
      }
    `);
@@ -384,7 +384,7 @@ describe('RelayQueryRoot', () => {
    const query = getNode(Relay.QL`
      query {
        route(waypoints: [
-         {lat: "0.0", lon: "0.0"},
+         {lat: "0.0", lon: "0.0"}
          {lat: "1.1", lon: "1.1"}
        ]) {
          steps {

--- a/src/query/__tests__/RelayQueryTransform-test.js
+++ b/src/query/__tests__/RelayQueryTransform-test.js
@@ -33,8 +33,8 @@ describe('RelayQueryTransform', () => {
         friends(first:$first,after:$after) {
           edges {
             node {
-              id,
-              name,
+              id
+              name
               address {
                 city
               }
@@ -46,15 +46,15 @@ describe('RelayQueryTransform', () => {
     query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
-          ${fragment},
+          id
+          ${fragment}
           friends(first:$first,after:$after) {
             edges {
               node {
-                id,
-                lastName,
+                id
+                lastName
                 address {
-                  city,
+                  city
                 }
               }
             }

--- a/src/query/__tests__/RelayQueryVisitor-test.js
+++ b/src/query/__tests__/RelayQueryVisitor-test.js
@@ -33,8 +33,8 @@ describe('RelayQueryVisitor', () => {
         friends(first:$first,after:$after) {
           edges {
             node {
-              id,
-              name,
+              id
+              name
               address {
                 city
               }
@@ -46,15 +46,15 @@ describe('RelayQueryVisitor', () => {
     query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
-          ${fragment},
+          id
+          ${fragment}
           friends(first:$first,after:$after) {
             edges {
               node {
-                id,
-                firstName,
+                id
+                firstName
                 address {
-                  city,
+                  city
                 }
               }
             }

--- a/src/query/__tests__/buildRQL-test.js
+++ b/src/query/__tests__/buildRQL-test.js
@@ -50,7 +50,7 @@ describe('buildRQL', () => {
       const builder = () => Relay.QL`
         query {
           node(id:"123") {
-            id,
+            id
           }
         }
       `;
@@ -61,7 +61,7 @@ describe('buildRQL', () => {
       const invalid = {};
       const builder = () => Relay.QL`
         fragment on Node {
-          ${invalid},
+          ${invalid}
         }
       `;
       expect(() => buildRQL.Fragment(builder, {})).toFailInvariant(
@@ -73,10 +73,10 @@ describe('buildRQL', () => {
     it('creates fragments with variables', () => {
       const builder = () => Relay.QL`
         fragment on Node {
-          id,
+          id
           profilePicture(size:$sizeVariable) {
-            uri,
-          },
+            uri
+          }
         }
       `;
       const node = buildRQL.Fragment(builder, {sizeVariable: null});
@@ -100,10 +100,10 @@ describe('buildRQL', () => {
     it('returns === fragments', () => {
       const builder = () => Relay.QL`
         fragment on Node {
-          id,
+          id
           profilePicture(size:$sizeVariable) {
-            uri,
-          },
+            uri
+          }
         }
       `;
       const node1 = buildRQL.Fragment(builder, {sizeVariable: null});
@@ -116,7 +116,7 @@ describe('buildRQL', () => {
     it('returns undefined if the node is not a query', () => {
       const builder = () => Relay.QL`
         fragment on Node {
-          id,
+          id
         }
       `;
       expect(
@@ -128,7 +128,7 @@ describe('buildRQL', () => {
       const builder = Component => Relay.QL`
         query {
           node(id:$id) {
-            id,
+            id
             ${Component.getFragment('foo')}
           }
         }

--- a/src/query/__tests__/toGraphQL-test.js
+++ b/src/query/__tests__/toGraphQL-test.js
@@ -100,7 +100,7 @@ describe('toGraphQL', function() {
       query {
         viewer {
           actor {
-            id,
+            id
             name
           }
         }
@@ -112,7 +112,7 @@ describe('toGraphQL', function() {
     expect(toGraphQL.Query).toConvert(Relay.QL`
       query {
         nodes(ids:["1","2","3"]) {
-          id,
+          id
           name
         }
       }
@@ -123,7 +123,7 @@ describe('toGraphQL', function() {
     expect(toGraphQL.Fragment).toConvert(Relay.QL`
       fragment on Viewer {
         actor {
-          id,
+          id
           name
         }
       }
@@ -135,7 +135,7 @@ describe('toGraphQL', function() {
       query {
         viewer {
           actor {
-            id,
+            id
             url(site:"www")
           }
         }
@@ -171,7 +171,7 @@ describe('toGraphQL', function() {
       query {
         viewer {
           actor {
-            ${defer(fragment)},
+            ${defer(fragment)}
           }
         }
       }
@@ -190,7 +190,7 @@ describe('toGraphQL', function() {
     const relayQuery = getNode(Relay.QL`
       query {
         checkinSearchQuery(query:$q) {
-          query,
+          query
         }
       }
     `, {

--- a/src/store/__tests__/RelayStoreData-test.js
+++ b/src/store/__tests__/RelayStoreData-test.js
@@ -46,11 +46,11 @@ describe('RelayStoreData', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            id,
-            doesViewerLike,
+            id
+            doesViewerLike
             topLevelComments {
-              count,
-            },
+              count
+            }
           }
         }
       `);
@@ -84,11 +84,11 @@ describe('RelayStoreData', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            id,
-            doesViewerLike,
+            id
+            doesViewerLike
             topLevelComments {
-              count,
-            },
+              count
+            }
           }
         }
       `);
@@ -135,11 +135,11 @@ describe('RelayStoreData', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            id,
-            doesViewerLike,
+            id
+            doesViewerLike
             topLevelComments {
-              count,
-            },
+              count
+            }
           }
         }
       `);
@@ -177,14 +177,14 @@ describe('RelayStoreData', () => {
       const mutationQuery = getNode(Relay.QL`
         mutation {
           feedbackLike(input:$input) {
-            clientMutationId,
+            clientMutationId
             feedback {
-              id,
-              doesViewerLike,
+              id
+              doesViewerLike
               topLevelComments {
-                count,
+                count
               }
-            },
+            }
           }
         }
       `);
@@ -223,14 +223,14 @@ describe('RelayStoreData', () => {
       const mutationQuery = getNode(Relay.QL`
         mutation {
           feedbackLike(input:$input) {
-            clientMutationId,
+            clientMutationId
             feedback {
-              id,
-              doesViewerLike,
+              id
+              doesViewerLike
               topLevelComments {
-                count,
+                count
               }
-            },
+            }
           }
         }
       `);
@@ -282,11 +282,11 @@ describe('RelayStoreData', () => {
         const query = getNode(Relay.QL`
           query {
             node(id:"123") {
-              id,
-              doesViewerLike,
+              id
+              doesViewerLike
               topLevelComments {
-                count,
-              },
+                count
+              }
             }
           }
         `);
@@ -306,14 +306,14 @@ describe('RelayStoreData', () => {
         const mutationQuery = getNode(Relay.QL`
           mutation {
             feedbackLike(input:$input) {
-              clientMutationId,
+              clientMutationId
               feedback {
-                id,
-                doesViewerLike,
+                id
+                doesViewerLike
                 topLevelComments {
-                  count,
+                  count
                 }
-              },
+              }
             }
           }
         `);
@@ -391,7 +391,7 @@ describe('RelayStoreData', () => {
       const node = getNode(Relay.QL`
         query {
           node(id: "123") {
-            id,
+            id
             ${addressFragment}
           }
         }
@@ -409,7 +409,7 @@ describe('RelayStoreData', () => {
 
       const fragment = getNode(Relay.QL`
         fragment on StreetAddress {
-          city,
+          city
         }
       `);
       const query = storeData.buildFragmentQueryForDataID(fragment, 'client:1');
@@ -417,15 +417,15 @@ describe('RelayStoreData', () => {
         query RelayStoreData($id_0: ID!) {
           node(id: $id_0) {
             ... on User {
-              id,
-              __typename,
+              id
+              __typename
               address {
                 ... on StreetAddress {
-                  city,
-                },
-              },
+                  city
+                }
+              }
             }
-          },
+          }
         }
       `, {id_0: '123'}));
       expect(query.getName()).toBe(node.getName());

--- a/src/store/__tests__/RelayStoreData_cacheManager-test.js
+++ b/src/store/__tests__/RelayStoreData_cacheManager-test.js
@@ -192,11 +192,11 @@ describe('RelayStoreData', function() {
     const query = getNode(Relay.QL`
       query {
         node(id:"123") {
-          id,
+          id
           hometown {
-            id,
-            url,
-          },
+            id
+            url
+          }
         }
       }
     `);
@@ -239,10 +239,10 @@ describe('RelayStoreData', function() {
     const query = getNode(Relay.QL`
       query {
         node(id:"123") {
-          id,
+          id
           screennames {
-            service,
-          },
+            service
+          }
         }
       }
     `);
@@ -292,19 +292,19 @@ describe('RelayStoreData', function() {
     const query = getNode(Relay.QL`
       query {
         node(id:"123") {
-          id,
+          id
           friends(first:"2") {
             edges {
               node {
                 id
-              },
-              cursor,
-            },
+              }
+              cursor
+            }
             pageInfo {
-              hasPreviousPage,
-              hasNextPage,
-            },
-          },
+              hasPreviousPage
+              hasNextPage
+            }
+          }
         }
       }
     `);
@@ -387,19 +387,19 @@ describe('RelayStoreData', function() {
     const query = getNode(Relay.QL`
       query {
         node(id:"123") {
-          id,
+          id
           friends(first:"2") {
             edges {
               node {
                 id
-              },
-              cursor,
-            },
+              }
+              cursor
+            }
             pageInfo {
-              hasPreviousPage,
-              hasNextPage,
-            },
-          },
+              hasPreviousPage
+              hasNextPage
+            }
+          }
         }
       }
     `);
@@ -455,11 +455,11 @@ describe('RelayStoreData', function() {
     const mutationQuery = getNode(Relay.QL`
       mutation {
         feedbackLike(input:$input) {
-          clientMutationId,
+          clientMutationId
           feedback {
-            id,
-            doesViewerLike,
-          },
+            id
+            doesViewerLike
+          }
         }
       }
     `);
@@ -492,19 +492,19 @@ describe('RelayStoreData', function() {
     const query = getNode(Relay.QL`
       query {
         node(id:"123") {
-          id,
+          id
           comments(first:"1") {
-            count,
+            count
             edges {
               node {
-                id,
-              },
-              cursor,
-            },
+                id
+              }
+              cursor
+            }
             pageInfo {
-              hasPreviousPage,
-              hasNextPage,
-            },
+              hasPreviousPage
+              hasNextPage
+            }
           }
         }
       }
@@ -543,22 +543,22 @@ describe('RelayStoreData', function() {
     const mutationQuery = getNode(Relay.QL`
       mutation {
         commentCreate(input:$input) {
-          clientMutationId,
+          clientMutationId
           feedback {
-            id,
+            id
             comments {
-              count,
-            },
-          },
+              count
+            }
+          }
           feedbackCommentEdge {
             node {
-              id,
-            },
-            cursor,
+              id
+            }
+            cursor
             source {
-              id,
-            },
-          },
+              id
+            }
+          }
         }
       }
     `);
@@ -614,19 +614,19 @@ describe('RelayStoreData', function() {
     const query = getNode(Relay.QL`
       query {
         node(id:"123") {
-          id,
+          id
           comments(first:"1") {
-            count,
+            count
             edges {
               node {
-                id,
-              },
-              cursor,
-            },
+                id
+              }
+              cursor
+            }
             pageInfo {
-              hasPreviousPage,
-              hasNextPage,
-            },
+              hasPreviousPage
+              hasNextPage
+            }
           }
         }
       }
@@ -664,14 +664,14 @@ describe('RelayStoreData', function() {
     const mutationQuery = getNode(Relay.QL`
       mutation {
         commentDelete(input:$input) {
-          clientMutationId,
-          deletedCommentId,
+          clientMutationId
+          deletedCommentId
           feedback {
-            id,
+            id
             comments {
-              count,
-            },
-          },
+              count
+            }
+          }
         }
       }
     `);

--- a/src/store/__tests__/readRelayQueryData-test.js
+++ b/src/store/__tests__/readRelayQueryData-test.js
@@ -292,9 +292,9 @@ describe('readRelayQueryData', () => {
     const query = getNode(Relay.QL`
       fragment on Actor {
         address {
-          city,
-        },
-        firstName,
+          city
+        }
+        firstName
       }
     `);
     const data = readData(getStoreData({records}), query, '1055790163');
@@ -315,8 +315,8 @@ describe('readRelayQueryData', () => {
     };
     const query = getNode(Relay.QL`
       fragment on Feedback {
-        id,
-        doesViewerLike,
+        id
+        doesViewerLike
       }
     `);
     let data = readData(getStoreData({records}), query, 'feedbackID');
@@ -515,8 +515,8 @@ describe('readRelayQueryData', () => {
     const fragment1 = Relay.QL`fragment on Actor{address{city}}`;
     const fragment2 = Relay.QL`fragment on Actor{address{country}}`;
     const query = getNode(Relay.QL`  fragment on Actor {
-            ${fragment1},
-            ${fragment2},
+            ${fragment1}
+            ${fragment2}
           }`);
     const data = readData(getStoreData({records}), query, '1055790163');
     expect(data).toEqual({
@@ -601,8 +601,8 @@ describe('readRelayQueryData', () => {
     const query = getNode(Relay.QL`
       fragment on Feedback {
         topLevelComments(first:"1") {
-          count,
-        },
+          count
+        }
       }
     `);
 
@@ -645,11 +645,11 @@ describe('readRelayQueryData', () => {
     const query = getNode(Relay.QL`
       fragment on Feedback {
         topLevelComments(first:"1") {
-          count,
+          count
           pageInfo {
-            hasNextPage,
-          },
-        },
+            hasNextPage
+          }
+        }
       }`
     );
 
@@ -721,9 +721,9 @@ describe('readRelayQueryData', () => {
       fragment on LikersOfContentConnection {
         edges {
           node {
-            name,
-          },
-        },
+            name
+          }
+        }
       }
     `;
     let query = getNode(Relay.QL`
@@ -731,8 +731,8 @@ describe('readRelayQueryData', () => {
         feedback {
           likers {
             ${edgesFragment}
-          },
-        },
+          }
+        }
       }
     `);
     expect(
@@ -743,8 +743,8 @@ describe('readRelayQueryData', () => {
     const pageInfoFragment = Relay.QL`
       fragment on LikersOfContentConnection {
         pageInfo {
-          hasNextPage,
-        },
+          hasNextPage
+        }
       }
     `;
     query = getNode(Relay.QL`
@@ -752,9 +752,9 @@ describe('readRelayQueryData', () => {
         feedback {
           likers {
             ${pageInfoFragment}
-          },
-        },
-      },
+          }
+        }
+      }
     `);
     expect(
       () => readData(getStoreData({records}), query, 'story_id')
@@ -904,9 +904,9 @@ describe('readRelayQueryData', () => {
     const query = getNode(Relay.QL`  fragment on Feedback{
             comments(first:"1") {
               pageInfo {
-                startCursor,
-                ${fragmentReference},
-              },
+                startCursor
+                ${fragmentReference}
+              }
             }
           }`);
 
@@ -976,11 +976,11 @@ describe('readRelayQueryData', () => {
               edges {
                 node {
                   id
-                },
-              },
+                }
+              }
               pageInfo {
                 startCursor
-              },
+              }
               ${fragmentReference}
             }
           }`);
@@ -1059,13 +1059,13 @@ describe('readRelayQueryData', () => {
     );
     const query = getNode(Relay.QL`
       fragment on User {
-        id,
+        id
         hometown {
-          name,
-        },
+          name
+        }
         screennames {
-          ${fragmentReference},
-        },
+          ${fragmentReference}
+        }
       }
     `);
 
@@ -1094,7 +1094,7 @@ describe('readRelayQueryData', () => {
         viewer {
           actor {
             name
-          },
+          }
         }
       }
     `);
@@ -1119,10 +1119,10 @@ describe('readRelayQueryData', () => {
   it('does not clobber previously-read sibling fields when a linked dataID is `null` or `undefined`', () => {
     const query = getNode(Relay.QL`
       fragment on User {
-        id,
+        id
         address {
-          city,
-        },
+          city
+        }
       }
     `);
     let records = {
@@ -1152,8 +1152,8 @@ describe('readRelayQueryData', () => {
       query {
         viewer {
           actor {
-            name,
-          },
+            name
+          }
         }
       }
     `);
@@ -1313,8 +1313,8 @@ describe('readRelayQueryData', () => {
     const query = getNode(Relay.QL`
       fragment on User {
         friends {
-          count,
-        },
+          count
+        }
       }
     `);
     let records = {
@@ -1368,7 +1368,7 @@ describe('readRelayQueryData', () => {
     // The `feedback` field here only has a generated `id`, so is "empty".
     let query = getNode(Relay.QL`
       fragment on Story {
-        id,
+        id
         feedback
       }
     `);
@@ -1422,11 +1422,11 @@ describe('readRelayQueryData', () => {
           edges {
             node {
               address {
-                city,
+                city
                 country
               }
-            },
-          },
+            }
+          }
         }
       `,
       {}
@@ -1434,8 +1434,8 @@ describe('readRelayQueryData', () => {
     const query = getNode(Relay.QL`
       fragment on User {
         friends(first:"25") {
-          ${fragmentReference},
-        },
+          ${fragmentReference}
+        }
       }
     `);
 
@@ -1560,9 +1560,9 @@ describe('readRelayQueryData', () => {
       fragment on Feedback {
         topLevelComments(first:"1") {
           pageInfo {
-            hasNextPage,
-          },
-        },
+            hasNextPage
+          }
+        }
       }`
     );
 
@@ -1862,7 +1862,7 @@ describe('readRelayQueryData', () => {
               startCursor
             }
           }
-        },
+        }
       `);
       // Missing edges due to non-empty `diffCalls`.
       GraphQLRange.prototype.retrieveRangeInfoForQuery.mockReturnValue({
@@ -1911,7 +1911,7 @@ describe('readRelayQueryData', () => {
           comments(first: "1") {
             edges {
               node {
-                id,
+                id
                 body {
                   text
                 }

--- a/src/store/__tests__/restoreRelayCacheData-test.js
+++ b/src/store/__tests__/restoreRelayCacheData-test.js
@@ -454,8 +454,8 @@ describe('restoreRelayCacheData', () => {
               friends(first:"5") {
                 edges {
                   node {
-                    name,
-                  },
+                    name
+                  }
                   cursor
                 }
               }
@@ -521,8 +521,8 @@ describe('restoreRelayCacheData', () => {
               friends(first:"5") {
                 edges {
                   node {
-                    name,
-                  },
+                    name
+                  }
                   cursor
                 }
               }
@@ -593,8 +593,8 @@ describe('restoreRelayCacheData', () => {
               friends(first:"5") {
                 edges {
                   node {
-                    name,
-                  },
+                    name
+                  }
                   cursor
                 }
               }
@@ -672,8 +672,8 @@ describe('restoreRelayCacheData', () => {
               friends(first:"5") {
                 edges {
                   node {
-                    name,
-                  },
+                    name
+                  }
                   cursor
                 }
               }
@@ -995,8 +995,8 @@ describe('restoreRelayCacheData', () => {
     it('calls `onFailure` when node is not in disk', () => {
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          id,
-          name,
+          id
+          name
         }
       `);
       const path = RelayQueryPath.create(getNode(Relay.QL`
@@ -1027,8 +1027,8 @@ describe('restoreRelayCacheData', () => {
     it('calls `onFailure` when a field is not on disk', () => {
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          id,
-          name,
+          id
+          name
         }
       `);
       const path = RelayQueryPath.create(getNode(Relay.QL`
@@ -1070,8 +1070,8 @@ describe('restoreRelayCacheData', () => {
     it('calls `onSuccess` when node is in disk', () => {
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          id,
-          name,
+          id
+          name
         }
       `);
       const path = RelayQueryPath.create(getNode(Relay.QL`
@@ -1114,8 +1114,8 @@ describe('restoreRelayCacheData', () => {
     it('calls `onSuccess` when node is in cached store', () => {
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          id,
-          name,
+          id
+          name
         }
       `);
       const path = RelayQueryPath.create(getNode(Relay.QL`
@@ -1155,8 +1155,8 @@ describe('restoreRelayCacheData', () => {
     it('calls `onSuccess` when node is in store', () => {
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          id,
-          name,
+          id
+          name
         }
       `);
       const path = RelayQueryPath.create(getNode(Relay.QL`
@@ -1198,8 +1198,8 @@ describe('restoreRelayCacheData', () => {
     it('does not call `onSuccess` if aborted', () => {
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          id,
-          name,
+          id
+          name
         }
       `);
       const path = RelayQueryPath.create(getNode(Relay.QL`
@@ -1232,8 +1232,8 @@ describe('restoreRelayCacheData', () => {
     it('does not `onFailure` if aborted', () => {
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          id,
-          name,
+          id
+          name
         }
       `);
       const path = RelayQueryPath.create(getNode(Relay.QL`

--- a/src/store/__tests__/validateRelayReadQuery-test.js
+++ b/src/store/__tests__/validateRelayReadQuery-test.js
@@ -59,17 +59,17 @@ describe('validateRelayReadQuery', () => {
     const fragment = Relay.QL`
       fragment on Node {
         profilePicture(size:"100") {
-          height,
-        },
+          height
+        }
       }
     `;
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
           profilePicture(size:"50") {
-            height,
-          },
-          ${fragment},
+            height
+          }
+          ${fragment}
         }
       }
     `);
@@ -81,22 +81,22 @@ describe('validateRelayReadQuery', () => {
     const fragment = Relay.QL`
       fragment on Node {
         profilePicture(size:"100") {
-          height,
-        },
+          height
+        }
       }
     `;
     const otherFragment = Relay.QL`
       fragment on Node {
         profilePicture(size:"50") {
-          height,
-        },
+          height
+        }
       }
     `;
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          ${fragment},
-          ${otherFragment},
+          ${fragment}
+          ${otherFragment}
         }
       }
     `);
@@ -109,25 +109,25 @@ describe('validateRelayReadQuery', () => {
       fragment on Viewer {
         actor {
           profilePicture(size:"100") {
-            height,
-          },
-        },
+            height
+          }
+        }
       }
     `;
     const fragment = Relay.QL`
       fragment on Viewer {
         actor {
           profilePicture(size:"50") {
-            height,
-          },
-        },
-        ${nestedFragment},
+            height
+          }
+        }
+        ${nestedFragment}
       }
     `;
     const query = getNode(Relay.QL`
       query {
         viewer {
-          ${fragment},
+          ${fragment}
         }
       }
     `);
@@ -140,11 +140,11 @@ describe('validateRelayReadQuery', () => {
       query {
         node(id:"4") {
           profilePicture(size:"50") {
-            height,
-          },
+            height
+          }
           profilePicture(size:"100") {
-            height,
-          },
+            height
+          }
         }
       }
     `);
@@ -157,11 +157,11 @@ describe('validateRelayReadQuery', () => {
       query {
         node(id:"4") {
           pic: profilePicture(size:"50") {
-            height,
-          },
+            height
+          }
           pic: profilePicture(size:"100") {
-            height,
-          },
+            height
+          }
         }
       }
     `);
@@ -174,9 +174,9 @@ describe('validateRelayReadQuery', () => {
       query {
         node(id:"4") {
           special: profilePicture(size:"50") {
-            height,
-          },
-          special: name,
+            height
+          }
+          special: name
         }
       }
     `);
@@ -192,10 +192,10 @@ describe('validateRelayReadQuery', () => {
         node(id:"4") {
           friends(first:"1") {
             pageInfo {
-              my_cursor: startCursor,
-              my_cursor: endCursor,
-            },
-          },
+              my_cursor: startCursor
+              my_cursor: endCursor
+            }
+          }
         }
       }
     `);
@@ -207,8 +207,8 @@ describe('validateRelayReadQuery', () => {
     const query = getNode(Relay.QL`
       fragment on User {
         count: friends {
-          count,
-        },
+          count
+        }
       }
     `);
     validateRelayReadQuery(query);
@@ -219,17 +219,17 @@ describe('validateRelayReadQuery', () => {
     const fragment = Relay.QL`
       fragment on Node {
         profilePicture(size:"100") {
-          height,
-        },
+          height
+        }
       }
     `;
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
           medium_profile: profilePicture(size:"50") {
-            height,
-          },
-          ${fragment},
+            height
+          }
+          ${fragment}
         }
       }
     `);
@@ -241,17 +241,17 @@ describe('validateRelayReadQuery', () => {
     const fragment = Relay.QL`
       fragment on Node {
         large_profile: profilePicture(size:"100") {
-          height,
-        },
+          height
+        }
       }
     `;
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
           profilePicture(size:"50") {
-            height,
-          },
-          ${fragment},
+            height
+          }
+          ${fragment}
         }
       }
     `);
@@ -263,17 +263,17 @@ describe('validateRelayReadQuery', () => {
     const fragment = Relay.QL`
       fragment on Node {
         large_profile: profilePicture(size:"100") {
-          height,
-        },
+          height
+        }
       }
     `;
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
           medium_profile: profilePicture(size:"50") {
-            height,
-          },
-          ${fragment},
+            height
+          }
+          ${fragment}
         }
       }
     `);
@@ -286,11 +286,11 @@ describe('validateRelayReadQuery', () => {
       query {
         node(id:"4") {
           medium_profile: profilePicture(size:"50") {
-            height,
-          },
+            height
+          }
           profilePicture(size:"100") {
-            height,
-          },
+            height
+          }
         }
       }
     `);
@@ -303,11 +303,11 @@ describe('validateRelayReadQuery', () => {
       query {
         node(id:"4") {
           medium_profile: profilePicture(size:"50") {
-            height,
-          },
+            height
+          }
           large_profile: profilePicture(size:"100") {
-            height,
-          },
+            height
+          }
         }
       }
     `);
@@ -323,9 +323,9 @@ describe('validateRelayReadQuery', () => {
     const query = getNode(Relay.QL`
       fragment on User {
         profilePicture(size:"50") {
-          height,
-        },
-        ${fragment},
+          height
+        }
+        ${fragment}
       }
     `);
     validateRelayReadQuery(query);
@@ -336,17 +336,17 @@ describe('validateRelayReadQuery', () => {
     const query = getNode(Relay.QL`
       fragment on User {
         profilePicture(size:"50") {
-          height,
-        },
+          height
+        }
         friends(first:"1") {
           edges {
             node {
               profilePicture(size:"100") {
-                height,
-              },
-            },
-          },
-        },
+                height
+              }
+            }
+          }
+        }
       }
     `);
     validateRelayReadQuery(query);

--- a/src/traversal/__tests__/checkRelayQueryData-test.js
+++ b/src/traversal/__tests__/checkRelayQueryData-test.js
@@ -154,7 +154,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             firstName
           }
         }
@@ -177,7 +177,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             firstName
           }
         }
@@ -206,7 +206,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             friends {count}
           }
         }
@@ -230,7 +230,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             friends {count}
           }
         }
@@ -257,7 +257,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             friends {count}
           }
         }
@@ -286,7 +286,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             screennames {service}
           }
         }
@@ -311,7 +311,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             screennames {service}
           }
         }
@@ -339,7 +339,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             screennames {service}
           }
         }
@@ -373,7 +373,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             friends(first:"10") {
               edges { node {id}}
             }
@@ -408,7 +408,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             friends(first:"10") {
               edges { node {id}}
             }
@@ -493,7 +493,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             friends(first:"10") {
               edges { node {id}, cursor}
             }
@@ -536,7 +536,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             friends(first:"10") {
               edges { node {id}, cursor}
             }
@@ -599,7 +599,7 @@ describe('checkRelayQueryData', () => {
       getNode(Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             ... on User {
               name
             }
@@ -623,7 +623,7 @@ describe('checkRelayQueryData', () => {
       getNode(Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             ... on User {
               name #unfetched
             }
@@ -647,7 +647,7 @@ describe('checkRelayQueryData', () => {
       getNode(Relay.QL`
         query {
           node(id:"1055790163") {
-            id,
+            id
             # non-matching type - should not count as missing data
             ... on Page {
               name

--- a/src/traversal/__tests__/diffRelayQuery-test.js
+++ b/src/traversal/__tests__/diffRelayQuery-test.js
@@ -45,7 +45,7 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           name
         }
       }
@@ -82,7 +82,7 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           name
         }
       }
@@ -104,7 +104,7 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           profilePicture(size:"32") { uri }
         }
       }
@@ -130,7 +130,7 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           profilePicture(size:"64") { uri }
         }
       }
@@ -156,7 +156,7 @@ describe('diffRelayQuery', () => {
   it('removes fetched fragments', () => {
     const fragment = Relay.QL`
       fragment on Actor {
-        id,
+        id
         name
       }
     `;
@@ -194,10 +194,10 @@ describe('diffRelayQuery', () => {
         node(id:"story") {
           feedback {
             topLevelComments(first:"10") {
-              count,
+              count
               edges {
                 node {
-                  id,
+                  id
                   body {
                     text
                   }
@@ -241,7 +241,7 @@ describe('diffRelayQuery', () => {
             topLevelComments(first:"10") {
               edges {
                 node {
-                  id,
+                  id
                   body {
                     text
                   }
@@ -262,11 +262,11 @@ describe('diffRelayQuery', () => {
     `;
     const fragment = Relay.QL`
       fragment on TopLevelCommentsConnection {
-        count,
+        count
         edges {
           node {
-            id,
-            ${body},
+            id
+            ${body}
           }
         }
       }
@@ -276,7 +276,7 @@ describe('diffRelayQuery', () => {
         node(id:"story") {
           feedback {
             topLevelComments(first:"10") {
-              ${fragment},
+              ${fragment}
             }
           }
         }
@@ -292,9 +292,9 @@ describe('diffRelayQuery', () => {
       fragment on TopLevelCommentsConnection {
         edges {
           node {
-            ${body},
-          },
-        },
+            ${body}
+          }
+        }
       }
     `;
     const expectedQuery = getNode(Relay.QL`
@@ -302,7 +302,7 @@ describe('diffRelayQuery', () => {
         node(id:"story") {
           feedback {
             topLevelComments(first:"10") {
-              ${edgesFragment},
+              ${edgesFragment}
             }
           }
         }
@@ -339,8 +339,8 @@ describe('diffRelayQuery', () => {
         node(id:"story") {
           feedback {
             topLevelComments {
-              count,
-              totalCount,
+              count
+              totalCount
             }
           }
         }
@@ -441,7 +441,7 @@ describe('diffRelayQuery', () => {
         node(id:"story") {
           feedback {
             topLevelComments(first:"10") {
-              count,
+              count
               edges {
                 node {
                   id
@@ -474,7 +474,7 @@ describe('diffRelayQuery', () => {
 
     const fragment = Relay.QL`
       fragment on TopLevelCommentsConnection {
-        count,
+        count
         edges {
           node {
             id
@@ -487,7 +487,7 @@ describe('diffRelayQuery', () => {
         node(id:"story") {
           feedback {
             topLevelComments(first:"10") {
-              ${fragment},
+              ${fragment}
             }
           }
         }
@@ -509,7 +509,7 @@ describe('diffRelayQuery', () => {
         node(id:"story") {
           feedback {
             topLevelComments(first:"10") {
-              ${edgesFragment},
+              ${edgesFragment}
             }
           }
         }
@@ -563,7 +563,7 @@ describe('diffRelayQuery', () => {
     let query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           name
         }
       }
@@ -584,7 +584,7 @@ describe('diffRelayQuery', () => {
       query {
         viewer {
           actor {
-            id,
+            id
             name
           }
         }
@@ -664,7 +664,7 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         nodes(ids:["4","4808495"]) {
-          id,
+          id
           name
         }
       }
@@ -721,8 +721,8 @@ describe('diffRelayQuery', () => {
         viewer {
           actor {
             id
-          },
-          primaryEmail,
+          }
+          primaryEmail
         }
       }
     `);
@@ -755,8 +755,8 @@ describe('diffRelayQuery', () => {
       query {
         viewer {
           actor {
-            id,
-            name,
+            id
+            name
             address {
               city
             }
@@ -792,8 +792,8 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          firstName,
-          ${frag},
+          firstName
+          ${frag}
         }
       }
     `);
@@ -817,8 +817,8 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          firstName,
-          ${frag},
+          firstName
+          ${frag}
         }
       }
     `);
@@ -841,8 +841,8 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          firstName,
-          ${fragment},
+          firstName
+          ${fragment}
         }
       }
     `);
@@ -862,7 +862,7 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
       query {
         node(id:"4") {
-          ${fragment},
+          ${fragment}
         }
       }
     `));
@@ -880,8 +880,8 @@ describe('diffRelayQuery', () => {
     let query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
-          firstName,
+          id
+          firstName
         }
       }
     `);
@@ -893,7 +893,7 @@ describe('diffRelayQuery', () => {
     query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
         }
       }
     `);
@@ -915,9 +915,9 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
-          firstName,
-          lastName,
+          id
+          firstName
+          lastName
         }
       }
     `);
@@ -929,7 +929,7 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           lastName
         }
       }
@@ -955,11 +955,11 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           hometown {
-            id,
-            name,
-            websites,
+            id
+            name
+            websites
           }
         }
       }
@@ -972,10 +972,10 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           hometown {
-            id,
-            websites,
+            id
+            websites
           }
         }
       }
@@ -1016,12 +1016,12 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"12345") {
-          id,
+          id
           actors {
-            id,
-            name,
-            firstName,
-            lastName,
+            id
+            name
+            firstName
+            lastName
           }
         }
       }
@@ -1034,14 +1034,14 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"4808495") {
-          __typename,
-          id,
+          __typename
+          id
           ... on Actor {
-            __typename,
-            id,
-            lastName,
-            name,
-          },
+            __typename
+            id
+            lastName
+            name
+          }
         }
       }
     `));
@@ -1049,14 +1049,14 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[1]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"1023896548") {
-          __typename,
-          id,
+          __typename
+          id
           ... on Actor {
-            __typename,
-            firstName,
-            id,
-            lastName,
-          },
+            __typename
+            firstName
+            id
+            lastName
+          }
         }
       }
     `));
@@ -1064,12 +1064,12 @@ describe('diffRelayQuery', () => {
     const trackedQuery = getNode(Relay.QL`
       query {
         node(id:"12345") {
-          id,
+          id
           actors {
-            id,
-            firstName,
-            lastName,
-            name,
+            id
+            firstName
+            lastName
+            name
           }
         }
       }
@@ -1103,10 +1103,10 @@ describe('diffRelayQuery', () => {
     const expected = getNode(Relay.QL`
       query {
         node(id:"12345") {
-          id,
+          id
           screennames {
-            name,
-          },
+            name
+          }
         }
       }
     `);
@@ -1115,9 +1115,9 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"12345") {
-          id,
+          id
           screennames {
-            name,
+            name
             service
           }
         }
@@ -1153,42 +1153,42 @@ describe('diffRelayQuery', () => {
     `;
     const nestingFrag = Relay.QL`
       fragment on Node {
-        ${firstNameFrag},
+        ${firstNameFrag}
         ${lastNameFrag}
       }
     `;
     const query = getNode(Relay.QL`
       query {
         nodes(ids:["4","4808495"]) {
-          id,
-          name,
-          ${defer(firstNameFrag)},
-          ${lastNameFrag},
-          ${defer(nestingFrag)},
+          id
+          name
+          ${defer(firstNameFrag)}
+          ${lastNameFrag}
+          ${defer(nestingFrag)}
         }
       }
     `);
     const expectedFragment = Relay.QL`
       fragment on Node {
-        ${firstNameFrag},
+        ${firstNameFrag}
       }
     `;
     const expected0 = getNode(Relay.QL`
       query {
         nodes(ids:["4"]) {
-          id,
-          ${firstNameFrag},
-          ${expectedFragment},
+          id
+          ${firstNameFrag}
+          ${expectedFragment}
         }
       }
     `);
     const expected1 = getNode(Relay.QL`
       query {
         nodes(ids:["4808495"]) {
-          id,
-          name,
-          ${defer(firstNameFrag)},
-          ${lastNameFrag},
+          id
+          name
+          ${defer(firstNameFrag)}
+          ${lastNameFrag}
           ${defer(nestingFrag)}
         }
       }
@@ -1234,16 +1234,16 @@ describe('diffRelayQuery', () => {
     const expected = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           friends(first:"5") {
             edges {
               node {
                 id
-              },
+              }
               cursor
-            },
+            }
             pageInfo {
-              hasNextPage,
+              hasNextPage
               hasPreviousPage
             }
           }
@@ -1254,8 +1254,8 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
-          name,
+          id
+          name
           friends(first:"5") {
             edges {
               node {
@@ -1308,16 +1308,16 @@ describe('diffRelayQuery', () => {
     const expected = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           friends(after:"cursor1",first:"4") {
             edges {
-              cursor,
+              cursor
               node {
                 id
               }
-            },
+            }
             pageInfo {
-              hasNextPage,
+              hasNextPage
               hasPreviousPage
             }
           }
@@ -1328,7 +1328,7 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           friends(first:"5") {
             edges {
               node {
@@ -1382,17 +1382,17 @@ describe('diffRelayQuery', () => {
     const expected1 = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           friends(after:"cursor1",first:"4") {
             edges{
-              cursor,
+              cursor
               node {
-                id,
+                id
                 name
               }
-            },
+            }
             pageInfo {
-              hasNextPage,
+              hasNextPage
               hasPreviousPage
             }
           }
@@ -1403,12 +1403,12 @@ describe('diffRelayQuery', () => {
     const expected2 = getVerbatimNode(Relay.QL`
       query {
         node(id:"4808495") {
-          id,
-          __typename,
+          id
+          __typename
           ... on User {
-            id,
-            name,
-          },
+            id
+            name
+          }
         }
       }
     `);
@@ -1416,11 +1416,11 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           friends(first:"5") {
             edges {
               node {
-                id,
+                id
                 name
               }
             }
@@ -1443,11 +1443,11 @@ describe('diffRelayQuery', () => {
     expect(trackedQueries[1][0]).toEqualQueryNode(getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           friends(first:"5") {
             edges {
               node {
-                id,
+                id
                 name
               }
             }
@@ -1501,17 +1501,17 @@ describe('diffRelayQuery', () => {
     const expected1 = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           friends(after:"cursor1",first:"4") {
             edges{
-              cursor,
+              cursor
               node {
-                id,
+                id
                 name
               }
-            },
+            }
             pageInfo {
-              hasNextPage,
+              hasNextPage
               hasPreviousPage
             }
           }
@@ -1521,12 +1521,12 @@ describe('diffRelayQuery', () => {
     const expected2 = getVerbatimNode(Relay.QL`
       query {
         node(id:"660361306") {
-          id,
-          __typename,
+          id
+          __typename
           ... on User {
-            id,
-            name,
-          },
+            id
+            name
+          }
         }
       }
     `);
@@ -1534,11 +1534,11 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           friends(first:"5") {
             edges {
               node {
-                id,
+                id
                 name
               }
             }
@@ -1562,11 +1562,11 @@ describe('diffRelayQuery', () => {
     expect(trackedQueries[1][0]).toEqualQueryNode(getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           friends(first:"5") {
             edges {
               node {
-                id,
+                id
                 name
               }
             }
@@ -1619,11 +1619,11 @@ describe('diffRelayQuery', () => {
             friends(first:"1") {
               edges {
                 node {
-                  name,
-                },
-              },
-            },
-          },
+                  name
+                }
+              }
+            }
+          }
         }
       }
     `);
@@ -1634,12 +1634,12 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"4808495"){
-          id,
-          __typename,
+          id
+          __typename
           ... on User {
-            id,
-            name,
-          },
+            id
+            name
+          }
         }
       }
     `));
@@ -1648,16 +1648,16 @@ describe('diffRelayQuery', () => {
       query {
         viewer {
           actor {
-            id,
+            id
             friends(first:"1") {
               edges {
                 node {
-                  id,
-                  name,
-                },
-              },
-            },
-          },
+                  id
+                  name
+                }
+              }
+            }
+          }
         }
       }
     `);
@@ -1702,12 +1702,12 @@ describe('diffRelayQuery', () => {
     const expected = getVerbatimNode(Relay.QL`
       query {
         node(id:"4808495") {
-          id,
-          __typename,
+          id
+          __typename
           ... on User {
-            id,
-            lastName,
-          },
+            id
+            lastName
+          }
         }
       }
     `);
@@ -1717,8 +1717,8 @@ describe('diffRelayQuery', () => {
         friends(first:"1") {
           edges {
             node {
-              firstName,
-              lastName,
+              firstName
+              lastName
             }
           }
         }
@@ -1741,8 +1741,8 @@ describe('diffRelayQuery', () => {
     const trackedQuery = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
-          ${fragment},
+          id
+          ${fragment}
         }
       }
     `);
@@ -1787,15 +1787,15 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         nodes(ids:"4") {
-          id,
+          id
           friends(first:"1") {
             edges {
               node {
                 id
-              },
+              }
               source {
-                id,
-                name,
+                id
+                name
                 firstName
               }
             }
@@ -1812,17 +1812,17 @@ describe('diffRelayQuery', () => {
       query {
         nodes(ids:"4") {
           ... on User {
-            id,
-            __typename,
+            id
+            __typename
             friends(find:"4808495") {
               edges {
-                cursor,
+                cursor
                 node {
-                  id,
+                  id
                   __typename, # not strictly required here
-                },
+                }
                 source {
-                  id,
+                  id
                   firstName
                 }
               }
@@ -1867,12 +1867,12 @@ describe('diffRelayQuery', () => {
     const expected = getVerbatimNode(Relay.QL`
       query {
         node(id:"4808495") {
-          id,
-          __typename,
+          id
+          __typename
           ... on User {
-            id,
-            lastName,
-          },
+            id
+            lastName
+          }
         }
       }
     `);
@@ -1880,19 +1880,19 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         nodes(ids:"4") {
-          id,
+          id
           friends(first:"1") {
             edges {
               node {
-                id,
-              },
+                id
+              }
               source {
-                id,
+                id
                 friends(first:"1") {
                   edges {
                     node {
-                      id,
-                      name,
+                      id
+                      name
                       lastName
                     }
                   }
@@ -1915,13 +1915,13 @@ describe('diffRelayQuery', () => {
     expect(trackedQueries[1][0]).toEqualQueryNode(getNode(Relay.QL`
       fragment on FriendsEdge {
         source {
-          id,
+          id
           friends(first:"1") {
             edges {
               node {
-                id,
-                name,
-                lastName,
+                id
+                name
+                lastName
               }
             }
           }
@@ -1933,16 +1933,16 @@ describe('diffRelayQuery', () => {
     expect(trackedQueries[4][0]).toEqualQueryNode(getNode(Relay.QL`
       query {
         nodes(ids:"4") {
-          id,
+          id
           friends(first:"1") {
             edges {
               source {
-                id,
+                id
                 friends(first:"1") {
                   edges {
                     node {
-                      id,
-                      name,
+                      id
+                      name
                       lastName
                     }
                   }
@@ -2071,7 +2071,7 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         route(waypoints:[
-          {lat: "49.246292", lon: "-123.116226"},
+          {lat: "49.246292", lon: "-123.116226"}
           {lat: "49.246292", lon: "-123.116226"}
         ]) {
           steps { note }

--- a/src/traversal/__tests__/diffRelayQuery_connection-test.js
+++ b/src/traversal/__tests__/diffRelayQuery_connection-test.js
@@ -387,7 +387,7 @@ describe('diffRelayQuery', () => {
             edges {
               node {
                 feedback {
-                  id,
+                  id
                   comments(first:"1") {
                     edges {
                       node {
@@ -450,11 +450,11 @@ describe('diffRelayQuery', () => {
             edges {
               node {
                 feedback {
-                  id,
+                  id
                   comments(first:"1") {
                     edges {
                       node {
-                        id,
+                        id
                         body {text}
                       }
                     }
@@ -471,7 +471,7 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getNode(Relay.QL`
       query {
         node(id:"commentid"){
-          __typename,
+          __typename
           ... on Comment {id, body {text}}
         }
       }
@@ -567,45 +567,45 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s1") {
-          id,
-          __typename,
+          id
+          __typename
           ... on FeedUnit {
             feedback {
-              id,
-            },
-            id,
-            __typename,
-          },
+              id
+            }
+            id
+            __typename
+          }
         }
       }
     `));
     expect(diffQueries[1]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s2") {
-          id,
-          __typename,
+          id
+          __typename
           ... on FeedUnit {
             feedback {
-              id,
-            },
-            id,
-            __typename,
-          },
+              id
+            }
+            id
+            __typename
+          }
         }
       }
     `));
     expect(diffQueries[2]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s3") {
-          id,
-          __typename,
+          id
+          __typename
           ... on FeedUnit {
             feedback {
-              id,
-            },
-            id,
-            __typename,
-          },
+              id
+            }
+            id
+            __typename
+          }
         }
       }
     `));
@@ -678,10 +678,10 @@ describe('diffRelayQuery', () => {
         viewer {
           newsFeed(first:"3") {
             edges {
-              sortKey,
+              sortKey
               node {
-                id,
-                __typename,
+                id
+                __typename
                 feedback {
                   id
                 }
@@ -696,15 +696,15 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s1") {
-          id,
-          __typename,
+          id
+          __typename
           ... on FeedUnit {
             feedback {
-              id,
-            },
-            id,
-            __typename,
-          },
+              id
+            }
+            id
+            __typename
+          }
         }
       }
     `));
@@ -713,12 +713,12 @@ describe('diffRelayQuery', () => {
         viewer {
           newsFeed(find:"s1") {
             edges {
-              cursor,
+              cursor
               node {
                 id
-                __typename,
-              },
-              sortKey,
+                __typename
+              }
+              sortKey
             }
           }
         }
@@ -727,15 +727,15 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[2]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s2") {
-          id,
-          __typename,
+          id
+          __typename
           ... on FeedUnit {
             feedback {
-              id,
-            },
-            id,
-            __typename,
-          },
+              id
+            }
+            id
+            __typename
+          }
         }
       }
     `));
@@ -744,12 +744,12 @@ describe('diffRelayQuery', () => {
         viewer {
           newsFeed(find:"s2") {
             edges {
-              cursor,
+              cursor
               node {
                 id
-                __typename,
-              },
-              sortKey,
+                __typename
+              }
+              sortKey
             }
           }
         }
@@ -758,15 +758,15 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[4]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s3") {
-          id,
-          __typename,
+          id
+          __typename
           ... on FeedUnit {
             feedback {
-              id,
-            },
-            id,
-            __typename,
-          },
+              id
+            }
+            id
+            __typename
+          }
         }
       }
     `));
@@ -775,12 +775,12 @@ describe('diffRelayQuery', () => {
         viewer {
           newsFeed(find:"s3") {
             edges {
-              cursor,
+              cursor
               node {
-                id,
-                __typename,
-              },
-              sortKey,
+                id
+                __typename
+              }
+              sortKey
             }
           }
         }
@@ -864,7 +864,7 @@ describe('diffRelayQuery', () => {
         viewer {
           notificationStories(first:"3") {
             edges {
-              showBeeper,
+              showBeeper
               node {
                 feedback {
                   id
@@ -880,45 +880,45 @@ describe('diffRelayQuery', () => {
     expect(diffQueries[0]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s1") {
-          id,
-          __typename,
+          id
+          __typename
           ... on FeedUnit {
             feedback {
-              id,
-            },
-            id,
-            __typename,
-          },
+              id
+            }
+            id
+            __typename
+          }
         }
       }
     `));
     expect(diffQueries[1]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s2") {
-          id,
-          __typename,
+          id
+          __typename
           ... on FeedUnit {
             feedback {
-              id,
-            },
-            id,
-            __typename,
-          },
+              id
+            }
+            id
+            __typename
+          }
         }
       }
     `));
     expect(diffQueries[2]).toEqualQueryRoot(getVerbatimNode(Relay.QL`
       query {
         node(id:"s3") {
-          id,
-          __typename,
+          id
+          __typename
           ... on FeedUnit {
             feedback {
-              id,
-            },
-            id,
-            __typename,
-          },
+              id
+            }
+            id
+            __typename
+          }
         }
       }
     `));
@@ -975,10 +975,10 @@ describe('diffRelayQuery', () => {
         viewer {
           newsFeed(first:"1") {
             edges {
-              ${edgeFragment},
+              ${edgeFragment}
               node {
-                ${nodeFragment},
-              },
+                ${nodeFragment}
+              }
             }
           }
         }

--- a/src/traversal/__tests__/diffRelayQuery_scalar-test.js
+++ b/src/traversal/__tests__/diffRelayQuery_scalar-test.js
@@ -46,9 +46,9 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         username(name:"joe") {
-          id,
-          firstName,
-          lastName,
+          id
+          firstName
+          lastName
         }
       }
     `);
@@ -65,9 +65,9 @@ describe('diffRelayQuery', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"123") {
-          id,
-          firstName,
-          lastName,
+          id
+          firstName
+          lastName
         }
       }
     `);
@@ -101,9 +101,9 @@ describe('diffRelayQuery', () => {
     const fetchQuery = getNode(Relay.QL`
       query {
         node(id:"123") {
-          id,
-          firstName,
-          lastName,
+          id
+          firstName
+          lastName
         }
       }
     `);

--- a/src/traversal/__tests__/filterRelayQuery-test.js
+++ b/src/traversal/__tests__/filterRelayQuery-test.js
@@ -66,13 +66,13 @@ describe('filterRelayQuery()', () => {
         viewer {
           newsFeed(first: "10") {
             edges {
-              cursor,
+              cursor
               node {
-                id,
+                id
               }
-            },
+            }
             pageInfo {
-              hasNextPage,
+              hasNextPage
               hasPreviousPage
             }
           }

--- a/src/traversal/__tests__/findRelayQueryLeaves-test.js
+++ b/src/traversal/__tests__/findRelayQueryLeaves-test.js
@@ -175,7 +175,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns pendingNodeStates when field is not in the store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         firstName
       }
     `);
@@ -205,7 +205,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns missingData when field is not in the cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         firstName
       }
     `);
@@ -231,7 +231,7 @@ describe('findRelayQueryLeaves', () => {
   it('has all required data when field is in store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         firstName
       }
     `);
@@ -257,7 +257,7 @@ describe('findRelayQueryLeaves', () => {
   it('has all required data when field is in cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         firstName
       }
     `);
@@ -284,7 +284,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns pendingNodeStates when linked node is not in the store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends {count}
       }
     `);
@@ -316,7 +316,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns missingData when linked node is not in the cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends {count}
       }
     `);
@@ -344,7 +344,7 @@ describe('findRelayQueryLeaves', () => {
   it('has all required data when linked node is in store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends {count}
       }
     `);
@@ -374,7 +374,7 @@ describe('findRelayQueryLeaves', () => {
   it('has all required data when linked node is in cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends {count}
       }
     `);
@@ -405,7 +405,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns pendingNodeStates when plural node is not in the store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         screennames {service}
       }
     `);
@@ -450,7 +450,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns missingData when plural node is not in the cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         screennames {service}
       }
     `);
@@ -482,7 +482,7 @@ describe('findRelayQueryLeaves', () => {
   it('has all required data when plural node is in store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         screennames {service}
       }
     `);
@@ -519,7 +519,7 @@ describe('findRelayQueryLeaves', () => {
   it('has all required data when plural node is in cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         screennames {service}
       }
     `);
@@ -559,7 +559,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns pendingNodeStates when range node is not in the store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends(first:"10") {
           edges { node {id}}
         }
@@ -599,7 +599,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns missingData when range node is not in the cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends(first:"10") {
           edges { node {id}}
         }
@@ -630,7 +630,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns pendingNodeStates when range field is not in the store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends(first:"10") {
           edges { node {id}}
         }
@@ -670,7 +670,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns missingData when range field is not in the cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends(first:"10") {
           edges { node {id}}
         }
@@ -703,7 +703,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns missingData when range has diffQuery in the store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends(first:"10") {
           edges { node {id}}
         }
@@ -740,7 +740,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns missingData when range has diffQuery in the cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         friends(first:"10") {
           edges { node {id}}
         }
@@ -1004,7 +1004,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns pendingNodeStates when matched fragment is not in the store', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         ... on User {
           firstName
         }
@@ -1039,7 +1039,7 @@ describe('findRelayQueryLeaves', () => {
   it('returns missingData when matched fragment is not in the cache', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         ... on User {
           firstName
         }
@@ -1067,7 +1067,7 @@ describe('findRelayQueryLeaves', () => {
   it('has all required data in store when ignoring unmatched fragment', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         ... on Page {
           name
         }
@@ -1094,7 +1094,7 @@ describe('findRelayQueryLeaves', () => {
   it('has all required data in cache when ignoring unmatched fragment', () => {
     const queryNode = getNode(Relay.QL`
       fragment on Node {
-        id,
+        id
         ... on Page {
           name
         }

--- a/src/traversal/__tests__/flattenRelayQuery-test.js
+++ b/src/traversal/__tests__/flattenRelayQuery-test.js
@@ -35,7 +35,7 @@ describe('flattenRelayQuery', () => {
             }
           }
           actor {
-            firstName,
+            firstName
             ... on Actor {
               lastName
             }
@@ -47,8 +47,8 @@ describe('flattenRelayQuery', () => {
       query {
         viewer {
           actor {
-            firstName,
-            name,
+            firstName
+            name
             lastName
           }
         }
@@ -61,7 +61,7 @@ describe('flattenRelayQuery', () => {
     const node = getNode(Relay.QL`
       fragment on Viewer {
         actor {
-          firstName,
+          firstName
           ... on Actor {
             lastName
             ... on Actor {
@@ -77,9 +77,9 @@ describe('flattenRelayQuery', () => {
     const expected = getNode(Relay.QL`
       fragment on Viewer {
         actor {
-          firstName,
-          lastName,
-          name,
+          firstName
+          lastName
+          name
           ... on User {
             username
           }
@@ -94,10 +94,10 @@ describe('flattenRelayQuery', () => {
       query {
         viewer {
           actor {
-            firstName,
-            name,
+            firstName
+            name
             ... on Actor {
-              name,
+              name
               lastName
             }
           }
@@ -108,8 +108,8 @@ describe('flattenRelayQuery', () => {
       query {
         viewer {
           actor {
-            firstName,
-            name,
+            firstName
+            name
             lastName
           }
         }
@@ -163,7 +163,7 @@ describe('flattenRelayQuery', () => {
       query {
         viewer {
           actor {
-            firstName,
+            firstName
             name
           }
         }

--- a/src/traversal/__tests__/intersectRelayQuery-test.js
+++ b/src/traversal/__tests__/intersectRelayQuery-test.js
@@ -29,13 +29,13 @@ describe('intersectRelayQuery', () => {
     it('returns null for mutually exclusive nodes', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Date {
-          day,
-          month,
+          day
+          month
         }
       `);
       const patternNode = getNode(Relay.QL`
         fragment on Date {
-          year,
+          year
         }
       `);
       expect(intersectRelayQuery(subjectNode, patternNode)).toBe(null);
@@ -44,19 +44,19 @@ describe('intersectRelayQuery', () => {
     it('intersects shallow fields', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Actor {
-          name,
-          firstName,
+          name
+          firstName
         }
       `);
       const patternNode = getNode(Relay.QL`
         fragment on Actor {
-          lastName,
-          name,
+          lastName
+          name
         }
       `);
       const expected = getNode(Relay.QL`
         fragment on Actor {
-          name,
+          name
         }
       `);
       expect(
@@ -68,31 +68,31 @@ describe('intersectRelayQuery', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Actor {
           birthdate {
-            day,
-            month,
-            year,
-          },
+            day
+            month
+            year
+          }
           hometown {
-            name,
-            url,
-          },
+            name
+            url
+          }
         }
       `);
       const patternNode = getNode(Relay.QL`
         fragment on Actor {
           hometown {
-            name,
-          },
+            name
+          }
           screennames {
-            service,
-          },
+            service
+          }
         }
       `);
       const expected = getNode(Relay.QL`
         fragment on Actor {
           hometown {
             name
-          },
+          }
         }
       `);
       expect(
@@ -103,19 +103,19 @@ describe('intersectRelayQuery', () => {
     it('includes fields with different arguments', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Actor {
-          id,
+          id
           url(site:"www")
         }
       `);
       const patternNode = getNode(Relay.QL`
         fragment on Actor {
-          id,
+          id
           url
         }
       `);
       const expected = getNode(Relay.QL`
         fragment on Actor {
-          id,
+          id
           url(site:"www")
         }
       `);
@@ -127,20 +127,20 @@ describe('intersectRelayQuery', () => {
     it('intersects aliased fields by storage key', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Actor {
-          name,
-          firstName,
+          name
+          firstName
         }
       `);
       const patternNode = getNode(Relay.QL`
         fragment on Actor {
-          name,
-          name: firstName,
+          name
+          name: firstName
         }
       `);
       const expected = getNode(Relay.QL`
         fragment on Actor {
-          name,
-          firstName,
+          name
+          firstName
         }
       `);
       expect(
@@ -152,22 +152,22 @@ describe('intersectRelayQuery', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Actor {
           hometown {
-            name,
-            url,
-          },
+            name
+            url
+          }
         }
       `);
       const patternNode = getNode(Relay.QL`
         fragment on Actor {
-          hometown,
+          hometown
         }
       `);
       const expected = getNode(Relay.QL`
         fragment on Actor {
           hometown {
-            name,
-            url,
-          },
+            name
+            url
+          }
         }
       `);
       expect(
@@ -183,8 +183,8 @@ describe('intersectRelayQuery', () => {
           friends(first: "10") {
             edges {
               node {
-                id,
-                name,
+                id
+                name
               }
             }
           }
@@ -200,8 +200,8 @@ describe('intersectRelayQuery', () => {
           friends(first: "10") {
             edges {
               node {
-                id,
-                name,
+                id
+                name
               }
             }
           }
@@ -216,12 +216,12 @@ describe('intersectRelayQuery', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Actor {
           friends(first: "10") {
-            count,
+            count
             edges {
               node {
-                id,
-                friends,
-                name,
+                id
+                friends
+                name
               }
             }
           }
@@ -250,11 +250,11 @@ describe('intersectRelayQuery', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Actor {
           friends(first: "10") {
-            count,
+            count
             edges {
               node {
-                id,
-                name,
+                id
+                name
               }
             }
           }
@@ -284,11 +284,11 @@ describe('intersectRelayQuery', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Actor {
           friends(orderby:"name",first: "10") {
-            count,
+            count
             edges {
               node {
-                id,
-                name,
+                id
+                name
               }
             }
           }
@@ -318,11 +318,11 @@ describe('intersectRelayQuery', () => {
       const subjectNode = getNode(Relay.QL`
         fragment on Actor {
           friends(first: "10") {
-            count,
+            count
             edges {
               node {
-                id,
-                name,
+                id
+                name
               }
             }
           }
@@ -331,11 +331,11 @@ describe('intersectRelayQuery', () => {
       const patternNode = getNode(Relay.QL`
         fragment on Actor @relay(pattern: true) {
           friends {
-            count,
+            count
             edges {
               node {
-                id,
-                name,
+                id
+                name
               }
             }
           }
@@ -344,11 +344,11 @@ describe('intersectRelayQuery', () => {
       const expected = getNode(Relay.QL`
         fragment on Actor {
           friends(first: "10") {
-            count,
+            count
             edges {
               node {
-                id,
-                name,
+                id
+                name
               }
             }
           }

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -35,8 +35,8 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query {
           me {
-            firstName,
-            lastName,
+            firstName
+            lastName
           }
         }
       `);
@@ -90,7 +90,7 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            name,
+            name
           }
         }
       `);
@@ -113,9 +113,9 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query FooQuery {
           node(id: 123) {
-            name,
-            id,
-          },
+            name
+            id
+          }
         }
       `);
       const {text, variables} = printRelayOSSQuery(query);
@@ -137,8 +137,8 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query {
           usernames(names:["a","b","c"]) {
-            firstName,
-            lastName,
+            firstName
+            lastName
           }
         }
       `);
@@ -162,8 +162,8 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query FooQuery {
           nodes(ids: [123, 456]) {
-            name,
-            id,
+            name
+            id
           }
         }
       `);
@@ -187,8 +187,8 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query FooQuery {
           settings(environment: $env) {
-            notificationSounds,
-          },
+            notificationSounds
+          }
         }
       `, {
         env: enumValue,
@@ -211,7 +211,7 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query {
           checkinSearchQuery(query: $q) {
-            query,
+            query
           }
         }
       `, {
@@ -235,7 +235,7 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query {
           checkinSearchQuery(query: {query: "Menlo Park"}) {
-            query,
+            query
           }
         }
       `);
@@ -410,8 +410,8 @@ describe('printRelayOSSQuery', () => {
       const fragment = getNode(Relay.QL`
         fragment on Viewer {
           actor {
-            id,
-          },
+            id
+          }
         }
       `);
       const {text, variables} = printRelayOSSQuery(fragment);
@@ -471,8 +471,8 @@ describe('printRelayOSSQuery', () => {
       const fragmentB = Relay.QL`fragment on User { lastName }`;
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          ${fragmentA},
-          ${fragmentB},
+          ${fragmentA}
+          ${fragmentB}
         }
       `);
       const {text, variables} = printRelayOSSQuery(fragment);
@@ -500,8 +500,8 @@ describe('printRelayOSSQuery', () => {
       const fragmentB = Relay.QL`fragment on User { name }`;
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          ${fragmentA},
-          ${fragmentB},
+          ${fragmentA}
+          ${fragmentB}
         }
       `);
       const {text, variables} = printRelayOSSQuery(fragment);
@@ -564,8 +564,8 @@ describe('printRelayOSSQuery', () => {
 
       const fragment = getNode(Relay.QL`
         fragment on Node {
-          ${fragmentA},
-          ${fragmentB},
+          ${fragmentA}
+          ${fragmentB}
         }
       `);
       const {text, variables} = printRelayOSSQuery(fragment);
@@ -728,9 +728,9 @@ describe('printRelayOSSQuery', () => {
       const fragment = getNode(Relay.QL`
         fragment on Actor {
           friends(
-            first: $first,
-            orderby: $orderby,
-            isViewerFriend: $isViewerFriend,
+            first: $first
+            orderby: $orderby
+            isViewerFriend: $isViewerFriend
           ) {
             edges {
               node {
@@ -777,7 +777,7 @@ describe('printRelayOSSQuery', () => {
       const query = getNode(Relay.QL`
         query {
           defaultSettings {
-            ${fragment},
+            ${fragment}
           }
         }
       `, {
@@ -806,9 +806,9 @@ describe('printRelayOSSQuery', () => {
       const fragment = getNode(Relay.QL`
         fragment on Viewer {
           actor {
-            id,
-            ${nestedFragment},
-            ${nestedFragment},
+            id
+            ${nestedFragment}
+            ${nestedFragment}
           }
         }
       `);
@@ -838,18 +838,18 @@ describe('printRelayOSSQuery', () => {
     const mutation = getNode(Relay.QL`
       mutation {
         feedbackLike(input: $input) {
-          clientMutationId,
+          clientMutationId
           feedback {
-            id,
+            id
             actor {
               profilePicture(preset: SMALL) {
-                uri,
-              },
-            },
-            likeSentence,
-            likers,
-          },
-        },
+                uri
+              }
+            }
+            likeSentence
+            likers
+          }
+        }
       }
     `, {input: inputValue});
 

--- a/src/traversal/__tests__/splitDeferredRelayQueries-test.js
+++ b/src/traversal/__tests__/splitDeferredRelayQueries-test.js
@@ -55,9 +55,9 @@ describe('splitDeferredRelayQueries()', () => {
     const node = Relay.QL`
       query {
         node(id:"4") {
-          id,
-          name,
-          ${fragment},
+          id
+          name
+          ${fragment}
         }
       }
     `;
@@ -74,20 +74,20 @@ describe('splitDeferredRelayQueries()', () => {
         newsFeed(first: "10") {
           edges {
             node {
-              id,
-              actorCount,
-            },
-          },
-        },
+              id
+              actorCount
+            }
+          }
+        }
       }
     `;
     const node = Relay.QL`
       query {
         viewer {
           actor {
-            id,
-          },
-          ${defer(fragment)},
+            id
+          }
+          ${defer(fragment)}
         }
       }
     `;
@@ -105,7 +105,7 @@ describe('splitDeferredRelayQueries()', () => {
     expect(deferred[0].required).toEqualQueryRoot(getNode(Relay.QL`
       query {
         viewer {
-          ${fragment},
+          ${fragment}
         }
       }
     `));
@@ -122,28 +122,28 @@ describe('splitDeferredRelayQueries()', () => {
         newsFeed(first: "10") {
           edges {
             node {
-              id,
-              actorCount,
-            },
-          },
-        },
+              id
+              actorCount
+            }
+          }
+        }
       }
     `;
     const fragment = Relay.QL`
       fragment on Viewer {
         actor {
-          name,
-        },
-        ${defer(nestedFragment)},
+          name
+        }
+        ${defer(nestedFragment)}
       }
     `;
     const node = Relay.QL`
       query {
         viewer {
           actor {
-            id,
-          },
-          ${fragment},
+            id
+          }
+          ${fragment}
         }
       }
     `;
@@ -156,8 +156,8 @@ describe('splitDeferredRelayQueries()', () => {
       query {
         viewer {
           actor {
-            id,
-          },
+            id
+          }
           ${Relay.QL`
       fragment on Viewer {
         actor {
@@ -175,7 +175,7 @@ describe('splitDeferredRelayQueries()', () => {
     expect(deferred[0].required).toEqualQueryRoot(getNode(Relay.QL`
       query {
         viewer {
-          ${nestedFragment},
+          ${nestedFragment}
         }
       }
     `));
@@ -192,20 +192,20 @@ describe('splitDeferredRelayQueries()', () => {
         newsFeed(first: "10") {
           edges {
             node {
-              tracking,
-              ${defer(nestedFragment)},
-            },
-          },
-        },
+              tracking
+              ${defer(nestedFragment)}
+            }
+          }
+        }
       }
     `;
     const node = Relay.QL`
       query {
         viewer {
           actor {
-            name,
-          },
-          ${defer(fragment)},
+            name
+          }
+          ${defer(fragment)}
         }
       }
     `;
@@ -266,14 +266,14 @@ describe('splitDeferredRelayQueries()', () => {
         viewer {
           newsFeed(first: "10") {
             edges {
-              cursor,
+              cursor
               node {
-                ${nestedFragment},
+                ${nestedFragment}
                 id
               }
-            },
+            }
             pageInfo {
-              hasNextPage,
+              hasNextPage
               hasPreviousPage
             }
           }
@@ -292,11 +292,11 @@ describe('splitDeferredRelayQueries()', () => {
     const node = Relay.QL`
       query {
         node(id:"4") {
-          id,
-          name,
+          id
+          name
           hometown {
-            ${defer(fragment)},
-          },
+            ${defer(fragment)}
+          }
         }
       }
     `;
@@ -324,7 +324,7 @@ describe('splitDeferredRelayQueries()', () => {
         Relay.QL`
           query {
             nodes(ids:$ref_q1) {
-              ${fragment},
+              ${fragment}
             }
           }
         `,
@@ -343,17 +343,17 @@ describe('splitDeferredRelayQueries()', () => {
     const fragment = Relay.QL`
       fragment on User {
         hometown {
-          name,
-          ${defer(nestedFragment)},
-        },
+          name
+          ${defer(nestedFragment)}
+        }
       }
     `;
     const node = Relay.QL`
       query {
         node(id:"4") {
-          id,
-          name,
-          ${defer(fragment)},
+          id
+          name
+          ${defer(fragment)}
         }
       }
     `;
@@ -397,7 +397,7 @@ describe('splitDeferredRelayQueries()', () => {
         Relay.QL`
           query {
             nodes(ids:$ref_q2) {
-              ${nestedFragment},
+              ${nestedFragment}
             }
           }
         `,
@@ -418,18 +418,18 @@ describe('splitDeferredRelayQueries()', () => {
       fragment on Page {
         profilePicture {
           uri
-        },
+        }
         ${defer(nestedFragment)}
       }
     `;
     const node = Relay.QL`
       query {
         node(id:"4") {
-          id,
-          name,
+          id
+          name
           hometown {
-            ${defer(fragment)},
-          },
+            ${defer(fragment)}
+          }
         }
       }
     `;
@@ -477,7 +477,7 @@ describe('splitDeferredRelayQueries()', () => {
         Relay.QL`
           query {
             nodes(ids:$ref_q2) {
-              ${nestedFragment},
+              ${nestedFragment}
             }
           }
         `,
@@ -497,17 +497,17 @@ describe('splitDeferredRelayQueries()', () => {
         newsFeed(first: "10") {
           edges {
             node {
-              id,
-              actorCount,
-            },
-          },
-        },
+              id
+              actorCount
+            }
+          }
+        }
       }
     `;
     const node = Relay.QL`
       query {
         viewer {
-          ${defer(fragment)},
+          ${defer(fragment)}
         }
       }
     `;
@@ -523,7 +523,7 @@ describe('splitDeferredRelayQueries()', () => {
     expect(deferred[0].required).toEqualQueryRoot(getNode(Relay.QL`
       query {
         viewer {
-          ${fragment},
+          ${fragment}
         }
       }
     `));
@@ -537,13 +537,13 @@ describe('splitDeferredRelayQueries()', () => {
     const nestedFragment = Relay.QL`fragment on Viewer{primaryEmail}`;
     const fragment = Relay.QL`
       fragment on Viewer {
-        ${defer(nestedFragment)},
+        ${defer(nestedFragment)}
       }
     `;
     const node = Relay.QL`
       query {
         viewer {
-          isFbEmployee,
+          isFbEmployee
           ${defer(fragment)}
         }
       }
@@ -571,7 +571,7 @@ describe('splitDeferredRelayQueries()', () => {
     expect(deferred[0].deferred[0].required).toEqualQueryRoot(getNode(Relay.QL`
       query {
         viewer {
-          ${nestedFragment},
+          ${nestedFragment}
         }
       }
     `));
@@ -585,16 +585,16 @@ describe('splitDeferredRelayQueries()', () => {
     const nestedFragment = Relay.QL`fragment on Actor{hometown{name}}`;
     const fragment = Relay.QL`
       fragment on Viewer {
-        ${defer(nestedFragment)},
+        ${defer(nestedFragment)}
       }
     `;
     const node = Relay.QL`
       query {
         viewer {
           actor {
-            name,
-            ${defer(fragment)},
-          },
+            name
+            ${defer(fragment)}
+          }
         }
       }
     `;
@@ -630,7 +630,7 @@ describe('splitDeferredRelayQueries()', () => {
         Relay.QL`
           query {
             nodes(ids:$ref_q1) {
-              ${nestedFragment},
+              ${nestedFragment}
             }
           }
         `,
@@ -650,8 +650,8 @@ describe('splitDeferredRelayQueries()', () => {
       query {
         node(id:"123") {
           actors {
-            id,
-            ${defer(fragment)},
+            id
+            ${defer(fragment)}
           }
         }
       }
@@ -665,7 +665,7 @@ describe('splitDeferredRelayQueries()', () => {
       query {
         node(id:"123") {
           actors {
-            id,
+            id
           }
         }
       }
@@ -680,7 +680,7 @@ describe('splitDeferredRelayQueries()', () => {
         Relay.QL`
           query {
             nodes(ids:$ref_q1) {
-              ${fragment},
+              ${fragment}
             }
           }
         `,
@@ -701,9 +701,9 @@ describe('splitDeferredRelayQueries()', () => {
         viewer {
           actor {
             hometown {
-              ${defer(fragment)},
-            },
-          },
+              ${defer(fragment)}
+            }
+          }
         }
       }
     `;
@@ -718,9 +718,9 @@ describe('splitDeferredRelayQueries()', () => {
         viewer {
           actor {
             hometown {
-              id,
-            },
-          },
+              id
+            }
+          }
         }
       }
     `));
@@ -734,7 +734,7 @@ describe('splitDeferredRelayQueries()', () => {
         Relay.QL`
           query {
             nodes(ids:$ref_q1) {
-              ${fragment},
+              ${fragment}
             }
           }
         `,
@@ -756,11 +756,11 @@ describe('splitDeferredRelayQueries()', () => {
           friends(first:"5") {
             edges {
               node {
-                name,
-                ${defer(fragment)},
-              },
-            },
-          },
+                name
+                ${defer(fragment)}
+              }
+            }
+          }
         }
       }
     `;
@@ -776,11 +776,11 @@ describe('splitDeferredRelayQueries()', () => {
           friends(first:"5") {
             edges {
               node {
-                id,
-                name,
-              },
-            },
-          },
+                id
+                name
+              }
+            }
+          }
         }
       }
     `));
@@ -797,7 +797,7 @@ describe('splitDeferredRelayQueries()', () => {
         Relay.QL`
           query {
             nodes(ids:$ref_q1) {
-              ${fragment},
+              ${fragment}
             }
           }
         `,
@@ -819,10 +819,10 @@ describe('splitDeferredRelayQueries()', () => {
           friends(first: "5") {
             edges {
               node {
-                ${defer(fragment)},
-              },
-            },
-          },
+                ${defer(fragment)}
+              }
+            }
+          }
         }
       }
     `;
@@ -838,10 +838,10 @@ describe('splitDeferredRelayQueries()', () => {
           friends(first: "5") {
             edges {
               node {
-                id,
-              },
-            },
-          },
+                id
+              }
+            }
+          }
         }
       }
     `));
@@ -858,7 +858,7 @@ describe('splitDeferredRelayQueries()', () => {
         Relay.QL`
           query {
             nodes(ids:$ref_q1) {
-              ${fragment},
+              ${fragment}
             }
           }
         `,
@@ -877,10 +877,10 @@ describe('splitDeferredRelayQueries()', () => {
     const node = Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           profilePicture(size:"100") {
-            ${defer(fragment)},
-          },
+            ${defer(fragment)}
+          }
         }
       }
     `;
@@ -898,8 +898,8 @@ describe('splitDeferredRelayQueries()', () => {
       query {
         node(id:"4") {
           profilePicture(size:"100") {
-            ${fragment},
-          },
+            ${fragment}
+          }
         }
       }
     `));
@@ -914,7 +914,7 @@ describe('splitDeferredRelayQueries()', () => {
     const node = Relay.QL`
       query {
         node(id:"4") {
-              ${defer(fragment)},
+              ${defer(fragment)}
             }
       }
     `;
@@ -930,7 +930,7 @@ describe('splitDeferredRelayQueries()', () => {
     expect(deferred[0].required).toEqualQueryRoot(getNode(Relay.QL`
       query {
           node(id:"4") {
-            ${fragment},
+            ${fragment}
         }
       }
     `));
@@ -1015,7 +1015,7 @@ describe('splitDeferredRelayQueries()', () => {
         Relay.QL`
           query {
             nodes(ids:$ref_q1) {
-              ${fragment},
+              ${fragment}
             }
           }
         `,
@@ -1034,8 +1034,8 @@ describe('splitDeferredRelayQueries()', () => {
     const node = Relay.QL`
       query {
         node(id:"4") {
-              id,
-              ${defer(fragment)},
+              id
+              ${defer(fragment)}
             }
       }
     `;
@@ -1052,7 +1052,7 @@ describe('splitDeferredRelayQueries()', () => {
     expect(deferred[0].required).toEqualQueryRoot(getNode(Relay.QL`
       query {
         node(id:"4") {
-          ${fragment},
+          ${fragment}
         }
       }
     `));
@@ -1069,8 +1069,8 @@ describe('splitDeferredRelayQueries()', () => {
     const node = Relay.QL`
       query {
         viewer {
-              primaryEmail,
-              ${defer(fragment)},
+              primaryEmail
+              ${defer(fragment)}
             }
       }
     `;
@@ -1092,7 +1092,7 @@ describe('splitDeferredRelayQueries()', () => {
     const query = getNode(Relay.QL`
       query {
         node(id:"4") {
-          ${defer(fragment)},
+          ${defer(fragment)}
         }
       }
     `);
@@ -1108,8 +1108,8 @@ describe('splitDeferredRelayQueries()', () => {
       query {
         node(id:"STORY_ID") {
           feedback {
-            ${defer(fragment)},
-          },
+            ${defer(fragment)}
+          }
         }
       }
     `);

--- a/src/traversal/__tests__/subtractRelayQuery-test.js
+++ b/src/traversal/__tests__/subtractRelayQuery-test.js
@@ -35,11 +35,11 @@ describe('subtractRelayQuery', () => {
     const minQuery = getNode(Relay.QL`
       query {
         node(id:"4") {
-          id,
+          id
           hometown {
-            id,
-            name,
-          },
+            id
+            name
+          }
           name
         }
       }
@@ -59,11 +59,11 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
-              name,
-            },
+              id
+              name
+            }
             name
           }
         }
@@ -81,10 +81,10 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
-            },
+              id
+            }
             name
           }
         }
@@ -104,9 +104,9 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
+              id
             }
           }
         }
@@ -128,9 +128,9 @@ describe('subtractRelayQuery', () => {
           node(id:"123") {
             friends(first:"10") {
               edges {
-                live_cursor: cursor,
-              },
-            },
+                live_cursor: cursor
+              }
+            }
           }
         }
       `);
@@ -138,8 +138,8 @@ describe('subtractRelayQuery', () => {
         query {
           node(id:"123") {
             friends(first:"1") {
-              count,
-            },
+              count
+            }
           }
         }
       `);
@@ -148,9 +148,9 @@ describe('subtractRelayQuery', () => {
           node(id:"123") {
             friends(first:"10") {
               edges {
-                live_cursor: cursor,
-              },
-            },
+                live_cursor: cursor
+              }
+            }
           }
         }
       `);
@@ -165,10 +165,10 @@ describe('subtractRelayQuery', () => {
             newsFeed(first:"1") {
               edges {
                 node {
-                  special_id: id,
-                },
-              },
-            },
+                  special_id: id
+                }
+              }
+            }
           }
         }
       `);
@@ -179,11 +179,11 @@ describe('subtractRelayQuery', () => {
               edges {
                 node {
                   actor {
-                    name,
-                  },
-                },
-              },
-            },
+                    name
+                  }
+                }
+              }
+            }
           }
         }
       `);
@@ -197,8 +197,8 @@ describe('subtractRelayQuery', () => {
         query {
           node(id:"UzpfSTU0MTUzNTg0MzoxMDE1Mjk3MDY0NjAzNTg0NA==") {
             feedback {
-              doesViewerLike,
-              ${defer(fragment)},
+              doesViewerLike
+              ${defer(fragment)}
             }
           }
         }
@@ -217,10 +217,10 @@ describe('subtractRelayQuery', () => {
       const expected = getNode(Relay.QL`
         query {
           node(id:"UzpfSTU0MTUzNTg0MzoxMDE1Mjk3MDY0NjAzNTg0NA==") {
-            id,
+            id
             feedback {
-              id,
-            },
+              id
+            }
           }
         }
       `);
@@ -232,11 +232,11 @@ describe('subtractRelayQuery', () => {
       let minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
-            name,
+            id
+            name
             birthdate {
               day
-            },
+            }
           }
         }
       `);
@@ -251,10 +251,10 @@ describe('subtractRelayQuery', () => {
       minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
-              name,
+              id
+              name
               url
             }
           }
@@ -268,9 +268,9 @@ describe('subtractRelayQuery', () => {
       expected = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
+              id
               url
             }
           }
@@ -283,11 +283,11 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
+              id
               address {
-                country,
+                country
                 city
               }
             }
@@ -302,9 +302,9 @@ describe('subtractRelayQuery', () => {
       const expected = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
+              id
               address {
                 city
               }
@@ -325,16 +325,16 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
-            name,
+            id
+            name
           }
         }
       `);
       const subQuery = getNode(Relay.QL`
         query {
           node(id:"660361306") {
-            id,
-            name,
+            id
+            name
           }
         }
       `);
@@ -350,7 +350,7 @@ describe('subtractRelayQuery', () => {
     it('preserves fields from fragments within a range', () => {
       const fragment = Relay.QL`
         fragment on User {
-          name,
+          name
         }
       `;
       const minQuery = getNode(Relay.QL`
@@ -359,11 +359,11 @@ describe('subtractRelayQuery', () => {
             friends(first: "10") {
               edges {
                 node {
-                  id,
-                  ${fragment},
-                },
-              },
-            },
+                  id
+                  ${fragment}
+                }
+              }
+            }
           }
         }
       `);
@@ -373,11 +373,11 @@ describe('subtractRelayQuery', () => {
             friends(first: "10") {
               edges {
                 node {
-                  id,
+                  id
                   firstName
-                },
-              },
-            },
+                }
+              }
+            }
           }
         }
       `);
@@ -388,7 +388,7 @@ describe('subtractRelayQuery', () => {
     it('preserves fields from deferred fragments within a range', () => {
       const fragment = Relay.QL`
         fragment on User {
-          name,
+          name
         }
       `;
       const minQuery = getNode(Relay.QL`
@@ -397,12 +397,12 @@ describe('subtractRelayQuery', () => {
             friends(first: "5") {
               edges {
                 node {
-                  id,
-                  firstName,
-                  ${defer(fragment)},
-                },
-              },
-            },
+                  id
+                  firstName
+                  ${defer(fragment)}
+                }
+              }
+            }
           }
         }
       `);
@@ -420,12 +420,12 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
-              name,
+              id
+              name
               url
-            },
+            }
             name
           }
         }
@@ -438,11 +438,11 @@ describe('subtractRelayQuery', () => {
       const expected = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
+              id
               name
-            },
+            }
             name
           }
         }
@@ -456,7 +456,7 @@ describe('subtractRelayQuery', () => {
           node(id:"123") {
             hometown {
               name
-            },
+            }
             friends(first:"5") {
               edges {
                 node {
@@ -498,7 +498,7 @@ describe('subtractRelayQuery', () => {
           viewer {
             actor {
               id
-            },
+            }
           }
         }
       `);
@@ -571,8 +571,8 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
-            name,
+            id
+            name
             ${minFragment}
           }
         }
@@ -600,12 +600,12 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
-              name,
+              id
+              name
               url
-            },
+            }
             name
           }
         }
@@ -615,7 +615,7 @@ describe('subtractRelayQuery', () => {
         query {
           node(id:"4") {
             hometown {
-              id,
+              id
               ${subFragment}
             }
           }
@@ -625,11 +625,11 @@ describe('subtractRelayQuery', () => {
       const expected = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             hometown {
-              id,
+              id
               url
-            },
+            }
             name
           }
         }
@@ -644,7 +644,7 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             ${minFragment}
           }
         }
@@ -655,9 +655,9 @@ describe('subtractRelayQuery', () => {
         query {
           node(id:"4") {
             hometown {
-              id,
+              id
               ${subFragmentPage}
-            },
+            }
             ${subFragmentNode}
           }
         }
@@ -761,7 +761,7 @@ describe('subtractRelayQuery', () => {
             friends(first:"3") {
               edges {
                 node {
-                  name,
+                  name
                   firstName
                 }
               }
@@ -803,17 +803,17 @@ describe('subtractRelayQuery', () => {
       const minQuery = getNode(Relay.QL`
         query {
           node(id:"4") {
-            id,
+            id
             friends(first:"5") {
               edges {
-                cursor,
+                cursor
                 node {
-                  id,
+                  id
                   name
                 }
-              },
+              }
               pageInfo {
-                hasNextPage,
+                hasNextPage
                 hasPreviousPage
               }
             }
@@ -825,14 +825,14 @@ describe('subtractRelayQuery', () => {
           node(id:"4") {
             friends(first:"5") {
               edges {
-                cursor,
+                cursor
                 node {
-                  id,
+                  id
                   name
                 }
-              },
+              }
               pageInfo {
-                hasNextPage,
+                hasNextPage
                 hasPreviousPage
               }
             }
@@ -849,7 +849,7 @@ describe('subtractRelayQuery', () => {
             friends(first:"5") {
               edges {
                 node {
-                  name,
+                  name
                   firstName
                 }
               }
@@ -880,7 +880,7 @@ describe('subtractRelayQuery', () => {
             friends(orderby:"importance",first:"3") {
               edges {
                 node {
-                  name,
+                  name
                   firstName
                 }
               }

--- a/src/traversal/__tests__/transformRelayQueryPayload-test.js
+++ b/src/traversal/__tests__/transformRelayQueryPayload-test.js
@@ -28,18 +28,18 @@ describe('transformClientPayload()', () => {
       query {
         node(id: "123") {
           friends(first:"1") {
-            count,
+            count
             edges {
               node {
-                id,
+                id
                 ... on User {
                   profilePicture(size: "32") {
-                    uri,
-                  },
-                },
-              },
-            },
-          },
+                    uri
+                  }
+                }
+              }
+            }
+          }
         }
       }
     `);
@@ -89,10 +89,10 @@ describe('transformClientPayload()', () => {
         nodes(ids: ["123", "456"]) {
           ... on User {
             profilePicture(size: "32") {
-              uri,
-            },
-          },
-        },
+              uri
+            }
+          }
+        }
       }
     `);
     const payload = {
@@ -131,10 +131,10 @@ describe('transformClientPayload()', () => {
         nodes(ids: ["123", "456"]) {
           ... on User {
             profilePicture(size: "32") {
-              uri,
-            },
-          },
-        },
+              uri
+            }
+          }
+        }
       }
     `);
     const payload = {
@@ -177,10 +177,10 @@ describe('transformClientPayload()', () => {
         nodes(ids: ["123", "456"]) {
           ... on User {
             profilePicture(size: "32") {
-              uri,
-            },
-          },
-        },
+              uri
+            }
+          }
+        }
       }
     `);
     const payload = {

--- a/src/traversal/__tests__/writeRelayQueryPayload_connectionField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_connectionField-test.js
@@ -57,17 +57,17 @@ describe('writeRelayQueryPayload()', () => {
         node(id:"123") {
           friends(first:"3") {
             edges {
-              cursor,
+              cursor
               node {
                 id
-              },
+              }
               source {
                 id
               }
-            },
+            }
             pageInfo {
-              hasNextPage,
-              hasPreviousPage,
+              hasNextPage
+              hasPreviousPage
             }
           }
         }
@@ -121,17 +121,17 @@ describe('writeRelayQueryPayload()', () => {
         node(id:"123") {
           friends(first:"3") {
             edges {
-              cursor,
+              cursor
               node {
                 id
-              },
+              }
               source {
                 id
               }
-            },
+            }
             pageInfo {
-              hasNextPage,
-              hasPreviousPage,
+              hasNextPage
+              hasPreviousPage
             }
           }
         }
@@ -238,17 +238,17 @@ describe('writeRelayQueryPayload()', () => {
         node(id:"123") {
           friends(first:"3") {
             edges {
-              cursor,
+              cursor
               node {
                 id
-              },
+              }
               source {
                 id
               }
-            },
+            }
             pageInfo {
-              hasNextPage,
-              hasPreviousPage,
+              hasNextPage
+              hasPreviousPage
             }
           }
         }
@@ -347,14 +347,14 @@ describe('writeRelayQueryPayload()', () => {
         node(id:"123") {
           friends(first:"3") {
             edges {
-              cursor,
+              cursor
               node {
                 id
-              },
-            },
+              }
+            }
             pageInfo {
-              hasNextPage,
-              hasPreviousPage,
+              hasNextPage
+              hasPreviousPage
             }
           }
         }
@@ -439,17 +439,17 @@ describe('writeRelayQueryPayload()', () => {
         node(id:"123") {
           friends(first:"1") {
             edges {
-              cursor,
+              cursor
               node {
                 id
-              },
+              }
               source {
                 id
               }
-            },
+            }
             pageInfo {
-              hasNextPage,
-              hasPreviousPage,
+              hasNextPage
+              hasPreviousPage
             }
           }
         }
@@ -514,17 +514,17 @@ describe('writeRelayQueryPayload()', () => {
     const edgesFragment = Relay.QL`
       fragment on FriendsConnection {
         edges {
-          cursor,
+          cursor
           node {
             id
-          },
+          }
           source {
             id
           }
-        },
+        }
         pageInfo {
-          hasNextPage,
-          hasPreviousPage,
+          hasNextPage
+          hasPreviousPage
         }
       }
     `;
@@ -678,7 +678,7 @@ describe('writeRelayQueryPayload()', () => {
             friends(first: "1") {
               edges {
                 node {
-                  id,
+                  id
                   name
                 }
               }
@@ -740,8 +740,8 @@ describe('writeRelayQueryPayload()', () => {
             friends(find:"node1") {
               edges {
                 node {
-                  id,
-                },
+                  id
+                }
                 source {
                   id
                 }

--- a/src/traversal/__tests__/writeRelayQueryPayload_defaultNull-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_defaultNull-test.js
@@ -41,7 +41,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            id,
+            id
             name
           }
         }
@@ -70,7 +70,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            id,
+            id
             name
           }
         }
@@ -172,14 +172,14 @@ describe('writeRelayQueryPayload()', () => {
           node(id:"123") {
             friends(first:"3") {
               edges {
-                cursor,
+                cursor
                 node {
                   id
-                },
-              },
+                }
+              }
               pageInfo {
-                hasNextPage,
-                hasPreviousPage,
+                hasNextPage
+                hasPreviousPage
               }
             }
           }

--- a/src/traversal/__tests__/writeRelayQueryPayload_linkedField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_linkedField-test.js
@@ -282,7 +282,7 @@ describe('writeRelayQueryPayload()', () => {
         query {
           viewer {
             actor {
-              id,
+              id
               __typename
             }
           }

--- a/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_paths-test.js
@@ -65,8 +65,8 @@ describe('writePayload()', () => {
         query {
           viewer {
             actor {
-              id,
-            },
+              id
+            }
           }
         }
       `);
@@ -103,7 +103,7 @@ describe('writePayload()', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            id,
+            id
           }
         }
       `);
@@ -134,9 +134,9 @@ describe('writePayload()', () => {
           viewer {
             actor {
               address {
-                city,
-              },
-            },
+                city
+              }
+            }
           }
         }
       `);
@@ -159,8 +159,8 @@ describe('writePayload()', () => {
         query {
           node(id:"123") {
             address {
-              city,
-            },
+              city
+            }
           }
         }
       `);
@@ -187,12 +187,12 @@ describe('writePayload()', () => {
         query {
           node(id:"123") {
             allPhones {
-              isVerified,
+              isVerified
               phoneNumber {
-                displayNumber,
-                countryCode,
-              },
-            },
+                displayNumber
+                countryCode
+              }
+            }
           }
         }
       `);
@@ -241,13 +241,13 @@ describe('writePayload()', () => {
             friends(first:"1") {
               edges {
                 node {
-                  id,
+                  id
                   address {
-                    city,
-                  },
-                },
-              },
-            },
+                    city
+                  }
+                }
+              }
+            }
           }
         }
       `);
@@ -358,8 +358,8 @@ describe('writePayload()', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            id,
-            name,
+            id
+            name
           }
         }
       `);
@@ -388,8 +388,8 @@ describe('writePayload()', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            ${fragment},
-            ${fragment},
+            ${fragment}
+            ${fragment}
           }
         }
       `);
@@ -421,8 +421,8 @@ describe('writePayload()', () => {
         query {
           viewer {
             actor {
-              name,
-            },
+              name
+            }
           }
         }
       `);
@@ -506,10 +506,10 @@ describe('writePayload()', () => {
             friends(first:"1") {
               edges {
                 node {
-                  name,
-                },
-              },
-            },
+                  name
+                }
+              }
+            }
           }
         }
       `);
@@ -557,10 +557,10 @@ describe('writePayload()', () => {
             friends(first:"1") {
               edges {
                 node {
-                  name,
-                },
-              },
-            },
+                  name
+                }
+              }
+            }
           }
         }
       `);
@@ -593,10 +593,10 @@ describe('writePayload()', () => {
             friends(after:"c1",first:"1") {
               edges {
                 node {
-                  name,
-                },
-              },
-            },
+                  name
+                }
+              }
+            }
           }
         }
       `);
@@ -635,19 +635,19 @@ describe('writePayload()', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            name,
+            name
             allPhones {
               phoneNumber {
-                displayNumber,
-              },
-            },
+                displayNumber
+              }
+            }
             friends(first:"1") {
               edges {
                 node {
-                  name,
-                },
-              },
-            },
+                  name
+                }
+              }
+            }
           }
         }
       `);

--- a/src/traversal/__tests__/writeRelayQueryPayload_pluralLinkedField-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_pluralLinkedField-test.js
@@ -96,10 +96,10 @@ describe('writeRelayQueryPayload()', () => {
         query {
           node(id:"123") {
             allPhones {
-              isVerified,
+              isVerified
               phoneNumber {
-                displayNumber,
-                countryCode,
+                displayNumber
+                countryCode
               }
             }
           }
@@ -180,10 +180,10 @@ describe('writeRelayQueryPayload()', () => {
         query {
           node(id:"123") {
             allPhones {
-              isVerified,
+              isVerified
               phoneNumber {
-                displayNumber,
-                countryCode,
+                displayNumber
+                countryCode
               }
             }
           }
@@ -259,8 +259,8 @@ describe('writeRelayQueryPayload()', () => {
           node(id:"123") {
             allPhones {
               phoneNumber {
-                displayNumber,
-                countryCode,
+                displayNumber
+                countryCode
               }
             }
           }
@@ -327,10 +327,10 @@ describe('writeRelayQueryPayload()', () => {
         query {
           node(id:"123") {
             allPhones {
-              isVerified,
+              isVerified
               phoneNumber {
-                displayNumber,
-                countryCode,
+                displayNumber
+                countryCode
               }
             }
           }

--- a/src/traversal/__tests__/writeRelayQueryPayload_rootRecord-test.js
+++ b/src/traversal/__tests__/writeRelayQueryPayload_rootRecord-test.js
@@ -54,7 +54,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getNode(Relay.QL`
         query {
           me {
-            id,
+            id
           }
         }
       `);
@@ -84,8 +84,8 @@ describe('writeRelayQueryPayload()', () => {
         query {
           viewer {
             actor {
-              id,
-            },
+              id
+            }
           }
         }
       `);
@@ -128,8 +128,8 @@ describe('writeRelayQueryPayload()', () => {
         query {
           viewer {
             actor {
-              id,
-            },
+              id
+            }
           }
         }
       `);
@@ -162,7 +162,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getNode(Relay.QL`
         query {
           username(name:"yuzhi") {
-            id,
+            id
           }
         }
       `);
@@ -191,7 +191,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getNode(Relay.QL`
         query {
           username(name:"yuzhi") {
-            id,
+            id
           }
         }
       `);
@@ -227,7 +227,7 @@ describe('writeRelayQueryPayload()', () => {
       let query = getNode(Relay.QL`
         query {
           username(name:"yuzhi") {
-            name,
+            name
           }
         }
       `);
@@ -353,7 +353,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getNode(Relay.QL`
         query {
           checkinSearchQuery(query: {query: "Facebook"}) {
-            query,
+            query
           }
         }
       `);
@@ -559,7 +559,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getRefNode(Relay.QL`
         query {
           nodes(ids:$ref_q0) {
-            id,
+            id
             name
           }
         }
@@ -693,7 +693,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            id,
+            id
             name
           }
         }
@@ -728,7 +728,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getNode(Relay.QL`
         query {
           node(id:"123") {
-            id,
+            id
           }
         }
       `);
@@ -754,7 +754,7 @@ describe('writeRelayQueryPayload()', () => {
       const query = getNode(Relay.QL`
         query {
           node(id: "123") {
-            id,
+            id
             __typename
           }
         }

--- a/src/traversal/__tests__/writeRelayUpdatePayload-test.js
+++ b/src/traversal/__tests__/writeRelayUpdatePayload-test.js
@@ -82,13 +82,13 @@ describe('writePayload()', () => {
         query {
           node(id:"feedback_id") {
             topLevelComments(first:"1") {
-              count,
+              count
               edges {
                 node {
-                  id,
-                },
-              },
-            },
+                  id
+                }
+              }
+            }
           }
         }
       `);
@@ -127,9 +127,9 @@ describe('writePayload()', () => {
           commentDelete(input:$input) {
             feedback {
               topLevelComments {
-                count,
-              },
-            },
+                count
+              }
+            }
           }
         }
       `, {
@@ -217,13 +217,13 @@ describe('writePayload()', () => {
         query {
           node(id:"feedback_id") {
             topLevelComments(first:"1") {
-              count,
+              count
               edges {
                 node {
-                  id,
-                },
-              },
-            },
+                  id
+                }
+              }
+            }
           }
         }
       `);
@@ -261,12 +261,12 @@ describe('writePayload()', () => {
       const mutation = getNode(Relay.QL`
         mutation {
           commentDelete(input:$input) {
-            deletedCommentId,
+            deletedCommentId
             feedback {
               topLevelComments {
-                count,
-              },
-            },
+                count
+              }
+            }
           }
         }
       `, {
@@ -346,12 +346,12 @@ describe('writePayload()', () => {
       const mutation = getNode(Relay.QL`
         mutation {
           commentDelete(input:$input) {
-            deletedCommentId,
+            deletedCommentId
             feedback {
               topLevelComments {
-                count,
-              },
-            },
+                count
+              }
+            }
           }
         }
       `, {
@@ -565,7 +565,7 @@ describe('writePayload()', () => {
         query {
           node(id:"feedback123") {
             topLevelComments(first:"1") {
-              count,
+              count
               edges {
                 node {
                   id
@@ -615,9 +615,9 @@ describe('writePayload()', () => {
       const mutation = getNode(Relay.QL`
         mutation {
           commentDelete(input:$input) {
-            deletedCommentId,
+            deletedCommentId
             feedback {
-              id,
+              id
               topLevelComments {
                 count
               }
@@ -713,9 +713,9 @@ describe('writePayload()', () => {
       const mutation = getNode(Relay.QL`
         mutation {
           commentDelete(input:$input) {
-            deletedCommentId,
+            deletedCommentId
             feedback {
-              id,
+              id
               topLevelComments {
                 count
               }
@@ -851,7 +851,7 @@ describe('writePayload()', () => {
       const mutation = getNode(Relay.QL`
         mutation {
           applicationRequestDeleteAll(input:$input) {
-            deletedRequestIds,
+            deletedRequestIds
           }
         }
       `, {
@@ -917,7 +917,7 @@ describe('writePayload()', () => {
       const mutation = getNode(Relay.QL`
         mutation {
           applicationRequestDeleteAll(input:$input) {
-            deletedRequestIds,
+            deletedRequestIds
           }
         }
       `, {
@@ -1014,7 +1014,7 @@ describe('writePayload()', () => {
         query {
           node(id:"feedback123") {
             topLevelComments(first:"1") {
-              count,
+              count
               edges {
                 node {
                   id
@@ -1057,11 +1057,11 @@ describe('writePayload()', () => {
         mutation {
           commentCreate(input:$input) {
             feedback {
-              id,
+              id
               topLevelComments {
-                count,
-              },
-            },
+                count
+              }
+            }
           }
         }
       `, {input: JSON.stringify(input)}
@@ -1124,23 +1124,23 @@ describe('writePayload()', () => {
         mutation {
           commentCreate(input:$input) {
             feedback {
-              id,
+              id
               topLevelComments {
-                count,
-              },
-            },
+                count
+              }
+            }
             feedbackCommentEdge {
-              cursor,
+              cursor
               node {
-                id,
+                id
                 body {
-                  text,
-                },
-              },
+                  text
+                }
+              }
               source {
-                id,
-              },
-            },
+                id
+              }
+            }
           }
         }
       `, {
@@ -1216,23 +1216,23 @@ describe('writePayload()', () => {
         mutation {
           commentCreate(input:$input) {
             feedback {
-              id,
+              id
               topLevelComments {
-                count,
-              },
-            },
+                count
+              }
+            }
             feedbackCommentEdge {
-              cursor,
+              cursor
               node {
-                id,
+                id
                 body {
-                  text,
-                },
-              },
+                  text
+                }
+              }
               source {
-                id,
-              },
-            },
+                id
+              }
+            }
           }
         }
       `, {
@@ -1311,23 +1311,23 @@ describe('writePayload()', () => {
         mutation {
           commentCreate(input:$input) {
             feedback {
-              id,
+              id
               topLevelComments {
-                count,
-              },
-            },
+                count
+              }
+            }
             feedbackCommentEdge {
-              cursor,
+              cursor
               node {
-                id,
+                id
                 body {
-                  text,
-                },
-              },
+                  text
+                }
+              }
               source {
-                id,
-              },
-            },
+                id
+              }
+            }
           }
         }
       `, {
@@ -1444,23 +1444,23 @@ describe('writePayload()', () => {
         mutation {
           commentCreate(input:$input) {
             feedback {
-              id,
+              id
               topLevelComments {
-                count,
-              },
-            },
+                count
+              }
+            }
             feedbackCommentEdge {
-              cursor,
+              cursor
               node {
-                id,
+                id
                 body {
-                  text,
-                },
-              },
+                  text
+                }
+              }
               source {
-                id,
-              },
-            },
+                id
+              }
+            }
           }
         }
       `, {


### PR DESCRIPTION
Found a python scripts on my computer to remove trailing commas from GraphQL fragments. Doesn't catch quite all of them, but it's a good start.