### PR TITLE
Print subscriptions

### DIFF
--- a/scripts/jest/testschema.graphql
+++ b/scripts/jest/testschema.graphql
@@ -1,6 +1,7 @@
 schema {
   query: Root
   mutation: Mutation
+  subscription: Subscription
 }
 
 type Root {
@@ -48,6 +49,10 @@ type Mutation {
   nodeSavedState(input: NodeSaveStateInput): NodeSavedStateResponsePayload
   unfriend(input: UnfriendInput): UnfriendResponsePayload
   viewerNotificationsUpdateAllSeenState(input: UpdateAllSeenStateInput): ViewerNotificationsUpdateAllSeenStateResponsePayload
+}
+
+type Subscription {
+  feedbackLikeSubscribe(input: FeedbackLikeInput): FeedbackLikeResponsePayload
 }
 
 input ActorSubscribeInput {

--- a/scripts/jest/testschema.json
+++ b/scripts/jest/testschema.json
@@ -7,7 +7,9 @@
       "mutationType": {
         "name": "Mutation"
       },
-      "subscriptionType": null,
+      "subscriptionType": {
+        "name": "Subscription"
+      },
       "types": [
         {
           "kind": "OBJECT",
@@ -7598,6 +7600,40 @@
                   "name": "Story",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "description": null,
+          "fields": [
+            {
+              "name": "feedbackLikeSubscribe",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "FeedbackLikeInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FeedbackLikeResponsePayload",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -883,6 +883,58 @@ describe('printRelayOSSQuery', () => {
     });
   });
 
+  it('prints a subscription', () => {
+    const inputValue = {
+      foo: 'bar',
+    };
+    const subscription = getNode(Relay.QL`
+      subscription {
+        feedbackLikeSubscribe(input: $input) {
+          clientSubscriptionId
+          feedback {
+            id
+            actor {
+              profilePicture(preset: SMALL) {
+                uri
+              }
+            }
+            likeSentence
+            likers
+          }
+        }
+      }
+    `, {input: inputValue});
+
+    const alias = generateRQLFieldAlias('profilePicture.preset(SMALL)');
+    const {text, variables} = printRelayOSSQuery(subscription);
+    expect(text).toEqualPrintedQuery(`
+      subscription PrintRelayOSSQuery(
+        $input_0: FeedbackLikeInput!,
+        $preset_1: PhotoSize!
+      ) {
+        feedbackLikeSubscribe(input: $input_0) {
+          clientSubscriptionId,
+          feedback {
+            id,
+            actor {
+              ${alias}: profilePicture(preset: $preset_1) {
+                uri
+              },
+              id,
+              __typename
+            },
+            likeSentence,
+            likers
+          }
+        }
+      }
+    `);
+    expect(variables).toEqual({
+      input_0: inputValue,
+      preset_1: 'SMALL',
+    });
+  });
+
   it('prints directives', () => {
     const params = {cond: true};
     const nestedFragment = Relay.QL`

--- a/src/traversal/printRelayOSSQuery.js
+++ b/src/traversal/printRelayOSSQuery.js
@@ -61,8 +61,8 @@ function printRelayOSSQuery(node: RelayQuery.Node): PrintedQuery {
   let queryText = null;
   if (node instanceof RelayQuery.Root) {
     queryText = printRoot(node, printerState);
-  } else if (node instanceof RelayQuery.Mutation) {
-    queryText = printMutation(node, printerState);
+  } else if (node instanceof RelayQuery.Operation) {
+    queryText = printOperation(node, printerState);
   } else if (node instanceof RelayQuery.Fragment) {
     queryText = printFragment(node, printerState);
   }
@@ -121,10 +121,8 @@ function printRoot(
     oneIndent + fieldName + children + newLine + '}';
 }
 
-function printMutation(
-  node: RelayQuery.Mutation,
-  printerState: PrinterState
-): string {
+function printOperation(node: RelayQuery.Operation, printerState: PrinterState): string {
+  const operationKind = node.getConcreteQueryNode().kind.toLowerCase();
   const call = node.getCall();
   const inputString = printArgument(
     node.getCallVariableName(),
@@ -134,18 +132,20 @@ function printMutation(
   );
   invariant(
     inputString,
-    'printRelayOSSQuery(): Expected mutation `%s` to have a value for `%s`.',
+    'printRelayOSSQuery(): Expected %s `%s` to have a value for `%s`.',
+    operationKind,
     node.getName(),
     node.getCallVariableName()
   );
   // Note: children must be traversed before printing variable definitions
   const children = printChildren(node, printerState, oneIndent);
-  const mutationString =
+  const operationString =
     node.getName() + printVariableDefinitions(printerState);
   const fieldName = call.name + '(' + inputString + ')';
 
-  return 'mutation ' + mutationString + ' {' + newLine +
+  return operationKind + ' ' + operationString + ' {' + newLine +
     oneIndent + fieldName + children + newLine + '}';
+
 }
 
 function printVariableDefinitions({variableMap}: PrinterState): string {

--- a/src/traversal/printRelayOSSQuery.js
+++ b/src/traversal/printRelayOSSQuery.js
@@ -61,7 +61,7 @@ function printRelayOSSQuery(node: RelayQuery.Node): PrintedQuery {
   let queryText = null;
   if (node instanceof RelayQuery.Root) {
     queryText = printRoot(node, printerState);
-  } else if (node instanceof RelayQuery.Operation) {
+  } else if (node instanceof RelayQuery.Mutation || node instanceof RelayQuery.Subscription) {
     queryText = printOperation(node, printerState);
   } else if (node instanceof RelayQuery.Fragment) {
     queryText = printFragment(node, printerState);
@@ -121,8 +121,11 @@ function printRoot(
     oneIndent + fieldName + children + newLine + '}';
 }
 
-function printOperation(node: RelayQuery.Operation, printerState: PrinterState): string {
-  const operationKind = node.getConcreteQueryNode().kind.toLowerCase();
+function printOperation(
+  node: RelayQuery.Mutation | RelayQuery.Subscription,
+  printerState: PrinterState
+): string {
+  const operationKind = node instanceof RelayQuery.Mutation ? 'mutation' : 'subscription';
   const call = node.getCall();
   const inputString = printArgument(
     node.getCallVariableName(),


### PR DESCRIPTION
I am not sure that we want to have this support but I think it would be nice.

I replaced the `printMutation` function with a `printOperation` function that can print any instance of `RelayQuery.Operation`. I am not sure if that's the behavior we want or if we should check for `RelayQuery.Subscription` and `RelayQuery.Mutation`.

Also as it is right now we always have to supply a `$input` argument which may not be the case when using subscriptions.