### PR TITLE
Do not reset variables if outside variable props of type Object are the same

### DIFF
--- a/src/container/RelayContainer.js
+++ b/src/container/RelayContainer.js
@@ -884,7 +884,7 @@ function resetPropOverridesForVariables(
 ): Variables {
   const initialVariables = spec.initialVariables;
   for (const key in initialVariables) {
-    if (key in props && props[key] !== variables[key]) {
+    if (key in props && !areEqual(props[key], variables[key])) {
       return initialVariables;
     }
   }

--- a/src/container/__tests__/RelayContainer_setVariables-test.js
+++ b/src/container/__tests__/RelayContainer_setVariables-test.js
@@ -792,5 +792,99 @@ describe('RelayContainer.setVariables', function() {
         size: 48,
       });
     });
+
+    it('does not reset variables if outside props are the same', () => {
+      class MockInnerComponent extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      const MockInnerContainer = Relay.createContainer(MockInnerComponent, {
+        fragments: {
+          entity: () => Relay.QL`  fragment on User {
+                        url(site:$site)
+                        storySearch(query:$query) {
+                          id
+                        }
+                        profilePicture(size:$size) {
+                          uri
+                        }
+                      }`,
+        },
+        initialVariables: {
+          site: 'mobile',
+          query: undefined, // <-- Object type
+          size: undefined // <-- Array type
+        },
+      });
+
+      class MockWrapperComponent extends React.Component {
+        render() {
+          return (
+            <MockInnerContainer
+              ref='inner'
+              query={this.props.relay.variables.query}
+              size={this.props.relay.variables.size}
+              entity={this.props.entity}
+            />
+          );
+        }
+      }
+
+      MockContainer = Relay.createContainer(MockWrapperComponent, {
+        fragments: {
+          entity: variables => Relay.QL`  fragment on User {
+            ${MockInnerContainer.getFragment('entity', {
+              query: variables.query,
+              size: variables.size,
+            })}
+          }`,
+        },
+        initialVariables: {
+          query: { text: 'recent' },
+          size: [32, 64]
+        },
+      });
+
+      mockInstance = RelayTestUtils.createRenderer(domContainer).render(
+        genMockPointer => <MockContainer entity={genMockPointer('42')} />,
+        environment
+      );
+      const innerComponent = mockInstance.refs.component.refs.inner;
+      expect(innerComponent.state.relayProp.variables.query).toEqual({
+        text: 'recent'
+      });
+      expect(innerComponent.state.relayProp.variables.size).toEqual([32, 64]);
+
+      innerComponent.setVariables({
+        site: 'www'
+      });
+      jest.runAllTimers();
+      environment.primeCache.mock.requests[0].succeed();
+      expect(innerComponent.state.relayProp.variables).toEqual({
+        site: 'www',
+        query: { text: 'recent' },
+        size: [32, 64]
+      });
+
+      mockInstance.setVariables({
+        query: { text: 'recent' },
+        size: [32, 64]
+      });
+      jest.runAllTimers();
+
+      environment.primeCache.mock.requests[1].succeed();
+      expect(mockInstance.state.relayProp.variables).toEqual({
+        query: { text: 'recent' },
+        size: [32, 64]
+      });
+
+      expect(innerComponent.state.relayProp.variables).toEqual({
+        site: 'www',
+        query: { text: 'recent' },
+        size: [32, 64]
+      });
+    });
   });
 });

--- a/src/container/__tests__/RelayContainer_setVariables-test.js
+++ b/src/container/__tests__/RelayContainer_setVariables-test.js
@@ -802,15 +802,15 @@ describe('RelayContainer.setVariables', function() {
 
       const MockInnerContainer = Relay.createContainer(MockInnerComponent, {
         fragments: {
-          entity: () => Relay.QL`  fragment on User {
-                        url(site:$site)
-                        storySearch(query:$query) {
-                          id
-                        }
-                        profilePicture(size:$size) {
-                          uri
-                        }
-                      }`,
+          entity: () => Relay.QL`fragment on User {
+            url(site: $site)
+            storySearch(query: $query) {
+              id
+            }
+            profilePicture(size: $size) {
+              uri
+            }
+          }`,
         },
         initialVariables: {
           site: 'mobile',
@@ -832,9 +832,9 @@ describe('RelayContainer.setVariables', function() {
         }
       }
 
-      MockContainer = Relay.createContainer(MockWrapperComponent, {
+      const MockWrapperContainer = Relay.createContainer(MockWrapperComponent, {
         fragments: {
-          entity: variables => Relay.QL`  fragment on User {
+          entity: variables => Relay.QL`fragment on User {
             ${MockInnerContainer.getFragment('entity', {
               query: variables.query,
               size: variables.size,
@@ -847,11 +847,11 @@ describe('RelayContainer.setVariables', function() {
         },
       });
 
-      mockInstance = RelayTestUtils.createRenderer(domContainer).render(
-        genMockPointer => <MockContainer entity={genMockPointer('42')} />,
+      const mockWrapperInstance = RelayTestUtils.createRenderer(domContainer).render(
+        genMockPointer => <MockWrapperContainer entity={genMockPointer('42')} />,
         environment
       );
-      const innerComponent = mockInstance.refs.component.refs.inner;
+      const innerComponent = mockWrapperInstance.refs.component.refs.inner;
       expect(innerComponent.state.relayProp.variables.query).toEqual({
         text: 'recent'
       });
@@ -868,14 +868,14 @@ describe('RelayContainer.setVariables', function() {
         size: [32, 64]
       });
 
-      mockInstance.setVariables({
+      mockWrapperInstance.setVariables({
         query: { text: 'recent' },
         size: [32, 64]
       });
       jest.runAllTimers();
 
       environment.primeCache.mock.requests[1].succeed();
-      expect(mockInstance.state.relayProp.variables).toEqual({
+      expect(mockWrapperInstance.state.relayProp.variables).toEqual({
         query: { text: 'recent' },
         size: [32, 64]
       });


### PR DESCRIPTION
Closes https://github.com/facebook/relay/issues/1357

When new props are received on a `RelayContainer` a verification step is executed with the new props and the current relay variables and if at least one prop variable has a different value than its corresponding relay variable then the current relay variables are reset to the initial state. But the problem was that `===` was used for comparison and this always return a mismatch for props of type `Object` (arrays, objects) resulting in relay variables always being reset to the initial state even if the prop variables are the same.

See github issue for a detailed example.

The fix was to use `areEquals` which does a deep comparison and can match `Object` javascript types.