### PR TITLE
Fix type of cursor argument in PaginationContainer example

### DIFF
--- a/docs/modern/PaginationContainer.md
+++ b/docs/modern/PaginationContainer.md
@@ -149,7 +149,7 @@ module.exports = createPaginationContainer(
     query: graphql`
       query FeedPaginationQuery(
         $count: Int!
-        $cursor: ID
+        $cursor: String
         $orderby: String!
       ) {
         user {


### PR DESCRIPTION
According to the GraphQL Connection documentation, the implied default type of `cursor` argument is `String`:
https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor

While other types are possible, I think it might be best to default to String as most implementations default to `String` type and it would greatly help newcomers who likely are using these implementations. 

Otherwise, many will encounter the following error:
`Variable "$cursor" of type "ID" used in position expecting type "String".`

See implementations where String type is implemented as default:
[GraphQL Ruby](https://github.com/rmosolgo/graphql-ruby/blob/974be7e7270ad624fde06a124073ec3b72dbaf47/lib/graphql/relay/connection_instrumentation.rb#L12)
[GraphQL Relay JS](https://github.com/graphql/graphql-relay-js/blob/373f2dab5fc6d4ac4cf6394aa94cbebd8cb64650/src/connection/connection.js#L33)
[GraphQL Python](https://github.com/graphql-python/graphene/blob/bd0d418986cf69b51801f8e4d361c0c9a5dbc17c/graphene/relay/connection.py#L100)
[Sangria GrapHQL for Scala](https://github.com/sangria-graphql/sangria-relay/blob/77874af7aac5b0813a99f68d7b3e0681433b0a52/src/main/scala/sangria/relay/Connection.scala#L22)