### PR TITLE
Add warning: must use QueryRenderer for dynamic initial query

### DIFF
--- a/docs/modern/ConversionPlaybook.md
+++ b/docs/modern/ConversionPlaybook.md
@@ -17,6 +17,8 @@ Install the latest version of Relay from the [getting started guide](./relay-mod
 
 Start converting your components and mutations to use the Relay Modern APIs from the `'react-relay/compat'` module (`createFragmentContainer`, `createRefetchContainer`, `createPaginationContainer`, `commitMutation`). It will be easier to go from the leaf components up. The [conversion scripts](https://github.com/relayjs/relay-codemod) should make this step less tedious.
 
+Note that if your container requires variables that are determined at runtime, [you must use <QueryRenderer> to set the variables](https://github.com/facebook/relay/issues/1770#issuecomment-302175983).
+
 ## Step 2: Introduce <QueryRenderer>
 
 Once all the components and mutations have been converted to use the Relay Modern APIs, convert to using `QueryRenderer` instead of using `Relay.Renderer` or `Relay.RootContainer`. You may supply `Store` from `'react-relay/classic'` as the `environment` for most cases.

--- a/docs/modern/ConversionPlaybook.md
+++ b/docs/modern/ConversionPlaybook.md
@@ -17,7 +17,7 @@ Install the latest version of Relay from the [getting started guide](./relay-mod
 
 Start converting your components and mutations to use the Relay Modern APIs from the `'react-relay/compat'` module (`createFragmentContainer`, `createRefetchContainer`, `createPaginationContainer`, `commitMutation`). It will be easier to go from the leaf components up. The [conversion scripts](https://github.com/relayjs/relay-codemod) should make this step less tedious.
 
-Note that if your container requires variables that are determined at runtime, [you must use <QueryRenderer> to set the variables](https://github.com/facebook/relay/issues/1770#issuecomment-302175983).
+If a fragment uses variables that are determined at runtime, [see below](#note-determining-variable-values-at-runtime).
 
 ## Step 2: Introduce <QueryRenderer>
 
@@ -30,3 +30,10 @@ Once a few or all of your views are using `QueryRenderer`, `Store` from `'react-
 ## Step 4: Clean up by replacing Relay Compat with Relay Modern.
 
 Switch the `'react-relay/compat'` references in your app to `'react-relay'`. This is more of a clean-up step that prevents your app from pulling in unnecessary `'react-relay/classic'` code.
+
+## Note: Determining variable values at runtime
+There is currently only one supported way to set the initial value of a variable dynamically: using global variables defined on the query that includes the fragment (or via `variables` on the `QueryRenderer`).
+
+For example, if `currentDate` is set in `QueryRenderer` `variables`, then $currentDate may be referenced in any fragment included in the `QueryRenderer` `query`.
+
+If you're using `createRefetchContainer` then your `refetch` method may also update these variables to render with new values.


### PR DESCRIPTION
I'd suggest a line like this so that no one runs into the wall I did while trying to convert all my containers via Step 1 before setting up the QueryRenderer per Step 2.

Query variables that are only known at runtime must be set in QueryRenderer so in that case Steps 1 and 2 must be combined.