### PR TITLE
Reduce travis build matrix and add node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,14 @@ matrix:
     env: TEST=.
   - node_js: '6'
     env: TEST=.
+  - node_js: '7'
+    env: TEST=.
 
   - node_js: '4'
     env: TEST=scripts/babel-relay-plugin
   - node_js: '6'
+    env: TEST=scripts/babel-relay-plugin
+  - node_js: '7'
     env: TEST=scripts/babel-relay-plugin
 
   - node_js: '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 ---
 language: node_js
-node_js:
-- '4'
-- '6'
 install: true
-env:
-- TEST=.
-- TEST=scripts/babel-relay-plugin
-- TYPECHECK=.
-- TYPECHECK=scripts/babel-relay-plugin
+matrix:
+  include:
+  - node_js: '4'
+    env: TEST=.
+  - node_js: '6'
+    env: TEST=.
+
+  - node_js: '4'
+    env: TEST=scripts/babel-relay-plugin
+  - node_js: '6'
+    env: TEST=scripts/babel-relay-plugin
+
+  - node_js: '6'
+    env: TYPECHECK=.
+
+  - node_js: '6'
+    env: TYPECHECK=scripts/babel-relay-plugin
 script:
 - |
     if [ $TEST ]; then


### PR DESCRIPTION
This changes from a full matrix to an explicit list of configurations. There's
no reason to run flow check on multiple node versions.

Also adds node 7 to the build matrix.