### PR TITLE
Don't hard-wrap Markdown documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,179 +14,90 @@
 ## 0.9.0 (May 26, 2016)
 
 * Relay is now built with Babel 6.
-* Upgraded the Babel Relay plugin to `graphql-js` 0.6.0. Developers interested
-  in upgrading to `graphql-js` 0.6.0 might have to make some changes to their
-  existing GraphQL schemas. Read the migration guide for more information:
-  https://gist.github.com/steveluscher/ffc1dfefbb10ad280c8a4c520a5c201c
-* Debug information detailing every step of a Relay mutation is now printed to
-  the console when `DEV` is true, and `console.groupCollapsed` and
-  `console.groupEnd` are available.
-* The `this.props.relay` prop passed into components by `Relay.Container` now
-  exposes `applyUpdate` and `commitUpdate` methods for dispatching mutations
-  in the context of the current `Relay.Environment`.
-* `RANGE_DELETE` mutations can now remove multiple nodes from a connection,
-  because `deletedIDFieldName` can now point to a plural field.
-* You can now define `rangeBehaviors` as a function that receives the connection
-  arguments and returns one of `GraphQLMutatorConstants.RANGE_OPERATIONS`.
-* `RelayNetworkDebug#init` now lets you pass in a `RelayEnvironment` against
-  which you would like to debug. This does not yet allow you to debug more than
-  one environment at a time, but at least you can make the choice of which one.
-* `RelayReadyState` now contains an `events` array; a stream of events that can
-  be accessed from a `RelayReadyStateCallback`. You can reduce over this list of
-  events to implement any kind of custom rendering logic you like.
-* `this.props.variables` now reflects the variables after being processed with
-  `prepareVariables`. The fact that variables were the un-prepared values was
-  a source of confusion for many.
-* Fixed a bug where `prepareVariables` could be called twice, breaking
-  components with non-idempotent `prepareVariables` functions.
-* Relay now warns when you try to set a variable using `setVariables`, or
-  produce one through `prepareVariables`, that you have not declared in
-  `initialVariables` upfront.
-* It's now possible for the `stale` prop of a `readyState` to change even if
-  there was previously an `error` present.
-* Fixed a bug formatting error messages when the error being pointed to starts
-  at column 0.
-* A container definition can now optionally include a
-  `shouldComponentUpdate: () => boolean` function. If specified, this function
-  *always* overrides the default implementation (ie. there is no fall-through to
-  the default).
+* Upgraded the Babel Relay plugin to `graphql-js` 0.6.0. Developers interested in upgrading to `graphql-js` 0.6.0 might have to make some changes to their existing GraphQL schemas. Read the migration guide for more information: https://gist.github.com/steveluscher/ffc1dfefbb10ad280c8a4c520a5c201c
+* Debug information detailing every step of a Relay mutation is now printed to the console when `DEV` is true, and `console.groupCollapsed` and `console.groupEnd` are available.
+* The `this.props.relay` prop passed into components by `Relay.Container` now exposes `applyUpdate` and `commitUpdate` methods for dispatching mutations in the context of the current `Relay.Environment`.
+* `RANGE_DELETE` mutations can now remove multiple nodes from a connection, because `deletedIDFieldName` can now point to a plural field.
+* You can now define `rangeBehaviors` as a function that receives the connection arguments and returns one of `GraphQLMutatorConstants.RANGE_OPERATIONS`.
+* `RelayNetworkDebug#init` now lets you pass in a `RelayEnvironment` against which you would like to debug. This does not yet allow you to debug more than one environment at a time, but at least you can make the choice of which one.
+* `RelayReadyState` now contains an `events` array; a stream of events that can be accessed from a `RelayReadyStateCallback`. You can reduce over this list of events to implement any kind of custom rendering logic you like.
+* `this.props.variables` now reflects the variables after being processed with `prepareVariables`. The fact that variables were the un-prepared values was a source of confusion for many.
+* Fixed a bug where `prepareVariables` could be called twice, breaking components with non-idempotent `prepareVariables` functions.
+* Relay now warns when you try to set a variable using `setVariables`, or produce one through `prepareVariables`, that you have not declared in `initialVariables` upfront.
+* It's now possible for the `stale` prop of a `readyState` to change even if there was previously an `error` present.
+* Fixed a bug formatting error messages when the error being pointed to starts at column 0.
+* A container definition can now optionally include a `shouldComponentUpdate: () => boolean` function. If specified, this function *always* overrides the default implementation (ie. there is no fall-through to the default).
 
 ## 0.8.1 (April 27, 2016)
 
 * `RelayNetworkDebug` now logs query variables.
