### PR TITLE
Remove nested Argument variable Invariant

### DIFF
--- a/packages/relay-compiler/core/RelayCodeGenerator.js
+++ b/packages/relay-compiler/core/RelayCodeGenerator.js
@@ -18,7 +18,6 @@ const RelaySchemaUtils = require('RelaySchemaUtils');
 
 const formatStorageKey = require('formatStorageKey');
 const invariant = require('invariant');
-const prettyStringify = require('prettyStringify');
 
 import type {
   ConcreteArgument,
@@ -207,15 +206,6 @@ const RelayCodeGenVisitor = {
     },
 
     Argument(node, key, parent, ancestors): ?ConcreteArgument {
-      invariant(
-        ['Variable', 'Literal'].indexOf(node.value.kind) >= 0,
-        'RelayCodeGenerator: Complex argument values (Lists or ' +
-        'InputObjects with nested variables) are not supported, argument ' +
-        '`%s` had value `%s`. Source: %s.',
-        node.name,
-        prettyStringify(node.value),
-        getErrorMessage(ancestors[0])
-      );
       return node.value.value !== null ? node.value : null;
     },
   },


### PR DESCRIPTION
👋  I don't expect to have this merged as is, since it just flat out removes the validation error and doesn't move it. I did think this is probably the clearest way to continue from the twitter conversation yesterday with @KyleAMathews, @wincent and @josephsavona

For some context I have up a POC using RelayModern's compiler to handle query validation and fragment composition in Gatsby https://github.com/gatsbyjs/gatsby/pull/876 We don't use the relay runtime just the tooling to extract and compose queries.

We have this problem where many top-level queries accept complex inputs like 

```graphql
query template_blog_post_Query($slug; String!) {
   markdownRemark(slug: { eq: $slug }) {
      id
      html
    }
}
```

Normally you could simply work around this by doing `slug: $slug` but in this case. the actual values of the arguments are provided via a build/tooling step and can't specify the variables alongside the query. In other words `$slug` is just provided to Pages as variable, and it'd be fairly impractical to provide every possible variant of the inputs.

With regard to this PR i'm happy to move or toggle the validation but I didn't see a good place to do that. so some input is appreciated :)

Thanks ya'll!

_PS. While we are at it, it would also be nice to toggle/disable the naming convention requirements for operations if that isn't required by compiler_