### PR TITLE
Remove reference to cache manager from RelayEnvironment code comment

### DIFF
--- a/src/store/RelayEnvironment.js
+++ b/src/store/RelayEnvironment.js
@@ -80,7 +80,6 @@ export interface RelayEnvironmentInterface {
  * - An in-memory cache of fetched data.
  * - A configurable network layer for resolving queries/mutations.
  * - A configurable task scheduler to control when internal tasks are executed.
- * - A configurable cache manager for persisting data between sessions.
  *
  * No data or configuration is shared between instances. We recommend creating
  * one `RelayEnvironment` instance per user: client apps may share a single


### PR DESCRIPTION
This isn't yet part of the `RelayEnvironment` interface, so let's remove it to avoid confusion. The referenced GitHub issue contains discussion about what the API is for, and why it isn't public or exposed on `RelayEnvironment` at this time.

Closes: https://github.com/facebook/relay/issues/1030