### PR TITLE
Pass call type in from/toGraphQL

### DIFF
--- a/src/graphmode/__tests__/transformPayloadToRelayGraphMode-test.js
+++ b/src/graphmode/__tests__/transformPayloadToRelayGraphMode-test.js
@@ -296,7 +296,7 @@ describe('transformPayloadToRelayGraphMode()', () => {
       },
       {
         op: 'putEdges',
-        args: [{name: 'first', value: '1'}, {name: 'orderby', value: 'date'}],
+        args: [{name: 'first', value: '1', type: null}, {name: 'orderby', value: 'date', type: null}],
         edges: [
           {
             __typename: 'CommentsEdge',

--- a/src/query/__tests__/RelayQuery-getCallsWithValues-test.js
+++ b/src/query/__tests__/RelayQuery-getCallsWithValues-test.js
@@ -36,6 +36,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: null,
+          type: null,
         }]);
       });
 
@@ -44,6 +45,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: 32,
+          type: null,
         }]);
       });
     });
@@ -56,6 +58,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: null,
+          type: null,
         }]);
       });
 
@@ -66,6 +69,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: [],
+          type: null, 
         }]);
       });
 
@@ -76,6 +80,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: 32,
+          type: null,
         }]);
       });
 
@@ -86,6 +91,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: [32],
+          type: null,
         }]);
       });
     });
@@ -98,6 +104,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: [],
+          type: null,
         }]);
       });
 
@@ -108,6 +115,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: [64],
+          type: null,
         }]);
       });
     });
@@ -121,6 +129,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: [null],
+          type: null,
         }]);
       });
 
@@ -132,6 +141,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: [[]],
+          type: null,
         }]);
       });
 
@@ -143,6 +153,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: [32],
+          type: null,
         }]);
       });
 
@@ -154,6 +165,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: [[32]],
+          type: null,
         }]);
       });
 
@@ -168,6 +180,7 @@ describe('RelayQueryNode.prototype.getCallsWithValues()', function() {
         expect(field.getCallsWithValues()).toEqual([{
           name: 'size',
           value: [32, 64],
+          type: null,
         }]);
       });
     });

--- a/src/query/__tests__/RelayQuery-test.js
+++ b/src/query/__tests__/RelayQuery-test.js
@@ -100,7 +100,7 @@ describe('RelayQuery', () => {
           {identifyingArgName: 'id'}
         );
         expect(root.getCallsWithValues()).toEqual([
-          {name: 'id', value: '123'},
+          {name: 'id', value: '123', type: null},
         ]);
       });
 
@@ -138,6 +138,7 @@ describe('RelayQuery', () => {
         expect(root.getIdentifyingArg()).toEqual({
           name: 'id',
           value: '123',
+          type: null,
         });
       });
 
@@ -377,7 +378,7 @@ describe('RelayQuery', () => {
         expect(mutation.getChildren().length).toBe(1);
         expect(mutation.getChildren()[0]).toBe(field);
         expect(mutation.getCall())
-          .toEqual({name: 'feedback_like', value: {feedback_id:'123'}});
+          .toEqual({name: 'feedback_like', value: {feedback_id:'123'}, type: null});
         expect(mutation.getCallVariableName()).toEqual('input');
         expect(mutation.getRoute().name).toBe('FooRoute');
       });
@@ -401,7 +402,7 @@ describe('RelayQuery', () => {
         expect(mutation.getChildren().length).toBe(1);
         expect(mutation.getChildren()[0]).toBe(field);
         expect(mutation.getCall())
-          .toEqual({name: 'feedback_like', value: ''});
+          .toEqual({name: 'feedback_like', value: '', type: null});
         expect(mutation.getCallVariableName()).toEqual('input');
       });
     });

