### PR TITLE
[babel-relay-plugin] Move remaining hardcoded Node `id` to constant.

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-iBURgkMDWYBoxIrvOIb32UNPOSI=
+lmbOTQ9brPduHvvU636JVox2Gv8=

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -178,7 +178,7 @@ module.exports = function (t, options) {
         var requisiteFields = {};
         var idFragment = void 0;
         if (fragmentType.hasField(ID)) {
-          requisiteFields.id = true;
+          requisiteFields[ID] = true;
         } else if (shouldGenerateIdFragment(fragment, fragmentType)) {
           idFragment = fragmentType.generateIdFragment();
         }
@@ -379,7 +379,7 @@ module.exports = function (t, options) {
         var requisiteFields = {};
         var idFragment = void 0;
         if (fieldType.hasField(ID)) {
-          requisiteFields.id = true;
+          requisiteFields[ID] = true;
         } else if (shouldGenerateIdFragment(field, fieldType)) {
           idFragment = fieldType.generateIdFragment();
         }

--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -197,7 +197,7 @@ module.exports = function(t: any, options: PrinterOptions): Function {
       const requisiteFields = {};
       let idFragment;
       if (fragmentType.hasField(ID)) {
-        requisiteFields.id = true;
+        requisiteFields[ID] = true;
       } else if (shouldGenerateIdFragment(fragment, fragmentType)) {
         idFragment = fragmentType.generateIdFragment();
       }
@@ -488,7 +488,7 @@ module.exports = function(t: any, options: PrinterOptions): Function {
       const requisiteFields = {};
       let idFragment;
       if (fieldType.hasField(ID)) {
-        requisiteFields.id = true;
+        requisiteFields[ID] = true;
       } else if (shouldGenerateIdFragment(field, fieldType)) {
         idFragment = fieldType.generateIdFragment();
       }


### PR DESCRIPTION
This finishes the work started in 57d1bfb181ce68ea9c45810920604e13f487bc89.