### PR TITLE
Ignore yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .nvmrc
+yarn.lock
 node_modules
 npm-debug.log
 /dist/


### PR DESCRIPTION
I removed the yarn.lock with a34867552d51c015f687bc550dcc675797398096, this ignores it for people who still want to `yarn install` the node_module dependencies.