### PR TITLE
Update .flowconfig to match internal copy

### DIFF
--- a/scripts/babel-relay-plugin/src/.flowconfig
+++ b/scripts/babel-relay-plugin/src/.flowconfig
@@ -5,6 +5,7 @@
 
 [include]
 ../node_modules/
+../../node_modules/
 ../../../node_modules/util/
 
 [libs]


### PR DESCRIPTION
Older versions of flow crashed when an `[include]`d directory didn't exist. This was fixed in flow and should allow us converge the `.flowconfig` again with the internal version that deals with a different directory structure.