### PR TITLE
Fix remaining lints

### DIFF
--- a/src/environment/__tests__/RelayFragmentSpecResolver-test.js
+++ b/src/environment/__tests__/RelayFragmentSpecResolver-test.js
@@ -532,7 +532,7 @@ describe('RelayFragmentSpecResolver', () => {
       );
       expect(resolver.resolve()).toEqual({
         user: [{
-            __dataID__: '4',
+          __dataID__: '4',
           id: '4',
           name: 'Zuck',
         }],
@@ -551,7 +551,7 @@ describe('RelayFragmentSpecResolver', () => {
       expect(callback).toBeCalled();
       expect(resolver.resolve()).toEqual({
         user: [{
-            __dataID__: '4',
+          __dataID__: '4',
           id: '4',
           name: 'Mark',
         }],
@@ -571,7 +571,7 @@ describe('RelayFragmentSpecResolver', () => {
       expect(callback).not.toBeCalled();
       expect(resolver.resolve()).toEqual({
         user: [{
-            __dataID__: '4',
+          __dataID__: '4',
           id: '4',
           name: 'Zuck', // does not reflect latest changes
         }],

--- a/src/environment/__tests__/RelaySelector-test.js
+++ b/src/environment/__tests__/RelaySelector-test.js
@@ -119,8 +119,9 @@ describe('RelaySelector', () => {
         );
       expect(() => getSelector(variables, UserFragment, [zuck]))
         .toFailInvariant(
-          'RelaySelector: Expected value for fragment `RelaySelector_user` to be an object, got ' +
-          '`[{"__dataID__":"4","__fragments__":{"0::client":[{"size":null,"cond":false}],"1::client":[{"size":null,"cond":false}]}}]`.'
+          'RelaySelector: Expected value for fragment `RelaySelector_user` to ' +
+          'be an object, got `[{"__dataID__":"4","__fragments__":{"0::client":' +
+          '[{"size":null,"cond":false}],"1::client":[{"size":null,"cond":false}]}}]`.'
         );
     });
 

--- a/src/query/__tests__/RelayQueryPath-test.js
+++ b/src/query/__tests__/RelayQueryPath-test.js
@@ -174,7 +174,7 @@ describe('RelayQueryPath', () => {
     expect(pathQuery.isAbstract()).toBe(true);
   });
 
-   it('creates roots with route from child', () => {
+  it('creates roots with route from child', () => {
     let query = getNode(Relay.QL`
       query {
         node(id:"123") {

--- a/src/store/__tests__/RelayEnvironment-test.js
+++ b/src/store/__tests__/RelayEnvironment-test.js
@@ -196,7 +196,7 @@ describe('RelayEnvironment', () => {
   });
 
   describe('sendMutation()', () => {
-    let FeedbackQuery,FeedbackMutation;
+    let FeedbackQuery, FeedbackMutation;
     let disposable, onCompleted, onError, sendMutation, requests, result;
 
     beforeEach(() => {

--- a/src/traversal/__tests__/printRelayOSSQuery-test.js
+++ b/src/traversal/__tests__/printRelayOSSQuery-test.js
@@ -441,15 +441,17 @@ describe('printRelayOSSQuery', () => {
 
     it('creates distinct variables for values of different types', () => {
       // Relay allows the same variable at both locations, regardless of type:
-      const query = getNode(Relay.QL`
-        query DistinctVars {
-          node(id: "123") {
-            ... on User {
-              storySearch(query: $query) {id}
-              storyCommentSearch(query: $query) {id}
+      const query = getNode(
+        Relay.QL`
+          query DistinctVars {
+            node(id: "123") {
+              ... on User {
+                storySearch(query: $query) {id}
+                storyCommentSearch(query: $query) {id}
+              }
             }
           }
-        }`,
+        `,
         {
           query: {text: 'foo'},
         },


### PR DESCRIPTION
Fixes various cosmetic lints (19 of them) with messages like:

    warning  Expected indentation of 10 spaces but found 12  indent

    warning  Line 123 exceeds the maximum line length of 120  max-len

    warning  A space is required after ','  comma-spacing

With this, we're lint-clean in the entire repo.