### PR TITLE
Fix `npm run lint` error

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint": "^3.0.1",
     "eslint-config-fbjs": "^1.0.0",
     "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-flow-vars": "^0.4.0",
+    "eslint-plugin-flowtype": "2.30.0",
     "eslint-plugin-react": "^5.2.2",
     "fbjs-scripts": "^0.7.1",
     "flow-bin": "^0.38.0",


### PR DESCRIPTION
Not sure when this broke, but `npm run lint` was bombing out with:

    ESLint couldn't find the plugin "eslint-plugin-flowtype".

So, add it, which fixes the error. Additionally, remove the "eslint-plugin-flow-vars" plug-in, which no longer seems to be necessary (removing it did not produce any new lint warnings).