--- a/src/query/__tests__/RelayQuery-test.js
+++ b/src/query/__tests__/RelayQuery-test.js
@@ -309,7 +309,7 @@ describe('RelayQuery', () => {
           type: 'ProfilePicture',
         });
         expect(field.getCallsWithValues()).toEqual([
-          {name: 'size', value: 32},
+          {name: 'size', value: 32, type: null},
         ]);
         field = RelayQuery.Field.build({
           fieldName: 'profilePicture',
@@ -320,7 +320,7 @@ describe('RelayQuery', () => {
           type: 'ProfilePicture',
         });
         expect(field.getCallsWithValues()).toEqual([
-          {name: 'size', value: ['32']},
+          {name: 'size', value: ['32'], type: null},
         ]);
       });
 
@@ -337,7 +337,7 @@ describe('RelayQuery', () => {
           type: 'ProfilePicture',
         });
         expect(field.getDirectives()).toEqual([{
-          args: [{name: 'bar', value: 'baz'}],
+          args: [{name: 'bar', value: 'baz', type: null}],
           name: 'foo',
         }]);
       });
@@ -484,7 +484,7 @@ describe('RelayQuery', () => {
       expect(grandchildren[0].getSchemaName()).toBe('id');
       expect(grandchildren[1].getSchemaName()).toBe('profilePicture');
       expect(grandchildren[1].getCallsWithValues()).toEqual([
-        {name: 'size', value: 'override'},
+        {name: 'size', value: 'override', type: null},
       ]);
     });
 
@@ -534,7 +534,7 @@ describe('RelayQuery', () => {
       expect(grandchildren[0].getSchemaName()).toBe('id');
       expect(grandchildren[1].getSchemaName()).toBe('profilePicture');
       expect(grandchildren[1].getCallsWithValues()).toEqual([
-        {name: 'size', value: 'override'},
+        {name: 'size', value: 'override', type: null},
       ]);
 
       expect(children[2] instanceof RelayQuery.Fragment);

--- a/src/query/__tests__/RelayQueryField-test.js
+++ b/src/query/__tests__/RelayQueryField-test.js
@@ -334,6 +334,7 @@ describe('RelayQueryField', () => {
           null,
           undefined,
         ],
+        type: null,
       },
     ]);
   });
