### PR TITLE
Clarify use of Relay.Store in GraphQLMutation

### DIFF
--- a/docs/APIReference-GraphQLMutation.md
+++ b/docs/APIReference-GraphQLMutation.md
@@ -96,6 +96,8 @@ const mutation = Relay.GraphQLMutation.create(
 );
 ```
 
+Note: In most cases, it is possible to rely on the default singleton instance of the environment, which is exposed as `Relay.Store`.
+
 See also: [GraphQLMutation > Constructor](#constructor)
 
 ### createWithFiles (static method)


### PR DESCRIPTION
I think it would be helpful to point out the most common use of this API.

Refers to the question in this issue: https://github.com/facebook/relay/issues/1531