### PR TITLE
Update links to point at relay-examples repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ Relay is a JavaScript framework for building data-driven React applications.
 
 ## Example
 
-The repository contains an implementation of [TodoMVC](http://todomvc.com/). To try it out:
+The [relay-examples](https://github.com/relayjs/relay-examples) repository contains an implementation of [TodoMVC](http://todomvc.com/). To try it out:
 
 ```
-git clone https://github.com/facebook/relay.git
-git checkout 081b4a3f17dcf
-cd relay/examples/todo && npm install
+git clone https://github.com/relayjs/relay-examples.git
+cd relay-examples/todo && npm install
 npm start
 ```
 

--- a/docs/QuickStart-GettingStarted.md
+++ b/docs/QuickStart-GettingStarted.md
@@ -25,7 +25,7 @@ To get started building Relay applications, you will need three things:
 
 2. **A GraphQL Server**
 
-  Any server can be taught to load a schema and speak GraphQL. Our [examples](https://github.com/facebook/relay/tree/081b4a3f17dcf/examples) use Express.
+  Any server can be taught to load a schema and speak GraphQL. Our [examples](https://github.com/relayjs/relay-examples) use Express.
 
   - **[express-graphql](https://github.com/graphql/express-graphql)** on [npm](https://www.npmjs.com/package/express-graphql)
 

--- a/docs/QuickStart-GettingStarted.zh-CN.md
+++ b/docs/QuickStart-GettingStarted.zh-CN.md
@@ -25,7 +25,7 @@ next: tutorial
 
 2. ** GraphQL 服务器 **
 
-  任何服务器都可以使用 GraphQL。我们的 [示例](https://github.com/facebook/relay/tree/081b4a3f17dcf/examples) 中用的是 Express。
+  任何服务器都可以使用 GraphQL。我们的 [示例](https://github.com/relayjs/relay-examples) 中用的是 Express。
 
   - **[express-graphql](https://github.com/graphql/express-graphql)** on [npm](https://www.npmjs.com/package/express-graphql)
 

--- a/docs/QuickStart-Tutorial.md
+++ b/docs/QuickStart-Tutorial.md
@@ -432,6 +432,6 @@ export default Relay.createContainer(App, {
 });
 ```
 
-A working copy of the treasure hunt can be found under the [`./examples/`](https://github.com/facebook/relay/tree/081b4a3f17dcf/examples) directory in the Relay repository.
+A working copy of the treasure hunt can be found in the [relay-examples](https://github.com/relayjs/relay-examples) repository.
 
 Now that we've gone through this tutorial, let's dive into what it means to build a GraphQL client framework and how this compares to clients for more traditional REST systems.

--- a/docs/QuickStart-Tutorial.zh-CN.md
+++ b/docs/QuickStart-Tutorial.zh-CN.md
@@ -431,6 +431,6 @@ export default Relay.createContainer(App, {
 });
 ```
 
-在 Relay 仓库的 [`./examples/`](https://github.com/facebook/relay/tree/081b4a3f17dcf/examples) 目录下，有这个寻宝游戏的副本。
+在 [relay-examples](https://github.com/relayjs/relay-examples) 仓库的，有这个寻宝游戏的副本。
 
 学完这篇教程后，我们将会深入了解构建一个 GraphQL 客户端框架到底意味着什么，以及如何将它与更多的为客户端搭建的 REST 系统作比较。

--- a/docs/QuickStart-Tutorial.zh-CN.md
+++ b/docs/QuickStart-Tutorial.zh-CN.md
@@ -431,6 +431,6 @@ export default Relay.createContainer(App, {
 });
 ```
 
-在 [relay-examples](https://github.com/relayjs/relay-examples) 仓库的，有这个寻宝游戏的副本。
+这个寻宝游戏的副本在 [relay-examples](https://github.com/relayjs/relay-examples) 仓库里。
 
 学完这篇教程后，我们将会深入了解构建一个 GraphQL 客户端框架到底意味着什么，以及如何将它与更多的为客户端搭建的 REST 系统作比较。


### PR DESCRIPTION
The repo is now public, so we can point at it.