### PR TITLE
Process test files with babel-plugin-graphql

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -14,32 +14,44 @@ const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction
 const fs = require('fs');
 const getBabelOptions = require('../getBabelOptions');
 const getBabelRelayPlugin = require('../babel-relay-plugin');
+const BabelPluginGraphQL = require('../../src/babel-plugin-graphql/BabelPluginGraphQL');
 const path = require('path');
 
 const SCHEMA_PATH = path.resolve(__dirname, 'testschema.json');
 
 const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8')).data;
 
-const babelOptions = getBabelOptions({
-  env: 'test',
-  moduleMap: {
-    'React': 'react',
-    'reactComponentExpect': 'react-dom/lib/reactComponentExpect',
-    'ReactDOM': 'react-dom',
-    'ReactDOMServer': 'react-dom/server',
-    'ReactTestRenderer': 'react-test-renderer',
-    'ReactTestUtils': 'react-addons-test-utils',
-    'StaticContainer.react': 'react-static-container',
-  },
-  plugins: [
-    getBabelRelayPlugin(schema, {substituteVariables: true}),
-  ],
-});
+function getBabelOptionsForFile(src, filename) {
+  let plugins = [];
+  if (src.match(/\bgraphql(?:\.\w+)?`/)) {
+    plugins.push(
+      BabelPluginGraphQL.create({relayExperimental: true})
+    );
+  }
+  if (src.match(/\b(?:RelayQL|Relay\.QL)`/)) {
+    plugins.push(
+      getBabelRelayPlugin(schema, {substituteVariables: true})
+    );
+  }
+  return getBabelOptions({
+    env: 'test',
+    moduleMap: {
+      'React': 'react',
+      'reactComponentExpect': 'react-dom/lib/reactComponentExpect',
+      'ReactDOM': 'react-dom',
+      'ReactDOMServer': 'react-dom/server',
+      'ReactTestRenderer': 'react-test-renderer',
+      'ReactTestUtils': 'react-addons-test-utils',
+      'StaticContainer.react': 'react-static-container',
+    },
+    plugins,
+  });
+}
 
 module.exports = {
   process: function(src, filename) {
-    const options = assign({}, babelOptions, {
-      filename: filename,
+    const options = assign({}, getBabelOptionsForFile(src, filename), {
+      filename,
       retainLines: true,
     });
     return babel.transform(src, options).code;
@@ -51,5 +63,6 @@ module.exports = {
     path.join(__dirname, '..', 'babel-relay-plugin', 'package.json'),
     path.join(path.dirname(require.resolve('babel-preset-fbjs')), 'package.json'),
     path.join(__dirname, '..', 'getBabelOptions.js'),
+    path.join(__dirname, '../../src/babel-plugin-graphql/BabelPluginGraphQL.js'),
   ]),
 };


### PR DESCRIPTION
Sneak preview of the kind of thing that is going to be necessary to unbreak the test suite.

Won't actually ship this yet (due to sync issues, I am going to have to move the plug-in) but just parking this here for now.