### PR TITLE
Remove compat wrappers from Relay Modern

### DIFF
--- a/packages/react-relay/compat/__tests__/RelayCompatFragmentContainer-test.js
+++ b/packages/react-relay/compat/__tests__/RelayCompatFragmentContainer-test.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+jest.autoMockOff();
+
+const RelayCompatFragmentContainer = require('RelayCompatContainer');
+const RelayStaticTestUtils = require('RelayStaticTestUtils');
+
+describe('RelayCompatFragmentContainer', () => {
+  beforeEach(() => {
+    jasmine.addMatchers(RelayStaticTestUtils.matchers);
+  });
+
+  it('throws for invalid fragments', () => {
+    expect(() => {
+      const TestComponent = () => <div />;
+      RelayCompatFragmentContainer.createContainer(TestComponent, {
+        foo: null,
+      });
+    }).toFailInvariant(
+      'ReactRelayCompatContainerBuilder: Could not create container for ' +
+      '`TestComponent`. The value of fragment `foo` was expected to be a ' +
+      'fragment, got `null` instead.'
+    );
+  });
+});

--- a/packages/react-relay/compat/react/RelayCompatContainer.js
+++ b/packages/react-relay/compat/react/RelayCompatContainer.js
@@ -19,6 +19,13 @@ const {buildCompatContainer} = require('ReactRelayCompatContainerBuilder');
 import type {GeneratedNodeMap} from 'ReactRelayTypes';
 import type {GraphQLTaggedNode} from 'RelayStaticGraphQLTag';
 
