### PR TITLE
extends: .eslintrc to .eslintrc.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
 parser: babel-eslint
 
 extends:
-  - ./node_modules/fbjs-scripts/eslint/.eslintrc
+  - ./node_modules/fbjs-scripts/eslint/.eslintrc.js
 
 plugins:
   - react


### PR DESCRIPTION
use fbjs's new .eslintrc.js