-* `RelayNetworkDebug` is now added as a subscriber instead of replacing any
-  existing network layers. It also no longer replaces the global `fetch`.
-* `Relay.Environment#injectNetworkLayer` (and, by extension
-  `Relay#injectNetworkLayer`) will now warn if injecting would overwrite a
-  previously injected layer.
-* Added experimental low-level `RelayGraphQLMutation` API (still being
-  finalized and not yet documented, so use at your own risk).
+* `RelayNetworkDebug` is now added as a subscriber instead of replacing any existing network layers. It also no longer replaces the global `fetch`.
+* `Relay.Environment#injectNetworkLayer` (and, by extension `Relay#injectNetworkLayer`) will now warn if injecting would overwrite a previously injected layer.
+* Added experimental low-level `RelayGraphQLMutation` API (still being finalized and not yet documented, so use at your own risk).
 
 ## 0.8.0 (April 11, 2016)
 
 * Added a React Native / Relay TodoMVC example app.
-* You can now render multiple Relay apps at once, each with their own store.
-  The following APIs are early versions and are as of yet undocumented so please
-  use them with caution.
-  * Added `Relay.Environment`. `Relay.Store` is now simply a global instance of
-    `RelayEnvironment`. To create your own isolated store and network subsystem,
-    create a `new RelayEnvironment()` and make use of it wherever `environment`
-    is required.
-  * Use `Relay.Environment#injectNetworkLayer` to inject a custom network layer
-    for use within the context of a particular `Relay.Environment` instance.
-  * Added `Relay.ReadyStateRenderer`. This component takes in an instance of
-    `Relay.Environment`, a `queryConfig` that conforms to the
-    `RelayQueryConfigInterface`, and a Relay `container`. It renders
-    synchronously based on the supplied `readyState`. This primitive enables you
-    to create alternatives to `Relay.Renderer` that fetch and handle data in a
-    custom way (eg. for server rendered applications).
-  * Added `Relay.Renderer` &ndash; a replacement for `Relay.RootContainer` that
-    composes a `Relay.ReadyStateRenderer` and performs data fetching.
-    `Relay.RootContainer` is now a wrapper around `Relay.Renderer` that
-    substitutes `Relay.Store` for `environment`.
+* You can now render multiple Relay apps at once, each with their own store. The following APIs are early versions and are as of yet undocumented so please use them with caution.
+  * Added `Relay.Environment`. `Relay.Store` is now simply a global instance of `RelayEnvironment`. To create your own isolated store and network subsystem, create a `new RelayEnvironment()` and make use of it wherever `environment` is required.
+  * Use `Relay.Environment#injectNetworkLayer` to inject a custom network layer for use within the context of a particular `Relay.Environment` instance.
+  * Added `Relay.ReadyStateRenderer`. This component takes in an instance of `Relay.Environment`, a `queryConfig` that conforms to the `RelayQueryConfigInterface`, and a Relay `container`. It renders synchronously based on the supplied `readyState`. This primitive enables you to create alternatives to `Relay.Renderer` that fetch and handle data in a custom way (eg. for server rendered applications).
+  * Added `Relay.Renderer` &ndash; a replacement for `Relay.RootContainer` that composes a `Relay.ReadyStateRenderer` and performs data fetching. `Relay.RootContainer` is now a wrapper around `Relay.Renderer` that substitutes `Relay.Store` for `environment`.
 * Renamed the Flow type `RelayRendererRenderCallback` to `RelayRenderCallback`.
 * Renamed the Flow type `RelayQueryConfigSpec` to `RelayQueryConfigInterface`.
