### PR TITLE
Avoid accessing private React modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "jest": "^14.0.0",
     "object-assign": "^4.1.0",
     "react": "^15.1.0",
+    "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.1.0",
     "run-sequence": "^1.2.1",
     "webpack": "^1.13.1",
@@ -98,6 +99,7 @@
       "<rootDir>/node_modules/fbjs/lib/(?!(ErrorUtils.js$|fetch.js$|fetchWithRetries.js$))",
       "<rootDir>/node_modules/object-assign/",
       "<rootDir>/node_modules/react/",
+      "<rootDir>/node_modules/react-addons-test-utils/",
       "<rootDir>/node_modules/react-dom/",
       "<rootDir>/node_modules/react-static-container/"
     ]

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -26,8 +26,7 @@ const babelOptions = getBabelOptions({
     'reactComponentExpect': 'react/lib/reactComponentExpect',
     'ReactDOM': 'react-dom',
     'ReactDOMServer': 'react-dom/server',
-    'ReactTestUtils': 'react/lib/ReactTestUtils.js',
-    'ReactUpdates': 'react/lib/ReactUpdates',
+    'ReactTestUtils': 'react-addons-test-utils',
     'StaticContainer.react': 'react-static-container',
   },
   plugins: [


### PR DESCRIPTION
We should not reach into `react/lib` directly to allow React to refactor the layout. Instead use the public module that exposes this. We still have `react/lib/reactComponentExpect` left, but that seems a bit more tricky.