### PR TITLE
Link to the release versions of Relay and the plugin in example code

### DIFF
--- a/examples/TodoMVC/.babelrc
+++ b/examples/TodoMVC/.babelrc
@@ -1,35 +1,11 @@
 {
-  "env": {
-    "development": {
-      "passPerPreset": true,
-      "presets": [
-        {
-          "plugins": [
-            "./plugins/babelRelayPlugin"
-          ]
-        },
-        "react-native"
-      ]
-    },
-    "production": {
-      "passPerPreset": true,
-      "presets": [
-        {
-          "plugins": [
-            "./plugins/babelRelayPlugin"
-          ]
-        },
-        "react-native"
-      ]
-    },
-    "server": {
+  "passPerPreset": true,
+  "presets": [
+    {
       "plugins": [
         "./plugins/babelRelayPlugin"
-      ],
-      "presets": [
-        "es2015",
-        "stage-0"
       ]
-    }
-  }
+    },
+    "react-native"
+  ]
 }

--- a/examples/TodoMVC/package.json
+++ b/examples/TodoMVC/package.json
@@ -3,15 +3,12 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "BABEL_ENV=server babel-node ./server.js",
-    "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install --ignore-scripts && cd scripts/babel-relay-plugin && npm install --ignore-scripts"
+    "start": "babel-node ./server.js",
+    "update-schema": "babel-node ./scripts/updateSchema.js"
   },
   "dependencies": {
-    "babel-preset-es2015": "6.9.0",
     "babel-preset-react-native": "1.9.0",
-    "babel-preset-stage-0": "6.5.0",
-    "babel-relay-plugin": "file:../../scripts/babel-relay-plugin",
+    "babel-relay-plugin": "0.9.0",
     "express": "4.13.4",
     "express-graphql": "0.5.2",
     "graphql": "0.6.0",
@@ -20,10 +17,11 @@
     "react-native": "0.26.2",
     "react-native-listitem": "1.0.5",
     "react-native-swipeout": "git+https://github.com/magrinj/react-native-swipeout#403d973504b58ede25c137fb31b0eff7e03b0a66",
-    "react-relay": "file:../../"
+    "react-relay": "0.9.0"
   },
   "devDependencies": {
-    "babel-cli": "6.9.0"
+    "babel-cli": "6.9.0",
+    "babel-core": "6.9.1"
   },
   "engines": {
     "npm": ">=3"

--- a/examples/relay-treasurehunt/package.json
+++ b/examples/relay-treasurehunt/package.json
@@ -2,8 +2,7 @@
   "private": true,
   "scripts": {
     "start": "babel-node ./server.js",
-    "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install --ignore-scripts && cd scripts/babel-relay-plugin && npm install --ignore-scripts"
+    "update-schema": "babel-node ./scripts/updateSchema.js"
   },
   "dependencies": {
     "babel-core": "6.9.0",
@@ -12,7 +11,7 @@
     "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-0": "6.5.0",
-    "babel-relay-plugin": "file:../../scripts/babel-relay-plugin/",
+    "babel-relay-plugin": "0.9.0",
     "babel-runtime": "6.9.0",
     "classnames": "2.2.5",
     "express": "4.13.4",
@@ -21,7 +20,7 @@
     "graphql-relay": "0.4.2",
     "react": "15.1.0",
     "react-dom": "15.1.0",
-    "react-relay": "file:../../",
+    "react-relay": "0.9.0",
     "webpack": "1.13.1",
     "webpack-dev-server": "1.14.1"
   },

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -2,8 +2,7 @@
   "private": true,
   "scripts": {
     "start": "babel-node ./server.js",
-    "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install --ignore-scripts && cd scripts/babel-relay-plugin && npm install --ignore-scripts"
+    "update-schema": "babel-node ./scripts/updateSchema.js"
   },
   "dependencies": {
     "babel-core": "6.9.0",
@@ -12,7 +11,7 @@
     "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-0": "6.5.0",
-    "babel-relay-plugin": "file:../../scripts/babel-relay-plugin/",
+    "babel-relay-plugin": "0.9.0",
     "babel-runtime": "6.9.0",
     "classnames": "2.2.5",
     "express": "4.13.4",
@@ -21,7 +20,7 @@
     "graphql-relay": "0.4.2",
     "react": "15.1.0",
     "react-dom": "15.1.0",
-    "react-relay": "file:../../",
+    "react-relay": "0.9.0",
     "webpack": "1.13.1",
     "webpack-dev-server": "1.14.1"
   },

--- a/examples/todo/package.json
+++ b/examples/todo/package.json
@@ -2,8 +2,7 @@
   "private": true,
   "scripts": {
     "start": "babel-node ./server.js",
-    "update-schema": "babel-node ./scripts/updateSchema.js",
-    "preinstall": "cd ../.. && npm install --ignore-scripts && cd scripts/babel-relay-plugin && npm install --ignore-scripts"
+    "update-schema": "babel-node ./scripts/updateSchema.js"
   },
   "dependencies": {
     "babel-core": "6.9.0",
@@ -12,7 +11,7 @@
     "babel-preset-es2015": "6.9.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-0": "6.5.0",
-    "babel-relay-plugin": "file:../../scripts/babel-relay-plugin/",
+    "babel-relay-plugin": "0.9.0",
     "babel-runtime": "6.9.0",
     "classnames": "2.2.5",
     "express": "4.13.4",
@@ -22,7 +21,7 @@
     "history": "2.1.2",
     "react": "15.1.0",
     "react-dom": "15.1.0",
-    "react-relay": "file:../../",
+    "react-relay": "0.9.0",
     "react-router": "2.4.1",
     "react-router-relay": "0.13.2",
     "todomvc-app-css": "2.0.6",


### PR DESCRIPTION
A while ago, we decided to use file: relative version specs in our examples. The idea was that you might want to develop the examples in tandem with Relay or the Babel plugin. Or that you might want to make a backward incompatible change to one of the examples.

In practice, this has kept a lot of people from being able to use the examples because of issues like npm/npm#10379. I'm going to change the dynamic today.

Now, we're going to lock the examples to the release version of react-relay and babel-relay-plugin. This will make the examples run reliably for most of us, and will fix all of the Node 5/6 issues I've just discovered as part of this bug report.

If you want to develop on the examples and Relay in tandem, then you can do a little bit of extra work to npm link your local copy of react-relay and the babel-relay-plugin. A guide on how to set all of that up can be found here: http://justjs.com/posts/npm-link-developing-your-own-npm-modules-without-tears

Closes #1177.