-* `RelayContainer.setVariables` will no longer check if the variables are
-  changed before re-running the variables. To prevent extra work, check the
-  current variables before calling `setVariables`.
-* You can now roll back mutations in the `COMMIT_QUEUED` state using
-  `RelayMutationTransaction#rollback`.
-* When specifying a `NODE_DELETE` or `RANGE_DELETE` mutation config, you can
-  omit `parentID` if your parent, in fact, does not have an ID.
-* In cases where you query for a field, but that field is unset in the response,
-  Relay will now write `null` into the store for that field. This allows you to
-  return smaller payloads over the wire by simply omitting a key in the JSON
-  response, rather than to write an explicit `fieldName: null`.
-* If the `relay` prop does not change between renders, we now recycle the same
-  object. This should enable you to make an efficient `this.props.relay ===
-  nextProps.relay` comparison in `shouldComponentUpdate`.
-* You can now craft a connection query having invalid combinations of connection
-  arguments (first/last/after/before) so long as the values of those arguments
-  are variables and not concrete values (eg. `friends(first: $first, last:
-  $last)` will no longer cause the Relay Babel plugin to throw).
-* Added runtime validation to mutation configs to help developers to debug their
-  `Relay.Mutation`.
-* Added `RelayNetworkDebug`. Invoke
-  `require('RelayNetworkDebug').init(Relay.DefaultNetworkLayer)` to enjoy simple
-  to read logs of your network requests and responses on the console. Substitute
-  your own network layer if you use one.
+* `RelayContainer.setVariables` will no longer check if the variables are changed before re-running the variables. To prevent extra work, check the current variables before calling `setVariables`.
+* You can now roll back mutations in the `COMMIT_QUEUED` state using `RelayMutationTransaction#rollback`.
+* When specifying a `NODE_DELETE` or `RANGE_DELETE` mutation config, you can omit `parentID` if your parent, in fact, does not have an ID.
+* In cases where you query for a field, but that field is unset in the response, Relay will now write `null` into the store for that field. This allows you to return smaller payloads over the wire by simply omitting a key in the JSON response, rather than to write an explicit `fieldName: null`.
+* If the `relay` prop does not change between renders, we now recycle the same object. This should enable you to make an efficient `this.props.relay === nextProps.relay` comparison in `shouldComponentUpdate`.
+* You can now craft a connection query having invalid combinations of connection arguments (first/last/after/before) so long as the values of those arguments are variables and not concrete values (eg. `friends(first: $first, last: $last)` will no longer cause the Relay Babel plugin to throw).
+* Added runtime validation to mutation configs to help developers to debug their `Relay.Mutation`.
+* Added `RelayNetworkDebug`. Invoke `require('RelayNetworkDebug').init(Relay.DefaultNetworkLayer)` to enjoy simple to read logs of your network requests and responses on the console. Substitute your own network layer if you use one.
 * Added two new `rangeBehaviors`:
   * `IGNORE` means the range should not be refetched at all.
   * `REFETCH` will refetch the entire connection.
-* Connection diff optimization: Enables a mode where Relay skips diffing
-  information about edges that have already been fetched. This can be enabled by
-  adding `@relay(variables: ['variableNames'])` to a connection fragment.
+* Connection diff optimization: Enables a mode where Relay skips diffing information about edges that have already been fetched. This can be enabled by adding `@relay(variables: ['variableNames'])` to a connection fragment.
 
 ## 0.7.3 (March 4, 2016)
 
-* The instance of Babel that the babel-relay-plugin receives will now be used
-  when making assertions about version numbers.
+* The instance of Babel that the babel-relay-plugin receives will now be used when making assertions about version numbers.
 
 ## 0.7.2 (March 4, 2016)
 
-* Identifying arguments on root fields can now be of any type - boolean, number,
-  string, or array/object of the the same.
-* Fixes a bug when we read connections or fragments without allocating a record
-  until we encounter a child field that is not null. We now ensure that we
-  allocate the record for connections and fragments (if it exists) regardless.
+* Identifying arguments on root fields can now be of any type - boolean, number, string, or array/object of the the same.
+* Fixes a bug when we read connections or fragments without allocating a record until we encounter a child field that is not null. We now ensure that we allocate the record for connections and fragments (if it exists) regardless.
 * Made babelAdapter compatible with Babel 6.6
 * `npm run build` now works on Windows
 * Tests now pass when using Node 5 / NPM 3
-* Passing an empty array as a prop corresponding to a plural fragment no longer
-  warns about mock data. The empty array is now passed through to the component
-  as-is.
-* Removed `uri` from `RelayQueryConfigSpec`. The `uri` property was part of
-  `RelayRoute`, but never `RelayQueryConfig`. This revision simply cleans up the
-  Flow shape in `RelayContainer`.
-* RelayRenderer now runs queries after mount to make sure `RelayRenderer` does
-  not run queries during synchronous server-side rendering.
+* Passing an empty array as a prop corresponding to a plural fragment no longer warns about mock data. The empty array is now passed through to the component as-is.
+* Removed `uri` from `RelayQueryConfigSpec`. The `uri` property was part of `RelayRoute`, but never `RelayQueryConfig`. This revision simply cleans up the Flow shape in `RelayContainer`.
+* RelayRenderer now runs queries after mount to make sure `RelayRenderer` does not run queries during synchronous server-side rendering.
 
 ## 0.7.1 (February 18, 2016)
 
