### PR TITLE
Expose injectCacheManager on RelayEnvironment

### DIFF
--- a/src/store/RelayEnvironment.js
+++ b/src/store/RelayEnvironment.js
@@ -35,6 +35,7 @@ import type {
   ReadyStateChangeCallback,
   StoreReaderData,
   StoreReaderOptions,
+  CacheManager,
 } from 'RelayTypes';
 
 import type {
@@ -142,6 +143,10 @@ class RelayEnvironment {
 
   injectTaskScheduler(scheduler: ?TaskScheduler): void {
     this._storeData.injectTaskScheduler(scheduler);
+  }
+
+  injectCacheManager(cacheManager: ?CacheManager): void {
+    this._storeData.injectCacheManager(cacheManager);
   }
 
   /**

--- a/src/store/RelayStoreData.js
+++ b/src/store/RelayStoreData.js
@@ -197,6 +197,10 @@ class RelayStoreData {
     return !!this._cacheManager;
   }
 
+  getCacheManager(): ?CacheManager {
+    return this._cacheManager;
+  }
+
   /**
    * Returns whether a given record is affected by an optimistic update.
    */

--- a/src/store/__tests__/RelayEnvironment-test.js
+++ b/src/store/__tests__/RelayEnvironment-test.js
@@ -262,5 +262,15 @@ describe('RelayEnvironment', () => {
         expect(mockTransaction.commit).not.toBeCalled();
       });
     });
+
+    describe('injectCacheManager()', () => {
+      it('passes down the cacheManager to the store data', () => {
+        const mockCacheManager = {};
+        environment.injectCacheManager(mockCacheManager);
+        expect(
+          environment.getStoreData().getCacheManager()
+        ).toBe(mockCacheManager);
+      });
+    });
   });
 });


### PR DESCRIPTION
`RelayEnvironment` exposes most of the other injection methods for `RelayStoreData`, so this just adds `injectCacheManager` as well. Even though it's not a documented API, adding it to `RelayEnvironment` will make it easier for those who do want to use it while its "experimental" which paves the way for a stable implementation.

I also added a basic test that just verifies the injection works as expected.