### PR TITLE
Allow @relay(pattern:true) directive on fields with required arguments.

### DIFF
--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-eI54pS3+xUz77YkcPbJWHT/wgbc=
+Mf7u9PhfPNKxu7u1tHpjhf2OMJ8=

--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-64QLenBrrPqdk0n6OnRUCvdPGgU=
+eI54pS3+xUz77YkcPbJWHT/wgbc=

--- a/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
@@ -181,9 +181,6 @@ var RelayQLTransformer = function () {
         validationErrors = _validate(this.schema, document);
       } else {
         var rules = [require('graphql/validation/rules/ArgumentsOfCorrectType').ArgumentsOfCorrectType, require('graphql/validation/rules/DefaultValuesOfCorrectType').DefaultValuesOfCorrectType, require('graphql/validation/rules/FieldsOnCorrectType').FieldsOnCorrectType, require('graphql/validation/rules/FragmentsOnCompositeTypes').FragmentsOnCompositeTypes, require('graphql/validation/rules/KnownArgumentNames').KnownArgumentNames, require('graphql/validation/rules/KnownTypeNames').KnownTypeNames, require('graphql/validation/rules/PossibleFragmentSpreads').PossibleFragmentSpreads, require('graphql/validation/rules/VariablesInAllowedPosition').VariablesInAllowedPosition];
-        if (!isMutation) {
-          rules.push(require('graphql/validation/rules/ProvidedNonNullArguments').ProvidedNonNullArguments);
-        }
         validationErrors = validate(this.schema, document, rules);
       }
 

--- a/scripts/babel-relay-plugin/src/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/src/RelayQLTransformer.js
@@ -270,13 +270,6 @@ class RelayQLTransformer {
           'graphql/validation/rules/VariablesInAllowedPosition'
         ).VariablesInAllowedPosition,
       ];
-      if (!isMutation) {
-        rules.push(
-          require(
-            'graphql/validation/rules/ProvidedNonNullArguments'
-          ).ProvidedNonNullArguments
-        );
-      }
       validationErrors = validate(this.schema, document, rules);
     }
 

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentPattern.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentPattern.fixture
@@ -1,8 +1,8 @@
 Input:
 var Relay = require('react-relay');
 var x = Relay.QL`
-  fragment on Viewer {
-    actorByName @relay(pattern: true) {
+  fragment on Viewer @relay(pattern: true) {
+    actorByName {
       name
     }
   }
@@ -12,7 +12,7 @@ Output:
 'use strict';
 
 var Relay = require('react-relay');
-var x = function () {
+var x = function() {
   return {
     children: [{
       children: [{
@@ -57,7 +57,6 @@ var x = function () {
       fieldName: 'actorByName',
       kind: 'Field',
       metadata: {
-        pattern: true,
         canHaveSubselections: true,
         isAbstract: true
       },
@@ -65,7 +64,9 @@ var x = function () {
     }],
     id: Relay.QL.__id(),
     kind: 'Fragment',
-    metadata: {},
+    metadata: {
+      pattern: true
+    },
     name: 'FragmentPatternRelayQL',
     type: 'Viewer'
   };

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentPattern.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentPattern.fixture
@@ -1,0 +1,72 @@
+Input:
+var Relay = require('react-relay');
+var x = Relay.QL`
+  fragment on Viewer {
+    actorByName @relay(pattern: true) {
+      name
+    }
+  }
+`;
+
+Output:
+'use strict';
+
+var Relay = require('react-relay');
+var x = function () {
+  return {
+    children: [{
+      children: [{
+        fieldName: 'name',
+        kind: 'Field',
+        metadata: {},
+        type: 'String'
+      }, {
+        fieldName: '__typename',
+        kind: 'Field',
+        metadata: {
+          isGenerated: true,
+          isRequisite: true
+        },
+        type: 'String'
+      }, {
+        children: [{
+          fieldName: 'id',
+          kind: 'Field',
+          metadata: {
+            isGenerated: true,
+            isRequisite: true
+          },
+          type: 'String'
+        }, {
+          fieldName: '__typename',
+          kind: 'Field',
+          metadata: {
+            isGenerated: true,
+            isRequisite: true
+          },
+          type: 'String'
+        }],
+        id: Relay.QL.__id(),
+        kind: 'Fragment',
+        metadata: {
+          isAbstract: true
+        },
+        name: 'IdFragment',
+        type: 'Node'
+      }],
+      fieldName: 'actorByName',
+      kind: 'Field',
+      metadata: {
+        pattern: true,
+        canHaveSubselections: true,
+        isAbstract: true
+      },
+      type: 'Actor'
+    }],
+    id: Relay.QL.__id(),
+    kind: 'Fragment',
+    metadata: {},
+    name: 'FragmentPatternRelayQL',
+    type: 'Viewer'
+  };
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentRequiredArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentRequiredArgs.fixture
@@ -1,0 +1,17 @@
+Input:
+var Relay = require('react-relay');
+var x = Relay.QL`
+  fragment on Viewer {
+    actorByName() {
+      name
+    }
+  }
+`;
+
+Output:
+'use strict';
+
+var Relay = require('react-relay');
+var x = function () {
+  throw new Error('Relay transform error ``Syntax Error fragmentRequiredArgs (2:17) Expected Name, found )\n\n1: fragment FragmentRequiredArgsRelayQL on Viewer {\n2:     actorByName() {\n                   ^\n3:       name\n`` in file `fragmentRequiredArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
+}();

