### PR TITLE
Update graphql dependency in plug-in

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -39,7 +39,7 @@
     "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "graphql": "0.8.2"
+    "graphql": "0.9.1"
   },
   "jest": {
     "automock": true,


### PR DESCRIPTION
In conjunction with:

https://github.com/facebook/relay/pull/1509

This fixes the remaining two Flow errors in the plug-in, making it clean again.

Closes: https://github.com/facebook/relay/issues/1508