### PR TITLE
Make `enforceSchema` a plugin option

### DIFF
--- a/scripts/babel-relay-plugin/lib/tools/readFixtures.js
+++ b/scripts/babel-relay-plugin/lib/tools/readFixtures.js
@@ -34,9 +34,12 @@ function readFixtures(fixturePath) {
     //   <code>
     parts = data.match(new RegExp('(?:^|\\n)' + ['Input:\\n([\\s\\S]*)', 'Output:\\n([\\s\\S]*)'].join('\\n') + '$'));
     if (parts) {
+      var input = parts[1].trim();
+      var output = parts[2].trim();
       fixtures[name] = {
-        input: parts[1].trim(),
-        output: parts[2].trim()
+        input: input,
+        output: output,
+        outputHasError: output.match(new RegExp('throw new Error')) !== null
       };
       return;
     }

--- a/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
@@ -32,17 +32,22 @@ function getSchema(schemaPath) {
   }
 }
 
-function transformGraphQL(schemaPath, source, filename) {
-  var relayPlugin = getBabelRelayPlugin(getSchema(schemaPath), {
+function transformGraphQL(schemaPath, source, filename, pluginOptions, babelOptions) {
+  var defaultPluginOptions = {
     debug: true,
     substituteVariables: true,
     suppressWarnings: true
-  });
-  return babel.transform(source, {
+  };
+
+  var relayPlugin = getBabelRelayPlugin(getSchema(schemaPath), Object.assign(defaultPluginOptions, pluginOptions || {}));
+
+  var defaultBabelOptions = {
     plugins: [relayPlugin],
     compact: false,
     filename: filename
-  }).code;
+  };
+
+  return babel.transform(source, Object.assign(defaultBabelOptions, babelOptions || {})).code;
 }
 
 module.exports = transformGraphQL;

--- a/scripts/babel-relay-plugin/src/__tests__/getBabelRelayPlugin-test.js
+++ b/scripts/babel-relay-plugin/src/__tests__/getBabelRelayPlugin-test.js
@@ -70,6 +70,23 @@ describe('getBabelRelayPlugin', () => {
         }
         ConsoleErrorQueue.clear();
       });
+
+      if (fixture.outputThrowsError) {
+        it('throws when enforceSchema is defined on plugin for `' + testName +'`', () => {
+          expect(() => {
+            transform(fixture.input, testName, {enforceSchema: true});
+          }).toThrow();
+          ConsoleErrorQueue.clear();
+        });
+
+        it('throws when enforceSchema is defined on babel options for `' + testName +'`', () => {
+          expect(() => {
+            transform(fixture.input, testName, null, {enforceSchema: true});
+          }).toThrow();
+          ConsoleErrorQueue.clear();
+        });
+
+      }
     } else {
       it('throws for GraphQL fixture: ' + testName, () => {
         let expected;

--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -40,6 +40,7 @@ function getBabelRelayPlugin(
     suppressWarnings?: ?boolean,
     substituteVariables?: ?boolean,
     validator?: ?Validator<any>,
+    enforceSchema: ?boolean,
   }
 ): Function {
   const options = pluginOptions || {};
@@ -215,7 +216,7 @@ function getBabelRelayPlugin(
               []
             );
 
-            if (state.opts && state.opts.enforceSchema) {
+            if ((state.opts && state.opts.enforceSchema) || options.enforceSchema) {
               throw new Error(util.format(
                 errorMessages.length ?
                   'Aborting due to a %s error:\n\n%s\n' :

--- a/scripts/babel-relay-plugin/src/tools/readFixtures.js
+++ b/scripts/babel-relay-plugin/src/tools/readFixtures.js
@@ -41,9 +41,14 @@ function readFixtures(fixturePath) {
       ].join('\\n') + '$'
     ));
     if (parts) {
+      var input = parts[1].trim();
+      var output = parts[2].trim();
       fixtures[name] = {
-        input: parts[1].trim(),
-        output: parts[2].trim(),
+        input: input,
+        output: output,
+        outputHasError: output.match(new RegExp(
+         'throw new Error'
+        )) !== null
       };
       return;
     }

--- a/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
@@ -36,17 +36,26 @@ function getSchema(schemaPath) {
   }
 }
 
-function transformGraphQL(schemaPath, source, filename) {
-  const relayPlugin = getBabelRelayPlugin(getSchema(schemaPath), {
+function transformGraphQL(schemaPath, source, filename, pluginOptions, babelOptions) {
+  const defaultPluginOptions = {
     debug: true,
     substituteVariables: true,
-    suppressWarnings: true,
-  });
-  return babel.transform(source, {
+    suppressWarnings: true
+  };
+
+  const relayPlugin = getBabelRelayPlugin(getSchema(schemaPath), 
+     Object.assign(defaultPluginOptions, pluginOptions || {})
+  );
+
+  const defaultBabelOptions = {
     plugins: [relayPlugin],
     compact: false,
     filename,
-  }).code;
+  }
+
+  return babel.transform(source, 
+    Object.assign(defaultBabelOptions, babelOptions || {})
+  ).code;
 }
 
 module.exports = transformGraphQL;


### PR DESCRIPTION
Allowing `babel-relay-plugin` be configured with `enforceSchema` by default,
so you don't have to set it in your Babel's options.

This is specially useful if you want to ship a custom plugin that includes default settings for your Relay/GraphQL projects.