-* Having fixed a bug, now you can *actually* interpolate an array of fragments
-  into a `Relay.QL` query. eg. `${containers.map(c => c.getFragment('foo'))}`
+* Having fixed a bug, now you can *actually* interpolate an array of fragments into a `Relay.QL` query. eg. `${containers.map(c => c.getFragment('foo'))}`
 
 ## 0.7.0 (February 12, 2016)
 
-* Eliminated a race condition that would cause `RelayGarbageCollector` to fatal
-  when, in the middle of a `readRelayDiskCache` traversal, a container attempts
-  to subscribe to a record not yet registered with the garbage collector.
-* The garbage collector now strictly increments references to all subscribed
-  nodes, and strictly decrements references to all previously subscribed nodes,
-  eliminating a class of race condition by ensuring an exact 1:1 correspondence
-  of increment/decrement calls for a given node.
-* Replaced `GraphQLStoreDataHandler` with `RelayRecord`, and added the
-  `RelayRecord#isRecord` method.
-* Introduced `RelayQueryIndexPath` which tracks fragment indexes to the nearest
-  parent field during query traversal. This replaces the existing logic used to
-  generate field serialization keys.
+* Eliminated a race condition that would cause `RelayGarbageCollector` to fatal when, in the middle of a `readRelayDiskCache` traversal, a container attempts to subscribe to a record not yet registered with the garbage collector.
+* The garbage collector now strictly increments references to all subscribed nodes, and strictly decrements references to all previously subscribed nodes, eliminating a class of race condition by ensuring an exact 1:1 correspondence of increment/decrement calls for a given node.
+* Replaced `GraphQLStoreDataHandler` with `RelayRecord`, and added the `RelayRecord#isRecord` method.
+* Introduced `RelayQueryIndexPath` which tracks fragment indexes to the nearest parent field during query traversal. This replaces the existing logic used to generate field serialization keys.
 * Added `RelayContext`, a step toward making all Relay state contextual.
 * Improved query printing performance via short circuiting and inlining.
-* Moved record writing functions out of `RelayRecordStore` and into a new
-  `RelayRecordWriter` class.
-* The Babel plugin now prints `canHaveSubselections` metadata on object-like
-  fields that can contain child fields, making it possible to determine if a
-  given field in a query is a true leaf node, or an object-type field having no
-  subselections. This replaces `RelayQueryNode#isScalar` with
-  `RelayQueryNode#canHaveSubselections`.
-* `RANGE_DELETE` mutation configs now allow you to specify an array path to a
-  deleted node, rather than just a `deletedIDFieldName`.
+* Moved record writing functions out of `RelayRecordStore` and into a new `RelayRecordWriter` class.
+* The Babel plugin now prints `canHaveSubselections` metadata on object-like fields that can contain child fields, making it possible to determine if a given field in a query is a true leaf node, or an object-type field having no subselections. This replaces `RelayQueryNode#isScalar` with `RelayQueryNode#canHaveSubselections`.
+* `RANGE_DELETE` mutation configs now allow you to specify an array path to a deleted node, rather than just a `deletedIDFieldName`.
 * Renamed `Records` to `RecordMap`.
-* Record reads from cache managers are now abortable. If the network request
-  finishes before the cache read, for instance, the cache read can be cancelled.
+* Record reads from cache managers are now abortable. If the network request finishes before the cache read, for instance, the cache read can be cancelled.
 * Added USERS.md; a catalog of products and developers that use Relay.
-* You can now interpolate an array of fragments into a `Relay.QL` query. eg.
-  `${containers.map(c => c.getFragment('foo'))}`
-* Fixed a bug where invalid queries could be printed due to different variables
-  having the same value; duplicates are now avoided.
+* You can now interpolate an array of fragments into a `Relay.QL` query. eg. `${containers.map(c => c.getFragment('foo'))}`
+* Fixed a bug where invalid queries could be printed due to different variables having the same value; duplicates are now avoided.
 
 ## 0.6.1 (January 8, 2016)
 
