### PR TITLE
Wrap tracked fragments in their own types to support union types in mutations

### DIFF
--- a/src/store/RelayQueryTracker.js
+++ b/src/store/RelayQueryTracker.js
@@ -60,8 +60,16 @@ class RelayQueryTracker {
     const {isMerged, trackedNodes} = trackedNodesByID;
     if (!isMerged) {
       const trackedChildren = [];
+      let wrapperNode = null;
       trackedNodes.forEach(trackedQuery => {
-        trackedChildren.push(...trackedQuery.getChildren());
+        wrapperNode = new RelayQuery.Fragment.build(
+          'RelayQueryTracker',
+          trackedQuery.getType(),
+          trackedQuery.getChildren()
+        );
+        if (wrapperNode) {
+          trackedChildren.push(wrapperNode);
+        }
       });
       trackedNodes.length = 0;
       trackedNodesByID.isMerged = true;

--- a/src/store/RelayQueryTracker.js
+++ b/src/store/RelayQueryTracker.js
@@ -59,18 +59,13 @@ class RelayQueryTracker {
     }
     const {isMerged, trackedNodes} = trackedNodesByID;
     if (!isMerged) {
-      const trackedChildren = [];
-      let wrapperNode = null;
-      trackedNodes.forEach(trackedQuery => {
-        wrapperNode = new RelayQuery.Fragment.build(
-          'RelayQueryTracker',
+      const trackedChildren = trackedNodes.map(trackedQuery =>
+        new RelayQuery.Fragment.build(
+          'RelayQueryTrackerWrapperFragment',
           trackedQuery.getType(),
           trackedQuery.getChildren()
-        );
-        if (wrapperNode) {
-          trackedChildren.push(wrapperNode);
-        }
-      });
+        )
+      );
       trackedNodes.length = 0;
       trackedNodesByID.isMerged = true;
       let containerNode = RelayQuery.Fragment.build(

--- a/src/store/__tests__/RelayQueryTracker-test.js
+++ b/src/store/__tests__/RelayQueryTracker-test.js
@@ -57,7 +57,9 @@ describe('RelayQueryTracker', () => {
     tracker.trackNodeForID(query, 'client:1');
     const trackedChildren = tracker.getTrackedChildrenForID('client:1');
     expect(trackedChildren.length).toBe(1);
-    expect(trackedChildren[0])
+    expect(trackedChildren[0].getChildren().length).toBe(1);
+
+    expect(trackedChildren[0].getChildren()[0])
       .toEqualQueryNode(query.getFieldByStorageKey('actor'));
   });
 
@@ -75,7 +77,8 @@ describe('RelayQueryTracker', () => {
     const tracker = new RelayQueryTracker();
 
     tracker.trackNodeForID(query, nodeID);
-    const trackedChildren = sortChildren(tracker.getTrackedChildrenForID(nodeID));
+    const trackedChildren =
+        sortChildren(tracker.getTrackedChildrenForID(nodeID));
     const children = sortChildren(query.getChildren());
     expect(trackedChildren.length).toBe(3);
     children.forEach((child, ii) => {
@@ -102,7 +105,7 @@ describe('RelayQueryTracker', () => {
     tracker.trackNodeForID(actor, actorID);
     const children = sortChildren(actor.getChildren());
     const trackedChildren =
-      sortChildren(tracker.getTrackedChildrenForID(actorID));
+      sortChildren(tracker.getTrackedChildrenForID(actorID)[0].getChildren());
     children.forEach((child, ii) => {
       expect(trackedChildren[ii]).toEqualQueryNode(child);
     });
@@ -170,17 +173,35 @@ describe('RelayQueryTracker', () => {
 
     tracker.trackNodeForID(firstActor, actorID);
     tracker.trackNodeForID(secondActor, actorID);
+
     const trackedChildren = tracker.getTrackedChildrenForID(actorID);
-    expect(trackedChildren.length).toBe(3);
-    expect(trackedChildren[0]).toEqualQueryNode(RelayQuery.Field.build({
+
+    expect(trackedChildren.length).toBe(1);
+    expect(trackedChildren[0].getChildren().length).toBe(4);
+
+    expect(trackedChildren[0].getChildren()[0]).toEqualQueryNode(RelayQuery.Field.build({
       fieldName: 'id',
       type: 'ID',
     }));
-    expect(trackedChildren[1]).toEqualQueryNode(RelayQuery.Field.build({
+    expect(trackedChildren[0].getChildren()[1]).toEqualQueryNode(RelayQuery.Field.build({
       fieldName: '__typename',
       type: 'String',
     }));
-    expect(trackedChildren[2]).toEqualQueryNode(RelayQuery.Fragment.build(
+    expect(trackedChildren[0].getChildren()[2]).toEqualQueryNode(RelayQuery.Fragment.build(
+      'Node',
+      'Node',
+      [
+        RelayQuery.Field.build({
+          fieldName: '__typename',
+          type: 'String',
+        }),
+        RelayQuery.Field.build({
+          fieldName: 'id',
+          type: 'ID',
+        }),
+      ]
+    ));
+    expect(trackedChildren[0].getChildren()[3]).toEqualQueryNode(RelayQuery.Fragment.build(
       'User',
       'User',
       [


### PR DESCRIPTION
Fixes #782 for my use case, when tracked fragments from a query on an union type leak in the intersected query of a mutation.

It breaks some tests for RelayQueryTracker and it needs new tests, please help me on this because I can't figure out how to do that.
