### PR TITLE
Fix Flow's inability to "see" ReactDOM

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -3,6 +3,7 @@
 .*/**/*.native.js
 .*/node_modules/graphql/.*
 .*/react/node_modules/.*
+.*/react-dom/node_modules/.*
 .*/react-static-container/node_modules/.*
 
 [include]
@@ -10,6 +11,7 @@
 ../node_modules/fbjs/lib
 ../node_modules/invariant
 ../node_modules/react
+../node_modules/react-dom
 ../node_modules/react-static-container/lib
 
 [libs]
@@ -17,6 +19,7 @@
 
 [options]
 module.system=haste
+module.name_mapper='^ReactDOM$' -> 'react-dom'
 
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable


### PR DESCRIPTION
This was causing errors like this:

```
src/tools/relayUnstableBatchedUpdates.js:15
 15: const ReactDOM = require('ReactDOM');
                      ^^^^^^^^^^^^^^^^^^^ ReactDOM. Required module not found
```

The configuration to fix it is three-fold:

1. We have to tell Flow to look in "react-dom".
2. We have to tell it *not* to look in "react-dom/node-modules" (because if it does it will freak out about duplicates).
3. We have to tell it that when we require "ReactDOM", we actually mean "react-dom", so we use a mapping.