### PR TITLE
Add warning: does not yet work with Android

### DIFF
--- a/docs/modern/Introduction.md
+++ b/docs/modern/Introduction.md
@@ -102,4 +102,4 @@ Relay Modern enables a variety of new features. Some are available via the Compa
 
 ## React Native
 
-Note that on Android, Relay Modern may not run properly because of an outstanding core-js issue.  [This polyfill](https://github.com/facebook/relay/issues/1704#issuecomment-297982006) is a workaround until this issue is fixed.
+Note that on Android, Relay Modern may not run properly (props don't load) because of an outstanding core-js issue.  [This polyfill](https://github.com/facebook/relay/issues/1704#issuecomment-297982006) is a workaround until this issue is fixed.

--- a/docs/modern/Introduction.md
+++ b/docs/modern/Introduction.md
@@ -99,3 +99,7 @@ One of the big ideas behind the new API is that execution can be made a lot more
 ## Comparing Relay Classic and Relay Modern
 
 Relay Modern enables a variety of new features. Some are available via the Compat API, while others require upgrading fully to the Modern runtime. See [what's new in Relay Modern](./new-in-relay-modern.html) for more details.
+
+## React Native
+
+Note that on Android, Relay Modern may not run properly because of an outstanding core-js issue.  [This polyfill](https://github.com/facebook/relay/issues/1704#issuecomment-297982006) is a workaround until this issue is fixed.

--- a/docs/modern/Introduction.md
+++ b/docs/modern/Introduction.md
@@ -102,4 +102,4 @@ Relay Modern enables a variety of new features. Some are available via the Compa
 
 ## React Native
 
-Note that on Android, Relay Modern may not run properly (props don't load) because of an outstanding core-js issue.  [This polyfill](https://github.com/facebook/relay/issues/1704#issuecomment-297982006) is a workaround until this issue is fixed.
+Note that on Android, [Relay Modern does not work](https://github.com/facebook/react-native/issues/13958) without a debugger attached (props will never be loaded).  [This polyfill](https://github.com/facebook/relay/issues/1704#issuecomment-297982006) is a workaround until this issue is fixed.


### PR DESCRIPTION
Relay just didn't work on Android for me.  My investigation here:
https://github.com/facebook/relay/issues/1797

Solution was posted here:
https://github.com/facebook/relay/issues/1704#issuecomment-297982006

I think this is an invaluable warning to save other early adopters hours trying to dig into Relay Modern source and debug this issue.  Thanks.