### PR TITLE
Improve type definition for Higher Order Component

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -84,10 +84,10 @@ const containerContextTypes = {
  *  - Propagate the `route` via context (available on `this.props.relay`).
  *
  */
-function createContainerComponent(
-  Component: ReactClass<any>,
+function createContainerComponent<DefaultProps, Props, State, C: React$Component<DefaultProps, Props, State>>(
+  Component: Class<C>,
   spec: RelayContainerSpec
-): RelayContainerClass {
+): React$Component<DefaultProps, Props, State> {
   const ComponentClass = getReactComponent(Component);
   const componentName = getComponentName(Component);
   const containerName = getContainerName(Component);


### PR DESCRIPTION
WIP: I'll probably have to make more changes to make this work correctly. Creating the PR so I can get early feedback.

The community at large has not been able to property define types for higher-order components for a long time

PropTypes on React Components are extremely important. They are perhaps, one of the most important types in a React App.
Higher Order Components are extremely common in React Apps.
Therefore, the fact that Higher Order Components eat the type definition of React Components is unacceptable.

After days of research and trial and error, I've found the type definitions that work.

This PR, adds the 'correct' (\* see footnote) type definitions for the HOC, so that when the time comes to publish the
flow type definition file(s) to NPM, Relay.CreateContainer does not eat type definitions.
- technically speaking, Relay.CreateContainer takes all the props that match fragment names and hydrates the values using ids.
  So the types aren't completely correct, but it's close enough. Perhaps the return value should be something like:
  `React$Component<DefaultProps, Props & {[key: $Keys<FragmentObj>]:{__DATA_ID__: string}}, State>`
