### PR TITLE
Update graphql dependency in plug-in

### DIFF
--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -14,9 +14,6 @@
     "update-fixtures": "babel-node ./src/tools/regenerateFixtures.js",
     "update-schema": "babel-node ./src/tools/generateSchemaJson.js"
   },
-  "engines" : {
-    "node" : "*"
-  },
   "files": [
     "LICENSE",
     "PATENTS",

--- a/scripts/babel-relay-plugin/package.json
+++ b/scripts/babel-relay-plugin/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^2.5.2"
   },
   "dependencies": {
-    "graphql": "0.8.2"
+    "graphql": "0.9.1"
   },
   "jest": {
     "automock": true,


### PR DESCRIPTION
In conjunction with:

https://github.com/facebook/relay/pull/1509

Supersedes:

https://github.com/facebook/relay/pull/1510

This fixes the remaining two Flow errors in the plug-in, making it clean again.

Closes: https://github.com/facebook/relay/issues/1508