### PR TITLE
Depend on new version of babel-relay-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-static-container": "^1.0.1"
   },
   "peerDependencies": {
-    "babel-relay-plugin": "0.10.0",
+    "babel-relay-plugin": "0.11.0",
     "react": "^15.0.0 || ^0.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I just published v0.11.0 of the plugin. Now trying to get the CI green for the main package in preparation for cutting a release.