### PR TITLE
Include pathToConnection in RANGE_DELETE example on the documentation

### DIFF
--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -455,6 +455,7 @@ class RemoveTagMutation extends Relay.Mutation {
       parentID: this.props.todo.id,
       connectionName: 'tags',
       deletedIDFieldName: 'removedTagIDs',
+      pathToConnection: ['todo', 'tags'],
     }];
   }
   /* ... */


### PR DESCRIPTION
Closes https://github.com/facebook/relay/issues/1262

As discussed on the Github issue, the `pathToConnection` argument on the `RANGE_DELETE` mutation type was made a required field (https://github.com/facebook/relay/commit/71e2350ccb2bd3c8ce145d270788c9042b5fbff5)  but the example on https://facebook.github.io/relay/docs/guides-mutations.html#range-delete-example does not includes this field and raises a validation error when executed on the latest version of `relay`.

This PR updates the docs to include this field.