-* Renamed `RelayStore#update` to `RelayStore#commitUpdate`. `RelayStore#commit`
-  will be removed in v0.8.0. For an automated codemod that you can use to
-  update your Relay app, visit https://github.com/relayjs/relay-codemod
-* Replaced `RelayTestUtils.unmockRelay();` with
-  `require('configureForRelayOSS');` in tests.
+* Renamed `RelayStore#update` to `RelayStore#commitUpdate`. `RelayStore#commit` will be removed in v0.8.0. For an automated codemod that you can use to update your Relay app, visit https://github.com/relayjs/relay-codemod
+* Replaced `RelayTestUtils.unmockRelay();` with `require('configureForRelayOSS');` in tests.
 * Fragment names in printed queries are now less verbose.
 * Fixed a bug that caused queries to be printed incorrectly.
 * Eliminated concrete fragment hashes.
@@ -200,14 +111,10 @@
 ## 0.6.0 (December 4, 2015)
 
 * Bump the `babel-relay-plugin` version to v0.6.0 (now Babel 6 compatible).
-* The keys in `rangeBehaviors` are now compared against the *sorted* filter
-  arguments of a field. For the field `foo(first: 10, b:true, a:false)` the
-  matching range behavior key will be `'a(false).b(true)'`.
+* The keys in `rangeBehaviors` are now compared against the *sorted* filter arguments of a field. For the field `foo(first: 10, b:true, a:false)` the matching range behavior key will be `'a(false).b(true)'`.
 * Relay will now throw an invariant if range behavior keys are unsorted.
 * Fragments are now supported in mutation fat queries.
-* Added `Relay.Store#applyUpdate` method to create a transaction optimistically
-  without committing it. Returns a transaction object that you can use to
-  `commit()` or `rollback()`.
+* Added `Relay.Store#applyUpdate` method to create a transaction optimistically without committing it. Returns a transaction object that you can use to `commit()` or `rollback()`.
 * Added `RelayStoreData#clearCacheManager` method.
 * Renamed `RelayQuery#getHash` to `RelayQuery#getConcreteFragmentHash`
 * Removed `RelayQueryPath#toJSON` and `RelayQueryPath#fromJSON`
@@ -216,20 +123,14 @@
 
 * Bump the `babel-relay-plugin` version to v0.4.1.
   * Added validation of arguments for connections with `edges` or `pageInfo`.
-    * Connections without arguments in fat queries can add the new fragment
-      directive `@relay(pattern: true)`.
+    * Connections without arguments in fat queries can add the new fragment directive `@relay(pattern: true)`.
   * Fixed validation of fields within inline fragments in connections.
-  * Print queries using a plain-object representation (instead of `GraphQL`
-    objects).
-* `RelayQueryField#getStorageKey` will now produce the same key regardless of
-  the order of a field's arguments.
+  * Print queries using a plain-object representation (instead of `GraphQL` objects).
+* `RelayQueryField#getStorageKey` will now produce the same key regardless of the order of a field's arguments.
 * Range behavior keys in mutation configs are now guaranteed to be sorted.
-* Added the `Relay.createQuery()` function which returns a
-  `RelayQuery.Root` (that can be used with `Relay.Store` methods).
-* Optimistic response keys now use GraphQL OSS syntax. (Usage of old, call-like
-  syntax is now deprecated and will warn.)
-* Fix a bug where optimistic queries could cause the error "Could not find a
-  type name for record ...".
+* Added the `Relay.createQuery()` function which returns a `RelayQuery.Root` (that can be used with `Relay.Store` methods).
+* Optimistic response keys now use GraphQL OSS syntax. (Usage of old, call-like syntax is now deprecated and will warn.)
+* Fix a bug where optimistic queries could cause the error "Could not find a type name for record ...".
 
 ## 0.4.0 (October 13, 2015)
 
