### PR TITLE
Use fragment variables in RefetchContainer docs

### DIFF
--- a/docs/modern/RefetchContainer.md
+++ b/docs/modern/RefetchContainer.md
@@ -71,8 +71,11 @@ class FeedStories extends React.Component {
 module.exports = createRefetchContainer(
   FeedStories,
   {
-    feed: graphql`
-      fragment FeedStories_feed on Feed {
+    feed: graphql.experimental`
+      fragment FeedStories_feed on Feed 
+      @argumentDefinitions(
+        count: {type: "Int", defaultValue: 10}
+      ) {
         stories(first: $count) {
           edges {
             node {
@@ -87,7 +90,7 @@ module.exports = createRefetchContainer(
   graphql`
     query FeedStoriesRefetchQuery($count: Int) {
       feed {
-        ...FeedStories_feed
+        ...FeedStories_feed @arguments(count: $count)
       }
     }
   `,


### PR DESCRIPTION
RefetchContainer and PaginationContainer were designed for use with fragment-local variables. This updates the documentation to reference and use this feature.