### PR TITLE
Allow for one-off query overrides for serverside rendering

### DIFF
--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -138,7 +138,7 @@ class RelayDefaultNetworkLayer {
   /**
    * Sends a POST request and retries if the request fails or times out.
    */
-  _sendQuery(request: RelayQueryRequest: Promise<any>, overrides?: Object = {}) {
+  _sendQuery(request: RelayQueryRequest, overrides?: Object = {}): Promise<any> {
     return fetchWithRetries(this._uri, {
       ...this._init,
       body: JSON.stringify({

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -62,9 +62,9 @@ class RelayDefaultNetworkLayer {
     );
   }
 
-  sendQueries(requests: Array<RelayQueryRequest>): ?Promise<any> {
+  sendQueries(requests: Array<RelayQueryRequest>, overrides?: Object = {}): ?Promise<any> {
     return Promise.all(requests.map(request => (
-      this._sendQuery(request).then(
+      this._sendQuery(request, overrides).then(
         result => result.json()
       ).then(payload => {
         if (payload.hasOwnProperty('errors')) {
@@ -138,7 +138,7 @@ class RelayDefaultNetworkLayer {
   /**
    * Sends a POST request and retries if the request fails or times out.
    */
-  _sendQuery(request: RelayQueryRequest): Promise<any> {
+  _sendQuery(request: RelayQueryRequest, overrides?: Object = {}): Promise<any> {
     return fetchWithRetries(this._uri, {
       ...this._init,
       body: JSON.stringify({

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -147,6 +147,7 @@ class RelayDefaultNetworkLayer {
       }),
       headers: {
         ...this._init.headers,
+        overrides.headers ? ...overrides.headers : {},
         'Accept': '*/*',
         'Content-Type': 'application/json',
       },

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -138,7 +138,7 @@ class RelayDefaultNetworkLayer {
   /**
    * Sends a POST request and retries if the request fails or times out.
    */
-  _sendQuery(request: RelayQueryRequest, overrides?: Object = {}): Promise<any> {
+  _sendQuery(request: RelayQueryRequest: Promise<any>, overrides?: Object = {}) {
     return fetchWithRetries(this._uri, {
       ...this._init,
       body: JSON.stringify({
@@ -147,7 +147,7 @@ class RelayDefaultNetworkLayer {
       }),
       headers: {
         ...this._init.headers,
-        overrides.headers ? ...overrides.headers : {},
+        ...overrides.headers,
         'Accept': '*/*',
         'Content-Type': 'application/json',
       },

--- a/src/network/RelayNetworkLayer.js
+++ b/src/network/RelayNetworkLayer.js
@@ -98,7 +98,7 @@ class RelayNetworkLayer {
     }
   }
 
-  sendQueries(queryRequests: Array<RelayQueryRequest>): void {
+  sendQueries(queryRequests: Array<RelayQueryRequest>, overrides?: Object = {}): void {
     const implementation = this._getImplementation();
     this._subscribers.forEach(({queryCallback}) => {
       if (queryCallback) {
@@ -108,7 +108,7 @@ class RelayNetworkLayer {
         });
       }
     });
-    const promise = implementation.sendQueries(queryRequests);
+    const promise = implementation.sendQueries(queryRequests, overrides);
     if (promise) {
       Promise.resolve(promise).done();
     }

--- a/src/network/__tests__/RelayNetworkLayer-test.js
+++ b/src/network/__tests__/RelayNetworkLayer-test.js
@@ -130,9 +130,10 @@ describe('RelayNetworkLayer', () => {
 
     it('delegates queries to the injected network layer', () => {
       const queries = [];
+      const overrides = {};
       expect(injectedNetworkLayer.sendQueries).not.toBeCalled();
-      networkLayer.sendQueries(queries);
-      expect(injectedNetworkLayer.sendQueries).toBeCalledWith(queries);
+      networkLayer.sendQueries(queries, overrides);
+      expect(injectedNetworkLayer.sendQueries).toBeCalledWith(queries, overrides);
     });
   });
 


### PR DESCRIPTION
First off, thank you guys for making this. This codebase is really awesome, and I love the approach to everything. Currently though, the main known open source serverside rendering solution (isomorphic-relay, another great codebase) is kind of in a bad spot when it comes to credential passing.

An example of this can be seen with isomorphic-relay, where the solution for passing httponly cookies in serverside rendering involves converting the endpoint to run sequentially, which is a major deoptimizer. By exposing overrides like this, we could skirt that approach by instead just passing in one off data into the sendQueries call.

Admittedly, I don't know this codebase all too well, and there are probably a lot of gotchas I'm overlooking, but I wanted to put this out there and just see what your guys thoughts were. Also, if you just want to see more polish and consistency, let me know and I can refactor / rebase this as needed.

Thanks as always!