@@ -263,13 +164,10 @@
 
 * Fix query variable printing for non-null and list types (#203).
 * Bumped React dependency to v0.14.0-rc.
-* Switched to using `ReactDOM` rather than `React` for performing batched
-  updates (via `unstable_batchedUpdates`).
+* Switched to using `ReactDOM` rather than `React` for performing batched updates (via `unstable_batchedUpdates`).
 * Updated the babel-relay-plugin to v0.2.3:
-  * Added support for compiling queries containing introspection fields such as
-    `__schema`, `__typename` and such.
-  * Use of `field(before: ..., first: ...)` or `field(after: ..., last: ...)` is
-    now an error.
+  * Added support for compiling queries containing introspection fields such as `__schema`, `__typename` and such.
+  * Use of `field(before: ..., first: ...)` or `field(after: ..., last: ...)` is now an error.
 * Various improvements to documentation, warnings and error messages.
 
 ## 0.2.1 (September 1, 2015)
@@ -279,18 +177,14 @@
 ## 0.2.0 (August 28, 2015)
 
 * Upgraded jest to 0.5 and switched Relay to use iojs v2+ only.
-* Changed `Relay.DefaultNetworkLayer` constructor to take an `init` object
-  instead of `fetchTimeout` and `retryDelays`.
-* Scalars other than strings are now allowed as cursors, so long as they
-  serialize to strings.
+* Changed `Relay.DefaultNetworkLayer` constructor to take an `init` object instead of `fetchTimeout` and `retryDelays`.
+* Scalars other than strings are now allowed as cursors, so long as they serialize to strings.
 * Added `npm run update-schema` to update the test schema.
 
 ## 0.1.1 (August 14, 2015)
 
-* The 'main' entrypoint can now be used in non-ES6 projects (now built w/
-  Babel).
-* Instance methods of `Relay.DefaultNetworkLayer` are bound to the instance,
-  facilitating reuse.
+* The 'main' entrypoint can now be used in non-ES6 projects (now built w/ Babel).
+* Instance methods of `Relay.DefaultNetworkLayer` are bound to the instance, facilitating reuse.
 * Renamed `GraphQL_EXPERIMENTAL` to `GraphQL` (internal change).
 * Update copyright headers.
 * Remove invariant in `RelayQueryField.getCallType()` when argument is unknown.

--- a/docs/GraphQL-Connections.md
+++ b/docs/GraphQL-Connections.md
@@ -8,10 +8,7 @@ indent: true
 next: graphql-mutations
 ---
 
-A faction has many ships in the Star Wars universe. Relay contains functionality
-to make manipulating one-to-many relationships easy, using a standardized way
-of expressing these one-to-many relationships. This standard connection
-model offers ways of slicing and paginating through the connection.
+A faction has many ships in the Star Wars universe. Relay contains functionality to make manipulating one-to-many relationships easy, using a standardized way of expressing these one-to-many relationships. This standard connection model offers ways of slicing and paginating through the connection.
 
 Let's take the rebels, and ask for their first ship:
 
@@ -49,10 +46,7 @@ yields
 }
 ```
 
-That used the `first` argument to `ships` to slice the result set down to the
-first one. But what if we wanted to paginate through it? On each edge, a cursor
-will be exposed that we can use to paginate. Let's ask for the first two this
-time, and get the cursor as well:
+That used the `first` argument to `ships` to slice the result set down to the first one. But what if we wanted to paginate through it? On each edge, a cursor will be exposed that we can use to paginate. Let's ask for the first two this time, and get the cursor as well:
 
 ```
 query MoreRebelShipsQuery {
@@ -96,10 +90,7 @@ and we get back
 }
 ```
 
-Notice that the cursor is a base64 string. That's the pattern from earlier: the
-server is reminding us that this is an opaque string. We can pass this string
-back to the server as the `after` argument to the `ships` field, which will let
-us ask for the next three ships after the last one in the previous result:
+Notice that the cursor is a base64 string. That's the pattern from earlier: the server is reminding us that this is an opaque string. We can pass this string back to the server as the `after` argument to the `ships` field, which will let us ask for the next three ships after the last one in the previous result:
 
 ```
 query EndOfRebelShipsQuery {
@@ -181,12 +172,7 @@ yields
 }
 ```
 
-Hm. There were no more ships; guess there were only five in the system for
-the rebels. It would have been nice to know that we'd reached the
-end of the connection, without having to do another round trip in order
-to verify that. The connection model exposes this capability with a type
-called `PageInfo`. So let's issue the two queries that got us ships again,
-but this time ask for `hasNextPage`:
+Hm. There were no more ships; guess there were only five in the system for the rebels. It would have been nice to know that we'd reached the end of the connection, without having to do another round trip in order to verify that. The connection model exposes this capability with a type called `PageInfo`. So let's issue the two queries that got us ships again, but this time ask for `hasNextPage`:
 
 ```
 query EndOfRebelShipsQuery {
@@ -265,12 +251,8 @@ and we get back
 }
 ```
 
-So on the first query for ships, GraphQL told us there was a next page,
-but on the next one, it told us we'd reached the end of the connection.
+So on the first query for ships, GraphQL told us there was a next page, but on the next one, it told us we'd reached the end of the connection.
 
-Relay uses all of this functionality to build out abstractions around
-connections, to make these easy to work with efficiently without having
-to manually manage cursors on the client.
+Relay uses all of this functionality to build out abstractions around connections, to make these easy to work with efficiently without having to manually manage cursors on the client.
 
-Complete details on how the server should behave are
-available in the [GraphQL Cursor Connections](../graphql/connections.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Cursor Connections](../graphql/connections.htm) spec.

--- a/docs/GraphQL-FurtherReading.md
+++ b/docs/GraphQL-FurtherReading.md
@@ -8,16 +8,6 @@ indent: true
 next: api-reference-relay
 ---
 
-This concludes the overview of the GraphQL Relay Specifications. For the
-detailed requirements of a Relay-compliant GraphQL server, a more formal
-description of the [Relay cursor connection](../graphql/connections.htm) model,
-the [Relay global object identification](../graphql/objectidentification.htm)
-model, and the [Relay input object mutation](../graphql/mutations.htm) are all
-available.
+This concludes the overview of the GraphQL Relay Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](../graphql/connections.htm) model, the [Relay global object identification](../graphql/objectidentification.htm) model, and the [Relay input object mutation](../graphql/mutations.htm) are all available.
 
-To see code implementing the specification, the
-[GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides
-helper functions for creating nodes, connections, and mutations; that
-repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__)
-folder contains an implementation of the above example as integration tests for
-the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/docs/GraphQL-Mutations.md
+++ b/docs/GraphQL-Mutations.md
@@ -8,17 +8,11 @@ indent: true
 next: graphql-further-reading
 ---
 
-Relay uses a common pattern for mutations, where they are root fields on the
-mutation type with a single argument, `input`, and where the input and output
-both contain a client mutation identifier used to reconcile requests and
-responses.
+Relay uses a common pattern for mutations, where they are root fields on the mutation type with a single argument, `input`, and where the input and output both contain a client mutation identifier used to reconcile requests and responses.
 
-By convention, mutations are named as verbs, their inputs are the name with
-"Input" appended at the end, and they return an object that is the name with
-"Payload" appended.
+By convention, mutations are named as verbs, their inputs are the name with "Input" appended at the end, and they return an object that is the name with "Payload" appended.
 
-So for our `introduceShip` mutation, we create two types: `IntroduceShipInput`
-and `IntroduceShipPayload`:
+So for our `introduceShip` mutation, we create two types: `IntroduceShipInput` and `IntroduceShipPayload`:
 
 ```
 input IntroduceShipInput {
@@ -80,6 +74,4 @@ and we'll get this result:
 }
 ```
 
-Complete details on how the server should behave are
-available in the [GraphQL Input Object Mutations](../graphql/mutations.htm)
-spec.
+Complete details on how the server should behave are available in the [GraphQL Input Object Mutations](../graphql/mutations.htm) spec.

--- a/docs/GraphQL-ObjectIdentification.md
+++ b/docs/GraphQL-ObjectIdentification.md
@@ -8,14 +8,9 @@ indent: true
 next: graphql-connections
 ---
 
-Both `Faction` and `Ship` have identifiers that we can use to refetch them. We
-expose this capability to Relay through the `Node` interface and the `node`
-field on the root query type.
+Both `Faction` and `Ship` have identifiers that we can use to refetch them. We expose this capability to Relay through the `Node` interface and the `node` field on the root query type.
 
-The `Node` interface contains a single field, `id`, which is a `ID!`. The
-`node` root field takes a single argument, a `ID!`, and returns a `Node`.
-These two work in concert to allow refetching; if we pass the `id` returned in
-that field to the `node` field, we get the object back.
+The `Node` interface contains a single field, `id`, which is a `ID!`. The `node` root field takes a single argument, a `ID!`, and returns a `Node`. These two work in concert to allow refetching; if we pass the `id` returned in that field to the `node` field, we get the object back.
 
 Let's see this in action, and query for the ID of the rebels:
 
@@ -63,8 +58,7 @@ returns
 }
 ```
 
