### PR TITLE
Fix travis tests for RelayFlowGenerator

### DIFF
--- a/packages/relay-compiler/core/RelayFlowGenerator.js
+++ b/packages/relay-compiler/core/RelayFlowGenerator.js
@@ -88,7 +88,9 @@ function selectionsToBabel(selections) {
     onlySelectsTypename(baseFields) &&
     (
       hasTypenameSelection(baseFields) ||
-      Object.values(byConcreteType).every(hasTypenameSelection)
+      Object.keys(byConcreteType).every(
+        type => hasTypenameSelection(byConcreteType[type])
+      )
     )
   ) {
     for (const concreteType in byConcreteType) {


### PR DESCRIPTION
Only Node 7+ has the recently added Object.values() method. Use Object.keys() which has been around for a while.