### PR TITLE
Parse serialized GraphQL range in getRangeMetadata

### DIFF
--- a/src/store/RelayRecordStore.js
+++ b/src/store/RelayRecordStore.js
@@ -356,10 +356,7 @@ class RelayRecordStore {
     if (connectionID == null) {
       return connectionID;
     }
-    let range: ?GraphQLRange = (this._getField(connectionID, RANGE): any);
-    if (Array.isArray(range)) {
-      range = GraphQLRange.fromJSON(range);
-    }
+    const range: ?GraphQLRange = (this._getField(connectionID, RANGE): any);
     if (range == null) {
       if (range === null) {
         warning(

--- a/src/store/RelayRecordStore.js
+++ b/src/store/RelayRecordStore.js
@@ -356,7 +356,10 @@ class RelayRecordStore {
     if (connectionID == null) {
       return connectionID;
     }
-    const range: ?GraphQLRange = (this._getField(connectionID, RANGE): any);
+    let range: ?GraphQLRange = (this._getField(connectionID, RANGE): any);
+    if (Array.isArray(range)) {
+      range = GraphQLRange.fromJSON(range);
+    }
     if (range == null) {
       if (range === null) {
         warning(

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -633,13 +633,9 @@ class RelayStoreData {
       nodeRangeMap,
     } = obj;
 
-    for (const key in records) {
-      const record = records[key];
-      const range = record.__range__;
-      if (range) {
-        record.__range__ = GraphQLRange.fromJSON(range);
-      }
-    }
+    deserializeRecordRanges(cachedRecords);
+    deserializeRecordRanges(queuedRecords);
+    deserializeRecordRanges(records);
 
     return new RelayStoreData(
       cachedRecords,
@@ -649,6 +645,20 @@ class RelayStoreData {
       rootCallMap,
       nodeRangeMap,
     );
+  }
+}
+
+/**
+ * A helper function which checks for serialized GraphQLRange
+ * instances and deserializes them in toJSON()
+ */
+function deserializeRecordRanges(records) {
+  for (const key in records) {
+    const record = records[key];
+    const range = record.__range__;
+    if (range) {
+      record.__range__ = GraphQLRange.fromJSON(range);
+    }
   }
 }
 

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -44,6 +44,7 @@ import type {RecordMap} from 'RelayRecord';
 const RelayRecordStore = require('RelayRecordStore');
 const RelayRecordWriter = require('RelayRecordWriter');
 const RelayTaskQueue = require('RelayTaskQueue');
+const GraphQLRange = require('GraphQLRange');
 import type {TaskScheduler} from 'RelayTaskQueue';
 import type {Abortable, CacheManager, CacheProcessorCallbacks} from 'RelayTypes';
 
@@ -631,6 +632,14 @@ class RelayStoreData {
       rootCallMap,
       nodeRangeMap,
     } = obj;
+
+    for (const key in records) {
+      const record = records[key];
+      const range = record.__range__;
+      if (range) {
+        record.__range__ = GraphQLRange.fromJSON(range);
+      }
+    }
 
     return new RelayStoreData(
       cachedRecords,


### PR DESCRIPTION
Resolves #1293 

Current if you try to de/serialize your RelayEnvironment you run into an error as `getRangeMetadata` tries calling a `GraphQLRange` method on the serialized array. To prevent this we check to see if we have a serialized instance (which is always an array) and parse it if we do.