### PR TITLE
RelayContainer shouldUpdate if there are pendingVariables

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -771,6 +771,7 @@ function createContainerComponent(
 
       const fragmentPointers = this._fragmentPointers;
       return (
+        !!nextState.relayProp.pendingVariables ||
         !RelayContainerComparators.areNonQueryPropsEqual(
           fragments,
           this.props,

--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -771,7 +771,6 @@ function createContainerComponent(
 
       const fragmentPointers = this._fragmentPointers;
       return (
-        !!nextState.relayProp.pendingVariables ||
         !RelayContainerComparators.areNonQueryPropsEqual(
           fragments,
           this.props,
@@ -788,6 +787,10 @@ function createContainerComponent(
         !RelayContainerComparators.areQueryVariablesEqual(
           this.state.relayProp.variables,
           nextState.relayProp.variables
+        ) ||
+        !RelayContainerComparators.areQueryVariablesEqual(
+          this.state.relayProp.pendingVariables,
+          nextState.relayProp.pendingVariables
         )
       );
     }

--- a/src/container/RelayContainerComparators.js
+++ b/src/container/RelayContainerComparators.js
@@ -20,8 +20,8 @@
  */
 function compareObjects(
   isEqual: (propA: any, propB: any, key: string) => boolean,
-  objectA: Object,
-  objectB: Object,
+  objectA: ?Object,
+  objectB: ?Object,
   filter?: Object
 ): boolean {
   let key;
@@ -32,9 +32,9 @@ function compareObjects(
       continue;
     }
 
-    if (objectA.hasOwnProperty(key) && (
+    if (!objectB || (objectA.hasOwnProperty(key) && (
           !objectB.hasOwnProperty(key) ||
-          !isEqual(objectA[key], objectB[key], key))) {
+          !isEqual(objectA[key], objectB[key], key)))) {
       return false;
     }
   }
@@ -44,7 +44,7 @@ function compareObjects(
       continue;
     }
 
-    if (objectB.hasOwnProperty(key) && !objectA.hasOwnProperty(key)) {
+    if (!objectA || (objectB.hasOwnProperty(key) && !objectA.hasOwnProperty(key))) {
       return false;
     }
   }
@@ -113,8 +113,8 @@ const RelayContainerComparators = {
   },
 
   areQueryVariablesEqual(
-    variables: Object,
-    nextVariables: Object
+    variables: ?Object,
+    nextVariables: ?Object
   ): boolean {
     return compareObjects(isScalarAndEqual, variables, nextVariables);
   },

--- a/src/container/__tests__/RelayContainer_setVariables-test.js
+++ b/src/container/__tests__/RelayContainer_setVariables-test.js
@@ -292,6 +292,15 @@ describe('RelayContainer.setVariables', function() {
       expect(mockInstance.state.queryData.entity).toBe(updatedQueryData);
     });
 
+    it('re-renders when there are pendingVariables', () => {
+      const before = render.mock.calls.length;
+      expect(render.mock.calls.length).toBe(1);
+      mockInstance.setVariables({site: 'www'});
+      jest.runAllTimers();
+      environment.primeCache.mock.requests[0].block();
+      expect(render.mock.calls.length - before).toBe(1);
+    });
+
     it('sets pendingVariables when request is in-flight', () => {
       mockInstance.setVariables({site: 'www'});
       jest.runAllTimers();

--- a/src/container/__tests__/RelayContainer_setVariables-test.js
+++ b/src/container/__tests__/RelayContainer_setVariables-test.js
@@ -293,12 +293,11 @@ describe('RelayContainer.setVariables', function() {
     });
 
     it('re-renders when there are pendingVariables', () => {
-      const before = render.mock.calls.length;
-      expect(render.mock.calls.length).toBe(1);
+      render.mockClear();
       mockInstance.setVariables({site: 'www'});
       jest.runAllTimers();
       environment.primeCache.mock.requests[0].block();
-      expect(render.mock.calls.length - before).toBe(1);
+      expect(render.mock.calls.length).toBe(1);
     });
 
     it('sets pendingVariables when request is in-flight', () => {


### PR DESCRIPTION
This pull-request is a follow-up of https://github.com/facebook/relay/pull/1069

I was trying to use the feature but got confused because my decorated component wouldn't receive the updated `this.props.pendingVariables` when calling `setVariables`. (see discussion https://github.com/facebook/relay/commit/3b8f67fc027a683e0f2cac71cc2a47ece0f5ed20).

The changes here make sure RelayContainer's `shouldComponentUpdate` returns `true` when the nextState has some `pendingVariables`.

I looked at adding some tests but wasn't sure really where to put them ? `RelayContainer-test.js` / `RelayContainer_setVariables-test.js` ? What should I test ? I was thinking either the count of `render.mock.calls.length` or the output of shouldComponentUpdate
