### PR TITLE
Range behaviours: Don't warn when value is IGNORE

### DIFF
--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -416,12 +416,16 @@ function addRangeNode(
     null;
 
   // no range behavior specified for this combination of filter calls
-  if (!rangeBehavior || rangeBehavior === IGNORE) {
+  if (!rangeBehavior) {
     warning(
       rangeBehavior,
       'Using `null` as a rangeBehavior value is deprecated. Use `ignore` to avoid ' +
       'refetching a range.'
     );
+    return;
+  }
+
+  if (rangeBehavior === IGNORE) {
     return;
   }
 


### PR DESCRIPTION
Closes https://github.com/facebook/relay/issues/1337

`IGNORE` should early return but not warn :)

I believe existing tests should cover that. Could write a regression and check for no warnings but that feels weird.