### PR TITLE
RelayGraphQLMutation: Add logging in dev

### DIFF
--- a/src/mutation/RelayGraphQLMutation.js
+++ b/src/mutation/RelayGraphQLMutation.js
@@ -323,6 +323,24 @@ class PendingGraphQLTransaction {
       );
       this._optimisticMutation =
         (mutation: any); // Cast RelayQuery.{Node -> Mutation}.
+      /* eslint-disable no-console */
+      if (__DEV__ && console.groupCollapsed && console.groupEnd) {
+        console.groupCollapsed(
+          'Optimistic query for `' + this._optimisticMutation.getCall().name + '`'
+        );
+        const printedQuery = this._optimisticMutation ? require('printRelayQuery')(this._optimisticMutation) : null;
+        console.groupCollapsed('Optimistic Variables');
+        console.log(printedQuery ? printedQuery.variables : {});
+        console.groupEnd();
+        console.groupCollapsed('Optimistic Query');
+        console.log(printedQuery ? printedQuery.text : '');
+        console.groupEnd();
+        console.groupCollapsed('Optimistic Response');
+        console.log(this.getOptimisticResponse());
+        console.groupEnd();
+        console.groupEnd();
+      }
+      /* eslint-enable no-console */
     }
     return this._optimisticMutation;
   }
@@ -343,6 +361,21 @@ class PendingGraphQLTransaction {
         this._getVariables()
       );
       this._mutation = (mutation: any); // Cast RelayQuery.{Node -> Mutation}.
+      /* eslint-disable no-console */
+      if (__DEV__ && console.groupCollapsed && console.groupEnd) {
+        console.groupCollapsed(
+          'Mutation query for `' + this.getCallName() + '`'
+        );
+        const printedQuery = this._mutation ? require('printRelayQuery')(this._mutation) : null;
+        console.groupCollapsed('Mutation Variables');
+        console.log(printedQuery ? printedQuery.variables : {});
+        console.groupEnd();
+        console.groupCollapsed('Mutation Query');
+        console.log(printedQuery ? printedQuery.text : '');
+        console.groupEnd();
+        console.groupEnd();
+      }
+      /* eslint-enable no-console */
     }
     return this._mutation;
   }


### PR DESCRIPTION
This PR is an attempt to address https://github.com/facebook/relay/issues/1501.

The changes here are driven by my assumption that `RelayGraphQLMutation` should not rely on any RelayMutation* modules (let me know if this is not the case). Therefore, I basically inlined `RelayMutationDebugPrinter`'s `printMutation` and `printOptimisticMutation` into `getQuery` and `getOptimisticQuery`, respectively.

**Edit**: I just noticed `RelayGraphQLMutation` already uses `RelayMutationTransactionStatus`. So perhaps my assumption was false?

I did not add printing of the mutation configs, because there's kind of a lot going on in [buildQuery](https://github.com/facebook/relay/blob/master/src/mutation/RelayMutationQuery.js#L368). I can take a stab at adding this if it's critical, though.

The changes didn't cause any additional test failures when I ran the tests. I also ran the code locally and verified that:
1. Variables and query are printed when `commit` is called
2. Variables, query, and optimistic response are printed when `applyOptimistic` is called

If someone can give me pointers on the type of tests they'd like to see for this, I'm happy to add.