@@ -363,7 +364,7 @@ describe('RelayQueryField', () => {
         Relay.QL`fragment on User { friends(first:"10",isViewerFriend:true) }`
       ).getChildren()[0];
       expect(connectionField.getRangeBehaviorCalls())
-        .toEqual([{name: 'isViewerFriend', value: true}]);
+        .toEqual([{name: 'isViewerFriend', value: true, type: null}]);
     });
 
     it('throws for non-connection fields', () => {
@@ -385,6 +386,7 @@ describe('RelayQueryField', () => {
       expect(ifFalse.getRangeBehaviorCalls()).toEqual([{
         name: 'if',
         value: false,
+        type: null,
       }]);
     });
 
@@ -395,6 +397,7 @@ describe('RelayQueryField', () => {
       expect(unlessTrue.getRangeBehaviorCalls()).toEqual([{
         name: 'unless',
         value: true,
+        type: null,
       }]);
 
       const unlessFalse = getNode(Relay.QL`
@@ -413,6 +416,7 @@ describe('RelayQueryField', () => {
       expect(friendsScalar.getRangeBehaviorCalls()).toEqual([{
         name: 'isViewerFriend',
         value: false,
+        type: null,
       }]);
 
       const friendsVariableRQL = Relay.QL`
@@ -424,6 +428,7 @@ describe('RelayQueryField', () => {
       expect(friendsVariable.getRangeBehaviorCalls()).toEqual([{
         name: 'isViewerFriend',
         value: false,
+        type: null,
       }]);
     });
   });
@@ -620,14 +625,14 @@ describe('RelayQueryField', () => {
   it('returns arguments with values', () => {
     // scalar values are converted to strings
     expect(friendsScalarField.getCallsWithValues()).toEqual([
-      {name: 'first', value: '10'},
-      {name: 'after', value: 'offset'},
-      {name: 'orderby', value: 'name'},
+      {name: 'first', value: '10', type: null},
+      {name: 'after', value: 'offset', type: null},
+      {name: 'orderby', value: 'name', type: null},
     ]);
     // variables return their values
     expect(friendsVariableField.getCallsWithValues()).toEqual([
-      {name: 'first', value: 10},
-      {name: 'after', value: 'offset'},
+      {name: 'first', value: 10, type: null},
+      {name: 'after', value: 'offset', type: null},
     ]);
 
     const pictureScalarRQL = Relay.QL`
@@ -637,7 +642,7 @@ describe('RelayQueryField', () => {
     `;
     const pictureScalar = getNode(pictureScalarRQL).getChildren()[0];
     expect(pictureScalar.getCallsWithValues()).toEqual([
-      {name: 'size', value: ['32', '64']},
+      {name: 'size', value: ['32', '64'], type: null},
     ]);
 
     const pictureVariableRQL = Relay.QL`
@@ -652,7 +657,7 @@ describe('RelayQueryField', () => {
     const pictureVariable =
       getNode(pictureVariableRQL, variables).getChildren()[0];
     expect(pictureVariable.getCallsWithValues()).toEqual([
-      {name: 'size', value: [32, '64']},
+      {name: 'size', value: [32, '64'], type: null},
     ]);
   });
 
@@ -664,7 +669,7 @@ describe('RelayQueryField', () => {
       }
     `, variables).getChildren()[0];
     expect(profilePicture.getCallsWithValues()).toEqual(
-      [{name: 'size', value: [32, 64]}]
+      [{name: 'size', value: [32, 64], type: null}]
     );
   });
 
@@ -792,7 +797,7 @@ describe('RelayQueryField', () => {
     expect(field.getDirectives()).toEqual([
       {
         args: [
-          {name: 'if', value: true},
+          {name: 'if', value: true, type: null},
         ],
         name: 'include',
       },

--- a/src/query/__tests__/RelayQueryField-test.js
+++ b/src/query/__tests__/RelayQueryField-test.js
@@ -685,8 +685,8 @@ describe('RelayQueryField', () => {
     clonedFeed = friendsVariableField.cloneFieldWithCalls(
       friendsVariableField.getChildren(),
       [
-        {name: 'first', value: 10},
-        {name: 'after', value: 'offset'},
+        {name: 'first', value: 10, type: null},
+        {name: 'after', value: 'offset', type: null},
       ]
     );
     expect(clonedFeed).toBe(friendsVariableField);

--- a/src/query/__tests__/RelayQueryFragment-test.js
+++ b/src/query/__tests__/RelayQueryFragment-test.js
@@ -197,7 +197,7 @@ describe('RelayQueryFragment', () => {
     expect(fragment.getDirectives()).toEqual([
       {
         args: [
-          {name: 'if', value: true},
+          {name: 'if', value: true, type: null},
         ],
         name: 'include',
       },

--- a/src/query/__tests__/RelayQueryMutation-test.js
+++ b/src/query/__tests__/RelayQueryMutation-test.js
@@ -57,6 +57,7 @@ describe('RelayQueryMutation', () => {
     expect(mutationQuery.getCall()).toEqual({
       name: 'commentCreate',
       value: input,
+      type: null,
     });
     const children = mutationQuery.getChildren();
     expect(children.length).toBe(2);

--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -441,7 +441,7 @@ describe('RelayQueryRoot', () => {
     expect(query.getDirectives()).toEqual([
       {
         args: [
-          {name: 'if', value: true},
+          {name: 'if', value: true, type: null},
         ],
         name: 'include',
       },

--- a/src/query/__tests__/RelayQueryRoot-test.js
+++ b/src/query/__tests__/RelayQueryRoot-test.js
@@ -159,7 +159,7 @@ describe('RelayQueryRoot', () => {
     expect(me.getIdentifyingArg()).toEqual(undefined);
 
     expect(usernames.getIdentifyingArg()).toEqual(
-      {name: 'names', value: 'mroch'}
+      {name: 'names', value: 'mroch', type: '[String!]!'}
     );
 
     expect(getNode(Relay.QL`

--- a/src/query/__tests__/buildRQL-test.js
+++ b/src/query/__tests__/buildRQL-test.js
@@ -100,7 +100,7 @@ describe('buildRQL', () => {
       expect(children[1].getSchemaName()).toBe('profilePicture');
       // Variable has the applied value, not initial value.
       expect(children[1].getCallsWithValues()).toEqual([
-        {name: 'size', value: '32'},
+        {name: 'size', value: '32', type: null},
       ]);
     });
 

--- a/src/query/__tests__/callsToGraphQL-test.js
+++ b/src/query/__tests__/callsToGraphQL-test.js
@@ -23,6 +23,7 @@ describe('callsToGraphQL', function() {
     const relayCalls = [{
       name: 'size',
       value: null,
+      type: null,
     }];
     const graphqlCalls = [RelayTestUtils.createCall('size', null)];
     expect(callsFromGraphQL(graphqlCalls)).toEqual(relayCalls);
@@ -33,6 +34,7 @@ describe('callsToGraphQL', function() {
     const relayCalls = [{
       name: 'size',
       value: [],
+      type: null,
     }];
     const graphqlCalls = [RelayTestUtils.createCall('size', [])];
     expect(callsFromGraphQL(graphqlCalls)).toEqual(relayCalls);
@@ -43,6 +45,7 @@ describe('callsToGraphQL', function() {
     const relayCalls = [{
       name: 'size',
       value: [32, 64],
+      type: null,
     }];
     const graphqlCalls = [RelayTestUtils.createCall('size', [32, 64])];
     expect(callsFromGraphQL(graphqlCalls)).toEqual(relayCalls);
@@ -53,6 +56,7 @@ describe('callsToGraphQL', function() {
     const relayCalls = [{
       name: 'size',
       value: 32,
+      type: null,
     }];
     const graphqlCalls = [RelayTestUtils.createCall('size', 32)];
     expect(callsFromGraphQL(graphqlCalls)).toEqual(relayCalls);

--- a/src/query/__tests__/createRelayQuery-test.js
+++ b/src/query/__tests__/createRelayQuery-test.js
@@ -47,7 +47,7 @@ describe('createRelayQuery', () => {
     );
     expect(root instanceof RelayQuery.Root).toBe(true);
     expect(root.getFieldByStorageKey('newsFeed').getCallsWithValues()).toEqual(
-      [{name: 'first', value: 10}]
+      [{name: 'first', value: 10, type: null}]
     );
   });
 });

--- a/src/query/callsFromGraphQL.js
+++ b/src/query/callsFromGraphQL.js
@@ -26,6 +26,7 @@ const invariant = require('invariant');
 type CallOrDirective = {
   name: string,
   value: ?ConcreteValue,
+  type?: ?string,
 };
 
 /**
@@ -43,6 +44,7 @@ function callsFromGraphQL(
   for (let ii = 0; ii < callsOrDirectives.length; ii++) {
     const callOrDirective = callsOrDirectives[ii];
     let {value} = callOrDirective;
+    let {type} = callOrDirective.metadata;
     if (value != null) {
       if (Array.isArray(value)) {
         value = value.map(arg => getCallValue(arg, variables));
@@ -53,7 +55,7 @@ function callsFromGraphQL(
         value = getCallValue(value, variables);
       }
     }
-    orderedCalls.push({name: callOrDirective.name, value});
+    orderedCalls.push({name: callOrDirective.name, value, type});
   }
   return orderedCalls;
 }

--- a/src/query/callsFromGraphQL.js
+++ b/src/query/callsFromGraphQL.js
@@ -23,10 +23,14 @@ import type {Variables} from 'RelayTypes';
 
 const invariant = require('invariant');
 
+type Metadata = {
+  type: ?string,
+};
+
 type CallOrDirective = {
   name: string,
   value: ?ConcreteValue,
-  type?: ?string,
+  metadata: ?Metadata,
 };
 
 /**
@@ -44,8 +48,8 @@ function callsFromGraphQL(
   for (let ii = 0; ii < callsOrDirectives.length; ii++) {
     const callOrDirective = callsOrDirectives[ii];
     let {value, metadata} = callOrDirective;
-    let type = undefined;
-    if (metadata){
+    let type?: string;
+    if (metadata && metadata.type){
       type = metadata.type;
     }
     if (value != null) {

--- a/src/query/callsFromGraphQL.js
+++ b/src/query/callsFromGraphQL.js
@@ -43,8 +43,11 @@ function callsFromGraphQL(
   const orderedCalls = [];
   for (let ii = 0; ii < callsOrDirectives.length; ii++) {
     const callOrDirective = callsOrDirectives[ii];
-    let {value} = callOrDirective;
-    let {type} = callOrDirective.metadata;
+    let {value, metadata} = callOrDirective;
+    let type = undefined;
+    if (metadata){
+      type = metadata.type;
+    }
     if (value != null) {
       if (Array.isArray(value)) {
         value = value.map(arg => getCallValue(arg, variables));

--- a/src/query/callsFromGraphQL.js
+++ b/src/query/callsFromGraphQL.js
@@ -48,7 +48,7 @@ function callsFromGraphQL(
   for (let ii = 0; ii < callsOrDirectives.length; ii++) {
     const callOrDirective = callsOrDirectives[ii];
     let {value, metadata} = callOrDirective;
-    let type: ?string;
+    let type: ?string = null;
     if (metadata && metadata.type){
       type = metadata.type;
     }

--- a/src/query/callsFromGraphQL.js
+++ b/src/query/callsFromGraphQL.js
@@ -48,7 +48,7 @@ function callsFromGraphQL(
   for (let ii = 0; ii < callsOrDirectives.length; ii++) {
     const callOrDirective = callsOrDirectives[ii];
     let {value, metadata} = callOrDirective;
-    let type?: string;
+    let type: ?string;
     if (metadata && metadata.type){
       type = metadata.type;
     }

--- a/src/query/callsToGraphQL.js
+++ b/src/query/callsToGraphQL.js
@@ -22,14 +22,14 @@ const QueryBuilder = require('QueryBuilder');
  * Convert from plain object `{name, value}` calls to GraphQL call nodes.
  */
 function callsToGraphQL(calls: Array<Call>): Array<ConcreteCall> {
-  return calls.map(({name, value}) => {
+  return calls.map(({name, value, type}) => {
     let concreteValue = null;
     if (Array.isArray(value)) {
       concreteValue = value.map(QueryBuilder.createCallValue);
     } else if (value != null)  {
       concreteValue = QueryBuilder.createCallValue(value);
     }
-    return QueryBuilder.createCall(name, concreteValue);
+    return QueryBuilder.createCall(name, concreteValue, type);
   });
 }
 

--- a/src/tools/RelayInternalTypes.js
+++ b/src/tools/RelayInternalTypes.js
@@ -23,7 +23,7 @@ import type RelayQuery from 'RelayQuery';
 
 export type Call = {
   name: string,
-  type?: string,
+  type?: ?string,
   value: CallValue,
 };
 export type CallValue = ?(


### PR DESCRIPTION
Currently types are ignored and not getting passed in `callsFromGraphQL`
or `callsToGraphQL`.
This results in dangerous output from `toGraphQL`, in which all calls have
type null. This can cause problems when using non-scalar types (like
enum).
For more details see #1256.