### PR TITLE
Improve error messages from assertFragmentMap()

### DIFF
--- a/packages/react-relay/classic/query/RelayGraphQLTag.js
+++ b/packages/react-relay/classic/query/RelayGraphQLTag.js
@@ -79,7 +79,10 @@ function getClassicFragment(
   const fragment = QueryBuilder.getFragmentDefinition(concreteNode);
   invariant(
     fragment,
-    'RelayGraphQLTag: Expected a fragment, got `%s`.',
+    'RelayGraphQLTag: Expected a fragment, got `%s`.\n' +
+    'The "relay" Babel plugin must enable "compat" mode to be used with ' +
+    '"react-relay/compat" or "react-relay/classic".\n' +
+    'See: https://facebook.github.io/relay/docs/babel-plugin-relay.html',
     concreteNode,
   );
   return fragment;
@@ -92,7 +95,10 @@ function getClassicOperation(
   const operation = QueryBuilder.getOperationDefinition(concreteNode);
   invariant(
     operation,
-    'RelayGraphQLTag: Expected an operation, got `%s`.',
+    'RelayGraphQLTag: Expected an operation, got `%s`.\n' +
+    'The "relay" Babel plugin must enable "compat" mode to be used with ' +
+    '"react-relay/compat" or "react-relay/classic".\n' +
+    'See: https://facebook.github.io/relay/docs/babel-plugin-relay.html',
     concreteNode,
   );
   return operation;

--- a/packages/react-relay/compat/ReactRelayCompatContainerBuilder.js
+++ b/packages/react-relay/compat/ReactRelayCompatContainerBuilder.js
@@ -157,11 +157,19 @@ function assertFragmentMap(
   componentName: string,
   fragments: GeneratedNodeMap,
 ): void {
+  invariant(
+    fragments && typeof fragments === 'object',
+    'ReactRelayCompatContainerBuilder: Could not create container for `%s`. ' +
+    'Expected a set of GraphQL fragments, got `%s` instead.',
+    componentName,
+    fragments,
+  );
+
   forEachObject(fragments, (fragment, key) => {
     invariant(
-      typeof fragment === 'object' && fragment !== null,
-      'ReactRelayCompatContainerBuilder: Could not create container for `%s`. The ' +
-      'value of fragment `%s` was expected to be a fragment, got `%s` instead.',
+      fragment && (typeof fragment === 'object' || typeof fragment === 'function'),
+      'ReactRelayCompatContainerBuilder: Could not create container for `%s`. ' +
+      'The value of fragment `%s` was expected to be a fragment, got `%s` instead.',
       componentName,
       key,
       fragment,

--- a/packages/react-relay/modern/__tests__/ReactRelayFragmentContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayFragmentContainer-test.js
@@ -133,6 +133,16 @@ describe('ReactRelayFragmentContainer', () => {
     expect(TestContainer.displayName).toBe('Relay(TestComponent)');
   });
 
+  it('throws for invalid fragment set', () => {
+    expect(() => {
+      ReactRelayFragmentContainer.createContainer(TestComponent, 'a string');
+    }).toFailInvariant(
+      'ReactRelayCompatContainerBuilder: Could not create container for ' +
+      '`TestComponent`. Expected a set of GraphQL fragments, got `a string` ' +
+      'instead.'
+    );
+  });
+
   it('throws for invalid fragments', () => {
     expect(() => {
       ReactRelayFragmentContainer.createContainer(TestComponent, {
@@ -143,6 +153,14 @@ describe('ReactRelayFragmentContainer', () => {
       '`TestComponent`. The value of fragment `foo` was expected to be a ' +
       'fragment, got `null` instead.'
     );
+  });
+
+  it('does not throw when fragments are in modern mode', () => {
+    expect(() => {
+      ReactRelayFragmentContainer.createContainer(TestComponent, {
+        foo: () => ({ kind: 'Fragment' }),
+      });
+    }).not.toThrow();
   });
 
   it('passes non-fragment props to the component', () => {


### PR DESCRIPTION
This adds additional error messages to compat container builder, especially highlighting a common problem of using compat containers while not enabling compat in the babel transform.