### PR TITLE
Example to fetch schema from remote GraphQL server

### DIFF
--- a/docs/Guides-BabelPlugin.md
+++ b/docs/Guides-BabelPlugin.md
@@ -109,6 +109,39 @@ For a complete example of how to load a `schema.js` file, run the introspection 
 
 If you're using a different GraphQL server implementation, we recommend adapting the above example to load the schema from your GraphQL server (e.g. via an HTTP request) and then save the result as JSON.
 
+An example using fetch looks like this:
+
+```javascript
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+const { introspectionQuery, printSchema, buildClientSchema } = require('graphql/utilities');
+const schemaPath = path.join(__dirname, '../data/schema');
+
+const SERVER = 'http://yourserver.com/graphql';
+
+// Save JSON of full schema introspection for Babel Relay Plugin to use
+fetch(`${SERVER}`, {
+  method: "POST",
+  headers: {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({"query": introspectionQuery}),
+}).then(res => res.json()).then((schemaJSON) => {
+  fs.writeFileSync(
+    `${schemaPath}.json`,
+    JSON.stringify(schemaJSON, null, 2)
+  );
+  
+  // Save user readable type system shorthand of schema
+  const graphQLSchema = buildClientSchema(schemaJSON.data);
+  fs.writeFileSync(
+    `${schemaPath}.graphql`,
+    printSchema(graphQLSchema)
+  );
+});
+```
 
 ## Additional Options
 


### PR DESCRIPTION
I added a simple fully working example for downloading a GraphQL schema from the server.
The examples in the repository only mention the generation of schemas locally.
I struggled a little till I found all the details on how to create a schema json that the babel plugin needs via the Introspection Query, and it also needed a good amount of time to realize a introspection query is in the utilities.

So I thought this might make it easier for other people who do not start of an example, but want to contact a existing GraphQL server.

Have found #1149 recently that is highly related, I just wanted the example to be completely working and still simple, rather than only be an idea people would have to write a script around.