### PR TITLE
Fix Flow issues related to util core module in plug-in

### DIFF
--- a/scripts/babel-relay-plugin/lib/GraphQLRelayDirective.js
+++ b/scripts/babel-relay-plugin/lib/GraphQLRelayDirective.js
@@ -13,12 +13,14 @@
 
 'use strict';
 
-var _require = require('./GraphQL'),
-    DirectiveLocation = _require.type_directives.DirectiveLocation,
-    GraphQLList = _require.type_definition.GraphQLList,
-    _require$type_scalars = _require.type_scalars,
-    GraphQLBoolean = _require$type_scalars.GraphQLBoolean,
-    GraphQLString = _require$type_scalars.GraphQLString;
+var _require = require('./GraphQL');
+
+var DirectiveLocation = _require.type_directives.DirectiveLocation;
+var GraphQLList = _require.type_definition.GraphQLList;
+var _require$type_scalars = _require.type_scalars;
+var GraphQLBoolean = _require$type_scalars.GraphQLBoolean;
+var GraphQLString = _require$type_scalars.GraphQLString;
+
 
 module.exports = {
   name: 'relay',

--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-BffGM6gCbjw+atc6MFjid8+S+iU=
+y5oDtOWJu8lMKoEspUlLc1xcxok=

--- a/scripts/babel-relay-plugin/lib/HASH
+++ b/scripts/babel-relay-plugin/lib/HASH
@@ -1,1 +1,1 @@
-y5oDtOWJu8lMKoEspUlLc1xcxok=
+2nE+VzDlh310noIXefLyv6IZ6YM=

--- a/scripts/babel-relay-plugin/lib/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLAST.js
@@ -28,9 +28,7 @@ var RelayTransformError = require('./RelayTransformError');
 
 var find = require('./find');
 var invariant = require('./invariant');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-var util = require('util');
+var util = require('./util');
 
 var _require = require('./GraphQL');
 

--- a/scripts/babel-relay-plugin/lib/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLAST.js
@@ -13,8 +13,6 @@
 
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -30,28 +28,34 @@ var RelayTransformError = require('./RelayTransformError');
 
 var find = require('./find');
 var invariant = require('./invariant');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 var util = require('util');
 
-var _require = require('./GraphQL'),
-    types = _require.type,
-    GraphQLDirective = _require.type_directives.GraphQLDirective,
-    _require$type_scalars = _require.type_scalars,
-    GraphQLBoolean = _require$type_scalars.GraphQLBoolean,
-    GraphQLFloat = _require$type_scalars.GraphQLFloat,
-    GraphQLID = _require$type_scalars.GraphQLID,
-    GraphQLInt = _require$type_scalars.GraphQLInt,
-    GraphQLString = _require$type_scalars.GraphQLString,
-    _require$type_introsp = _require.type_introspection,
-    SchemaMetaFieldDef = _require$type_introsp.SchemaMetaFieldDef,
-    TypeMetaFieldDef = _require$type_introsp.TypeMetaFieldDef,
-    TypeNameMetaFieldDef = _require$type_introsp.TypeNameMetaFieldDef;
+var _require = require('./GraphQL');
 
-var _require2 = require('./RelayQLNodeInterface'),
-    ID = _require2.ID;
+var types = _require.type;
+var GraphQLDirective = _require.type_directives.GraphQLDirective;
+var _require$type_scalars = _require.type_scalars;
+var GraphQLBoolean = _require$type_scalars.GraphQLBoolean;
+var GraphQLFloat = _require$type_scalars.GraphQLFloat;
+var GraphQLID = _require$type_scalars.GraphQLID;
+var GraphQLInt = _require$type_scalars.GraphQLInt;
+var GraphQLString = _require$type_scalars.GraphQLString;
+var _require$type_introsp = _require.type_introspection;
+var SchemaMetaFieldDef = _require$type_introsp.SchemaMetaFieldDef;
+var TypeMetaFieldDef = _require$type_introsp.TypeMetaFieldDef;
+var TypeNameMetaFieldDef = _require$type_introsp.TypeNameMetaFieldDef;
+
+var _require2 = require('./RelayQLNodeInterface');
+
+var ID = _require2.ID;
+
 
 var GraphQLRelayDirectiveInstance = new GraphQLDirective(GraphQLRelayDirective);
 
 // TODO: Import types from `graphql`.
+
 
 var RelayQLNode = function () {
   function RelayQLNode(context, ast) {
@@ -144,7 +148,7 @@ var RelayQLDefinition = function (_RelayQLNode) {
   function RelayQLDefinition() {
     _classCallCheck(this, RelayQLDefinition);
 
-    return _possibleConstructorReturn(this, (RelayQLDefinition.__proto__ || Object.getPrototypeOf(RelayQLDefinition)).apply(this, arguments));
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(RelayQLDefinition).apply(this, arguments));
   }
 
   _createClass(RelayQLDefinition, [{
@@ -182,7 +186,7 @@ var RelayQLFragment = function (_RelayQLDefinition) {
     // @relay(isStaticFragment: true)
     var isStaticFragment = relayDirectiveArgs.isStaticFragment && relayDirectiveArgs.isStaticFragment.kind === 'BooleanValue' && relayDirectiveArgs.isStaticFragment.value;
 
-    var _this4 = _possibleConstructorReturn(this, (RelayQLFragment.__proto__ || Object.getPrototypeOf(RelayQLFragment)).call(this, _extends({}, context, { isPattern: isPattern }), ast));
+    var _this4 = _possibleConstructorReturn(this, Object.getPrototypeOf(RelayQLFragment).call(this, _extends({}, context, { isPattern: isPattern }), ast));
 
     _this4.hasStaticFragmentID = isStaticFragment;
     _this4.parentType = parentType;
@@ -234,7 +238,7 @@ var RelayQLMutation = function (_RelayQLDefinition2) {
   function RelayQLMutation() {
     _classCallCheck(this, RelayQLMutation);
 
-    return _possibleConstructorReturn(this, (RelayQLMutation.__proto__ || Object.getPrototypeOf(RelayQLMutation)).apply(this, arguments));
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(RelayQLMutation).apply(this, arguments));
   }
 
   _createClass(RelayQLMutation, [{
@@ -253,7 +257,7 @@ var RelayQLQuery = function (_RelayQLDefinition3) {
   function RelayQLQuery() {
     _classCallCheck(this, RelayQLQuery);
 
-    return _possibleConstructorReturn(this, (RelayQLQuery.__proto__ || Object.getPrototypeOf(RelayQLQuery)).apply(this, arguments));
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(RelayQLQuery).apply(this, arguments));
   }
 
   _createClass(RelayQLQuery, [{
@@ -272,7 +276,7 @@ var RelayQLSubscription = function (_RelayQLDefinition4) {
   function RelayQLSubscription() {
     _classCallCheck(this, RelayQLSubscription);
 
-    return _possibleConstructorReturn(this, (RelayQLSubscription.__proto__ || Object.getPrototypeOf(RelayQLSubscription)).apply(this, arguments));
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(RelayQLSubscription).apply(this, arguments));
   }
 
   _createClass(RelayQLSubscription, [{
@@ -291,7 +295,7 @@ var RelayQLField = function (_RelayQLNode2) {
   function RelayQLField(context, ast, parentType) {
     _classCallCheck(this, RelayQLField);
 
-    var _this8 = _possibleConstructorReturn(this, (RelayQLField.__proto__ || Object.getPrototypeOf(RelayQLField)).call(this, context, ast));
+    var _this8 = _possibleConstructorReturn(this, Object.getPrototypeOf(RelayQLField).call(this, context, ast));
 
     var fieldName = _this8.ast.name.value;
     var fieldDef = parentType.getFieldDefinition(fieldName, ast);
@@ -372,7 +376,7 @@ var RelayQLFragmentSpread = function (_RelayQLNode3) {
   function RelayQLFragmentSpread() {
     _classCallCheck(this, RelayQLFragmentSpread);
 
-    return _possibleConstructorReturn(this, (RelayQLFragmentSpread.__proto__ || Object.getPrototypeOf(RelayQLFragmentSpread)).apply(this, arguments));
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(RelayQLFragmentSpread).apply(this, arguments));
   }
 
   _createClass(RelayQLFragmentSpread, [{
@@ -396,7 +400,7 @@ var RelayQLInlineFragment = function (_RelayQLNode4) {
   function RelayQLInlineFragment(context, ast, parentType) {
     _classCallCheck(this, RelayQLInlineFragment);
 
-    var _this11 = _possibleConstructorReturn(this, (RelayQLInlineFragment.__proto__ || Object.getPrototypeOf(RelayQLInlineFragment)).call(this, context, ast));
+    var _this11 = _possibleConstructorReturn(this, Object.getPrototypeOf(RelayQLInlineFragment).call(this, context, ast));
 
     _this11.parentType = parentType;
     return _this11;
@@ -527,10 +531,11 @@ var RelayQLType = function () {
 
     this.context = context;
 
-    var _stripMarkerTypes = stripMarkerTypes(schemaModifiedType),
-        isListType = _stripMarkerTypes.isListType,
-        isNonNullType = _stripMarkerTypes.isNonNullType,
-        schemaUnmodifiedType = _stripMarkerTypes.schemaUnmodifiedType;
+    var _stripMarkerTypes = stripMarkerTypes(schemaModifiedType);
+
+    var isListType = _stripMarkerTypes.isListType;
+    var isNonNullType = _stripMarkerTypes.isNonNullType;
+    var schemaUnmodifiedType = _stripMarkerTypes.schemaUnmodifiedType;
 
     this.isListType = isListType;
     this.isNonNullType = isNonNullType;
@@ -746,6 +751,7 @@ var RelayQLType = function () {
           }
         }
       };
+      // ID field will be generated by the printer; we won't declare it here.
       return new RelayQLFragment(this.context, generatedFragmentAST, this);
     }
   }]);
@@ -805,10 +811,11 @@ var RelayQLArgumentType = function () {
   function RelayQLArgumentType(schemaModifiedArgType) {
     _classCallCheck(this, RelayQLArgumentType);
 
-    var _stripMarkerTypes2 = stripMarkerTypes(schemaModifiedArgType),
-        isListType = _stripMarkerTypes2.isListType,
-        isNonNullType = _stripMarkerTypes2.isNonNullType,
-        schemaUnmodifiedType = _stripMarkerTypes2.schemaUnmodifiedType;
+    var _stripMarkerTypes2 = stripMarkerTypes(schemaModifiedArgType);
+
+    var isListType = _stripMarkerTypes2.isListType;
+    var isNonNullType = _stripMarkerTypes2.isNonNullType;
+    var schemaUnmodifiedType = _stripMarkerTypes2.schemaUnmodifiedType;
 
     this.isListType = isListType;
     this.isNonNullType = isNonNullType;
@@ -902,46 +909,30 @@ function stripMarkerTypes(schemaModifiedType) {
 }
 
 function getLiteralValue(value) {
-  var _ret2 = function () {
-    switch (value.kind) {
-      case 'IntValue':
-        return {
-          v: parseInt(value.value, 10)
-        };
-      case 'FloatValue':
-        return {
-          v: parseFloat(value.value)
-        };
-      case 'StringValue':
-      case 'BooleanValue':
-      case 'EnumValue':
-        return {
-          v: value.value
-        };
-      case 'ListValue':
-        return {
-          v: value.values.map(getLiteralValue)
-        };
-      case 'NullValue':
-        return {
-          v: null
-        };
-      case 'ObjectValue':
-        var object = {};
-        value.fields.forEach(function (field) {
-          object[field.name.value] = getLiteralValue(field.value);
-        });
-        return {
-          v: object
-        };
-      case 'Variable':
-        throw new RelayTransformError(util.format('Unexpected nested variable `%s`; variables are supported as top-' + 'level arguments - `node(id: $id)` - or directly within lists - ' + '`nodes(ids: [$id])`.', value.name.value), value.loc);
-      default:
-        throw new RelayTransformError(util.format('Unexpected value kind: %s', value.kind), value.loc);
-    }
-  }();
-
-  if ((typeof _ret2 === 'undefined' ? 'undefined' : _typeof(_ret2)) === "object") return _ret2.v;
+  switch (value.kind) {
+    case 'IntValue':
+      return parseInt(value.value, 10);
+    case 'FloatValue':
+      return parseFloat(value.value);
+    case 'StringValue':
+    case 'BooleanValue':
+    case 'EnumValue':
+      return value.value;
+    case 'ListValue':
+      return value.values.map(getLiteralValue);
+    case 'NullValue':
+      return null;
+    case 'ObjectValue':
+      var object = {};
+      value.fields.forEach(function (field) {
+        object[field.name.value] = getLiteralValue(field.value);
+      });
+      return object;
+    case 'Variable':
+      throw new RelayTransformError(util.format('Unexpected nested variable `%s`; variables are supported as top-' + 'level arguments - `node(id: $id)` - or directly within lists - ' + '`nodes(ids: [$id])`.', value.name.value), value.loc);
+    default:
+      throw new RelayTransformError(util.format('Unexpected value kind: %s', value.kind), value.loc);
+  }
 }
 
 module.exports = {

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
@@ -27,24 +27,29 @@ var RelayTransformError = require('./RelayTransformError');
 
 var find = require('./find');
 var invariant = require('./invariant');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 var util = require('util');
 
-var _require = require('./RelayQLAST'),
-    RelayQLArgument = _require.RelayQLArgument,
-    RelayQLArgumentType = _require.RelayQLArgumentType,
-    RelayQLDefinition = _require.RelayQLDefinition,
-    RelayQLDirective = _require.RelayQLDirective,
-    RelayQLField = _require.RelayQLField,
-    RelayQLFragment = _require.RelayQLFragment,
-    RelayQLFragmentSpread = _require.RelayQLFragmentSpread,
-    RelayQLInlineFragment = _require.RelayQLInlineFragment,
-    RelayQLMutation = _require.RelayQLMutation,
-    RelayQLQuery = _require.RelayQLQuery,
-    RelayQLSubscription = _require.RelayQLSubscription,
-    RelayQLType = _require.RelayQLType;
+var _require = require('./RelayQLAST');
 
-var _require2 = require('./RelayQLNodeInterface'),
-    ID = _require2.ID;
+var RelayQLArgument = _require.RelayQLArgument;
+var RelayQLArgumentType = _require.RelayQLArgumentType;
+var RelayQLDefinition = _require.RelayQLDefinition;
+var RelayQLDirective = _require.RelayQLDirective;
+var RelayQLField = _require.RelayQLField;
+var RelayQLFragment = _require.RelayQLFragment;
+var RelayQLFragmentSpread = _require.RelayQLFragmentSpread;
+var RelayQLInlineFragment = _require.RelayQLInlineFragment;
+var RelayQLMutation = _require.RelayQLMutation;
+var RelayQLQuery = _require.RelayQLQuery;
+var RelayQLSubscription = _require.RelayQLSubscription;
+var RelayQLType = _require.RelayQLType;
+
+var _require2 = require('./RelayQLNodeInterface');
+
+var ID = _require2.ID;
+
 
 module.exports = function (t, options) {
   var formatFields = options.snakeCase ? function (fields) {
@@ -85,7 +90,7 @@ module.exports = function (t, options) {
     _createClass(RelayQLPrinter, [{
       key: 'print',
       value: function print(definition, substitutions) {
-        var enableValidation = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+        var enableValidation = arguments.length <= 2 || arguments[2] === undefined ? true : arguments[2];
 
         var printedDocument = void 0;
         if (definition instanceof RelayQLQuery) {
@@ -306,7 +311,7 @@ module.exports = function (t, options) {
       value: function printSelections(parent, requisiteFields, extraFragments) {
         var _this2 = this;
 
-        var isGeneratedQuery = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+        var isGeneratedQuery = arguments.length <= 3 || arguments[3] === undefined ? false : arguments[3];
 
         var fields = [];
         var printedFragments = [];
@@ -346,7 +351,7 @@ module.exports = function (t, options) {
       value: function printFields(fields, parent, requisiteFields) {
         var _this3 = this;
 
-        var isGeneratedQuery = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+        var isGeneratedQuery = arguments.length <= 3 || arguments[3] === undefined ? false : arguments[3];
 
         var parentType = parent.getType();
         if (parentType.isConnection() && parentType.hasField(FIELDS.pageInfo) && fields.some(function (field) {
@@ -374,7 +379,7 @@ module.exports = function (t, options) {
       value: function printField(field, parent, requisiteSiblings, generatedSiblings) {
         var _this4 = this;
 
-        var isGeneratedQuery = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : false;
+        var isGeneratedQuery = arguments.length <= 4 || arguments[4] === undefined ? false : arguments[4];
 
         var fieldType = field.getType();
 
@@ -444,7 +449,6 @@ module.exports = function (t, options) {
           directives: this.printDirectives(field.getDirectives()),
           fieldName: t.valueToNode(field.getName()),
           kind: t.valueToNode('Field'),
-          // $FlowFixMe
           metadata: this.printRelayDirectiveMetadata(field, metadata),
           type: t.valueToNode(fieldType.getName({ modifiers: false }))
         });
@@ -531,7 +535,11 @@ module.exports = function (t, options) {
       }
     }, {
       key: 'printRelayDirectiveMetadata',
-      value: function printRelayDirectiveMetadata(node, maybeMetadata) {
+      value: function printRelayDirectiveMetadata(node,
+      /* $FlowFixMe(>=0.38.0 site=react_native_fb) - Flow error detected during
+       * the deployment of v0.38.0. To see the error, remove this comment and
+       * run flow */
+      maybeMetadata) {
         var properties = [];
         var relayDirective = findRelayDirective(node);
         if (relayDirective) {
@@ -609,11 +617,10 @@ module.exports = function (t, options) {
   }
 
   function validateConnectionField(field) {
-    var _ref = [field.findArgument('first'), field.findArgument('last'), field.findArgument('before'), field.findArgument('after')],
-        first = _ref[0],
-        last = _ref[1],
-        before = _ref[2],
-        after = _ref[3];
+    var first = field.findArgument('first');
+    var last = field.findArgument('last');
+    var before = field.findArgument('before');
+    var after = field.findArgument('after');
 
     var condition = !first || !last || first.isVariable() && last.isVariable();
     if (!condition) {

--- a/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLPrinter.js
@@ -27,9 +27,7 @@ var RelayTransformError = require('./RelayTransformError');
 
 var find = require('./find');
 var invariant = require('./invariant');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-var util = require('util');
+var util = require('./util');
 
 var _require = require('./RelayQLAST');
 

--- a/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
@@ -34,9 +34,7 @@ var RelayQLSubscription = _require.RelayQLSubscription;
 var RelayQLPrinter = require('./RelayQLPrinter');
 
 var invariant = require('./invariant');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-var util = require('util');
+var util = require('./util');
 
 /**
  * Transforms a TemplateLiteral node into a RelayQLDefinition, which is then

--- a/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/lib/RelayQLTransformer.js
@@ -18,27 +18,31 @@ var _createClass = function () { function defineProperties(target, props) { for 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var GraphQL = require('./GraphQL');
-var formatError = GraphQL.error.formatError,
-    parser = GraphQL.language_parser,
-    Source = GraphQL.language_source.Source,
-    validate = GraphQL.validation.validate;
+var formatError = GraphQL.error.formatError;
+var parser = GraphQL.language_parser;
+var Source = GraphQL.language_source.Source;
+var validate = GraphQL.validation.validate;
 
-var _require = require('./RelayQLAST'),
-    RelayQLDefinition = _require.RelayQLDefinition,
-    RelayQLFragment = _require.RelayQLFragment,
-    RelayQLMutation = _require.RelayQLMutation,
-    RelayQLQuery = _require.RelayQLQuery,
-    RelayQLSubscription = _require.RelayQLSubscription;
+var _require = require('./RelayQLAST');
+
+var RelayQLDefinition = _require.RelayQLDefinition;
+var RelayQLFragment = _require.RelayQLFragment;
+var RelayQLMutation = _require.RelayQLMutation;
+var RelayQLQuery = _require.RelayQLQuery;
+var RelayQLSubscription = _require.RelayQLSubscription;
 
 var RelayQLPrinter = require('./RelayQLPrinter');
 
 var invariant = require('./invariant');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 var util = require('util');
 
 /**
  * Transforms a TemplateLiteral node into a RelayQLDefinition, which is then
  * transformed into a Babel AST via RelayQLPrinter.
  */
+
 var RelayQLTransformer = function () {
   function RelayQLTransformer(schema, options) {
     _classCallCheck(this, RelayQLTransformer);
@@ -51,10 +55,11 @@ var RelayQLTransformer = function () {
     key: 'transform',
     value: function transform(t, // Babel
     node, options) {
-      var _processTemplateLiter = this.processTemplateLiteral(node, options.documentName),
-          substitutions = _processTemplateLiter.substitutions,
-          templateText = _processTemplateLiter.templateText,
-          variableNames = _processTemplateLiter.variableNames;
+      var _processTemplateLiter = this.processTemplateLiteral(node, options.documentName);
+
+      var substitutions = _processTemplateLiter.substitutions;
+      var templateText = _processTemplateLiter.templateText;
+      var variableNames = _processTemplateLiter.variableNames;
 
       var documentText = this.processTemplateText(templateText, options);
       var definition = this.processDocumentText(documentText, options);
@@ -103,8 +108,8 @@ var RelayQLTransformer = function () {
   }, {
     key: 'processTemplateText',
     value: function processTemplateText(templateText, _ref) {
-      var documentName = _ref.documentName,
-          propName = _ref.propName;
+      var documentName = _ref.documentName;
+      var propName = _ref.propName;
 
       var pattern = /^(fragment|mutation|query|subscription)\s*(\w*)?([\s\S]*)/;
       var matches = pattern.exec(templateText);
@@ -128,8 +133,8 @@ var RelayQLTransformer = function () {
   }, {
     key: 'processDocumentText',
     value: function processDocumentText(documentText, _ref2) {
-      var documentName = _ref2.documentName,
-          enableValidation = _ref2.enableValidation;
+      var documentName = _ref2.documentName;
+      var enableValidation = _ref2.enableValidation;
 
       var document = parser.parse(new Source(documentText, documentName));
       var validationErrors = enableValidation ? this.validateDocument(document, documentName) : null;
@@ -173,8 +178,9 @@ var RelayQLTransformer = function () {
       var validator = this.options.validator;
       var validationErrors = void 0;
       if (validator) {
-        var _validator = validator(GraphQL),
-            _validate = _validator.validate;
+        var _validator = validator(GraphQL);
+
+        var _validate = _validator.validate;
 
         validationErrors = _validate(this.schema, document);
       } else {

--- a/scripts/babel-relay-plugin/lib/computeLocation.js
+++ b/scripts/babel-relay-plugin/lib/computeLocation.js
@@ -16,9 +16,9 @@
 // Convert a GraphQL location object with relative start/end position in RelayQLDocument in
 // source into {line, column, source} information.
 function computeLocation(_ref) {
-  var start = _ref.start,
-      end = _ref.end,
-      source = _ref.source;
+  var start = _ref.start;
+  var end = _ref.end;
+  var source = _ref.source;
 
   if (!source) {
     return null;

--- a/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
@@ -21,9 +21,7 @@ var RelayTransformError = require('./RelayTransformError');
 var babelAdapter = require('./babelAdapter');
 var computeLocation = require('./computeLocation');
 var invariant = require('./invariant');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-var util = require('util');
+var util = require('./util');
 
 var _require = require('./GraphQL');
 

--- a/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/lib/getBabelRelayPlugin.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
 var RelayQLTransformer = require('./RelayQLTransformer');
 var RelayTransformError = require('./RelayTransformError');
@@ -21,11 +21,15 @@ var RelayTransformError = require('./RelayTransformError');
 var babelAdapter = require('./babelAdapter');
 var computeLocation = require('./computeLocation');
 var invariant = require('./invariant');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 var util = require('util');
 
-var _require = require('./GraphQL'),
-    buildClientSchema = _require.utilities_buildClientSchema.buildClientSchema,
-    buildASTSchema = _require.utilities_buildASTSchema.buildASTSchema;
+var _require = require('./GraphQL');
+
+var buildClientSchema = _require.utilities_buildClientSchema.buildClientSchema;
+var buildASTSchema = _require.utilities_buildASTSchema.buildASTSchema;
+
 
 var PROVIDES_MODULE = 'providesModule';
 var RELAY_QL_GENERATED = 'RelayQL_GENERATED';
@@ -48,9 +52,9 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
   });
 
   return function (_ref) {
-    var Plugin = _ref.Plugin,
-        types = _ref.types,
-        version = _ref.version;
+    var Plugin = _ref.Plugin;
+    var types = _ref.types;
+    var version = _ref.version;
 
     return babelAdapter(Plugin, types, version, 'relay-query', function (t) {
       return {
@@ -58,6 +62,7 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
           /**
            * Extract the module name from `@providesModule`.
            */
+
           Program: function Program(_ref2, state) {
             var parent = _ref2.parent;
 
@@ -140,15 +145,15 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
               } else {
                 // Print a console warning and replace the code with a function
                 // that will immediately throw an error in the browser.
-                var sourceText = error.sourceText,
-                    validationErrors = error.validationErrors;
+                var sourceText = error.sourceText;
+                var validationErrors = error.validationErrors;
 
                 var isValidationError = !!(validationErrors && sourceText);
                 if (isValidationError) {
                   var sourceLines = sourceText.split('\n');
                   validationErrors.forEach(function (_ref3) {
-                    var message = _ref3.message,
-                        locations = _ref3.locations;
+                    var message = _ref3.message;
+                    var locations = _ref3.locations;
 
                     errorMessages.push(message);
                     warning('\n-- GraphQL Validation Error -- %s --\n', basename);
@@ -181,8 +186,8 @@ function getBabelRelayPlugin(schemaProvider, pluginOptions) {
             if (state.isLegacyState) {
               return result; // eslint-disable-line consistent-return
             } else {
-              path.replaceWith(result);
-            }
+                path.replaceWith(result);
+              }
           }
         }
       };

--- a/scripts/babel-relay-plugin/lib/invariant.js
+++ b/scripts/babel-relay-plugin/lib/invariant.js
@@ -13,6 +13,8 @@
 
 'use strict';
 
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
+
 var util = require('util');
 
 function invariant(condition, format) {

--- a/scripts/babel-relay-plugin/lib/invariant.js
+++ b/scripts/babel-relay-plugin/lib/invariant.js
@@ -13,9 +13,7 @@
 
 'use strict';
 
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-
-var util = require('util');
+var util = require('./util');
 
 function invariant(condition, format) {
   if (!condition) {

--- a/scripts/babel-relay-plugin/lib/tools/regenerateFixtures.js
+++ b/scripts/babel-relay-plugin/lib/tools/regenerateFixtures.js
@@ -38,7 +38,8 @@ function genFixtures() {
       try {
         var graphql = transform(fixture.input, filename);
         writeFixture(filename, ['Input:', fixture.input, '', // newline
-        'Output:', graphql, ''].join('\n'));
+        'Output:', graphql, '']. // newline
+        join('\n'));
         console.log('Updated fixture `%s`.', filename);
       } catch (e) {
         console.error('Failed to transform fixture `%s`: %s: %s', filename, e.message, e.stack);

--- a/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
@@ -14,6 +14,8 @@
 
 var babel = require('babel-core');
 var fs = require('fs');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 var util = require('util');
 
 var getBabelRelayPlugin = require('../getBabelRelayPlugin');

--- a/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/lib/tools/transformGraphQL.js
@@ -14,9 +14,7 @@
 
 var babel = require('babel-core');
 var fs = require('fs');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-var util = require('util');
+var util = require('./util');
 
 var getBabelRelayPlugin = require('../getBabelRelayPlugin');
 

--- a/scripts/babel-relay-plugin/lib/util.js
+++ b/scripts/babel-relay-plugin/lib/util.js
@@ -1,3 +1,4 @@
+// @generated
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  * All rights reserved.
@@ -6,22 +7,14 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @flow
- * @fullSyntaxTransform
+ * 
  */
 
 'use strict';
 
-const util = require('./util');
+// Flow: https://github.com/facebook/relay/issues/1508
 
-function invariant(
-  condition: mixed,
-  format: string,
-  ...args: Array<mixed>
-): void {
-  if (!condition) {
-    throw new Error(util.format(format, ...args));
-  }
-}
+var resolved = require.resolve('util');
+var util = require(resolved);
 
-module.exports = invariant;
+module.exports = util;

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -14,9 +14,6 @@
     "update-fixtures": "babel-node ./src/tools/regenerateFixtures.js",
     "update-schema": "babel-node ./src/tools/generateSchemaJson.js"
   },
-  "engines" : {
-    "node" : "*"
-  },
   "files": [
     "LICENSE",
     "PATENTS",

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -14,6 +14,9 @@
     "update-fixtures": "babel-node ./src/tools/regenerateFixtures.js",
     "update-schema": "babel-node ./src/tools/generateSchemaJson.js"
   },
+  "engines" : {
+    "node" : "*"
+  },
   "files": [
     "LICENSE",
     "PATENTS",

--- a/scripts/babel-relay-plugin/src/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/src/RelayQLAST.js
@@ -17,6 +17,8 @@ const RelayTransformError = require('./RelayTransformError');
 
 const find = require('./find');
 const invariant = require('./invariant');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 const util = require('util');
 
 const {

--- a/scripts/babel-relay-plugin/src/RelayQLAST.js
+++ b/scripts/babel-relay-plugin/src/RelayQLAST.js
@@ -17,9 +17,7 @@ const RelayTransformError = require('./RelayTransformError');
 
 const find = require('./find');
 const invariant = require('./invariant');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-const util = require('util');
+const util = require('./util');
 
 const {
   type: types,

--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -16,6 +16,8 @@ const RelayTransformError = require('./RelayTransformError');
 
 const find = require('./find');
 const invariant = require('./invariant');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 const util = require('util');
 
 const {

--- a/scripts/babel-relay-plugin/src/RelayQLPrinter.js
+++ b/scripts/babel-relay-plugin/src/RelayQLPrinter.js
@@ -16,9 +16,7 @@ const RelayTransformError = require('./RelayTransformError');
 
 const find = require('./find');
 const invariant = require('./invariant');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-const util = require('util');
+const util = require('./util');
 
 const {
   RelayQLArgument,

--- a/scripts/babel-relay-plugin/src/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/src/RelayQLTransformer.js
@@ -30,6 +30,8 @@ const {
 const RelayQLPrinter = require('./RelayQLPrinter');
 
 const invariant = require('./invariant');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 const util = require('util');
 
 import type {

--- a/scripts/babel-relay-plugin/src/RelayQLTransformer.js
+++ b/scripts/babel-relay-plugin/src/RelayQLTransformer.js
@@ -30,9 +30,7 @@ const {
 const RelayQLPrinter = require('./RelayQLPrinter');
 
 const invariant = require('./invariant');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-const util = require('util');
+const util = require('./util');
 
 import type {
   DocumentNode,

--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -18,9 +18,7 @@ const RelayTransformError = require('./RelayTransformError');
 const babelAdapter = require('./babelAdapter');
 const computeLocation = require('./computeLocation');
 const invariant = require('./invariant');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-const util = require('util');
+const util = require('./util');
 
 const {
   utilities_buildClientSchema: {buildClientSchema},

--- a/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
+++ b/scripts/babel-relay-plugin/src/getBabelRelayPlugin.js
@@ -18,6 +18,8 @@ const RelayTransformError = require('./RelayTransformError');
 const babelAdapter = require('./babelAdapter');
 const computeLocation = require('./computeLocation');
 const invariant = require('./invariant');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 const util = require('util');
 
 const {

--- a/scripts/babel-relay-plugin/src/invariant.js
+++ b/scripts/babel-relay-plugin/src/invariant.js
@@ -12,6 +12,7 @@
 
 'use strict';
 
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 const util = require('util');
 
 function invariant(

--- a/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
@@ -13,9 +13,7 @@
 
 const babel = require('babel-core');
 const fs = require('fs');
-
-// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
-const util = require('util');
+const util = require('./util');
 
 const getBabelRelayPlugin = require('../getBabelRelayPlugin');
 

--- a/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
+++ b/scripts/babel-relay-plugin/src/tools/transformGraphQL.js
@@ -13,6 +13,8 @@
 
 const babel = require('babel-core');
 const fs = require('fs');
+
+// $FlowFixMe: Resolves to third-party module instead of core Node.js module.
 const util = require('util');
 
 const getBabelRelayPlugin = require('../getBabelRelayPlugin');

--- a/scripts/babel-relay-plugin/src/util.js
+++ b/scripts/babel-relay-plugin/src/util.js
@@ -7,21 +7,12 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @flow
- * @fullSyntaxTransform
  */
 
 'use strict';
 
-const util = require('./util');
+// Flow: https://github.com/facebook/relay/issues/1508
+const resolved = require.resolve('util');
+const util = require(resolved);
 
-function invariant(
-  condition: mixed,
-  format: string,
-  ...args: Array<mixed>
-): void {
-  if (!condition) {
-    throw new Error(util.format(format, ...args));
-  }
-}
-
-module.exports = invariant;
+module.exports = util;


### PR DESCRIPTION
Mitigates: #1508

Flow is complaining about these `require('util')` calls in the plug-in, reporting errors like:

```
src/getBabelRelayPlugin.js:21
21: const util = require('util');
  This modules resolves to
  "<<PROJECT_ROOT>>/../../node_modules/util/package.json", which is
  outside both your root directory and all of the entries in the
  [include] section of your .flowconfig. You should either add this
  directory to the [include] section of your .flowconfig, move your
  .flowconfig file higher in the project directory tree, or move this
  package under your Flow root directory.
```

Confirmed with the Flow team that this is a bug in the resolver implementation. This page indicates that it is supposed to look for core modules before searching `node_modules`:

https://nodejs.org/api/modules.html#modules_all_together

As a workaround for now, let's just suppress the errors.