### PR TITLE
Fix TypeError

### DIFF
--- a/packages/react-relay/classic/traversal/printRelayOSSQuery.js
+++ b/packages/react-relay/classic/traversal/printRelayOSSQuery.js
@@ -76,8 +76,7 @@ function printRelayOSSQuery(node: RelayQuery.Node): PrintedQuery {
   }
   invariant(
     queryText,
-    'printRelayOSSQuery(): Unsupported node type, got `%s`.',
-    JSON.stringify(node),
+    'printRelayOSSQuery(): Unsupported node type.'
   );
   const variables = {};
   variableMap.forEach(variablesForType => {


### PR DESCRIPTION
Currently, [this test](https://github.com/facebook/relay/blob/master/packages/react-relay/classic/traversal/__tests__/printRelayOSSQuery-test.js#L536) fails with a `TypeError: Converting circular structure to JSON`.

This PR fixes (or rather, works around) this by changing the message back to the way it was before a89f623ba69b7b38b06af274d67ac260a9e64bf7.

Also, the tests at https://github.com/relay-tools/react-router-relay and https://github.com/relay-tools/relay-local-schema no longer failed after this change when I ran locally (swapping out the `react-relay` imports for `react-relay/classic`).