### PR TITLE
Disable node 4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ language: node_js
 install: true
 matrix:
   include:
-  - node_js: '4'
-    env: TEST=.
   - node_js: '6'
     env: TEST=.
   - node_js: '7'
     env: TEST=.
 
-  - node_js: '4'
-    env: TEST=scripts/babel-relay-plugin
   - node_js: '6'
     env: TEST=scripts/babel-relay-plugin
   - node_js: '7'


### PR DESCRIPTION
In order to run travis tests on node 4 we would need to either compile more of
the CI infra with babel or remove syntax features that are not supported by
node 4. Node 4 tests also run a lot slower and occationally segfault on travis
for some reason. Let's disable them for the time being and see if there's a
need.