### PR TITLE
Add content-type header to network layer example

### DIFF
--- a/docs/modern/NetworkLayer.md
+++ b/docs/modern/NetworkLayer.md
@@ -26,7 +26,10 @@ function fetchQuery(
 ) {
   return fetch('/graphql', {
     method: 'POST',
-    headers: {}, // Add authentication and other headers here
+    headers: {
+      // Add authentication and other headers here
+      'content-type': 'application/json'
+    },
     body: JSON.stringify({
       query: operation.text, // GraphQL text from input
       variables,


### PR DESCRIPTION
graphql-js will treat requests with no content-type as form-encoded. Since the example is sending JSON, add a content-type header to the request.