### PR TITLE
Fix erroneous warning about already injected network layer

### DIFF
--- a/src/__forks__/Relay.js
+++ b/src/__forks__/Relay.js
@@ -27,7 +27,7 @@ if (__DEV__) {
 
 // By default, assume that GraphQL is served at `/graphql` on the same domain.
 // To override, use `Relay.injectNetworkLayer`.
-RelayStore.injectDefaultNetworkLayer(new RelayDefaultNetworkLayer('/graphql'));
+RelayStore.injectDefaultNetworkLayer();
 
 module.exports = {
   ...RelayPublic,

--- a/src/network/RelayNetworkLayer.js
+++ b/src/network/RelayNetworkLayer.js
@@ -14,6 +14,7 @@
 
 import type {ChangeSubscription} from 'RelayInternalTypes';
 import type RelayMutationRequest from 'RelayMutationRequest';
+const RelayDefaultNetworkLayer = require('RelayDefaultNetworkLayer');
 const RelayProfiler = require('RelayProfiler');
 import type RelayQuery from 'RelayQuery';
 const RelayQueryRequest = require('RelayQueryRequest');
@@ -63,6 +64,12 @@ class RelayNetworkLayer {
   }
 
   injectImplementation(implementation: ?NetworkLayer): void {
+    // Handle the case where this is called with the default implementation
+    // instead of using `injectDefaultImplementation`.
+    if (implementation instanceof RelayDefaultNetworkLayer) {
+      this.injectDefaultImplementation(implementation);
+      return;
+    }
     if (this._implementation) {
       warning(
         false,


### PR DESCRIPTION
Issue likey caused by https://github.com/facebook/relay/commit/173ca148f07f5df069fe098d88fa642ec530f874.