### PR TITLE
Update graphql to 0.9.0 in babel-relay-plugin

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -39,7 +39,7 @@
     "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "graphql": "0.8.2"
+    "graphql": "0.9.0"
   },
   "jest": {
     "automock": true,


### PR DESCRIPTION
This updates the graphql dependency to 0.9.0.

I haven't run the tests yet, if they fail I will check. But the changelog looked rather non-breaking.
