### PR TITLE
RelayContainer now uses stateless component names

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -1008,8 +1008,10 @@ function getComponentName(Component: ReactClass<any>): string {
   const ComponentClass = getReactComponent(Component);
   if (ComponentClass) {
     name = ComponentClass.displayName || ComponentClass.name;
-  } else {
+  } else if (typeof Component === 'function') {
     // This is a stateless functional component.
+    name = Component.displayName || Component.name || 'StatelessComponent';
+  } else {
     name = 'props => ReactElement';
   }
   return name;

--- a/src/container/__tests__/RelayContainer_Component-test.js
+++ b/src/container/__tests__/RelayContainer_Component-test.js
@@ -83,8 +83,26 @@ describe('RelayContainer', function() {
     expect(typeof MockContainer.getFragment).toEqual('function');
   });
 
-  it('has the correct displayName based on the inner component', () => {
+  it('has the correct displayName when using class components', () => {
     expect(MockContainer.displayName).toEqual('Relay(MockComponent)');
+  });
+
+  it('has the correct displayName when using stateless components', () => {
+    function MyComponent() {
+      return <span />;
+    }
+    mockCreateContainer(MyComponent);
+    expect(MockContainer.displayName).toEqual('Relay(MyComponent)');
+  });
+
+  it('defaults to "StatelessComponent" when using a component without name', () => {
+    mockCreateContainer(() => <span />);
+    expect(MockContainer.displayName).toEqual('Relay(StatelessComponent)');
+  });
+
+  it('defaults to "props => ReactElement" when using a ReactElement', () => {
+    mockCreateContainer(<span />);
+    expect(MockContainer.displayName).toEqual('Relay(props => ReactElement)');
   });
 
   it('works with ES6 classes', () => {


### PR DESCRIPTION
RelayContainer now uses stateless component names instead of using `props => ReactElement`

Closes https://github.com/facebook/relay/issues/1224