### PR TITLE
Fixes issue using 'node' as a key in mutation payloads

### DIFF
--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -193,13 +193,13 @@ function handleMerge(
     if (typeof payloadData !== 'object' || payloadData == null) {
       continue;
     }
-    // if the field is an argument-less root call, determine the corresponding
-    // root record ID
-    const rootID = store.getDataID(fieldName);
+
     // check for valid data (has an ID or is an array) and write the field
     if (
       ID in payloadData ||
-      rootID ||
+      // if the field is an argument-less root call, determine the corresponding
+      // root record ID
+      store.getDataID(fieldName) ||
       Array.isArray(payloadData)
     ) {
       mergeField(


### PR DESCRIPTION
I ran into an issue trying to make common Mutation classes (so as to abstract common functionality). Consider this interface:

``` graphql
interface UpdatePayload {
  node: Node
  clientMutationId: ID
}
```

and these Mutation classes:

``` js
class UpdateMutation extends Relay.Mutation {
  static fragments = {
    node: () => Relay.QL`fragment on Node { id }`,
  }

  getVariables() {
    return this.props.input;
  }

  getFatQuery() {
    return Relay.QL`fragment on UpdatePayload { node }`;
  }

  getConfigs() {
    return [{
      type: 'FIELDS_CHANGE',
      fieldIDs: { node: this.props.node.id },
    }];
  }
}

class UpdateComicMutation extends UpdateMutation {
  getMutation() {
    return Relay.QL`mutation { updateComic }`;
  }
}
```

And this server response:

```
{"data":{"updateComic":{"clientMutationId":"0","node":{"id":"Q29taWM6NGNlYjliOWQtOGM5OC00ZjhkLTliZmEtNWJkN2VhMDAxODRm","__typename":"Comic","title":"Foo"}}}}
```

Relay complains when trying to merge the response, it seems like the payload key `"node"` is problematic:

```
RelayRecordStore.getDataID(): Argument to `node()` cannot be null or undefined.
```

This is caused by a call to `store.getDataID("node")`, which isn't necessary since the response contains an `"id"` (`ID in payloadData === true`), so we can skip the call to `store.getDataID`.
