### PR TITLE
Better regexp to use for pre-compiled module names.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -135,7 +135,7 @@ const PRODUCTION_HEADER = [
 const buildDist = function(filename, opts, isProduction) {
   const webpackOpts = {
     debug: !isProduction,
-    externals: [/^[-/a-zA-Z0-9]+$/],
+    externals: [/^[-a-z0-9]+(\/.+)?$/],
     target: opts.target,
     node: {
       fs: 'empty',


### PR DESCRIPTION
This regexp runs before transforming module names it seems, so avoid translating normal haste modules.