### PR TITLE
Update license headers to BSD style

### DIFF
--- a/packages/relay-compiler/codegen/CodegenDirectory.js
+++ b/packages/relay-compiler/codegen/CodegenDirectory.js
@@ -1,5 +1,10 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule CodegenDirectory
  * @flow

--- a/packages/relay-compiler/codegen/FindRelayQL.js
+++ b/packages/relay-compiler/codegen/FindRelayQL.js
@@ -1,5 +1,10 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule FindRelayQL
  * @flow

--- a/packages/relay-compiler/codegen/RelayCodegenWatcher.js
+++ b/packages/relay-compiler/codegen/RelayCodegenWatcher.js
@@ -1,5 +1,10 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule RelayCodegenWatcher
  * @flow

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -1,5 +1,10 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule RelayFileWriter
  * @flow

--- a/packages/relay-compiler/codegen/__tests__/FindRelayQL-test.js
+++ b/packages/relay-compiler/codegen/__tests__/FindRelayQL-test.js
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 'use strict';
 

--- a/packages/relay-compiler/codegen/writeFlowFile.js
+++ b/packages/relay-compiler/codegen/writeFlowFile.js
@@ -1,8 +1,13 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
  *
- * @flow
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
  * @providesModule writeFlowFile
+ * @flow
  */
 
 'use strict';

--- a/packages/relay-compiler/codegen/writeRelayQLFile.js
+++ b/packages/relay-compiler/codegen/writeRelayQLFile.js
@@ -1,8 +1,13 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
  *
- * @flow
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
  * @providesModule writeRelayQLFile
+ * @flow
  */
 
 'use strict';

--- a/packages/relay-compiler/core/ASTConvert.js
+++ b/packages/relay-compiler/core/ASTConvert.js
@@ -1,5 +1,10 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule ASTConvert
  * @flow

--- a/packages/relay-compiler/core/FileParser.js
+++ b/packages/relay-compiler/core/FileParser.js
@@ -1,5 +1,10 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule FileParser
  * @flow

--- a/packages/relay-compiler/core/RelayFileIRParser.js
+++ b/packages/relay-compiler/core/RelayFileIRParser.js
@@ -1,5 +1,10 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule RelayFileIRParser
  * @flow

--- a/packages/relay-compiler/testutils/parseGraphQLText.js
+++ b/packages/relay-compiler/testutils/parseGraphQLText.js
@@ -1,5 +1,10 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule parseGraphQLText
  * @flow

--- a/packages/relay-runtime/util/RelayDefaultHandleKey.js
+++ b/packages/relay-runtime/util/RelayDefaultHandleKey.js
@@ -1,5 +1,10 @@
 /**
- * Copyright 2004-present Facebook. All Rights Reserved.
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule RelayDefaultHandleKey
  * @flow


### PR DESCRIPTION
In the process of open sourcing, we forgot to update the license header in some
places. This fixes the headers.