-If we do the same thing with the Empire, we'll find that it returns a different
-ID, and we can refetch it as well:
+If we do the same thing with the Empire, we'll find that it returns a different ID, and we can refetch it as well:
 
 ```
 query EmpireQuery {
@@ -110,17 +104,8 @@ yields
 }
 ```
 
-The `Node` interface and `node` field assume globally unique IDs for this
-refetching. A system without globally unique IDs can usually synthesize them
-by combining the type with the type-specific ID, which is what was done
-in this example.
+The `Node` interface and `node` field assume globally unique IDs for this refetching. A system without globally unique IDs can usually synthesize them by combining the type with the type-specific ID, which is what was done in this example.
 
-The IDs we got back were base64 strings. IDs are designed to be opaque (the
-only thing that should be passed to the `id` argument on `node` is the
-unaltered result of querying `id` on some object in the system), and base64ing
-a string is a useful convention in GraphQL to remind viewers that the string is
-an opaque identifier.
+The IDs we got back were base64 strings. IDs are designed to be opaque (the only thing that should be passed to the `id` argument on `node` is the unaltered result of querying `id` on some object in the system), and base64ing a string is a useful convention in GraphQL to remind viewers that the string is an opaque identifier.
 
-Complete details on how the server should behave are
-available in the
-[GraphQL Object Identification](../graphql/objectidentification.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Object Identification](../graphql/objectidentification.htm) spec.

