### PR TITLE
Fix ReferenceError in mutations docs

### DIFF
--- a/docs/modern/Mutations.md
+++ b/docs/modern/Mutations.md
@@ -62,8 +62,6 @@ const mutation = graphql`
   }
 `;
 
-
-
 function markNotificationAsRead(source, storyID) {
   const variables = {
     input: {

--- a/docs/modern/Mutations.md
+++ b/docs/modern/Mutations.md
@@ -62,14 +62,16 @@ const mutation = graphql`
   }
 `;
 
-const variables = {
-  input: {
-    source,
-    storyID,
-  },
-};
+
 
 function markNotificationAsRead(source, storyID) {
+  const variables = {
+    input: {
+      source,
+      storyID,
+    },
+  };
+
   commitMutation(
     environment,
     {


### PR DESCRIPTION
I'm _fairly_ sure that the code as previously written would result in a `ReferenceError` due to `source` and `storyId` not having been declared at the top-level scope. I think the intent here was to pull the values for `variables.input` from the `source` and `storyId` params in the `markNotificationAsRead` method, so I moved the `variables` declaration inside that method.

All of that said, my understanding of Relay is very limited, so my apologies if there is some Relay magic going on here I'm just not grokking.