### PR TITLE
Allow non null connections

### DIFF
--- a/packages/relay-compiler/core/RelaySchemaUtils.js
+++ b/packages/relay-compiler/core/RelaySchemaUtils.js
@@ -204,7 +204,7 @@ function isSchemaDefinitionAST(ast: ASTNode): boolean %checks {
   );
 }
 
-function assertTypeWithFields(type: GraphQLType): GraphQLObjectType | GraphQLInterfaceType {
+function assertTypeWithFields(type: ?GraphQLType): GraphQLObjectType | GraphQLInterfaceType {
   invariant(
     type instanceof GraphQLObjectType ||
     type instanceof GraphQLInterfaceType,

--- a/packages/relay-compiler/handlers/connection/RelayConnectionTransform.js
+++ b/packages/relay-compiler/handlers/connection/RelayConnectionTransform.js
@@ -253,7 +253,9 @@ function generateConnectionFragment(
   context: RelayCompilerContext,
   type: GraphQLType
 ): InlineFragment {
-  const compositeType = assertCompositeType(type);
+  const compositeType = assertCompositeType(
+    RelaySchemaUtils.getNullableType((type: $FlowFixMe))
+  );
   const ast = GraphQL.parse(`
     fragment ConnectionFragment on ${String(compositeType)} {
       ${EDGES} {
@@ -347,7 +349,9 @@ function validateConnectionType(
   definitionName: string,
   type: GraphQLType,
 ): void {
-  const typeWithFields = RelaySchemaUtils.assertTypeWithFields(type);
+  const typeWithFields = RelaySchemaUtils.assertTypeWithFields(
+    RelaySchemaUtils.getNullableType((type: $FlowFixMe))
+  );
   const typeFields = typeWithFields.getFields();
   const edges = typeFields[EDGES];
 


### PR DESCRIPTION
`GraphQLNonNull<Connection>` caused relay compiler errors. This adds a few more `getNullableType` to make sure it works with non nullable fields.

Had some issues getting it to pass flow properly and had to change the signature of `getNullableType` because of some incompatible type errors. Since this is in the graphql-js package I just copied it in for now and if the change seems fine I can PR on the graphql-js  repo and remove it when updated.