### PR TITLE
filter null plural fields

### DIFF
--- a/packages/react-relay/classic/store/readRelayQueryData.js
+++ b/packages/react-relay/classic/store/readRelayQueryData.js
@@ -225,7 +225,8 @@ class RelayStoreReader extends RelayQueryVisitor<State> {
     if (dataIDs) {
       const applicationName = node.getApplicationName();
       const previousData = getDataValue(state, applicationName);
-      const nextData = dataIDs.map((dataID, ii) => {
+      const nextData = [];
+      dataIDs.forEach((dataID, ii) => {
         let data;
         if (previousData instanceof Object) {
           data = previousData[ii];
@@ -239,11 +240,13 @@ class RelayStoreReader extends RelayQueryVisitor<State> {
           seenDataIDs: state.seenDataIDs,
           storeDataID: dataID,
         });
+        // remove null plural fields
+        if (!nextState.data) {return;}
         node.getChildren().forEach(child => this.visit(child, nextState));
         if (nextState.isPartial) {
           state.isPartial = true;
         }
-        return nextState.data;
+        nextData.push(nextState.data);
       });
       this._setDataValue(state, applicationName, nextData);
     }


### PR DESCRIPTION
Using NODE_DELETE, lists become [null] array with 1 item as per the discussion in https://github.com/facebook/relay/issues/693.

There was a PR for fixing this here: https://github.com/facebook/relay/pull/722 but it was closed and @josephsavona suggested `readRelayQueryData` is the right pace to fix this. Refer: https://github.com/facebook/relay/pull/722#issuecomment-181581707

This looks like a breaking change. Let me know if there is anything i can do to fix this.

cc @yuzhi @josephsavona @jquense @itajaja