### PR TITLE
Update childContext to include new variables in RefetchContainer

### DIFF
--- a/packages/react-relay/compat/react/RelayCompatRefetchContainer.js
+++ b/packages/react-relay/compat/react/RelayCompatRefetchContainer.js
@@ -14,6 +14,7 @@
 'use strict';
 
 const ReactRelayRefetchContainer = require('ReactRelayRefetchContainer');
+const RelayPropTypes = require('RelayPropTypes');
 
 const {buildCompatContainer} = require('ReactRelayCompatContainerBuilder');
 
@@ -32,7 +33,7 @@ function createContainer<TBase: ReactClass<*>>(
   fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
   taggedNode: GraphQLTaggedNode,
 ): TBase {
-  return buildCompatContainer(
+  const Container = buildCompatContainer(
     Component,
     (fragmentSpec: any),
     (ComponentClass, fragments) => {
@@ -43,6 +44,10 @@ function createContainer<TBase: ReactClass<*>>(
       );
     },
   );
+  Container.childContextTypes = {
+    relay: RelayPropTypes.Relay,
+  };
+  return Container;
 }
 
 module.exports = {createContainer};

--- a/packages/react-relay/modern/ReactRelayRefetchContainer.js
+++ b/packages/react-relay/modern/ReactRelayRefetchContainer.js
@@ -67,6 +67,7 @@ function createContainerWithFragments<TBase: ReactClass<*>>(
     _localVariables: ?Variables;
     _pendingRefetch: ?Disposable;
     _references: Array<Disposable>;
+    _relayContext: RelayContext;
     _resolver: FragmentSpecResolver;
 
     constructor(props, context) {

--- a/packages/react-relay/modern/ReactRelayRefetchContainer.js
+++ b/packages/react-relay/modern/ReactRelayRefetchContainer.js
@@ -271,6 +271,15 @@ function createContainerWithFragments<TBase: ReactClass<*>>(
       };
     };
 
+    getChildContext(): Object {
+      return {
+        relay: {
+          environment: this.context.relay.environment,
+          variables: this._localVariables || this.context.relay.variables,
+        },
+      };
+    }
+
     render() {
       if (ComponentClass) {
         return (
@@ -320,12 +329,14 @@ function createContainer<TBase: ReactClass<*>>(
   fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
   taggedNode: GraphQLTaggedNode,
 ): TBase {
-  return buildReactRelayContainer(
+  const Container = buildReactRelayContainer(
     Component,
     fragmentSpec,
     (ComponentClass, fragments) =>
       createContainerWithFragments(ComponentClass, fragments, taggedNode),
   );
+  Container.childContextTypes = containerContextTypes;
+  return Container;
 }
 
 module.exports = {createContainer, createContainerWithFragments};

--- a/packages/react-relay/modern/ReactRelayRefetchContainer.js
+++ b/packages/react-relay/modern/ReactRelayRefetchContainer.js
@@ -121,6 +121,10 @@ function createContainerWithFragments<TBase: ReactClass<*>>(
       ) {
         this._release();
         this._localVariables = null;
+        this._relayContext = {
+          environment: relay.environment,
+          variables: relay.variables
+        };
         this._resolver = createFragmentSpecResolver(
           relay,
           containerName,

--- a/packages/react-relay/modern/ReactRelayRefetchContainer.js
+++ b/packages/react-relay/modern/ReactRelayRefetchContainer.js
@@ -83,6 +83,10 @@ function createContainerWithFragments<TBase: ReactClass<*>>(
         props,
         this._handleFragmentDataUpdate,
       );
+      this._relayContext = {
+        environment: this.context.relay.environment,
+        variables: this.context.relay.variables,
+      };
       this.state = {
         data: this._resolver.resolve(),
         relayProp: this._buildRelayProp(relay),
@@ -225,6 +229,10 @@ function createContainerWithFragments<TBase: ReactClass<*>>(
         }
         // TODO t15106389: add helper utility for fetching more data
         this._pendingRefetch = null;
+        this._relayContext = {
+          environment: this.context.relay.environment,
+          variables: fragmentVariables
+        };
         callback && callback();
         this._resolver.setVariables(fragmentVariables);
         this.setState({data: this._resolver.resolve()});
@@ -272,12 +280,7 @@ function createContainerWithFragments<TBase: ReactClass<*>>(
     };
 
     getChildContext(): Object {
-      return {
-        relay: {
-          environment: this.context.relay.environment,
-          variables: this._localVariables || this.context.relay.variables,
-        },
-      };
+      return {relay: this._relayContext};
     }
 
     render() {

--- a/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
@@ -775,5 +775,36 @@ describe('ReactRelayRefetchContainer', () => {
       expect(references.length).toBe(1);
       expect(references[0].dispose).toBeCalled();
     });
+
+    it('updates child context if updated with new variables', async () => {
+      expect.assertions(2);
+      const refetchVariables = {
+        cond: false,
+        id: '4',
+      };
+      refetch(refetchVariables, null, jest.fn());
+      await environment.mock.resolve(UserQuery, {
+        data: {
+          node: {
+            id: '4',
+            __typename: 'User',
+            name: 'Zuck',
+          },
+        },
+      });
+
+      const updateVariables = {
+        cond: true,
+        id: '842472'
+      };
+      instance.getInstance().setContext(
+        environment,
+        updateVariables
+      );
+
+      expect(relayContext.environment).toBe(environment);
+      expect(relayContext.variables).toEqual(updateVariables);
+    });
+
   });
 });


### PR DESCRIPTION
See https://github.com/facebook/relay/issues/1695. 

```js
<QueryRenderer ... />
  <MyRefetchComponent ... />
    <MyFragmentComponent ... />
  </MyRefetchComponent>
<QueryRenderer>
```

In a structure like this, `MyFragmentComponent` will never be rendered with data fetched by `MyRefetchComponent`