### PR TITLE
add extensions option to relay-compiler

### DIFF
--- a/packages/relay-compiler/core/RelayFileIRParser.js
+++ b/packages/relay-compiler/core/RelayFileIRParser.js
@@ -26,7 +26,7 @@ import type {DocumentNode} from 'graphql';
 // Throws an error if parsing the file fails
 function parseFile(file: string): ?DocumentNode {
   const text = fs.readFileSync(file, 'utf8');
-  const moduleName = path.basename(file, '.js');
+  const moduleName = path.basename(file, path.extname(file));
 
   invariant(
     text.indexOf('graphql') >= 0,


### PR DESCRIPTION
Allows you to pass an extensions argument to relay compiler. A lot of people use alternative extensions like `.jsx` for React components. I followed the convention of `jscodeshift` of making the extensions comma separated.

```
relay-compiler --src ./src/ --schema schema.graphql --extensions=js,jsx
```