### PR TITLE
Use polyfill in compiler executable for benefit of Node 4 and 5

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ const babelOptions = require('./scripts/getBabelOptions')({
   moduleMap: {
     'babel-core': 'babel-core',
     'babel-generator': 'babel-generator',
+    'babel-polyfill': 'babel-polyfill',
     'babel-runtime/core-js/array/from': 'babel-runtime/core-js/array/from',
     'babel-runtime/core-js/json/stringify': 'babel-runtime/core-js/json/stringify',
     'babel-runtime/core-js/map': 'babel-runtime/core-js/map',

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -13,6 +13,8 @@
 
 'use strict';
 
+require('babel-polyfill');
+
 const RelayCodegenRunner = require('RelayCodegenRunner');
 const RelayFileIRParser = require('RelayFileIRParser');
 const RelayFileWriter = require('RelayFileWriter');

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "babel-generator": "6.24.0",
+    "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.23.0",
     "babel-traverse": "6.23.1",
     "babel-types": "6.23.0",


### PR DESCRIPTION
Noticed this Travis job fail under Node 4 and 5 due to trying to access `Array.prototype.includes`:

https://travis-ci.org/relayjs/relay-examples/jobs/235860128

Not sure if there are other Node 4/5 issues, so this may be the first in a series of whack-a-mole changes.