### PR TITLE
Remove dangling reference to base62 module

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -6,7 +6,6 @@
 .*/react-static-container/node_modules/.*
 
 [include]
-../node_modules/base62
 ../node_modules/fbjs/lib
 ../node_modules/invariant
 ../node_modules/react


### PR DESCRIPTION
This lives at "../node_modules/fbjs/lib/base62.js", not "../node_modules/base62".

Making this change stops the following from being output during `npm run
typecheck`:

    Skipping /Users/glh/code/relay/node_modules/base62: No such file or directory