### PR TITLE
Fix flow error by fixing the site scoping of suppression comments

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -26,8 +26,8 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-4]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-4]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*\\)?)\\)? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-4]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*relay[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-4]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*relay[a-z,_]*\\)?)\\)? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 [version]


### PR DESCRIPTION
We use the `site=` part of the suppression comment to scope a suppression
comment to a specific root. So for example, we could add a comment like

    // $FlowFixMe(site=relay)

and it should only work when you're typechecking relay. Before this change,
however, relay was accepting suppression comments with any site. After, relay
will only accept suppression comments like

    // $FlowFixMe - This one has no site
    // $FlowFixMe(site=relay) - only relay
    // $FlowFixMe(site=bar,baz,relay,foo) - relay and some others