### PR TITLE
corrects in the doc, parentId is optional when using NODE_DELETE

### DIFF
--- a/docs/Guides-Mutations.md
+++ b/docs/Guides-Mutations.md
@@ -266,9 +266,9 @@ Given a parent, a connection, and one or more DataIDs in the response payload, R
 
   The field name in the response that represents the parent of the connection
 
-- `parentID: string`
+- `parentID?: string`
 
-  The DataID of the parent node that contains the connection
+  The DataID of the parent node that contains the connection. This argument is optional.
 
 - `connectionName: string`
 


### PR DESCRIPTION
According to https://github.com/facebook/relay/blob/ad5efb124cf455a42c0adb10fb1e977fe051811e/src/tools/RelayTypes.js#L157-L163 parentId seems to be optional.

The current documentation seems to not specify it : https://facebook.github.io/relay/docs/guides-mutations.html#node-delete