### PR TITLE
Replace deprecated function in tests

### DIFF
--- a/src/container/__tests__/RelayContainer_Component-test.js
+++ b/src/container/__tests__/RelayContainer_Component-test.js
@@ -73,7 +73,7 @@ describe('RelayContainer', function() {
       .expectRenderedChild()
       .toBeCompositeComponentWithType(MockComponent)
       .expectRenderedChild()
-      .toBeDOMComponentWithTag('div');
+      .toBeComponentOfType('div');
   });
 
   it('provides Relay statics', () => {
@@ -103,6 +103,6 @@ describe('RelayContainer', function() {
       .expectRenderedChild()
       .toBeCompositeComponentWithType(MyComponent)
       .expectRenderedChild()
-      .toBeDOMComponentWithTag('span');
+      .toBeComponentOfType('span');
   });
 });


### PR DESCRIPTION
`toBeDOMComponentWithTag` is deprecated and has been replaced by `toBeComponentOfType`. See https://github.com/facebook/react/blob/master/src/test/reactComponentExpect.js#L170-178

Related to facebook/react#6536 