### PR TITLE
Fix Renderer Example in Documentation

### DIFF
--- a/docs/APIReference-Renderer.md
+++ b/docs/APIReference-Renderer.md
@@ -110,7 +110,7 @@ If the callback returns `undefined`, the previously rendered view (or nothing if
   Container={ProfilePicture}
   queryConfig={profileRoute}
   environment={Relay.Store}
-  render={({done, error, props, retry, stale}) => {
+  render={({props, done, error, retry, stale}) => {
         if (error) {
           return <ErrorComponent />;
         } else if (props) {


### PR DESCRIPTION
Fix the order of the parameters in the function so that it actually matches the implementation.