### PR TITLE
Add basic external transformation support to relay-compiler

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -60,6 +60,7 @@ async function run(options: {
   schema: string,
   src: string,
   extensions: Array<string>,
+  transform: Array<string>,
   watch?: ?boolean,
 }) {
   const schemaPath = path.resolve(process.cwd(), options.schema);
@@ -87,7 +88,7 @@ Ensure that one such file exists in ${srcDir} or its parents.
     default: {
       baseDir: srcDir,
       getFileFilter: RelayFileIRParser.getFileFilter,
-      getParser: RelayFileIRParser.getParser,
+      getParser: RelayFileIRParser.getParser(options.transform),
       getSchema: () => getSchema(schemaPath),
       watchmanExpression: buildWatchExpression(options),
     },
@@ -191,6 +192,11 @@ const argv = yargs
       array: true,
       default: ['js'],
       describe: 'File extensions to compile (--extensions js jsx)',
+      type: 'string',
+    },
+    'transform': {
+      array: true,
+      describe: 'Use a transform module on top-level files',
       type: 'string',
     },
     'watch': {


### PR DESCRIPTION
Hello, thanks for the great library. We are using TypeScript for our codebase and it will be very useful to enable custom pre-transformations for a source code before parsing, so we can compile our typescript modules without complex configuration. The PR adds such support.

It is a very basic implementation for discussion purposes.

Proposed usage:

```
yarn add  relay-compiler-typescript
relay-compiler --transform relay-compiler-typescript --extensions ts tsx js jsx
```

You can find example transformer implementation here: https://github.com/s-panferov/relay-compiler-typescript/tree/master