### PR TITLE
Remove some more unnecessary indirection working with Deferred instances

### DIFF
--- a/src/mutation/__tests__/RelayGraphQLMutation-test.js
+++ b/src/mutation/__tests__/RelayGraphQLMutation-test.js
@@ -83,7 +83,7 @@ describe('RelayGraphQLMutation', () => {
     queue = storeData.getMutationQueue();
     sendMutation = jest.fn(request => {
       requests.push(request);
-      return request.getPromise();
+      return request;
     });
     storeData.getNetworkLayer().injectImplementation({sendMutation});
 

--- a/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
+++ b/src/network-layer/default/__tests__/RelayDefaultNetworkLayer-test.js
@@ -301,7 +301,7 @@ describe('RelayDefaultNetworkLayer', () => {
     it('rejects invalid JSON response payloads', () => {
       const rejectCallback = jest.fn();
       networkLayer.sendQueries([requestA]);
-      requestA.getPromise().catch(rejectCallback);
+      requestA.catch(rejectCallback);
       jest.runAllTimers();
 
       fetchWithRetries.mock.deferreds[0].resolve({
@@ -320,7 +320,7 @@ describe('RelayDefaultNetworkLayer', () => {
     it('rejects errors in query responses', () => {
       const rejectCallback = jest.fn();
       networkLayer.sendQueries([requestA]);
-      requestA.getPromise().catch(rejectCallback);
+      requestA.catch(rejectCallback);
       jest.runAllTimers();
 
       const payloadA = {
@@ -353,7 +353,7 @@ describe('RelayDefaultNetworkLayer', () => {
       const rejectACallback = jest.fn();
       const resolveBCallback = jest.fn();
       networkLayer.sendQueries([requestA, requestB]);
-      requestA.getPromise().catch(rejectACallback);
+      requestA.catch(rejectACallback);
       requestB.done(resolveBCallback);
       jest.runAllTimers();
 


### PR DESCRIPTION
We don't need to call `getPromise()` on `Deferred` in order to invoke `catch()`; we can just invoke `catch()` directly.

I did some of this a while back in D3183390, but since then, [[ https://github.com/facebook/fbjs/commit/e3cd4970f5 | e3cd4970f5 ]] landed in fbjs, adding a `catch` method to `Deferred`, and as of [[ https://github.com/facebook/relay/commit/d653f0e5443 | d653f0e5443 ]] we're using the latest release of fbjs in Relay, so we can make use of it.