### PR TITLE
Improve QueryRenderer graphql naming convention

### DIFF
--- a/docs/modern/QueryRenderer.md
+++ b/docs/modern/QueryRenderer.md
@@ -40,3 +40,7 @@ const {
   }}
 />
 ```
+
+### Query naming convention
+
+`relay-compiler` is enforcing a naming convention for your queries of `FileName|OperationType`. So for the above example to be valid, the code is expected to be saved into a file called `Example.js`.

--- a/docs/modern/QueryRenderer.md
+++ b/docs/modern/QueryRenderer.md
@@ -43,4 +43,4 @@ const {
 
 ### Query naming convention
 
-`relay-compiler` is enforcing a naming convention for your queries of `FileName|OperationType`. So for the above example to be valid, the code is expected to be saved into a file called `Example.js`.
+To enable [compatibility mode](./relay-compat.html), `relay-compiler` enforces a simple naming convention for your queries. Queries must be named as `<FileName><OperationType>`, where "<OperationType>" is one of "Query", "Mutation", or "Subscription". The query above is named `ExampleQuery` so should be placed in `Example.js`.


### PR DESCRIPTION
I've been playing a little bit with the release candidate and I was stuck on the relay compiler failing to parse the file. After checking the source code of the compiler I realised that it has a strict check on the expected query name. 

I'm adding a small paragraph trying my best to explain how it works to avoid some confustion. In the case that someone in Facebook has had the time to improve documentations feel free to close the PR.