### PR TITLE
Generate plural Flow types

### DIFF
--- a/packages/relay-compiler/core/RelayFlowGenerator.js
+++ b/packages/relay-compiler/core/RelayFlowGenerator.js
@@ -192,6 +192,18 @@ function mergeSelections(a, b) {
   return merged;
 }
 
+function isPlural({ directives }): boolean {
+  const relayDirective = directives.find(({name}) => name === 'relay');
+
+  if (relayDirective) {
+    return !!relayDirective.args.find(({name, value}) => (
+      name === 'plural' && value.value
+    ));
+  } else {
+    return false;
+  }
+}
+
 const RelayCodeGenVisitor = {
   leave: {
     Root(node) {
@@ -207,11 +219,14 @@ const RelayCodeGenVisitor = {
     },
 
     Fragment(node) {
+      const baseType = selectionsToBabel(node.selections);
+      const type = isPlural(node) ? arrayOfType(baseType) : baseType;
+
       return t.exportNamedDeclaration(
         t.typeAlias(
           t.identifier(node.name),
           null,
-          selectionsToBabel(node.selections),
+          type,
         ),
         [],
         null,

--- a/packages/relay-compiler/core/__tests__/RelayFlowGenerator-test.js
+++ b/packages/relay-compiler/core/__tests__/RelayFlowGenerator-test.js
@@ -16,9 +16,12 @@ jest.disableAutomock();
 const RelayCompilerContext = require('RelayCompilerContext');
 const RelayFlowGenerator = require('RelayFlowGenerator');
 const RelayTestSchema = require('RelayTestSchema');
+const RelayRelayDirectiveTransform = require('RelayRelayDirectiveTransform');
 
 const getGoldenMatchers = require('getGoldenMatchers');
 const parseGraphQLText = require('parseGraphQLText');
+
+const {transformASTSchema} = require('ASTConvert');
 
 describe('RelayFlowGenerator', () => {
   beforeEach(() => {
@@ -27,7 +30,10 @@ describe('RelayFlowGenerator', () => {
 
   it('matches expected output', () => {
     expect('fixtures/flow-generator').toMatchGolden(text => {
-      const {definitions} = parseGraphQLText(RelayTestSchema, text);
+      const schema = transformASTSchema(RelayTestSchema, [
+        RelayRelayDirectiveTransform.SCHEMA_EXTENSION,
+      ]);
+      const {definitions} = parseGraphQLText(schema, text);
       const context = new RelayCompilerContext(RelayTestSchema).addAll(
         definitions,
       );

--- a/packages/relay-compiler/core/__tests__/fixtures/flow-generator/plural-fragment.golden.txt
+++ b/packages/relay-compiler/core/__tests__/fixtures/flow-generator/plural-fragment.golden.txt
@@ -1,0 +1,3 @@
+export type PluralFragment = $ReadOnlyArray<{|
+  +id: string;
+|}>;

--- a/packages/relay-compiler/core/__tests__/fixtures/flow-generator/plural-fragment.input.rql
+++ b/packages/relay-compiler/core/__tests__/fixtures/flow-generator/plural-fragment.input.rql
@@ -1,0 +1,3 @@
+fragment PluralFragment on Node @relay(plural: true) {
+  id
+}


### PR DESCRIPTION
I'm pretty new to Relay/GraphQL, so I wanted to run a failing test by the team to make sure this is the expected behavior before I spend time fixing the actual issue. If somebody gives me the go ahead I can look into fixing this.

Currently, if you declare a fragment with the directive `@relay(plural: true)` the generated Flow type is an object of that type. I would expect this to be an array of that type. This commit adds a failing test to reproduce this scenario.

