### PR TITLE
RFC: Use dist/babel-plugin-relay in jest preprocessor

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const BabelPluginRelay = require('../../packages/babel-plugin-relay/BabelPluginRelay.js');
+const BabelPluginRelay = require('../../dist/babel-plugin-relay');
 
 const assign = require('object-assign');
 const babel = require('babel-core');


### PR DESCRIPTION
This allows us to use things like flowtypes and other >ES2015 features in babel-plugin-relay without breaking tests.