### PR TITLE
Ignore node_modules while compiling queries

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -37,6 +37,7 @@ const WATCH_EXPRESSION = [
   'allof',
   ['type', 'f'],
   ['suffix', 'js'],
+  ['not', ['match', 'node_modules/**', 'wholename']],
   ['not', ['match', '**/__mocks__/**', 'wholename']],
   ['not', ['match', '**/__tests__/**', 'wholename']],
   ['not', ['match', '**/__generated__/**', 'wholename']],

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -37,7 +37,7 @@ const WATCH_EXPRESSION = [
   'allof',
   ['type', 'f'],
   ['suffix', 'js'],
-  ['not', ['match', 'node_modules/**', 'wholename']],
+  ['not', ['match', '**/node_modules/**', 'wholename']],
   ['not', ['match', '**/__mocks__/**', 'wholename']],
   ['not', ['match', '**/__tests__/**', 'wholename']],
   ['not', ['match', '**/__generated__/**', 'wholename']],


### PR DESCRIPTION
This prevents nonintuitive errors like `'createRefetchContainer' expects a second argument of fragment definitions.` when using the project root (including node_modules) as source directory.


(fixes #1635)