### PR TITLE
Fix require for regenerator-runtime

### DIFF
--- a/scripts/jest/environment.js
+++ b/scripts/jest/environment.js
@@ -1,4 +1,4 @@
-require('regenerator-runtime/runtime');
+require('babel-runtime/regenerator');
 
 /* eslint-disable no-console */
 


### PR DESCRIPTION
`package.json` has a dependency on `babel-runtime` which pulls in
regenerator-runtime. In npm 3 we were able to require `regenerator-runtime`
directly due to flattening, but we should only require what we list in the
package.json directly.

Going the route via babel-runtime helps us keep the runtime and compiler in
sync.