### PR TITLE
Ensure top level package can't be published

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-relay",
+  "name": "relay",
   "description": "A framework for building data-driven React applications.",
   "version": "1.0.0-alpha.2",
   "license": "BSD-3-Clause",
@@ -64,6 +64,7 @@
     "webpack-stream": "^3.2.0",
     "yargs": "^7.0.2"
   },
+  "private": true,
   "devEngines": {
     "node": ">=4.x",
     "npm": ">=2.x"


### PR DESCRIPTION
The top level package.json doesn't represent an npm package, it represents a mono-repo of packages. Rename to make that clear and add private:true to protect against accidental deploys.