### PR TITLE
Tweak QuickStart-Tutorial.zh-CN.md metadata for consistency

### DIFF
--- a/docs/QuickStart-Tutorial.zh-CN.md
+++ b/docs/QuickStart-Tutorial.zh-CN.md
@@ -1,9 +1,9 @@
 ---
-id: tutorial-zh-CN
+id: tutorial
 title: 教程
 layout: docs
 category: Quick Start
-permalink: docs/tutorial-zh-CN.html
+permalink: docs/tutorial.zh-CN.html
 next: thinking-in-graphql
 ---
 

--- a/website/core/metadata.js
+++ b/website/core/metadata.js
@@ -280,11 +280,11 @@ module.exports = {
       "source": "QuickStart-Tutorial.md"
     },
     {
-      "id": "tutorial-zh-CN",
+      "id": "tutorial",
       "title": "教程",
       "layout": "docs",
       "category": "Quick Start",
-      "permalink": "docs/tutorial-zh-CN.html",
+      "permalink": "docs/tutorial.zh-CN.html",
       "next": "thinking-in-graphql",
       "source": "QuickStart-Tutorial.zh-CN.md"
     },


### PR DESCRIPTION
Make this one like our other translations:

- Use `.zh-CN` suffix instead of `-zh-CN`: this means that an appropriately configured web server can choose to serve up the right file based on the `Accept-Language` header.
- Use same `id` as canonical version. We might end up changing our minds about that (see https://github.com/facebook/relay/pull/1238), but in the meantime we should at least be consistent.

I think we likely still have some issues here, so I'm going to keep poking around after this. Basically, I think at this point that we've *unbroken* our English docs and our Chinese docs are at least consistently defined, but the build process for the translations isn't producing a useful/accessible result.