### PR TITLE
Fix scope error in Mutations.md

### DIFF
--- a/docs/modern/Mutations.md
+++ b/docs/modern/Mutations.md
@@ -62,14 +62,14 @@ const mutation = graphql`
   }
 `;
 
-const variables = {
-  input: {
-    source,
-    storyID,
-  },
-};
-
 function markNotificationAsRead(source, storyID) {
+  const variables = {
+    input: {
+      source,
+      storyID,
+    },
+  };
+
   commitMutation(
     environment,
     {


### PR DESCRIPTION
Variables depends on `source` and `storyID` and must be embedded inside `markNotificationAsRead` in order to resolve properly.