### PR TITLE
PaginationContainer docs are missing data

### DIFF
--- a/docs/modern/PaginationContainer.md
+++ b/docs/modern/PaginationContainer.md
@@ -127,6 +127,10 @@ module.exports = createPaginationContainer(
     `,
   },
   {
+    direction: 'forward',
+    getConnectionFromProps(props) {
+      return props.user && props.user.feed;
+    },
     getFragmentVariables(prevVars, totalCount) {
       return {
         ...prevVars,


### PR DESCRIPTION
ReactRelayPaginationContainer will throw an invariant:
`Unable to synthesize a getConnectionFromProps function.` 

... if you do not specify `getConnectionFromProps()` and `direction`