### PR TITLE
Teach website sidebar to prefer en-US

### DIFF
--- a/website/core/DocsSidebar.js
+++ b/website/core/DocsSidebar.js
@@ -20,7 +20,7 @@ const Metadata = require('Metadata');
  * the "canonical" (non-localized) version.
  */
 function shouldOverwritePreviousWithCanonical(previous, maybeCanonical) {
-  let match = previous.permalink.match(/^(.+)\.([a-z]+-[a-z]+)\.html$/);
+  let match = previous.permalink.match(/^(.+)\.([a-z]+-[a-z]+)\.html$/i);
   if (match) {
     // `previous` is a localized file.
     const previousBase = match[1];

--- a/website/core/DocsSidebar.js
+++ b/website/core/DocsSidebar.js
@@ -13,11 +13,46 @@
 
 const Metadata = require('Metadata');
 
+/**
+ * We're not really set up to support translations well at the moment (ie.
+ * multiple documents with the same `id` but different `permalink`s of the
+ * form "foo.html" and "foo.zh-CN.html"), so we make sure we always prefer
+ * the "canonical" (non-localized) version.
+ */
+function shouldOverwritePreviousWithCanonical(previous, maybeCanonical) {
+  let match = previous.permalink.match(/^(.+)\.([a-z]+-[a-z]+)\.html$/);
+  if (match) {
+    // `previous` is a localized file.
+    const previousBase = match[1];
+    const previousLocale = match[2];
+    match = maybeCanonical.permalink.match(/^(.+)\.html/);
+    if (match && match[1] === previousBase) {
+      // Found canonical "foo.html"; should overwrite "foo.zh-CN.html".
+      return true;
+    }
+  }
+  return false;
+}
+
 const DocsSidebar = React.createClass({
   getCategories: function() {
-    const metadatas = Metadata.files.filter(function(metadata) {
-      return metadata.layout === 'docs';
-    });
+    // Skip over non-docs and non-en_US entries.
+    const metadatas = Array.from(
+        Metadata.files.reduce(function(acc, metadata) {
+          if (metadata.layout === 'docs') {
+            const previous = acc.get(metadata.id);
+            if (
+              !previous ||
+              shouldOverwritePreviousWithCanonical(previous, metadata)
+            ) {
+              acc.delete(metadata.id);
+              acc.set(metadata.id, metadata);
+            }
+          }
+          return acc;
+        }, new Map()
+      ).values()
+    );
 
     // Build a hashmap of article_id -> metadata
     const articles = {};


### PR DESCRIPTION
When I reran the website build toolchain for the 0.9.1 release I ended up updating the `metadata.js` file:

https://github.com/facebook/relay/commit/88c41e94945092655a7f841e2d25b27f6f5fcf0c

This in turn meant that we had multiple documents with the same id; eg:

- thinking-in-graphql

But different permalinks:

- docs/thinking-in-graphql.zh-CN.html
- docs/thinking-in-graphql.html

When I committed and pushed the generated documentation, ie:

https://github.com/facebook/relay/commit/eef148d1061b06e7838e2d12993f87e3d0a4bbcf

I saw that our sidebar table of contents was now using the localized version of the document; ie:

> 深入理解 GraphQL

instead of:

> Thinking in GraphQL

The solution for now is to always prefer non-localized resources in the sidebar, but in the long term we'll want the localized version of each page to prefer localized links in the sidebar, if they exist. This may be tricky to implement, however, because we don't control the gh-pages environment and so can't necessarily implement the logical `Accept-Language` solution (although perhaps GitHub will... maybe they already do?). For now just getting the fix out. The updated, published documentation went out in:

https://github.com/facebook/relay/commit/52b908ddf53c66d2c33555c6c8c2a40449ee29bd

Aside: this commit takes care to preserve ordering, so that the "find first element which doesn't have any previous" logic can rely on it. But this is not well-defined behavior because (I think) the order in which we're visiting the source files (as returned by `glob.sync(MD_DIR + '**/*.*')` in `website/server/convert.js`) is actually filesystem-dependent. On HFS+ (macOS) this happens to be lexicographically ordered, but I know of other filesystems where it is dependent on things like inode metadata layout and such.