+/**
+ * Wrap the basic `createContainer()` function with logic to adapt to the
+ * `context.relay.environment` in which it is rendered. Specifically, the
+ * extraction of the environment-specific version of fragments in the
+ * `fragmentSpec` is memoized once per environment, rather than once per
+ * instance of the container constructed/rendered.
+ */
 function createContainer<TBase: ReactClass<*>>(
   Component: TBase,
   fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
@@ -26,7 +33,7 @@ function createContainer<TBase: ReactClass<*>>(
   return buildCompatContainer(
     Component,
     (fragmentSpec: any),
-    ReactRelayFragmentContainer.createContainerWithFragments,
+    ReactRelayFragmentContainer.createContainer,
   );
 }
 

--- a/packages/react-relay/compat/react/RelayCompatPaginationContainer.js
+++ b/packages/react-relay/compat/react/RelayCompatPaginationContainer.js
@@ -20,6 +20,13 @@ import type {ConnectionConfig} from 'ReactRelayPaginationContainer';
 import type {GeneratedNodeMap} from 'ReactRelayTypes';
 import type {GraphQLTaggedNode} from 'RelayStaticGraphQLTag';
 
+/**
+ * Wrap the basic `createContainer()` function with logic to adapt to the
+ * `context.relay.environment` in which it is rendered. Specifically, the
+ * extraction of the environment-specific version of fragments in the
+ * `fragmentSpec` is memoized once per environment, rather than once per
+ * instance of the container constructed/rendered.
+ */
 function createContainer<TBase: ReactClass<*>>(
   Component: TBase,
   fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
@@ -29,7 +36,7 @@ function createContainer<TBase: ReactClass<*>>(
     Component,
     (fragmentSpec: any),
     (ComponentClass, fragments) => {
-      return ReactRelayPaginationContainer.createContainerWithFragments(
+      return ReactRelayPaginationContainer.createContainer(
         ComponentClass,
         fragments,
         connectionConfig,

--- a/packages/react-relay/compat/react/RelayCompatRefetchContainer.js
+++ b/packages/react-relay/compat/react/RelayCompatRefetchContainer.js
@@ -19,6 +19,13 @@ const {buildCompatContainer} = require('ReactRelayCompatContainerBuilder');
 import type {GeneratedNodeMap} from 'ReactRelayTypes';
 import type {GraphQLTaggedNode} from 'RelayStaticGraphQLTag';
 
+/**
+ * Wrap the basic `createContainer()` function with logic to adapt to the
+ * `context.relay.environment` in which it is rendered. Specifically, the
+ * extraction of the environment-specific version of fragments in the
+ * `fragmentSpec` is memoized once per environment, rather than once per
+ * instance of the container constructed/rendered.
+ */
 function createContainer<TBase: ReactClass<*>>(
   Component: TBase,
   fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
@@ -28,7 +35,7 @@ function createContainer<TBase: ReactClass<*>>(
     Component,
     (fragmentSpec: any),
     (ComponentClass, fragments) => {
-      return ReactRelayRefetchContainer.createContainerWithFragments(
+      return ReactRelayRefetchContainer.createContainer(
         ComponentClass,
         fragments,
         taggedNode,

--- a/packages/react-relay/modern/ReactRelayFragmentContainer.js
+++ b/packages/react-relay/modern/ReactRelayFragmentContainer.js
@@ -21,15 +21,13 @@ const isRelayContext = require('isRelayContext');
 const isScalarAndEqual = require('isScalarAndEqual');
 const nullthrows = require('nullthrows');
 
-const {buildCompatContainer} = require('ReactRelayCompatContainerBuilder');
 const {profileContainer} = require('ReactRelayContainerProfiler');
 const {getComponentName, getReactComponent} = require('RelayContainerUtils');
 
-import type {GeneratedNodeMap, RelayProp} from 'ReactRelayTypes';
+import type {RelayProp} from 'ReactRelayTypes';
 import type {
   FragmentSpecResolver,
 } from 'RelayCombinedEnvironmentTypes';
-import type {GraphQLTaggedNode} from 'RelayStaticGraphQLTag';
 import type {
   FragmentMap,
   RelayContext,
@@ -49,7 +47,7 @@ const containerContextTypes = {
  * props, resolving them with the provided fragments and subscribing for
  * updates.
  */
-function createContainerWithFragments<TDefaultProps, TProps>(
+function createContainer<TDefaultProps, TProps>(
   Component: Class<React.Component<TDefaultProps, TProps, *>> | ReactClass<TProps>,
   fragments: FragmentMap,
 ): Class<React.Component<TDefaultProps, TProps, *>> {
@@ -184,25 +182,4 @@ function assertRelayContext(relay: mixed): RelayContext {
   return (relay: any);
 }
 
-/**
- * Wrap the basic `createContainer()` function with logic to adapt to the
- * `context.relay.environment` in which it is rendered. Specifically, the
- * extraction of the environment-specific version of fragments in the
- * `fragmentSpec` is memoized once per environment, rather than once per
- * instance of the container constructed/rendered.
- */
-function createContainer<TBase: ReactClass<*>>(
-  Component: TBase,
-  fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
-): TBase {
-  return buildCompatContainer(
-    Component,
-    (fragmentSpec: any),
-    createContainerWithFragments,
-  );
-}
-
-module.exports = {
-  createContainer,
-  createContainerWithFragments,
-};
+module.exports = {createContainer};

--- a/packages/react-relay/modern/ReactRelayPaginationContainer.js
+++ b/packages/react-relay/modern/ReactRelayPaginationContainer.js
@@ -23,7 +23,6 @@ const isScalarAndEqual = require('isScalarAndEqual');
 const nullthrows = require('nullthrows');
 const warning = require('warning');
 
-const {buildCompatContainer} = require('ReactRelayCompatContainerBuilder');
 const {profileContainer} = require('ReactRelayContainerProfiler');
 const {
   EDGES,
@@ -36,7 +35,6 @@ const {
 const {getComponentName, getReactComponent} = require('RelayContainerUtils');
 
 import type {
-  GeneratedNodeMap,
   RefetchOptions,
   RelayPaginationProp,
 } from 'ReactRelayTypes';
@@ -86,12 +84,12 @@ export type ConnectionData = {
 };
 
 /**
- * Extends the functionality of RelayCompatContainer by providing a mechanism
+ * Extends the functionality of RelayFragmentContainer by providing a mechanism
  * to load more data from a connection.
  *
  * # Configuring a PaginationContainer
  *
- * PaginationContainer accepts the standard CompatContainer arguments and an
+ * PaginationContainer accepts the standard FragmentContainer arguments and an
  * additional `connectionConfig` argument:
  *
  * - `Component`: the component to be wrapped/rendered.
@@ -286,7 +284,7 @@ function findConnectionMetadata(fragments): ReactConnectionMetadata {
   return foundConnectionMetadata || ({}: any);
 }
 
-function createContainerWithFragments<TDefaultProps, TProps>(
+function createContainer<TDefaultProps, TProps>(
   Component: Class<React.Component<TDefaultProps, TProps, *>> | ReactClass<TProps>,
   fragments: FragmentMap,
   connectionConfig: ConnectionConfig,
@@ -695,28 +693,4 @@ function assertRelayContext(relay: mixed): RelayContext {
   return (relay: any);
 }
 
-/**
- * Wrap the basic `createContainer()` function with logic to adapt to the
- * `context.relay.environment` in which it is rendered. Specifically, the
- * extraction of the environment-specific version of fragments in the
- * `fragmentSpec` is memoized once per environment, rather than once per
- * instance of the container constructed/rendered.
- */
-function createContainer<TBase: ReactClass<*>>(
-  Component: TBase,
-  fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
-  connectionConfig: ConnectionConfig,
-): TBase {
-  return buildCompatContainer(
-    Component,
-    (fragmentSpec: any),
-    (ComponentClass, fragments) => {
-      return createContainerWithFragments(ComponentClass, fragments, connectionConfig);
-    },
-  );
-}
-
-module.exports = {
-  createContainer,
-  createContainerWithFragments,
-};
+module.exports = {createContainer};

--- a/packages/react-relay/modern/ReactRelayRefetchContainer.js
+++ b/packages/react-relay/modern/ReactRelayRefetchContainer.js
@@ -22,12 +22,10 @@ const isRelayContext = require('isRelayContext');
 const isScalarAndEqual = require('isScalarAndEqual');
 const nullthrows = require('nullthrows');
 
-const {buildCompatContainer} = require('ReactRelayCompatContainerBuilder');
 const {profileContainer} = require('ReactRelayContainerProfiler');
 const {getComponentName, getReactComponent} = require('RelayContainerUtils');
 
 import type {
-  GeneratedNodeMap,
   RefetchOptions,
   RelayRefetchProp,
 } from 'ReactRelayTypes';
@@ -57,7 +55,7 @@ const containerContextTypes = {
  * props, resolving them with the provided fragments and subscribing for
  * updates.
  */
-function createContainerWithFragments<TDefaultProps, TProps>(
+function createContainer<TDefaultProps, TProps>(
   Component: Class<React.Component<TDefaultProps, TProps, *>> | ReactClass<TProps>,
   fragments: FragmentMap,
   taggedNode: GraphQLTaggedNode,
@@ -302,28 +300,4 @@ function assertRelayContext(relay: mixed): RelayContext {
   return (relay: any);
 }
 
-/**
- * Wrap the basic `createContainer()` function with logic to adapt to the
- * `context.relay.environment` in which it is rendered. Specifically, the
- * extraction of the environment-specific version of fragments in the
- * `fragmentSpec` is memoized once per environment, rather than once per
- * instance of the container constructed/rendered.
- */
-function createContainer<TBase: ReactClass<*>>(
-  Component: TBase,
-  fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
-  taggedNode: GraphQLTaggedNode,
-): TBase {
-  return buildCompatContainer(
-    Component,
-    (fragmentSpec: any),
-    (ComponentClass, fragments) => {
-      return createContainerWithFragments(ComponentClass, fragments, taggedNode);
-    },
-  );
-}
-
-module.exports = {
-  createContainer,
-  createContainerWithFragments,
-};
+module.exports = {createContainer};

--- a/packages/react-relay/modern/__tests__/ReactRelayFragmentContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayFragmentContainer-test.js
@@ -133,18 +133,6 @@ describe('ReactRelayFragmentContainer', () => {
     expect(TestContainer.displayName).toBe('Relay(TestComponent)');
   });
 
-  it('throws for invalid fragments', () => {
-    expect(() => {
-      ReactRelayFragmentContainer.createContainer(TestComponent, {
-        foo: null,
-      });
-    }).toFailInvariant(
-      'ReactRelayCompatContainerBuilder: Could not create container for ' +
-      '`TestComponent`. The value of fragment `foo` was expected to be a ' +
-      'fragment, got `null` instead.'
-    );
-  });
-
   it('passes non-fragment props to the component', () => {
     ReactTestRenderer.create(
       <ContextSetter environment={environment} variables={variables}>

--- a/packages/react-relay/modern/__tests__/ReactRelayPaginationContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayPaginationContainer-test.js
@@ -211,18 +211,6 @@ describe('ReactRelayPaginationContainer', () => {
     expect(TestContainer.displayName).toBe('Relay(TestComponent)');
   });
 
-  it('throws for invalid fragments', () => {
-    expect(() => {
-      ReactRelayPaginationContainer.createContainer(TestComponent, {
-        foo: null,
-      });
-    }).toFailInvariant(
-      'ReactRelayCompatContainerBuilder: Could not create container for ' +
-      '`TestComponent`. The value of fragment `foo` was expected to be a ' +
-      'fragment, got `null` instead.'
-    );
-  });
-
   it('passes non-fragment props to the component', () => {
     ReactTestRenderer.create(
       <ContextSetter environment={environment} variables={variables}>

--- a/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
@@ -140,18 +140,6 @@ describe('ReactRelayRefetchContainer', () => {
     expect(TestContainer.displayName).toBe('Relay(TestComponent)');
   });
 
-  it('throws for invalid fragments', () => {
-    expect(() => {
-      ReactRelayRefetchContainer.createContainer(TestComponent, {
-        foo: null,
-      });
-    }).toFailInvariant(
-      'ReactRelayCompatContainerBuilder: Could not create container for ' +
-      '`TestComponent`. The value of fragment `foo` was expected to be a ' +
-      'fragment, got `null` instead.'
-    );
-  });
-
   it('passes non-fragment props to the component', () => {
     ReactTestRenderer.create(
       <ContextSetter environment={environment} variables={variables}>


### PR DESCRIPTION
It looks like during extraction of Modern from our Compat packages that we mistakenly left compat wrappers around Relay Modern code. This cleans that up.

Fixes #1631