### PR TITLE
Fix getRangeBehavior to allow non-string calls

### DIFF
--- a/src/mutation/__tests__/getRangeBehavior-test.js
+++ b/src/mutation/__tests__/getRangeBehavior-test.js
@@ -28,6 +28,14 @@ describe('getRangeBehavior()', () => {
       const rangeBehavior = getRangeBehavior(rangeBehaviors, calls);
       expect(rangeBehavior).toBe('append');
     });
+
+    describe('when calls contain non-string values', () => {
+      it('returns the rangeBehavior for the calls', () => {
+        const calls = [{name: 'status', value: 1}];
+        const rangeBehavior = getRangeBehavior(rangeBehaviors, calls);
+        expect(rangeBehavior).toBe('refetch');
+      });
+    });
   });
 
   describe('when rangeBehaviors are a plain object', () => {

--- a/src/mutation/getRangeBehavior.js
+++ b/src/mutation/getRangeBehavior.js
@@ -70,15 +70,7 @@ function getObjectFromCalls(
 ): {[argName: string]: string} {
   const behaviors = {};
   calls.forEach(call => {
-    const behavior = call.value;
-    invariant(
-      typeof behavior === 'string',
-      'getRangeBehavior(): Expected range behavior for key `%s` to be a ' +
-      'string, got `%s`.',
-      call.name,
-      behavior
-    );
-    behaviors[call.name] = behavior;
+    behaviors[call.name] = call.value;
   });
   return behaviors;
 }


### PR DESCRIPTION
Fixes #1208

That `invariant` doesn't seem to make sense in that function, removing it will allow us to use `rangeBehavior` functions with other types than string.

@josephsavona