### PR TITLE
[RFC] Don't delete invisible files in CodegenDirectory

### DIFF
--- a/packages/relay-compiler/codegen/CodegenDirectory.js
+++ b/packages/relay-compiler/codegen/CodegenDirectory.js
@@ -128,6 +128,10 @@ class CodegenDirectory {
     }
   }
 
+  /**
+   * Deletes all non-generated files, except for invisible "dot" files (ie.
+   * files with names starting with ".").
+   */
   deleteExtraFiles(): void {
     fs.readdirSync(this._dir).forEach(actualFile => {
       if (!this._files.has(actualFile) && !/^\./.test(actualFile)) {

--- a/packages/relay-compiler/codegen/CodegenDirectory.js
+++ b/packages/relay-compiler/codegen/CodegenDirectory.js
@@ -130,7 +130,7 @@ class CodegenDirectory {
 
   deleteExtraFiles(): void {
     fs.readdirSync(this._dir).forEach(actualFile => {
-      if (!this._files.has(actualFile)) {
+      if (!this._files.has(actualFile) && !/^\./.test(actualFile)) {
         if (!this.onlyValidate) {
           fs.unlinkSync(path.join(this._dir, actualFile));
         }


### PR DESCRIPTION
In a side-project, I have put an `.eslintrc` file in my `__generated__` directories in order to stop eslint complaining about the use of `'use strict';` in the generated files. Specifically, it contains:

```
{
  "rules": {
    "strict": [0]
  }
}
```

Running the compiler, however, causes those invisible files to be blown away:

```
Created:
 - FooQuery.graphql.js
Deleted:
 - .eslintrc
 - .eslintrc
```

This commit makes it so that we never delete invisible files (ie. files starting with a dot), which will allow people to stick `.eslintrc`, `.gitignore` etc in their `__generated__` directories without interference. We might want to consider a whitelist approach instead (ie. only delete files with a ".graphql.js" extension), but that would be a more invasive change.