### PR TITLE
Rename __configs__ to configs

### DIFF
--- a/packages/react-relay/classic/traversal/__tests__/checkRelayQueryData-test.js
+++ b/packages/react-relay/classic/traversal/__tests__/checkRelayQueryData-test.js
@@ -423,7 +423,7 @@ describe('checkRelayQueryData', () => {
   it('returns true when `edges` is available on non-connections', () => {
     const records = {
       viewer_id: {
-        '__configs__{named:"some_gk"}': {__dataID__:'configs_id'},
+        'configs{named:"some_gk"}': {__dataID__:'configs_id'},
         __dataID__: 'viewer_id',
       },
       configs_id: {
@@ -444,7 +444,7 @@ describe('checkRelayQueryData', () => {
       Relay.QL`
         query {
           viewer {
-            __configs__(named:"some_gk") {
+            configs(named:"some_gk") {
               edges {
                 node {
                   name

--- a/packages/relay-compiler/testutils/testschema.graphql
+++ b/packages/relay-compiler/testutils/testschema.graphql
@@ -657,7 +657,7 @@ input StoryCommentSearchInput {
 }
 
 type Viewer {
-  __configs__(named: [String]): ConfigsConnection
+  configs(named: [String]): ConfigsConnection
   actor: Actor
   allTimezones: [TimezoneInfo]
   isFbEmployee: Boolean

--- a/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
+++ b/scripts/babel-relay-plugin/src/__fixtures__/metadataConnectionLimitable.fixture
@@ -3,7 +3,7 @@ var Relay = require('react-relay');
 var x = Relay.QL`
   query {
     viewer {
-      __configs__ {
+      configs {
         edges {
           node {
             name
@@ -53,7 +53,7 @@ var x = function () {
         },
         type: 'ConfigsConnectionEdge'
       }],
-      fieldName: '__configs__',
+      fieldName: 'configs',
       kind: 'Field',
       metadata: {
         canHaveSubselections: true

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.graphql
@@ -68,7 +68,7 @@ type ActorSubscribeSubscription {
 }
 
 type Viewer {
-  __configs__: ConfigsConnection
+  configs: ConfigsConnection
   newsFeed(first: Int): NewsFeedConnection
   pendingPosts(first: Int): PendingPostsConnection
   actor: User

--- a/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
+++ b/scripts/babel-relay-plugin/src/__tests__/testschema.rfc.json
@@ -1077,7 +1077,7 @@
           "description": "",
           "fields": [
             {
-              "name": "__configs__",
+              "name": "configs",
               "description": "",
               "args": [],
               "type": {

--- a/scripts/jest/environment.js
+++ b/scripts/jest/environment.js
@@ -10,15 +10,3 @@
 'use strict';
 
 require('babel-runtime/regenerator');
-
-/* eslint-disable no-console */
-
-// TODO(t16118961) remove below once graphql-js updates to suppress this error
-const origError = console.error;
-console.error = (format, ...args) => {
-  if (typeof format === 'string' && format.indexOf('__configs__') >= 0) {
-    // ignore warning about __configs__ being a reserved word
-    return;
-  }
-  origError.call(console, format, ...args);
-};


### PR DESCRIPTION
`__configs__` is a legacy field and shouldn't be used anymore. Trying if we can
rename it in the test schema without breaking too much internally.