--- a/docs/GraphQL-RelaySpecification.md
+++ b/docs/GraphQL-RelaySpecification.md
@@ -9,8 +9,7 @@ next: graphql-object-identification
 
 # Getting Started
 
-The three core assumptions that Relay makes about a GraphQL server are that it
-provides:
+The three core assumptions that Relay makes about a GraphQL server are that it provides:
 
 1. A mechanism for refetching an object.
 2. A description of how to page through connections.
@@ -18,28 +17,17 @@ provides:
 
 This example demonstrates all three of these assumptions.
 
-This example is not comprehensive, but it is designed to quickly introduce
-these core assumptions, to provide some context before diving into
-the more detailed specification or the library.
+This example is not comprehensive, but it is designed to quickly introduce these core assumptions, to provide some context before diving into the more detailed specification or the library.
 
-The premise of the example is that we want to use GraphQL to query for
-information about ships and factions in the original Star Wars
-trilogy.
+The premise of the example is that we want to use GraphQL to query for information about ships and factions in the original Star Wars trilogy.
 
-It is assumed that the reader is already familiar with GraphQL; if not,
-the README for [GraphQL.js](https://github.com/graphql/graphql-js) is a
-good place to start.
+It is assumed that the reader is already familiar with GraphQL; if not, the README for [GraphQL.js](https://github.com/graphql/graphql-js) is a good place to start.
 
-It is also assumed that the reader is already familiar with Star Wars; if not,
-the 1977 version of Star Wars is a good place to start, though the 1997
-Special Edition will serve for the purposes of this document.
+It is also assumed that the reader is already familiar with Star Wars; if not, the 1977 version of Star Wars is a good place to start, though the 1997 Special Edition will serve for the purposes of this document.
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality
-that a GraphQL server used by Relay should implement. The two core types
-are a faction and a ship in the Star Wars universe, where a faction
-has many ships associated with it. The schema below is the output of the
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the
 GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
 
 ```


### PR DESCRIPTION
When preparing the 0.9.1 release notes in `CHANGLOG.md` and previewing them on GitHub, I noticed some awkward wrapping in the rendered HTML near places where I had put hard line breaks in the file. This was fixed by not wrapping the 0.9.1 chunk of the release notes.

In this commit I've gone back and unwrapped all the Markdown files where we were hard-wrapping (the vast majority already don't hardwrap).

I was too lazy to visually inspect all the files, so I identified the likely candidates with this snippet of Ruby:

```
Dir['docs/*'].map{|d|File.read(d).lines.max_by{|l|l.size}}.map(&:size)
```

Which returned a list of the longest line of all files in "docs/":

```
=> [518, 448, 170, 423, 310, 181, 208, 204, 269, 81, 98, 79, 80, 112, 404,
467, 557, 269, 312, 325, 391, 177, 224, 172, 339, 186, 871, 306, 767, 401,
211, 153]
```

The obvious candidates were the chunk in the middle with lengths 81, 98, 79, 80 and 112, corresponding to the GraphQL docs, and sure enough, they were all hard-wrapped. Unwrapped by mashing `J` mindlessly in Vim.