### PR TITLE
Add support to multiple files upload

### DIFF
--- a/docs/APIReference-Mutation.md
+++ b/docs/APIReference-Mutation.md
@@ -387,10 +387,10 @@ class LikeStoryMutation extends Relay.Mutation {
 getFiles(): ?FileMap
 
 // Type of the FileMap object
-type FileMap = {[key: string]: File};
+type FileMap = {[key: string]: File | FileList};
 ```
 
-Implement this method to return a map of `File` objects to upload as part of a mutation.
+Implement this method to return a map of `File` or `FileList` objects to upload as part of a mutation.
 
 #### Example
 

--- a/docs/Interfaces-MutationRequest.md
+++ b/docs/Interfaces-MutationRequest.md
@@ -64,10 +64,10 @@ Gets the variables used by the mutation. These variables should be serialized an
 ### getFiles
 
 ```
-getFiles(): ?{[key: string]: File}
+getFiles(): ?{[key: string]: File | FileList}
 ```
 
-Gets an optional map from name to File objects.
+Gets an optional map from name to File objects or FileList objects.
 
 ### getID
 

--- a/src/mutation/RelayMutation.js
+++ b/src/mutation/RelayMutation.js
@@ -33,7 +33,7 @@ import type {
 } from 'RelayTypes';
 import type {RelayQLFragmentBuilder} from 'buildRQL';
 
-export type FileMap = {[key: string]: File};
+export type FileMap = {[key: string]: File | FileList};
 export type RelayMutationFragments<Tk> = {
   [key: Tk]: RelayQLFragmentBuilder;
 };

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -90,17 +90,24 @@ class RelayDefaultNetworkLayer {
    */
   _sendMutation(request: RelayMutationRequest): Promise<any> {
     let init;
-    const files = request.getFiles();
-    if (files) {
+    const filesMap = request.getFiles();
+    if (filesMap) {
       if (!global.FormData) {
         throw new Error('Uploading files without `FormData` not supported.');
       }
       const formData = new FormData();
       formData.append('query', request.getQueryString());
       formData.append('variables', JSON.stringify(request.getVariables()));
-      for (const filename in files) {
-        if (files.hasOwnProperty(filename)) {
-          formData.append(filename, files[filename]);
+      for (const filename in filesMap) {
+        if (filesMap.hasOwnProperty(filename)) {
+          var files = filesMap[filename];
+          if(typeof files.item === 'function'){
+            for(var i=0; i<files.length; i++) {
+              formData.append(filename, files.item(i));
+            }
+          } else {
+            formData.append(filename, files);
+          }
         }
       }
       init = {

--- a/src/network-layer/default/RelayDefaultNetworkLayer.js
+++ b/src/network-layer/default/RelayDefaultNetworkLayer.js
@@ -101,6 +101,7 @@ class RelayDefaultNetworkLayer {
       for (const filename in filesMap) {
         if (filesMap.hasOwnProperty(filename)) {
           var files = filesMap[filename];
+          // cheking if it is a FileList:
           if(typeof files.item === 'function'){
             for(var i=0; i<files.length; i++) {
               formData.append(filename, files.item(i));


### PR DESCRIPTION
A suggestion was made on https://github.com/facebook/relay/issues/586 but I thought using:

``` javascript
type FileMap = {[key: string]: File | FileList};
```

was a better idea since I would not need write a loop through the FileList (since its what is provided by the file input's API) to construct an array of files every time I need to send multiple files to a Mutation, this way Relay will handle it for me, I just need to write:

``` javascript
class AttachMultipleDocumentsMutation extends Relay.Mutation {
  getFiles() {
    return {
      files: this.props.files,
    };
  }
}
class FilesUploader extends React.Component {
  handleSubmit() {
    Relay.Store.commitUpdate(
      new AttachMultipleDocumentsMutation({file: this.refs.fileInput.files})
    );
  }
}
```
