### PR TITLE
Teach RelayResponseNormalizer to cope with objects vended directly from graphql-js

### DIFF
--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -203,7 +203,7 @@ class RelayResponseNormalizer {
       }
       if (__DEV__) {
         warning(
-          data.hasOwnProperty(responseKey),
+          Object.prototype.hasOwnProperty.call(data, responseKey),
           'RelayResponseNormalizer(): Payload did not contain a value ' +
             'for field `%s: %s`. Check that you are parsing with the same ' +
             'query that was used to fetch the payload.',


### PR DESCRIPTION
Just noticed this line bailing on a side-project of mine under very specific circumstances:

- In `__DEV__` mode.
- In an isomorphic app where the server is directly calling `graphql()` in process (ie. not over HTTP).

Because graphql-js returns objects created with `Object.create(null)`, the usual `hasOwnProperty` method is not available on them and this line was blowing up. Work around that by `call`-ing the original method instead.