### PR TITLE
Re-enable tests for QueryRenderer, RefetchContainer, PaginationContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,11 +89,6 @@
       "<rootDir>/node_modules/fbjs-scripts/jest/environment.js",
       "<rootDir>/scripts/jest/environment.js"
     ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/packages/react-relay/modern/__tests__/ReactRelayPaginationContainer-test.js",
-      "<rootDir>/packages/react-relay/modern/__tests__/ReactRelayQueryRenderer-test.js",
-      "<rootDir>/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js"
-    ],
     "timers": "fake",
     "transform": {
       ".*": "<rootDir>/scripts/jest/preprocessor.js"

--- a/packages/react-relay/modern/__tests__/ReactRelayPaginationContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayPaginationContainer-test.js
@@ -645,10 +645,10 @@ describe('ReactRelayPaginationContainer', () => {
       expect(hasMore()).toBe(false);
     });
 
-    it('updates after pagination (if more results)', () => {
+    it('updates after pagination (if more results)', async () => {
       expect.assertions(1);
       loadMore(1, jest.fn());
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             __typename: 'User',
@@ -672,15 +672,14 @@ describe('ReactRelayPaginationContainer', () => {
             },
           },
         },
-      }).then(() => {
-        expect(hasMore()).toBe(true);
       });
+      expect(hasMore()).toBe(true);
     });
 
-    it('updates after pagination (if no more results)', () => {
+    it('updates after pagination (if no more results)', async () => {
       expect.assertions(1);
       loadMore(1, jest.fn());
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             __typename: 'User',
@@ -704,9 +703,8 @@ describe('ReactRelayPaginationContainer', () => {
             },
           },
         },
-      }).then(() => {
-        expect(hasMore()).toBe(false);
       });
+      expect(hasMore()).toBe(false);
     });
   });
 
@@ -739,10 +737,10 @@ describe('ReactRelayPaginationContainer', () => {
       expect(isLoading()).toBe(false);
     });
 
-    it('returns false once a fetch completes', () => {
+    it('returns false once a fetch completes', async () => {
       expect.assertions(1);
       loadMore(1, jest.fn());
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
@@ -751,9 +749,8 @@ describe('ReactRelayPaginationContainer', () => {
             friends: null,
           },
         },
-      }).then(() => {
-        expect(isLoading()).toBe(false);
       });
+      expect(isLoading()).toBe(false);
     });
   });
 
@@ -881,7 +878,7 @@ describe('ReactRelayPaginationContainer', () => {
       ).toBe(true);
     });
 
