### PR TITLE
Update flow-bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "fb-watchman": "2.0.0",
     "fbjs": "0.8.12",
     "fbjs-scripts": "0.7.1",
-    "flow-bin": "^0.46.0",
+    "flow-bin": "^0.47.0",
     "graphql": "0.9.6",
     "gulp": "3.9.1",
     "gulp-babel": "6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1621,9 +1621,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.46.0:
-  version "0.46.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.46.0.tgz#06ad7fe19dddb1042264438064a2a32fee12b872"
+flow-bin@^0.47.0:
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.47.0.tgz#a2a08ab3e0d1f1cb57d17e27b30b118b62fda367"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Because CI is currently red without it:

https://travis-ci.org/facebook/relay/jobs/236551035

    $ flow check
    Wrong version of Flow. The config specifies version ^0.47.0 but this
    is version 0.46.0