### PR TITLE
Added more useful error message to case when an operation or fragment definition does not have a name.

### DIFF
--- a/packages/relay-compiler/codegen/FindGraphQLTags.js
+++ b/packages/relay-compiler/codegen/FindGraphQLTags.js
@@ -230,6 +230,12 @@ function getSourceTextForLocation(text, loc) {
 function validateTemplate(template, moduleName, keyName) {
   const ast = graphql.parse(template);
   ast.definitions.forEach((def: any) => {
+    invariant(
+      def.name,
+      'FindGraphQLTags: In module `%s`, a definition of kind `%s` requires a name.',
+      moduleName,
+      def.kind,
+    );
     const definitionName = def.name.value;
     if (def.kind === 'OperationDefinition') {
       const operationNameParts =


### PR DESCRIPTION
In response to this issue: https://github.com/facebook/relay/issues/1711