--- a/scripts/babel-relay-plugin/src/__fixtures__/fragmentRequiredArgs.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/fragmentRequiredArgs.fixture
@@ -2,7 +2,7 @@ Input:
 var Relay = require('react-relay');
 var x = Relay.QL`
   fragment on Viewer {
-    actorByName() {
+    actorByName {
       name
     }
   }
@@ -12,6 +12,6 @@ Output:
 'use strict';
 
 var Relay = require('react-relay');
-var x = function () {
-  throw new Error('Relay transform error ``Syntax Error fragmentRequiredArgs (2:17) Expected Name, found )\n\n1: fragment FragmentRequiredArgsRelayQL on Viewer {\n2:     actorByName() {\n                   ^\n3:       name\n`` in file `fragmentRequiredArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
+var x = function() {
+    throw new Error('GraphQL validation error ``Field "actorByName" argument "name" of type "String!" is required but not provided.`` in file `fragmentRequiredArgs.fixture`. Try updating your GraphQL schema if an argument/field/type was recently added.');
 }();

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -69,6 +69,7 @@ type Viewer {
   newsFeed(first: Int): NewsFeedConnection
   pendingPosts(first: Int): PendingPostsConnection
   actor: User
+  actorByName(name: String!): Actor
 }
 
 type ConfigsConnection {

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -1085,6 +1085,33 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "actorByName",
+              "description": null,
+              "args": [
+                {
+                  "name": "name",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Actor",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,


### PR DESCRIPTION
## Overview

Issue #1300. Allows using `@relay(pattern: true)` on fat queries for non-connection fields that have required arguments.  

Currently the pattern directive only can be used on connections and fields without arguments.  This prevents fat queries from being used to force the server to invalidate separate fields you know have changed but don't directly relate to the current object being mutated.
## Implementation

Disables the GraphQL rule for `ProvidedNonNullArguments`, instead relying on Relay to throw those errors.  
## Example

Full star wars example on [this branch](https://github.com/relayjs/relay-examples/compare/master...ddgromit:query-arg-patterns#diff-4826482ddf3139031cac42eff2e6706dR17)

You might have non-connection field that you query with arguments like `viewer { factions(names: ["empire", "rebels"]) }`.  Then run a mutation that updates the names of all the ships across all factions - not just the ones you've queried.  This change allows you to make a fat query that says all ships across all calls to `factions` are now invalid.

```
  fragments: {
    viewer: () => Relay.QL`
      fragment on Viewer {
        factions(names: ["empire", "rebels"]) {
          ships(first: 10) {
            edges {
              node {
                name
              }
            }
          }
        }
      }
    `,
  },
```

```
  getMutation() {
    return Relay.QL`mutation { changeAllShips }`;
  }

  getFatQuery() {
    return Relay.QL`
      fragment on ChangeAllShipsPayload @relay(pattern: true) {
        viewer {
          name
          factions {
            ships
          }
        }
      }
    `;
  }
```
