### PR TITLE
Update Relay plugins in jest preprocessor

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -16,9 +16,11 @@ const getBabelOptions = require('../getBabelOptions');
 const getBabelRelayPlugin = require('../babel-relay-plugin');
 const path = require('path');
 
-const SCHEMA_PATH = path.resolve(__dirname, 'testschema.json');
+const getSchemaIntrospection = require('../../packages/babel-plugin-relay/getSchemaIntrospection');
 
-const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8')).data;
+const SCHEMA_PATH = path.resolve(__dirname, 'testschema.graphql');
+
+const schema = getSchemaIntrospection(SCHEMA_PATH);
 
 const babelOptions = getBabelOptions({
   env: 'test',
@@ -32,6 +34,7 @@ const babelOptions = getBabelOptions({
     'StaticContainer.react': 'react-static-container',
   },
   plugins: [
+    require('../../packages/babel-plugin-relay/BabelPluginRelay.js'),
     getBabelRelayPlugin(schema, {substituteVariables: true}),
   ],
 });


### PR DESCRIPTION
This adds the new BabelPluginRelay and also fixes loading the schema which was missing some information when loaded from the json file.