### PR TITLE
RelayGraphQLMutation: Fix file attachment

### DIFF
--- a/src/mutation/RelayGraphQLMutation.js
+++ b/src/mutation/RelayGraphQLMutation.js
@@ -266,6 +266,7 @@ class PendingGraphQLTransaction {
     this._configs = [];
     this._query = query;
     this._variables = variables;
+    this._files = files;
     this._optimisticQuery = optimisticQuery || null;
     this._optimisticResponse = optimisticResponse || null;
     this._collisionKey = collisionKey;


### PR DESCRIPTION
`this._files` was not being set in [`PendingGraphQLTransaction`'s constructor](https://github.com/facebook/relay/blob/5e4c38b23d1278c0fee02846995275f1e6ca5456/src/mutation/RelayGraphQLMutation.js#L256), which meant `files` was always `undefined` in [_sendMutation](https://github.com/facebook/relay/blob/5e4c38b23d1278c0fee02846995275f1e6ca5456/src/network-layer/default/RelayDefaultNetworkLayer.js#L94).

I believe this fixes https://github.com/facebook/relay/issues/1507.