### PR TITLE
Export QueryResponseCache

### DIFF
--- a/packages/relay-runtime/RelayRuntime.js
+++ b/packages/relay-runtime/RelayRuntime.js
@@ -20,6 +20,7 @@ const RelayMarkSweepStore = require('RelayMarkSweepStore');
 const RelayModernEnvironment = require('RelayModernEnvironment');
 const RelayModernGraphQLTag = require('RelayModernGraphQLTag');
 const RelayNetwork = require('RelayNetwork');
+const RelayQueryResponseCache = require('RelayQueryResponseCache');
 const RelayViewerHandler = require('RelayViewerHandler');
 
 const commitLocalUpdate = require('commitLocalUpdate');
@@ -41,6 +42,7 @@ module.exports = {
   // Core API
   Environment: RelayModernEnvironment,
   Network: RelayNetwork,
+  QueryResponseCache: RelayQueryResponseCache,
   RecordSource: RelayInMemoryRecordSource,
   Store: RelayMarkSweepStore,
 


### PR DESCRIPTION
This is useful when implementing the network interface, especially given that we don't render from the in-memory cache by default.