### PR TITLE
Add `Relay.disableQueryCache` static method

### DIFF
--- a/src/RelayPublic.js
+++ b/src/RelayPublic.js
@@ -29,7 +29,6 @@ const createRelayQuery = require('createRelayQuery');
 const getRelayQueries = require('getRelayQueries');
 const isRelayContainer = require('isRelayContainer');
 
-
 if (typeof global.__REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined') {
   global.__REACT_DEVTOOLS_GLOBAL_HOOK__._relayInternals = RelayInternals;
 }

--- a/src/RelayPublic.js
+++ b/src/RelayPublic.js
@@ -23,10 +23,12 @@ const RelayRenderer = require('RelayRenderer');
 const RelayRootContainer = require('RelayRootContainer');
 const RelayRoute = require('RelayRoute');
 const RelayStore = require('RelayStore');
+const DisableRelayQueryCache = require('DisableRelayQueryCache');
 
 const createRelayQuery = require('createRelayQuery');
 const getRelayQueries = require('getRelayQueries');
 const isRelayContainer = require('isRelayContainer');
+
 
 if (typeof global.__REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined') {
   global.__REACT_DEVTOOLS_GLOBAL_HOOK__._relayInternals = RelayInternals;
@@ -50,6 +52,7 @@ const RelayPublic = {
   createContainer: RelayContainer.create,
   createQuery: createRelayQuery,
   getQueries: getRelayQueries,
+  disableQueryCache: DisableRelayQueryCache.disableCache,
   injectNetworkLayer: RelayStore.injectNetworkLayer.bind(RelayStore),
   injectTaskScheduler: RelayStore.injectTaskScheduler.bind(RelayStore),
   isContainer: isRelayContainer,

--- a/src/query/__tests__/buildRQL-test.js
+++ b/src/query/__tests__/buildRQL-test.js
@@ -21,6 +21,8 @@ const Relay = require('Relay');
 const RelayQuery = require('RelayQuery');
 const RelayTestUtils = require('RelayTestUtils');
 
+const DisableRelayQueryCache = require('DisableRelayQueryCache');
+
 const buildRQL = require('buildRQL');
 
 describe('buildRQL', () => {
@@ -187,6 +189,20 @@ describe('buildRQL', () => {
       `;
       const node1 = buildRQL.Query(builder, MockContainer, 'foo', {id: null});
       const node2 = buildRQL.Query(builder, MockContainer2, 'foo', {id: null});
+      expect(node1 === node2).toBe(false);
+    });
+
+    it('returns different queries for the same component if cache is disabled', () => {
+      DisableRelayQueryCache.disableCache();
+      const builder = Component => Relay.QL`
+        query {
+          node(id:$id) {
+            ${Component.getFragment('foo')}
+          }
+        }
+      `;
+      const node1 = buildRQL.Query(builder, MockContainer, 'foo', {id: null});
+      const node2 = buildRQL.Query(builder, MockContainer, 'foo', {id: null});
       expect(node1 === node2).toBe(false);
     });
 

--- a/src/query/__tests__/buildRQL-test.js
+++ b/src/query/__tests__/buildRQL-test.js
@@ -203,7 +203,7 @@ describe('buildRQL', () => {
       `;
       const node1 = buildRQL.Query(builder, MockContainer, 'foo', {id: null});
       const node2 = buildRQL.Query(builder, MockContainer, 'foo', {id: null});
-      expect(node1 === node2).toBe(false);
+      expect(node1).not.toBe(node2);
     });
 
     it('filters the variables passed to components', () => {

--- a/src/query/buildRQL.js
+++ b/src/query/buildRQL.js
@@ -97,66 +97,22 @@ const buildRQL = {
     queryName: string,
     values: Variables
   ): ?ConcreteQuery {
-    let node;
-    let componentCache = {};
     const queryCacheEnabled = DisableRelayQueryCache.getCacheEnabled();
-    if (queryCacheEnabled) {
-      componentCache = queryCache.get(queryBuilder);
+    let node;
+    if (!queryCacheEnabled) {
+      node = buildNode(queryBuilder, Component, queryName, values);
+    } else {
+      let componentCache = queryCache.get(queryBuilder);
       if (!componentCache) {
         componentCache = new Map();
         queryCache.set(queryBuilder, componentCache);
       } else {
         node = componentCache.get(Component);
       }
-    }
-    if (!node) {
-      const variables = toVariables(values);
-      invariant(
-        !isDeprecatedCallWithArgCountGreaterThan(queryBuilder, 2),
-        'Relay.QL: Deprecated usage detected. If you are trying to define a ' +
-        'query, use `(Component, variables) => Relay.QL`.'
-      );
-      if (isDeprecatedCallWithArgCountGreaterThan(queryBuilder, 0)) {
-        node = queryBuilder(Component, variables);
-      } else {
-        node = queryBuilder(Component, variables);
-        const query = QueryBuilder.getQuery(node);
-        if (query) {
-          let hasFragment = false;
-          let hasScalarFieldsOnly = true;
-          if (query.children) {
-            query.children.forEach(child => {
-              if (child) {
-                hasFragment = hasFragment || child.kind === 'Fragment';
-                hasScalarFieldsOnly = hasScalarFieldsOnly && (
-                  child.kind === 'Field' &&
-                  (!child.children || child.children.length === 0)
-                );
-              }
-            });
-          }
-          if (!hasFragment) {
-            const children = query.children ? [...query.children] : [];
-            invariant(
-              hasScalarFieldsOnly,
-              'Relay.QL: Expected query `%s` to be empty. For example, use ' +
-              '`node(id: $id)`, not `node(id: $id) { ... }`.',
-              query.fieldName
-            );
-            const fragmentVariables = filterObject(variables, (_, name) =>
-              Component.hasVariable(name)
-            );
-            children.push(Component.getFragment(queryName, fragmentVariables));
-            node = {
-              ...query,
-              children,
-            };
-          }
-        }
+      if (!node) {
+        node = buildNode(queryBuilder, Component, queryName, values);
       }
-      if (queryCacheEnabled) {
-        componentCache.set(Component, node);
-      }
+      componentCache.set(Component, node);
     }
     if (node) {
       return QueryBuilder.getQuery(node) || undefined;
@@ -164,6 +120,63 @@ const buildRQL = {
     return null;
   },
 };
+
+/**
+ * @internal
+ */
+function buildNode(
+  queryBuilder: RelayQLQueryBuilder,
+  Component: any,
+  queryName: string,
+  values: Variables
+): ?mixed {
+  const variables = toVariables(values);
+  invariant(
+    !isDeprecatedCallWithArgCountGreaterThan(queryBuilder, 2),
+    'Relay.QL: Deprecated usage detected. If you are trying to define a ' +
+    'query, use `(Component, variables) => Relay.QL`.'
+  );
+  let node;
+  if (isDeprecatedCallWithArgCountGreaterThan(queryBuilder, 0)) {
+    node = queryBuilder(Component, variables);
+  } else {
+    node = queryBuilder(Component, variables);
+    const query = QueryBuilder.getQuery(node);
+    if (query) {
+      let hasFragment = false;
+      let hasScalarFieldsOnly = true;
+      if (query.children) {
+        query.children.forEach(child => {
+          if (child) {
+            hasFragment = hasFragment || child.kind === 'Fragment';
+            hasScalarFieldsOnly = hasScalarFieldsOnly && (
+              child.kind === 'Field' &&
+              (!child.children || child.children.length === 0)
+            );
+          }
+        });
+      }
+      if (!hasFragment) {
+        const children = query.children ? [...query.children] : [];
+        invariant(
+          hasScalarFieldsOnly,
+          'Relay.QL: Expected query `%s` to be empty. For example, use ' +
+          '`node(id: $id)`, not `node(id: $id) { ... }`.',
+          query.fieldName
+        );
+        const fragmentVariables = filterObject(variables, (_, name) =>
+          Component.hasVariable(name)
+        );
+        children.push(Component.getFragment(queryName, fragmentVariables));
+        node = {
+          ...query,
+          children,
+        };
+      }
+    }
+  }
+  return node;
+}
 
 function toVariables(variables: Variables): {
   [key: string]: $FlowIssue; // ConcreteCallVariable should flow into mixed

--- a/src/tools/DisableRelayQueryCache.js
+++ b/src/tools/DisableRelayQueryCache.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule disableRelayQueryCache
+ * @flow
+ */
+'use strict';
+
+
+let queryCacheEnabled = true;
+
+/**
+ * `disableQueryCache` turns off caching of queries for `getRelayQueryies` and `buildRQL`
+ */
+function disableCache(): void {
+  queryCacheEnabled = false;
+}
+
+/**
+ * @internal
+ *
+ */
+function getCacheEnabled(): boolean {
+  return queryCacheEnabled;
+}
+
+module.exports = {
+  disableCache,
+  getCacheEnabled,
+}

--- a/src/tools/__mocks__/DisableRelayQueryCache.js
+++ b/src/tools/__mocks__/DisableRelayQueryCache.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = require.requireActual('disableRelayQueryCache');


### PR DESCRIPTION
This allows for disabling the query cache in `createRelayQuery` and `buildRQL` by calling `Relay.disableQueryCache()`. 

Submitted in response to https://github.com/facebook/relay/issues/754#issuecomment-234995746

Because keys used to store queries include params, the query caches can grow to an unbounded size in certain circumstances (like text search input as a param). This allows the the cache to be disabled manually in circumstances where that is problematic, such as server side rendering. 

This PR does not disable the `fragmentCache` in `buildRQL`, which I believe only uses fragments and initial variables, and so has a bounded upper limit in terms of size. 
