### PR TITLE
Add `replaceSchema` method to the `babel-relay-plugin`

### DIFF
--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -48,15 +48,19 @@ function getBabelRelayPlugin(
     function() {} :
     console.warn.bind(console);
 
-  const schema = getSchema(schemaProvider);
-  const transformer = new RelayQLTransformer(schema, {
-    inputArgumentName: options.inputArgumentName,
-    snakeCase: !!options.snakeCase,
-    substituteVariables: !!options.substituteVariables,
-    validator: options.validator,
-  });
+  let transformer;
+  function initTransformer(schemaProvider) {
+    const schema = getSchema(schemaProvider);
+    transformer = new RelayQLTransformer(schema, {
+      inputArgumentName: options.inputArgumentName,
+      snakeCase: !!options.snakeCase,
+      substituteVariables: !!options.substituteVariables,
+      validator: options.validator,
+    });
+  }
+  initTransformer(schemaProvider);
 
-  return function({Plugin, types, version}) {
+  const plugin = function({Plugin, types, version}) {
     return babelAdapter(Plugin, types, version, 'relay-query', t => ({
       visitor: {
         /**
@@ -242,6 +246,9 @@ function getBabelRelayPlugin(
       },
     }));
   };
+
+  plugin.replaceSchema = initTransformer;
+  return plugin;
 }
 
 function getSchema(schemaProvider: GraphQLSchemaProvider): GraphQLSchema {


### PR DESCRIPTION
I'm using Webpack with babel-loader. So when I changing my GraphQL Schema, my `schema.graphql.json` file is rebuilt automatically. And babelRelayPlugin sends to console errors according to old schema.

But loaded instance of `babelRelayPlugin` in babel with webpack has no way to update the schema. Required full restart for webpack (and it takes minutes). This PR adds method `replaceSchema` to `babelRelayPlugin` for updating schema on the fly.

Right now my `./lib/babel-relay-plugin.js` for `babel-loader` in Webpack has following working code, which tracks changes and calls new `replaceSchema` method:
```js
const getBabelRelayPlugin = require('babel-relay-plugin');
const fs = require('fs');
const path = require('path');
const chalk = require('chalk');

// path to generated schema
const schemaPath = path.resolve(__dirname, '../../build/schema.graphql.json');

// errorless start if schema file does not exist
let schema;
try {
  fs.accessSync(schemaPath, fs.F_OK);
  schema = require(schemaPath);
} catch (e) {
  schema = null;
  console.log(chalk.white.bgRed.bold(`[BabelRelayPlugin] Cannot resolve GraphQL Schema from file ${schemaPath}`));
}
const emptyPlugin = () => ({});
const plugin = schema ? getBabelRelayPlugin(schema.data) : emptyPlugin;

// if `replaceSchema` exists then create unblocking event loop task which track changes 
// in the schema file, and reload schema in plugin Transformer
// PS. fs.watch blocks babel from exit, so using `setTimeout` with `unref`
// Checking changes every 2 second.
if (plugin.replaceSchema) {
  let prevMtime;
  const watcherFn = () => {
    try {
      const stats = fs.statSync(schemaPath);
      if (stats) {
        if (!prevMtime) prevMtime = stats.mtime;
        if (stats.mtime.getTime() !== prevMtime.getTime()) {
          prevMtime = stats.mtime;
          console.log(chalk.yellow.bold(`[BabelRelayPlugin] Reload GraphQL Schema from file ${schemaPath}`));
          delete require.cache[require.resolve(schemaPath)];
          schema = require(schemaPath);
          plugin.replaceSchema(schema.data);
        }
      }
      setTimeout(watcherFn, 2000).unref();
    } catch (e) {
      console.log(chalk.red.bold(`[BabelRelayPlugin] ${e}`));
    }
  };
  watcherFn();
}

module.exports = plugin;
```

For testing you may use this built package (which contains code from this PR):
```
npm i https://www.dropbox.com/s/jb0qjkkfvvr6vbe/babel-relay-plugin-0.9.3.tgz\?dl\=1
```