-    it('calls the callback when the fetch succeeds', () => {
+    it('calls the callback when the fetch succeeds', async () => {
       expect.assertions(2);
       const callback = jest.fn();
       variables = {
@@ -890,35 +887,32 @@ describe('ReactRelayPaginationContainer', () => {
         id: '4',
       };
       loadMore(1, callback);
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: null,
         },
-      }).then(() => {
-        expect(callback.mock.calls.length).toBe(1);
-        expect(callback.mock.calls[0].length).toBe(0);
       });
+      expect(callback.mock.calls.length).toBe(1);
+      expect(callback.mock.calls[0].length).toBe(0);
     });
 
-    it('calls the callback when the fetch fails', () => {
+    it('calls the callback when the fetch fails', async () => {
       expect.assertions(2);
       const callback = jest.fn();
       loadMore(1, callback);
       const error = new Error('oops');
-      return environment.mock.reject(UserQuery, error)
-        .then(() => {
-          expect(callback.mock.calls.length).toBe(1);
-          expect(callback).toBeCalledWith(error);
-        });
+      await environment.mock.reject(UserQuery, error);
+      expect(callback.mock.calls.length).toBe(1);
+      expect(callback).toBeCalledWith(error);
     });
 
-    it('renders with the results of the new variables on success', () => {
+    it('renders with the results of the new variables on success', async () => {
       expect.assertions(5);
       expect(render.mock.calls.length).toBe(1);
       expect(render.mock.calls[0][0].user.friends.edges.length).toBe(1);
       loadMore(1, jest.fn());
       expect(render.mock.calls.length).toBe(1);
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
@@ -942,20 +936,17 @@ describe('ReactRelayPaginationContainer', () => {
             },
           },
         },
-      }).then(() => {
-        expect(render.mock.calls.length).toBe(2);
-        expect(render.mock.calls[1][0].user.friends.edges.length).toBe(2);
       });
+      expect(render.mock.calls.length).toBe(2);
+      expect(render.mock.calls[1][0].user.friends.edges.length).toBe(2);
     });
 
-    it('does not update variables on failure', () => {
+    it('does not update variables on failure', async () => {
       expect.assertions(1);
       render.mockClear();
       loadMore(1, jest.fn());
-      return environment.mock.reject(UserQuery, new Error('oops'))
-        .then(() => {
-          expect(render.mock.calls.length).toBe(0);
-        });
+      await environment.mock.reject(UserQuery, new Error('oops'));
+      expect(render.mock.calls.length).toBe(0);
     });
 
     it('continues the fetch if new props refer to the same records', () => {
@@ -986,10 +977,10 @@ describe('ReactRelayPaginationContainer', () => {
       expect(dispose).toBeCalled();
     });
 
-    it('holds pagination results if new props refer to the same records', () => {
+    it('holds pagination results if new props refer to the same records', async () => {
       expect.assertions(2);
       loadMore(1, jest.fn());
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
@@ -998,22 +989,21 @@ describe('ReactRelayPaginationContainer', () => {
             friends: null,
           },
         },
-      }).then(() => {
-        const userPointer = environment.lookup({
-          dataID: ROOT_ID,
-          node: UserQuery.fragment,
-          variables, // same user
-        }).data.node;
-        instance.getInstance().setProps({user: userPointer});
-        expect(references.length).toBe(1);
-        expect(references[0].dispose).not.toBeCalled();
       });
+      const userPointer = environment.lookup({
+        dataID: ROOT_ID,
+        node: UserQuery.fragment,
+        variables, // same user
+      }).data.node;
+      instance.getInstance().setProps({user: userPointer});
+      expect(references.length).toBe(1);
+      expect(references[0].dispose).not.toBeCalled();
     });
 
-    it('releases pagination results if new props refer to different records', () => {
+    it('releases pagination results if new props refer to different records', async () => {
       expect.assertions(2);
       loadMore(1, jest.fn());
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
@@ -1022,20 +1012,19 @@ describe('ReactRelayPaginationContainer', () => {
             friends: null,
           },
         },
-      }).then(() => {
-        const userPointer = environment.lookup({
-          dataID: ROOT_ID,
-          node: UserQuery.fragment,
-          variables: {
-            after: null,
-            first: 1,
-            id: '842472', // different user
-          },
-        }).data.node;
-        instance.getInstance().setProps({user: userPointer});
-        expect(references.length).toBe(1);
-        expect(references[0].dispose).toBeCalled();
       });
+      const userPointer = environment.lookup({
+        dataID: ROOT_ID,
+        node: UserQuery.fragment,
+        variables: {
+          after: null,
+          first: 1,
+          id: '842472', // different user
+        },
+      }).data.node;
+      instance.getInstance().setProps({user: userPointer});
+      expect(references.length).toBe(1);
+      expect(references[0].dispose).toBeCalled();
     });
   });
 
@@ -1124,7 +1113,7 @@ describe('ReactRelayPaginationContainer', () => {
       ).toBe(true);
     });
 
-    it('calls the callback when the fetch succeeds', () => {
+    it('calls the callback when the fetch succeeds', async () => {
       expect.assertions(2);
       const callback = jest.fn();
       variables = {
@@ -1132,35 +1121,32 @@ describe('ReactRelayPaginationContainer', () => {
         id: '4',
       };
       refetchConnection(1, callback);
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: null,
         },
-      }).then(() => {
-        expect(callback.mock.calls.length).toBe(1);
-        expect(callback.mock.calls[0].length).toBe(0);
       });
+      expect(callback.mock.calls.length).toBe(1);
+      expect(callback.mock.calls[0].length).toBe(0);
     });
 
-    it('calls the callback when the fetch fails', () => {
+    it('calls the callback when the fetch fails', async () => {
       expect.assertions(2);
       const callback = jest.fn();
       refetchConnection(1, callback);
       const error = new Error('oops');
-      return environment.mock.reject(UserQuery, error)
-        .then(() => {
-          expect(callback.mock.calls.length).toBe(1);
-          expect(callback).toBeCalledWith(error);
-        });
+      await environment.mock.reject(UserQuery, error);
+      expect(callback.mock.calls.length).toBe(1);
+      expect(callback).toBeCalledWith(error);
     });
 
-    it('renders with the results of the new variables on success', () => {
+    it('renders with the results of the new variables on success', async () => {
       expect.assertions(6);
       expect(render.mock.calls.length).toBe(1);
       expect(render.mock.calls[0][0].user.friends.edges.length).toBe(1);
       refetchConnection(1, jest.fn());
       expect(render.mock.calls.length).toBe(1);
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
@@ -1184,47 +1170,44 @@ describe('ReactRelayPaginationContainer', () => {
             },
           },
         },
-      }).then(() => {
-        expect(render.mock.calls.length).toBe(2);
-        expect(render.mock.calls[1][0].user.friends.edges.length).toBe(1);
-        expect(render.mock.calls[1][0]).toEqual({
-          user: {
-            id: '4',
-            friends: {
-              edges: [
-                {
-                  node: {
-                    id: 'node:2',
-                  },
+      });
+      expect(render.mock.calls.length).toBe(2);
+      expect(render.mock.calls[1][0].user.friends.edges.length).toBe(1);
+      expect(render.mock.calls[1][0]).toEqual({
+        user: {
+          id: '4',
+          friends: {
+            edges: [
+              {
+                node: {
+                  id: 'node:2',
                 },
-              ],
-              pageInfo: {
-                endCursor: 'cursor:2',
-                hasNextPage: true,
-                hasPreviousPage: false,
-                startCursor: 'cursor:1',
               },
+            ],
+            pageInfo: {
+              endCursor: 'cursor:2',
+              hasNextPage: true,
+              hasPreviousPage: false,
+              startCursor: 'cursor:1',
             },
           },
-          relay: {
-            environment: jasmine.any(Object),
-            hasMore: jasmine.any(Function),
-            isLoading: jasmine.any(Function),
-            loadMore: jasmine.any(Function),
-            refetchConnection: jasmine.any(Function),
-          },
-        });
+        },
+        relay: {
+          environment: jasmine.any(Object),
+          hasMore: jasmine.any(Function),
+          isLoading: jasmine.any(Function),
+          loadMore: jasmine.any(Function),
+          refetchConnection: jasmine.any(Function),
+        },
       });
     });
 
-    it('does not update variables on failure', () => {
+    it('does not update variables on failure', async () => {
       expect.assertions(1);
       render.mockClear();
       refetchConnection(1, jest.fn());
-      return environment.mock.reject(UserQuery, new Error('oops'))
-        .then(() => {
-          expect(render.mock.calls.length).toBe(0);
-        });
+      await environment.mock.reject(UserQuery, new Error('oops'))
+      expect(render.mock.calls.length).toBe(0);
     });
 
     it('continues the fetch if new props refer to the same records', () => {
@@ -1255,10 +1238,10 @@ describe('ReactRelayPaginationContainer', () => {
       expect(dispose).toBeCalled();
     });
 
-    it('holds pagination results if new props refer to the same records', () => {
+    it('holds pagination results if new props refer to the same records', async () => {
       expect.assertions(2);
       refetchConnection(1, jest.fn());
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
@@ -1267,22 +1250,21 @@ describe('ReactRelayPaginationContainer', () => {
             friends: null,
           },
         },
-      }).then(() => {
-        const userPointer = environment.lookup({
-          dataID: ROOT_ID,
-          node: UserQuery.fragment,
-          variables, // same user
-        }).data.node;
-        instance.getInstance().setProps({user: userPointer});
-        expect(references.length).toBe(1);
-        expect(references[0].dispose).not.toBeCalled();
       });
+      const userPointer = environment.lookup({
+        dataID: ROOT_ID,
+        node: UserQuery.fragment,
+        variables, // same user
+      }).data.node;
+      instance.getInstance().setProps({user: userPointer});
+      expect(references.length).toBe(1);
+      expect(references[0].dispose).not.toBeCalled();
     });
 
-    it('releases pagination results if new props refer to different records', () => {
+    it('releases pagination results if new props refer to different records', async () => {
       expect.assertions(2);
       refetchConnection(1, jest.fn());
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
@@ -1291,20 +1273,19 @@ describe('ReactRelayPaginationContainer', () => {
             friends: null,
           },
         },
-      }).then(() => {
-        const userPointer = environment.lookup({
-          dataID: ROOT_ID,
-          node: UserQuery.fragment,
-          variables: {
-            after: null,
-            first: 1,
-            id: '842472', // different user
-          },
-        }).data.node;
-        instance.getInstance().setProps({user: userPointer});
-        expect(references.length).toBe(1);
-        expect(references[0].dispose).toBeCalled();
       });
+      const userPointer = environment.lookup({
+        dataID: ROOT_ID,
+        node: UserQuery.fragment,
+        variables: {
+          after: null,
+          first: 1,
+          id: '842472', // different user
+        },
+      }).data.node;
+      instance.getInstance().setProps({user: userPointer});
+      expect(references.length).toBe(1);
+      expect(references[0].dispose).toBeCalled();
     });
   });
 });

--- a/packages/react-relay/modern/__tests__/ReactRelayPaginationContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayPaginationContainer-test.js
@@ -1206,7 +1206,7 @@ describe('ReactRelayPaginationContainer', () => {
       expect.assertions(1);
       render.mockClear();
       refetchConnection(1, jest.fn());
-      await environment.mock.reject(UserQuery, new Error('oops'))
+      await environment.mock.reject(UserQuery, new Error('oops'));
       expect(render.mock.calls.length).toBe(0);
     });
 

--- a/packages/react-relay/modern/__tests__/ReactRelayQueryRenderer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayQueryRenderer-test.js
@@ -49,7 +49,7 @@ describe('ReactRelayQueryRenderer', () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(function() {
     jest.resetModules();
     jasmine.addMatchers({
       toBeRendered() {
@@ -186,6 +186,7 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('sets an environment and variables on context', () => {
+      expect.assertions(2);
       ReactTestRenderer.create(
         <ReactRelayQueryRenderer
           environment={environment}
@@ -194,10 +195,11 @@ describe('ReactRelayQueryRenderer', () => {
           variables={variables}
         />,
       );
-      environment.mock.resolve(TestQuery, response);
-
-      expect(relayContext.environment).toBe(environment);
-      expect(relayContext.variables).toEqual(variables);
+      return environment.mock.resolve(TestQuery, response)
+        .then(() => {
+          expect(relayContext.environment).toBe(environment);
+          expect(relayContext.variables).toEqual(variables);
+        });
     });
 
     it('sets an environment and variables on context with empty query', () => {
@@ -221,6 +223,7 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('updates the context when the environment changes', () => {
+      expect.assertions(3);
       const instance = ReactTestRenderer.create(
         <PropsSetter>
           <ReactRelayQueryRenderer
@@ -231,22 +234,25 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      environment.mock.resolve(TestQuery, response);
-      environment = createMockEnvironment();
-      const previousContext = relayContext;
-      instance.getInstance().setProps({
-        environment,
-        query: TestQuery,
-        render,
-        variables,
-      });
+      return environment.mock.resolve(TestQuery, response)
+        .then(() => {
+          environment = createMockEnvironment();
+          const previousContext = relayContext;
+          instance.getInstance().setProps({
+            environment,
+            query: TestQuery,
+            render,
+            variables,
+          });
 
-      expect(relayContext).not.toBe(previousContext);
-      expect(relayContext.environment).toBe(environment);
-      expect(relayContext.variables).toEqual(variables);
+          expect(relayContext).not.toBe(previousContext);
+          expect(relayContext.environment).toBe(environment);
+          expect(relayContext.variables).toEqual(variables);
+        });
     });
 
     it('updates the context when the query changes', () => {
+      expect.assertions(3);
       const instance = ReactTestRenderer.create(
         <PropsSetter>
           <ReactRelayQueryRenderer
@@ -257,22 +263,25 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      environment.mock.resolve(TestQuery, response);
-      TestQuery = {...TestQuery};
-      const previousContext = relayContext;
-      instance.getInstance().setProps({
-        environment,
-        query: TestQuery,
-        render,
-        variables,
-      });
+      return environment.mock.resolve(TestQuery, response)
+        .then(() => {
+          TestQuery = {...TestQuery};
+          const previousContext = relayContext;
+          instance.getInstance().setProps({
+            environment,
+            query: TestQuery,
+            render,
+            variables,
+          });
 
-      expect(relayContext).not.toBe(previousContext);
-      expect(relayContext.environment).toBe(environment);
-      expect(relayContext.variables).toEqual(variables);
+          expect(relayContext).not.toBe(previousContext);
+          expect(relayContext.environment).toBe(environment);
+          expect(relayContext.variables).toEqual(variables);
+        });
     });
 
     it('updates the context when variables change', () => {
+      expect.assertions(3);
       const instance = ReactTestRenderer.create(
         <PropsSetter>
           <ReactRelayQueryRenderer
@@ -283,24 +292,27 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      environment.mock.resolve(TestQuery, response);
-      variables = {};
-      const previousContext = relayContext;
-      instance.getInstance().setProps({
-        environment,
-        query: TestQuery,
-        render,
-        variables,
-      });
+      return environment.mock.resolve(TestQuery, response)
+        .then(() => {
+          variables = {};
+          const previousContext = relayContext;
+          instance.getInstance().setProps({
+            environment,
+            query: TestQuery,
+            render,
+            variables,
+          });
 
-      expect(relayContext).not.toBe(previousContext);
-      expect(relayContext.environment).toBe(environment);
-      expect(relayContext.variables).toEqual({
-        id: '<default>',
-      });
+          expect(relayContext).not.toBe(previousContext);
+          expect(relayContext.environment).toBe(environment);
+          expect(relayContext.variables).toEqual({
+            id: '<default>',
+          });
+        });
     });
 
     it('does not update the context for equivalent variables', () => {
+      expect.assertions(3);
       variables = {foo: ['bar']};
       const instance = ReactTestRenderer.create(
         <PropsSetter>
@@ -312,20 +324,22 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      environment.mock.resolve(TestQuery, response);
-      variables = simpleClone(variables);
-      const previousContext = relayContext;
-      const previousVariables = previousContext.variables;
-      instance.getInstance().setProps({
-        environment,
-        query: TestQuery,
-        render,
-        variables,
-      });
+      return environment.mock.resolve(TestQuery, response)
+        .then(() => {
+          variables = simpleClone(variables);
+          const previousContext = relayContext;
+          const previousVariables = previousContext.variables;
+          instance.getInstance().setProps({
+            environment,
+            query: TestQuery,
+            render,
+            variables,
+          });
 
-      expect(relayContext).toBe(previousContext);
-      expect(relayContext.environment).toBe(environment);
-      expect(relayContext.variables).toBe(previousVariables);
+          expect(relayContext).toBe(previousContext);
+          expect(relayContext.environment).toBe(environment);
+          expect(relayContext.variables).toBe(previousVariables);
+        });
     });
   });
 
@@ -405,145 +419,155 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('refetches if the `environment` prop changes', () => {
-      environment.mock.resolve(TestQuery, {
+      expect.assertions(4);
+      return environment.mock.resolve(TestQuery, {
         data: {
           node: null,
         },
-      });
-      render.mockClear();
+      }).then(() => {
+        render.mockClear();
 
-      // Update with a different environment
-      environment.mockClear();
-      environment = createMockEnvironment();
-      instance.getInstance().setProps({
-        environment,
-        query: TestQuery,
-        render,
-        variables,
+        // Update with a different environment
+        environment.mockClear();
+        environment = createMockEnvironment();
+        instance.getInstance().setProps({
+          environment,
+          query: TestQuery,
+          render,
+          variables,
+        });
+        expect(
+          environment.mock.isLoading(TestQuery, variables, cacheConfig),
+        ).toBe(true);
+        expect({
+          error: null,
+          props: null,
+          retry: null,
+        }).toBeRendered();
       });
-      expect(
-        environment.mock.isLoading(TestQuery, variables, cacheConfig),
-      ).toBe(true);
-      expect({
-        error: null,
-        props: null,
-        retry: null,
-      }).toBeRendered();
     });
 
     it('refetches if the `variables` prop changes', () => {
-      environment.mock.resolve(TestQuery, {
+      expect.assertions(4);
+      return environment.mock.resolve(TestQuery, {
         data: {
           node: null,
         },
-      });
-      environment.mockClear();
-      render.mockClear();
+      }).then(() => {
+        environment.mockClear();
+        render.mockClear();
 
-      // Update with different variables
-      variables = {id: 'beast'};
-      instance.getInstance().setProps({
-        environment,
-        query: TestQuery,
-        render,
-        variables,
+        // Update with different variables
+        variables = {id: 'beast'};
+        instance.getInstance().setProps({
+          environment,
+          query: TestQuery,
+          render,
+          variables,
+        });
+        expect(
+          environment.mock.isLoading(TestQuery, variables, cacheConfig),
+        ).toBe(true);
+        expect({
+          error: null,
+          props: null,
+          retry: null,
+        }).toBeRendered();
       });
-      expect(
-        environment.mock.isLoading(TestQuery, variables, cacheConfig),
-      ).toBe(true);
-      expect({
-        error: null,
-        props: null,
-        retry: null,
-      }).toBeRendered();
     });
 
     it('refetches with default values if the `variables` prop changes', () => {
-      environment.mock.resolve(TestQuery, {
+      expect.assertions(4);
+      return environment.mock.resolve(TestQuery, {
         data: {
           node: null,
         },
-      });
-      environment.mockClear();
-      render.mockClear();
+      }).then(() => {
+        environment.mockClear();
+        render.mockClear();
 
-      // Update with different variables
-      variables = {}; // no `id`
-      const expectedVariables = {id: '<default>'};
-      instance.getInstance().setProps({
-        environment,
-        query: TestQuery,
-        render,
-        variables,
+        // Update with different variables
+        variables = {}; // no `id`
+        const expectedVariables = {id: '<default>'};
+        instance.getInstance().setProps({
+          environment,
+          query: TestQuery,
+          render,
+          variables,
+        });
+        expect(
+          environment.mock.isLoading(TestQuery, expectedVariables, cacheConfig),
+        ).toBe(true);
+        expect({
+          error: null,
+          props: null,
+          retry: null,
+        }).toBeRendered();
       });
-      expect(
-        environment.mock.isLoading(TestQuery, expectedVariables, cacheConfig),
-      ).toBe(true);
-      expect({
-        error: null,
-        props: null,
-        retry: null,
-      }).toBeRendered();
     });
 
     it('refetches if the `query` prop changes', () => {
-      environment.mock.resolve(TestQuery, {
+      expect.assertions(4);
+      return environment.mock.resolve(TestQuery, {
         data: {
           node: null,
         },
-      });
-      environment.mockClear();
-      render.mockClear();
+      }).then(() => {
+        environment.mockClear();
+        render.mockClear();
 
-      // Update with a different query
-      TestQuery = {...TestQuery};
-      instance.getInstance().setProps({
-        cacheConfig,
-        environment,
-        query: TestQuery,
-        render,
-        variables,
+        // Update with a different query
+        TestQuery = {...TestQuery};
+        instance.getInstance().setProps({
+          cacheConfig,
+          environment,
+          query: TestQuery,
+          render,
+          variables,
+        });
+        expect(
+          environment.mock.isLoading(TestQuery, variables, cacheConfig),
+        ).toBe(true);
+        expect({
+          error: null,
+          props: null,
+          retry: null,
+        }).toBeRendered();
       });
-      expect(
-        environment.mock.isLoading(TestQuery, variables, cacheConfig),
-      ).toBe(true);
-      expect({
-        error: null,
-        props: null,
-        retry: null,
-      }).toBeRendered();
     });
 
     it('renders if the `query` prop changes to null', () => {
-      environment.mock.resolve(TestQuery, {
+      expect.assertions(7);
+      return environment.mock.resolve(TestQuery, {
         data: {
           me: null,
         },
+      }).then(() => {
+        const disposeHold = environment.retain.mock.dispose;
+        expect(disposeHold).not.toBeCalled();
+        const disposeUpdate = environment.subscribe.mock.dispose;
+        expect(disposeUpdate).not.toBeCalled();
+
+        environment.mockClear();
+        render.mockClear();
+
+        // Update with a null query
+        instance.getInstance().setProps({
+          cacheConfig,
+          environment,
+          query: null,
+          render,
+          variables,
+        });
+
+        expect(disposeHold).toBeCalled();
+        expect(disposeUpdate).toBeCalled();
+        expect({
+          error: null,
+          props: {},
+          retry: null,
+        }).toBeRendered();
       });
-      const disposeHold = environment.retain.mock.dispose;
-      expect(disposeHold).not.toBeCalled();
-      const disposeUpdate = environment.subscribe.mock.dispose;
-      expect(disposeUpdate).not.toBeCalled();
-
-      environment.mockClear();
-      render.mockClear();
-
-      // Update with a null query
-      instance.getInstance().setProps({
-        cacheConfig,
-        environment,
-        query: null,
-        render,
-        variables,
-      });
-
-      expect(disposeHold).toBeCalled();
-      expect(disposeUpdate).toBeCalled();
-      expect({
-        error: null,
-        props: {},
-        retry: null,
-      }).toBeRendered();
     });
   });
 
@@ -560,52 +584,63 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('continues retaining the initial selection', () => {
-      environment.mock.reject(TestQuery, new Error('fail'));
-      expect(environment.retain.mock.dispose).not.toBeCalled();
+      expect.assertions(1);
+      return environment.mock.reject(TestQuery, new Error('fail'))
+        .then(() => {
+          expect(environment.retain.mock.dispose).not.toBeCalled();
+        });
     });
 
     it('renders the error and retry', () => {
+      expect.assertions(3);
       render.mockClear();
       const error = new Error('fail');
-      environment.mock.reject(TestQuery, error);
-      expect({
-        error,
-        props: null,
-        retry: jasmine.any(Function),
-      }).toBeRendered();
+      return environment.mock.reject(TestQuery, error)
+        .then(() => {
+          expect({
+            error,
+            props: null,
+            retry: jasmine.any(Function),
+          }).toBeRendered();
+        });
     });
 
     it('refetch the query if `retry`', () => {
+      expect.assertions(4);
       render.mockClear();
       const error = new Error('network fails');
-      environment.mock.reject(TestQuery, error);
-      const readyState = render.mock.calls[0][0];
-      expect(readyState.retry).not.toBe(null);
+      return environment.mock.reject(TestQuery, error)
+        .then(() => {
+          const readyState = render.mock.calls[0][0];
+          expect(readyState.retry).not.toBe(null);
 
-      readyState.retry();
-      const response = {
-        data: {
-          node: {
-            __typename: 'User',
-            id: '4',
-            name: 'Zuck',
-          },
-        },
-      };
-      environment.mock.resolve(TestQuery, response);
-      expect({
-        error: null,
-        props: {
-          node: {
-            id: '4',
-            __fragments: {
-              TestFragment: {},
+          render.mockClear();
+          readyState.retry();
+          const response = {
+            data: {
+              node: {
+                __typename: 'User',
+                id: '4',
+                name: 'Zuck',
+              },
             },
-            __id: '4',
-          },
-        },
-        retry: null,
-      }).toBeRendered;
+          };
+          return environment.mock.resolve(TestQuery, response);
+        }).then(() => {
+          expect({
+            error: null,
+            props: {
+              node: {
+                id: '4',
+                __fragments: {
+                  TestFragment: {},
+                },
+                __id: '4',
+              },
+            },
+            retry: jasmine.any(Function),
+          }).toBeRendered();
+        });
     });
   });
 
@@ -633,39 +668,48 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('publishes and notifies the store with changes', () => {
-      environment.mock.resolve(TestQuery, response);
-      expect(store.publish).toBeCalled();
-      expect(store.notify).toBeCalled();
+      expect.assertions(2);
+      return environment.mock.resolve(TestQuery, response)
+        .then(() => {
+          expect(store.publish).toBeCalled();
+          expect(store.notify).toBeCalled();
+        });
     });
 
     it('renders the query results', () => {
+      expect.assertions(3);
       render.mockClear();
-      environment.mock.resolve(TestQuery, response);
-      expect({
-        error: null,
-        props: {
-          node: {
-            id: '4',
-            __fragments: {
-              TestFragment: {},
+      return environment.mock.resolve(TestQuery, response)
+        .then(() => {
+          expect({
+            error: null,
+            props: {
+              node: {
+                id: '4',
+                __fragments: {
+                  TestFragment: {},
+                },
+                __id: '4',
+              },
             },
-            __id: '4',
-          },
-        },
-        retry: jasmine.any(Function),
-      }).toBeRendered();
+            retry: jasmine.any(Function),
+          }).toBeRendered();
+        });
     });
 
     it('subscribes to the root fragment', () => {
-      environment.mock.resolve(TestQuery, response);
-      expect(environment.subscribe).toBeCalled();
-      expect(environment.subscribe.mock.calls[0][0].dataID).toBe('client:root');
-      expect(environment.subscribe.mock.calls[0][0].node).toBe(
-        TestQuery.fragment,
-      );
-      expect(environment.subscribe.mock.calls[0][0].variables).toEqual(
-        variables,
-      );
+      expect.assertions(4);
+      return environment.mock.resolve(TestQuery, response)
+        .then(() => {
+          expect(environment.subscribe).toBeCalled();
+          expect(environment.subscribe.mock.calls[0][0].dataID).toBe('client:root');
+          expect(environment.subscribe.mock.calls[0][0].node).toBe(
+            TestQuery.fragment,
+          );
+          expect(environment.subscribe.mock.calls[0][0].variables).toEqual(
+            variables,
+          );
+        });
     });
   });
 
@@ -797,14 +841,16 @@ describe('ReactRelayQueryRenderer', () => {
         </PropsSetter>,
       );
       error = new Error('fail');
-      environment.mock.reject(TestQuery, error);
-      render.mockClear();
-      nextProps = {
-        environment,
-        query: NextQuery,
-        render,
-        variables,
-      };
+      return environment.mock.reject(TestQuery, error)
+        .then(() => {
+          render.mockClear();
+          nextProps = {
+            environment,
+            query: NextQuery,
+            render,
+            variables,
+          };
+        });
     });
 
     it('does not dispose the previous fetch', () => {
@@ -823,18 +869,20 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('retains the new selection', () => {
+      expect.assertions(5);
       environment.mockClear();
       instance.getInstance().setProps(nextProps);
       expect(environment.retain.mock.calls.length).toBe(1);
       expect(environment.retain.mock.calls[0][0].dataID).toBe('client:root');
       expect(environment.retain.mock.calls[0][0].node).toBe(NextQuery.query);
       expect(environment.retain.mock.calls[0][0].variables).toEqual(variables);
-      environment.mock.resolve(NextQuery, {
+      return environment.mock.resolve(NextQuery, {
         data: {
           node: null,
         },
+      }).then(() => {
+        expect(environment.retain.mock.dispose).not.toBeCalled();
       });
-      expect(environment.retain.mock.dispose).not.toBeCalled();
     });
 
     it('renders the pending state', () => {
@@ -847,6 +895,7 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('publishes and notifies the store with changes', () => {
+      expect.assertions(2);
       environment.mockClear();
       instance.getInstance().setProps(nextProps);
       const response = {
@@ -858,9 +907,11 @@ describe('ReactRelayQueryRenderer', () => {
           },
         },
       };
-      environment.mock.resolve(NextQuery, response);
-      expect(store.publish).toBeCalled();
-      expect(store.notify).toBeCalled();
+      return environment.mock.resolve(NextQuery, response)
+        .then(() => {
+          expect(store.publish).toBeCalled();
+          expect(store.notify).toBeCalled();
+        });
     });
   });
 
@@ -892,7 +943,7 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      environment.mock.resolve(TestQuery, {
+      return environment.mock.resolve(TestQuery, {
         data: {
           node: {
             __typename: 'User',
@@ -900,14 +951,15 @@ describe('ReactRelayQueryRenderer', () => {
             name: 'Zuck',
           },
         },
+      }).then(() => {
+        render.mockClear();
+        nextProps = {
+          environment,
+          query: NextQuery,
+          render,
+          variables,
+        };
       });
-      render.mockClear();
-      nextProps = {
-        environment,
-        query: NextQuery,
-        render,
-        variables,
-      };
     });
 
     it('does not dispose the previous fetch', () => {
@@ -933,6 +985,7 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('disposes the previous selection and retains the new one', () => {
+      expect.assertions(6);
       const prevDispose = environment.retain.mock.dispose;
       environment.mockClear();
       instance.getInstance().setProps(nextProps);
@@ -940,13 +993,14 @@ describe('ReactRelayQueryRenderer', () => {
       expect(environment.retain.mock.calls[0][0].dataID).toBe('client:root');
       expect(environment.retain.mock.calls[0][0].node).toBe(NextQuery.query);
       expect(environment.retain.mock.calls[0][0].variables).toEqual(variables);
-      environment.mock.resolve(NextQuery, {
+      return environment.mock.resolve(NextQuery, {
         data: {
           node: null,
         },
+      }).then(() => {
+        expect(prevDispose).toBeCalled();
+        expect(environment.retain.mock.dispose).not.toBeCalled();
       });
-      expect(prevDispose).toBeCalled();
-      expect(environment.retain.mock.dispose).not.toBeCalled();
     });
 
     it('renders the pending and previous state', () => {
@@ -960,6 +1014,7 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('publishes and notifies the store with changes', () => {
+      expect.assertions(2);
       environment.mockClear();
       instance.getInstance().setProps(nextProps);
       const response = {
@@ -971,9 +1026,11 @@ describe('ReactRelayQueryRenderer', () => {
           },
         },
       };
-      environment.mock.resolve(NextQuery, response);
-      expect(store.publish).toBeCalled();
-      expect(store.notify).toBeCalled();
+      return environment.mock.resolve(NextQuery, response)
+        .then(() => {
+          expect(store.publish).toBeCalled();
+          expect(store.notify).toBeCalled();
+        });
     });
   });
 

--- a/packages/react-relay/modern/__tests__/ReactRelayQueryRenderer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayQueryRenderer-test.js
@@ -185,7 +185,7 @@ describe('ReactRelayQueryRenderer', () => {
       };
     });
 
-    it('sets an environment and variables on context', () => {
+    it('sets an environment and variables on context', async () => {
       expect.assertions(2);
       ReactTestRenderer.create(
         <ReactRelayQueryRenderer
@@ -195,11 +195,9 @@ describe('ReactRelayQueryRenderer', () => {
           variables={variables}
         />,
       );
-      return environment.mock.resolve(TestQuery, response)
-        .then(() => {
-          expect(relayContext.environment).toBe(environment);
-          expect(relayContext.variables).toEqual(variables);
-        });
+      await environment.mock.resolve(TestQuery, response)
+      expect(relayContext.environment).toBe(environment);
+      expect(relayContext.variables).toEqual(variables);
     });
 
     it('sets an environment and variables on context with empty query', () => {
@@ -222,7 +220,7 @@ describe('ReactRelayQueryRenderer', () => {
       expect(relayContext.variables).toEqual(variables);
     });
 
-    it('updates the context when the environment changes', () => {
+    it('updates the context when the environment changes', async () => {
       expect.assertions(3);
       const instance = ReactTestRenderer.create(
         <PropsSetter>
@@ -234,24 +232,22 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      return environment.mock.resolve(TestQuery, response)
-        .then(() => {
-          environment = createMockEnvironment();
-          const previousContext = relayContext;
-          instance.getInstance().setProps({
-            environment,
-            query: TestQuery,
-            render,
-            variables,
-          });
+      await environment.mock.resolve(TestQuery, response)
+      environment = createMockEnvironment();
+      const previousContext = relayContext;
+      instance.getInstance().setProps({
+        environment,
+        query: TestQuery,
+        render,
+        variables,
+      });
 
-          expect(relayContext).not.toBe(previousContext);
-          expect(relayContext.environment).toBe(environment);
-          expect(relayContext.variables).toEqual(variables);
-        });
+      expect(relayContext).not.toBe(previousContext);
+      expect(relayContext.environment).toBe(environment);
+      expect(relayContext.variables).toEqual(variables);
     });
 
-    it('updates the context when the query changes', () => {
+    it('updates the context when the query changes', async () => {
       expect.assertions(3);
       const instance = ReactTestRenderer.create(
         <PropsSetter>
@@ -263,24 +259,22 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      return environment.mock.resolve(TestQuery, response)
-        .then(() => {
-          TestQuery = {...TestQuery};
-          const previousContext = relayContext;
-          instance.getInstance().setProps({
-            environment,
-            query: TestQuery,
-            render,
-            variables,
-          });
+      await environment.mock.resolve(TestQuery, response);
+      TestQuery = {...TestQuery};
+      const previousContext = relayContext;
+      instance.getInstance().setProps({
+        environment,
+        query: TestQuery,
+        render,
+        variables,
+      });
 
-          expect(relayContext).not.toBe(previousContext);
-          expect(relayContext.environment).toBe(environment);
-          expect(relayContext.variables).toEqual(variables);
-        });
+      expect(relayContext).not.toBe(previousContext);
+      expect(relayContext.environment).toBe(environment);
+      expect(relayContext.variables).toEqual(variables);
     });
 
-    it('updates the context when variables change', () => {
+    it('updates the context when variables change', async () => {
       expect.assertions(3);
       const instance = ReactTestRenderer.create(
         <PropsSetter>
@@ -292,26 +286,24 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      return environment.mock.resolve(TestQuery, response)
-        .then(() => {
-          variables = {};
-          const previousContext = relayContext;
-          instance.getInstance().setProps({
-            environment,
-            query: TestQuery,
-            render,
-            variables,
-          });
+      await environment.mock.resolve(TestQuery, response);
+      variables = {};
+      const previousContext = relayContext;
+      instance.getInstance().setProps({
+        environment,
+        query: TestQuery,
+        render,
+        variables,
+      });
 
-          expect(relayContext).not.toBe(previousContext);
-          expect(relayContext.environment).toBe(environment);
-          expect(relayContext.variables).toEqual({
-            id: '<default>',
-          });
-        });
+      expect(relayContext).not.toBe(previousContext);
+      expect(relayContext.environment).toBe(environment);
+      expect(relayContext.variables).toEqual({
+        id: '<default>',
+      });
     });
 
-    it('does not update the context for equivalent variables', () => {
+    it('does not update the context for equivalent variables', async () => {
       expect.assertions(3);
       variables = {foo: ['bar']};
       const instance = ReactTestRenderer.create(
@@ -324,22 +316,20 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      return environment.mock.resolve(TestQuery, response)
-        .then(() => {
-          variables = simpleClone(variables);
-          const previousContext = relayContext;
-          const previousVariables = previousContext.variables;
-          instance.getInstance().setProps({
-            environment,
-            query: TestQuery,
-            render,
-            variables,
-          });
+      await environment.mock.resolve(TestQuery, response)
+      variables = simpleClone(variables);
+      const previousContext = relayContext;
+      const previousVariables = previousContext.variables;
+      instance.getInstance().setProps({
+        environment,
+        query: TestQuery,
+        render,
+        variables,
+      });
 
-          expect(relayContext).toBe(previousContext);
-          expect(relayContext.environment).toBe(environment);
-          expect(relayContext.variables).toBe(previousVariables);
-        });
+      expect(relayContext).toBe(previousContext);
+      expect(relayContext.environment).toBe(environment);
+      expect(relayContext.variables).toBe(previousVariables);
     });
   });
 
@@ -418,156 +408,151 @@ describe('ReactRelayQueryRenderer', () => {
       expect(environment.streamQuery).not.toBeCalled();
     });
 
-    it('refetches if the `environment` prop changes', () => {
+    it('refetches if the `environment` prop changes', async () => {
       expect.assertions(4);
-      return environment.mock.resolve(TestQuery, {
+      await environment.mock.resolve(TestQuery, {
         data: {
           node: null,
         },
-      }).then(() => {
-        render.mockClear();
-
-        // Update with a different environment
-        environment.mockClear();
-        environment = createMockEnvironment();
-        instance.getInstance().setProps({
-          environment,
-          query: TestQuery,
-          render,
-          variables,
-        });
-        expect(
-          environment.mock.isLoading(TestQuery, variables, cacheConfig),
-        ).toBe(true);
-        expect({
-          error: null,
-          props: null,
-          retry: null,
-        }).toBeRendered();
       });
+      render.mockClear();
+
+      // Update with a different environment
+      environment.mockClear();
+      environment = createMockEnvironment();
+      instance.getInstance().setProps({
+        environment,
+        query: TestQuery,
+        render,
+        variables,
+      });
+      expect(
+        environment.mock.isLoading(TestQuery, variables, cacheConfig),
+      ).toBe(true);
+      expect({
+        error: null,
+        props: null,
+        retry: null,
+      }).toBeRendered();
     });
 
-    it('refetches if the `variables` prop changes', () => {
+    it('refetches if the `variables` prop changes', async () => {
       expect.assertions(4);
-      return environment.mock.resolve(TestQuery, {
+      await environment.mock.resolve(TestQuery, {
         data: {
           node: null,
         },
-      }).then(() => {
-        environment.mockClear();
-        render.mockClear();
-
-        // Update with different variables
-        variables = {id: 'beast'};
-        instance.getInstance().setProps({
-          environment,
-          query: TestQuery,
-          render,
-          variables,
-        });
-        expect(
-          environment.mock.isLoading(TestQuery, variables, cacheConfig),
-        ).toBe(true);
-        expect({
-          error: null,
-          props: null,
-          retry: null,
-        }).toBeRendered();
       });
+      environment.mockClear();
+      render.mockClear();
+
+      // Update with different variables
+      variables = {id: 'beast'};
+      instance.getInstance().setProps({
+        environment,
+        query: TestQuery,
+        render,
+        variables,
+      });
+      expect(
+        environment.mock.isLoading(TestQuery, variables, cacheConfig),
+      ).toBe(true);
+      expect({
+        error: null,
+        props: null,
+        retry: null,
+      }).toBeRendered();
     });
 
-    it('refetches with default values if the `variables` prop changes', () => {
+    it('refetches with default values if the `variables` prop changes', async () => {
       expect.assertions(4);
-      return environment.mock.resolve(TestQuery, {
+      await environment.mock.resolve(TestQuery, {
         data: {
           node: null,
         },
-      }).then(() => {
-        environment.mockClear();
-        render.mockClear();
-
-        // Update with different variables
-        variables = {}; // no `id`
-        const expectedVariables = {id: '<default>'};
-        instance.getInstance().setProps({
-          environment,
-          query: TestQuery,
-          render,
-          variables,
-        });
-        expect(
-          environment.mock.isLoading(TestQuery, expectedVariables, cacheConfig),
-        ).toBe(true);
-        expect({
-          error: null,
-          props: null,
-          retry: null,
-        }).toBeRendered();
       });
+      environment.mockClear();
+      render.mockClear();
+
+      // Update with different variables
+      variables = {}; // no `id`
+      const expectedVariables = {id: '<default>'};
+      instance.getInstance().setProps({
+        environment,
+        query: TestQuery,
+        render,
+        variables,
+      });
+      expect(
+        environment.mock.isLoading(TestQuery, expectedVariables, cacheConfig),
+      ).toBe(true);
+      expect({
+        error: null,
+        props: null,
+        retry: null,
+      }).toBeRendered();
     });
 
-    it('refetches if the `query` prop changes', () => {
+    it('refetches if the `query` prop changes', async () => {
       expect.assertions(4);
-      return environment.mock.resolve(TestQuery, {
+      await environment.mock.resolve(TestQuery, {
         data: {
           node: null,
         },
-      }).then(() => {
-        environment.mockClear();
-        render.mockClear();
-
-        // Update with a different query
-        TestQuery = {...TestQuery};
-        instance.getInstance().setProps({
-          cacheConfig,
-          environment,
-          query: TestQuery,
-          render,
-          variables,
-        });
-        expect(
-          environment.mock.isLoading(TestQuery, variables, cacheConfig),
-        ).toBe(true);
-        expect({
-          error: null,
-          props: null,
-          retry: null,
-        }).toBeRendered();
       });
+      environment.mockClear();
+      render.mockClear();
+
+      // Update with a different query
+      TestQuery = {...TestQuery};
+      instance.getInstance().setProps({
+        cacheConfig,
+        environment,
+        query: TestQuery,
+        render,
+        variables,
+      });
+      expect(
+        environment.mock.isLoading(TestQuery, variables, cacheConfig),
+      ).toBe(true);
+      expect({
+        error: null,
+        props: null,
+        retry: null,
+      }).toBeRendered();
     });
 
-    it('renders if the `query` prop changes to null', () => {
+    it('renders if the `query` prop changes to null', async () => {
       expect.assertions(7);
-      return environment.mock.resolve(TestQuery, {
+      await environment.mock.resolve(TestQuery, {
         data: {
           me: null,
         },
-      }).then(() => {
-        const disposeHold = environment.retain.mock.dispose;
-        expect(disposeHold).not.toBeCalled();
-        const disposeUpdate = environment.subscribe.mock.dispose;
-        expect(disposeUpdate).not.toBeCalled();
-
-        environment.mockClear();
-        render.mockClear();
-
-        // Update with a null query
-        instance.getInstance().setProps({
-          cacheConfig,
-          environment,
-          query: null,
-          render,
-          variables,
-        });
-
-        expect(disposeHold).toBeCalled();
-        expect(disposeUpdate).toBeCalled();
-        expect({
-          error: null,
-          props: {},
-          retry: null,
-        }).toBeRendered();
       });
+      const disposeHold = environment.retain.mock.dispose;
+      expect(disposeHold).not.toBeCalled();
+      const disposeUpdate = environment.subscribe.mock.dispose;
+      expect(disposeUpdate).not.toBeCalled();
+
+      environment.mockClear();
+      render.mockClear();
+
+      // Update with a null query
+      instance.getInstance().setProps({
+        cacheConfig,
+        environment,
+        query: null,
+        render,
+        variables,
+      });
+
+      expect(disposeHold).toBeCalled();
+      expect(disposeUpdate).toBeCalled();
+      expect({
+        error: null,
+        props: {},
+        retry: null,
+      }).toBeRendered();
     });
   });
 
@@ -583,64 +568,57 @@ describe('ReactRelayQueryRenderer', () => {
       );
     });
 
-    it('continues retaining the initial selection', () => {
+    it('continues retaining the initial selection', async () => {
       expect.assertions(1);
-      return environment.mock.reject(TestQuery, new Error('fail'))
-        .then(() => {
-          expect(environment.retain.mock.dispose).not.toBeCalled();
-        });
+      await environment.mock.reject(TestQuery, new Error('fail'));
+      expect(environment.retain.mock.dispose).not.toBeCalled();
     });
 
-    it('renders the error and retry', () => {
+    it('renders the error and retry', async () => {
       expect.assertions(3);
       render.mockClear();
       const error = new Error('fail');
-      return environment.mock.reject(TestQuery, error)
-        .then(() => {
-          expect({
-            error,
-            props: null,
-            retry: jasmine.any(Function),
-          }).toBeRendered();
-        });
+      await environment.mock.reject(TestQuery, error);
+      expect({
+        error,
+        props: null,
+        retry: jasmine.any(Function),
+      }).toBeRendered();
     });
 
-    it('refetch the query if `retry`', () => {
+    it('refetch the query if `retry`', async() => {
       expect.assertions(4);
       render.mockClear();
       const error = new Error('network fails');
-      return environment.mock.reject(TestQuery, error)
-        .then(() => {
-          const readyState = render.mock.calls[0][0];
-          expect(readyState.retry).not.toBe(null);
+      await environment.mock.reject(TestQuery, error);
+      const readyState = render.mock.calls[0][0];
+      expect(readyState.retry).not.toBe(null);
 
-          render.mockClear();
-          readyState.retry();
-          const response = {
-            data: {
-              node: {
-                __typename: 'User',
-                id: '4',
-                name: 'Zuck',
-              },
+      render.mockClear();
+      readyState.retry();
+      const response = {
+        data: {
+          node: {
+            __typename: 'User',
+            id: '4',
+            name: 'Zuck',
+          },
+        },
+      };
+      await environment.mock.resolve(TestQuery, response);
+      expect({
+        error: null,
+        props: {
+          node: {
+            id: '4',
+            __fragments: {
+              TestFragment: {},
             },
-          };
-          return environment.mock.resolve(TestQuery, response);
-        }).then(() => {
-          expect({
-            error: null,
-            props: {
-              node: {
-                id: '4',
-                __fragments: {
-                  TestFragment: {},
-                },
-                __id: '4',
-              },
-            },
-            retry: jasmine.any(Function),
-          }).toBeRendered();
-        });
+            __id: '4',
+          },
+        },
+        retry: jasmine.any(Function),
+      }).toBeRendered();
     });
   });
 
@@ -667,49 +645,43 @@ describe('ReactRelayQueryRenderer', () => {
       };
     });
 
-    it('publishes and notifies the store with changes', () => {
+    it('publishes and notifies the store with changes', async () => {
       expect.assertions(2);
-      return environment.mock.resolve(TestQuery, response)
-        .then(() => {
-          expect(store.publish).toBeCalled();
-          expect(store.notify).toBeCalled();
-        });
+      await environment.mock.resolve(TestQuery, response)
+      expect(store.publish).toBeCalled();
+      expect(store.notify).toBeCalled();
     });
 
-    it('renders the query results', () => {
+    it('renders the query results', async () => {
       expect.assertions(3);
       render.mockClear();
-      return environment.mock.resolve(TestQuery, response)
-        .then(() => {
-          expect({
-            error: null,
-            props: {
-              node: {
-                id: '4',
-                __fragments: {
-                  TestFragment: {},
-                },
-                __id: '4',
-              },
+      await environment.mock.resolve(TestQuery, response);
+      expect({
+        error: null,
+        props: {
+          node: {
+            id: '4',
+            __fragments: {
+              TestFragment: {},
             },
-            retry: jasmine.any(Function),
-          }).toBeRendered();
-        });
+            __id: '4',
+          },
+        },
+        retry: jasmine.any(Function),
+      }).toBeRendered();
     });
 
-    it('subscribes to the root fragment', () => {
+    it('subscribes to the root fragment', async () => {
       expect.assertions(4);
-      return environment.mock.resolve(TestQuery, response)
-        .then(() => {
-          expect(environment.subscribe).toBeCalled();
-          expect(environment.subscribe.mock.calls[0][0].dataID).toBe('client:root');
-          expect(environment.subscribe.mock.calls[0][0].node).toBe(
-            TestQuery.fragment,
-          );
-          expect(environment.subscribe.mock.calls[0][0].variables).toEqual(
-            variables,
-          );
-        });
+      await environment.mock.resolve(TestQuery, response);
+      expect(environment.subscribe).toBeCalled();
+      expect(environment.subscribe.mock.calls[0][0].dataID).toBe('client:root');
+      expect(environment.subscribe.mock.calls[0][0].node).toBe(
+        TestQuery.fragment,
+      );
+      expect(environment.subscribe.mock.calls[0][0].variables).toEqual(
+        variables,
+      );
     });
   });
 
@@ -816,7 +788,7 @@ describe('ReactRelayQueryRenderer', () => {
     let instance;
     let nextProps;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       ({NextQuery} = environment.mock.compile(
         `
         query NextQuery($id: ID!) {
@@ -841,16 +813,14 @@ describe('ReactRelayQueryRenderer', () => {
         </PropsSetter>,
       );
       error = new Error('fail');
-      return environment.mock.reject(TestQuery, error)
-        .then(() => {
-          render.mockClear();
-          nextProps = {
-            environment,
-            query: NextQuery,
-            render,
-            variables,
-          };
-        });
+      await environment.mock.reject(TestQuery, error);
+      render.mockClear();
+      nextProps = {
+        environment,
+        query: NextQuery,
+        render,
+        variables,
+      };
     });
 
     it('does not dispose the previous fetch', () => {
@@ -868,7 +838,7 @@ describe('ReactRelayQueryRenderer', () => {
       ).toBe(true);
     });
 
-    it('retains the new selection', () => {
+    it('retains the new selection', async () => {
       expect.assertions(5);
       environment.mockClear();
       instance.getInstance().setProps(nextProps);
@@ -876,13 +846,12 @@ describe('ReactRelayQueryRenderer', () => {
       expect(environment.retain.mock.calls[0][0].dataID).toBe('client:root');
       expect(environment.retain.mock.calls[0][0].node).toBe(NextQuery.query);
       expect(environment.retain.mock.calls[0][0].variables).toEqual(variables);
-      return environment.mock.resolve(NextQuery, {
+      await environment.mock.resolve(NextQuery, {
         data: {
           node: null,
         },
-      }).then(() => {
-        expect(environment.retain.mock.dispose).not.toBeCalled();
       });
+      expect(environment.retain.mock.dispose).not.toBeCalled();
     });
 
     it('renders the pending state', () => {
@@ -894,7 +863,7 @@ describe('ReactRelayQueryRenderer', () => {
       }).toBeRendered();
     });
 
-    it('publishes and notifies the store with changes', () => {
+    it('publishes and notifies the store with changes', async () => {
       expect.assertions(2);
       environment.mockClear();
       instance.getInstance().setProps(nextProps);
@@ -907,11 +876,9 @@ describe('ReactRelayQueryRenderer', () => {
           },
         },
       };
-      return environment.mock.resolve(NextQuery, response)
-        .then(() => {
-          expect(store.publish).toBeCalled();
-          expect(store.notify).toBeCalled();
-        });
+      await environment.mock.resolve(NextQuery, response);
+      expect(store.publish).toBeCalled();
+      expect(store.notify).toBeCalled();
     });
   });
 
@@ -920,7 +887,7 @@ describe('ReactRelayQueryRenderer', () => {
     let instance;
     let nextProps;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       ({NextQuery} = environment.mock.compile(
         `
         query NextQuery($id: ID!) {
@@ -943,7 +910,7 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      return environment.mock.resolve(TestQuery, {
+      await environment.mock.resolve(TestQuery, {
         data: {
           node: {
             __typename: 'User',
@@ -951,15 +918,14 @@ describe('ReactRelayQueryRenderer', () => {
             name: 'Zuck',
           },
         },
-      }).then(() => {
-        render.mockClear();
-        nextProps = {
-          environment,
-          query: NextQuery,
-          render,
-          variables,
-        };
       });
+      render.mockClear();
+      nextProps = {
+        environment,
+        query: NextQuery,
+        render,
+        variables,
+      };
     });
 
     it('does not dispose the previous fetch', () => {
@@ -984,7 +950,7 @@ describe('ReactRelayQueryRenderer', () => {
       ).toBe(true);
     });
 
-    it('disposes the previous selection and retains the new one', () => {
+    it('disposes the previous selection and retains the new one', async () => {
       expect.assertions(6);
       const prevDispose = environment.retain.mock.dispose;
       environment.mockClear();
@@ -993,14 +959,13 @@ describe('ReactRelayQueryRenderer', () => {
       expect(environment.retain.mock.calls[0][0].dataID).toBe('client:root');
       expect(environment.retain.mock.calls[0][0].node).toBe(NextQuery.query);
       expect(environment.retain.mock.calls[0][0].variables).toEqual(variables);
-      return environment.mock.resolve(NextQuery, {
+      await environment.mock.resolve(NextQuery, {
         data: {
           node: null,
         },
-      }).then(() => {
-        expect(prevDispose).toBeCalled();
-        expect(environment.retain.mock.dispose).not.toBeCalled();
       });
+      expect(prevDispose).toBeCalled();
+      expect(environment.retain.mock.dispose).not.toBeCalled();
     });
 
     it('renders the pending and previous state', () => {
@@ -1013,7 +978,7 @@ describe('ReactRelayQueryRenderer', () => {
       }).toBeRendered();
     });
 
-    it('publishes and notifies the store with changes', () => {
+    it('publishes and notifies the store with changes', async () => {
       expect.assertions(2);
       environment.mockClear();
       instance.getInstance().setProps(nextProps);
@@ -1026,11 +991,9 @@ describe('ReactRelayQueryRenderer', () => {
           },
         },
       };
-      return environment.mock.resolve(NextQuery, response)
-        .then(() => {
-          expect(store.publish).toBeCalled();
-          expect(store.notify).toBeCalled();
-        });
+      await environment.mock.resolve(NextQuery, response)
+      expect(store.publish).toBeCalled();
+      expect(store.notify).toBeCalled();
     });
   });
 

--- a/packages/react-relay/modern/__tests__/ReactRelayQueryRenderer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayQueryRenderer-test.js
@@ -49,7 +49,7 @@ describe('ReactRelayQueryRenderer', () => {
     }
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     jest.resetModules();
     jasmine.addMatchers({
       toBeRendered() {
@@ -195,7 +195,8 @@ describe('ReactRelayQueryRenderer', () => {
           variables={variables}
         />,
       );
-      await environment.mock.resolve(TestQuery, response)
+      await environment.mock.resolve(TestQuery, response);
+
       expect(relayContext.environment).toBe(environment);
       expect(relayContext.variables).toEqual(variables);
     });
@@ -232,7 +233,7 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      await environment.mock.resolve(TestQuery, response)
+      await environment.mock.resolve(TestQuery, response);
       environment = createMockEnvironment();
       const previousContext = relayContext;
       instance.getInstance().setProps({
@@ -316,7 +317,7 @@ describe('ReactRelayQueryRenderer', () => {
           />
         </PropsSetter>,
       );
-      await environment.mock.resolve(TestQuery, response)
+      await environment.mock.resolve(TestQuery, response);
       variables = simpleClone(variables);
       const previousContext = relayContext;
       const previousVariables = previousContext.variables;
@@ -647,7 +648,7 @@ describe('ReactRelayQueryRenderer', () => {
 
     it('publishes and notifies the store with changes', async () => {
       expect.assertions(2);
-      await environment.mock.resolve(TestQuery, response)
+      await environment.mock.resolve(TestQuery, response);
       expect(store.publish).toBeCalled();
       expect(store.notify).toBeCalled();
     });
@@ -991,7 +992,7 @@ describe('ReactRelayQueryRenderer', () => {
           },
         },
       };
-      await environment.mock.resolve(NextQuery, response)
+      await environment.mock.resolve(NextQuery, response);
       expect(store.publish).toBeCalled();
       expect(store.notify).toBeCalled();
     });

--- a/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
@@ -514,7 +514,7 @@ describe('ReactRelayRefetchContainer', () => {
       });
     });
 
-    it('calls the callback when the fetch succeeds', () => {
+    it('calls the callback when the fetch succeeds', async () => {
       expect.assertions(2);
       const callback = jest.fn();
       variables = {
@@ -522,20 +522,19 @@ describe('ReactRelayRefetchContainer', () => {
         id: '4',
       };
       refetch(variables, null, callback);
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
             __typename: 'User',
           },
         },
-      }).then(() => {
-        expect(callback.mock.calls.length).toBe(1);
-        expect(callback.mock.calls[0].length).toBe(0);
       });
+      expect(callback.mock.calls.length).toBe(1);
+      expect(callback.mock.calls[0].length).toBe(0);
     });
 
-    it('calls the callback when the fetch fails', () => {
+    it('calls the callback when the fetch fails', async () => {
       expect.assertions(2);
       const callback = jest.fn();
       variables = {
@@ -544,14 +543,12 @@ describe('ReactRelayRefetchContainer', () => {
       };
       refetch(variables, null, callback);
       const error = new Error('oops');
-      return environment.mock.reject(UserQuery, error)
-        .then(() => {
-          expect(callback.mock.calls.length).toBe(1);
-          expect(callback).toBeCalledWith(error);
-        });
+      await environment.mock.reject(UserQuery, error);
+      expect(callback.mock.calls.length).toBe(1);
+      expect(callback).toBeCalledWith(error);
     });
 
-    it('renders with the results of the new variables on success', () => {
+    it('renders with the results of the new variables on success', async () => {
       expect.assertions(5);
       expect(render.mock.calls.length).toBe(1);
       expect(render.mock.calls[0][0].user.name).toBe('Zuck');
@@ -561,7 +558,7 @@ describe('ReactRelayRefetchContainer', () => {
       };
       refetch(variables, null, jest.fn());
       expect(render.mock.calls.length).toBe(1);
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
@@ -569,13 +566,12 @@ describe('ReactRelayRefetchContainer', () => {
             name: 'Zuck',
           },
         },
-      }).then(() => {
-        expect(render.mock.calls.length).toBe(2);
-        expect(render.mock.calls[1][0].user.name).toBe(undefined);
       });
+      expect(render.mock.calls.length).toBe(2);
+      expect(render.mock.calls[1][0].user.name).toBe(undefined);
     });
 
-    it('does not update variables on failure', () => {
+    it('does not update variables on failure', async () => {
       expect.assertions(4);
       expect(render.mock.calls.length).toBe(1);
       expect(render.mock.calls[0][0].user.name).toBe('Zuck');
@@ -585,10 +581,8 @@ describe('ReactRelayRefetchContainer', () => {
       };
       refetch(variables, null, jest.fn());
       expect(render.mock.calls.length).toBe(1);
-      return environment.mock.reject(UserQuery, new Error('oops'))
-        .then(() => {
-          expect(render.mock.calls.length).toBe(1);
-        });
+      await environment.mock.reject(UserQuery, new Error('oops'));
+      expect(render.mock.calls.length).toBe(1);
     });
 
     it('continues the fetch if new props refer to the same records', () => {
@@ -623,56 +617,54 @@ describe('ReactRelayRefetchContainer', () => {
       expect(dispose).toBeCalled();
     });
 
-    it('holds refetch results if new props refer to the same records', () => {
+    it('holds refetch results if new props refer to the same records', async () => {
       expect.assertions(2);
       variables = {
         cond: false,
         id: '4',
       };
       refetch(variables, null, jest.fn());
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
             __typename: 'User',
           },
         },
-      }).then(() => {
-        const userPointer = environment.lookup({
-          dataID: ROOT_ID,
-          node: UserQuery.fragment,
-          variables: {id: '4'}, // same user
-        }).data.node;
-        instance.getInstance().setProps({user: userPointer});
-        expect(references.length).toBe(1);
-        expect(references[0].dispose).not.toBeCalled();
       });
+      const userPointer = environment.lookup({
+        dataID: ROOT_ID,
+        node: UserQuery.fragment,
+        variables: {id: '4'}, // same user
+      }).data.node;
+      instance.getInstance().setProps({user: userPointer});
+      expect(references.length).toBe(1);
+      expect(references[0].dispose).not.toBeCalled();
     });
 
-    it('releases refetch results if new props refer to different records', () => {
+    it('releases refetch results if new props refer to different records', async () => {
       expect.assertions(2);
       variables = {
         cond: false,
         id: '4',
       };
       refetch(variables, null, jest.fn());
-      return environment.mock.resolve(UserQuery, {
+      await environment.mock.resolve(UserQuery, {
         data: {
           node: {
             id: '4',
             __typename: 'User',
           },
         },
-      }).then(() => {
-        const userPointer = environment.lookup({
-          dataID: ROOT_ID,
-          node: UserQuery.fragment,
-          variables: {id: '842472'}, // different user
-        }).data.node;
-        instance.getInstance().setProps({user: userPointer});
-        expect(references.length).toBe(1);
-        expect(references[0].dispose).toBeCalled();
       });
+      const userPointer = environment.lookup({
+        dataID: ROOT_ID,
+        node: UserQuery.fragment,
+        variables: {id: '842472'}, // different user
+      }).data.node;
+      instance.getInstance().setProps({user: userPointer});
+      expect(references.length).toBe(1);
+      expect(references[0].dispose).toBeCalled();
     });
   });
 });

--- a/packages/relay-runtime/__mocks__/RelayModernMockEnvironment.js
+++ b/packages/relay-runtime/__mocks__/RelayModernMockEnvironment.js
@@ -118,6 +118,14 @@ function createMockEnvironment(options: {
     pendingFetches = pendingFetches.filter(pending => pending !== pendingFetch);
     pendingFetch.deferred.reject(error);
     jest.runOnlyPendingTimers();
+    return new Promise((resolve) => {
+      pendingFetch.deferred.getPromise()
+        .catch(() => {
+          // setImmediate so all handlers for pendingFetch are called before
+          // tests are run
+          setImmediate(resolve);
+        });
+    });
   };
   const resolve = (query, payload) => {
     invariant(
@@ -137,6 +145,14 @@ function createMockEnvironment(options: {
     pendingFetches = pendingFetches.filter(pending => pending !== pendingFetch);
     pendingFetch.deferred.resolve(payload);
     jest.runOnlyPendingTimers();
+    return new Promise((resolve) => {
+      pendingFetch.deferred.getPromise()
+        .then(() => {
+          // setImmediate so all handlers for pendingFetch are called before
+          // tests are run
+          setImmediate(resolve);
+        });
+    });
   };
 
   // Initialize a store debugger to help resolve test issues

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -39,7 +39,6 @@ const babelOptions = getBabelOptions({
       schema: SCHEMA_PATH,
     }],
     require('babel-plugin-transform-async-to-generator'),
-    require('babel-plugin-transform-regenerator'),
   ],
 });
 


### PR DESCRIPTION
I wanted to write tests for the two PRs I have open (https://github.com/facebook/relay/pull/1702, https://github.com/facebook/relay/pull/1760) but noticed the tests for those files were disabled by @kassens in https://github.com/facebook/relay/pull/1588.

It seems like the only way they could pass was if a Promise polyfill that resolves synchronously was in place. I'm assuming that's how the FB internal testing environment is set up. 

I am able to make the disabled tests pass by modifying `RelayModernMockEnvironment`'s `resolve` and `reject` methods to return promises that wait for the handlers to be called first and then updating the failing tests to wait for that promise to resolve before making assertions.

Let me know if you think this is the wrong approach.