### PR TITLE
Replace references to deprecated react-addons-test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "prettier": "^1.3.1",
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
-    "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",
     "react-static-container": "1.0.1",
     "react-test-renderer": "^15.5.4",
@@ -110,7 +109,6 @@
       "<rootDir>/node_modules/fbjs/node_modules/promise/",
       "<rootDir>/node_modules/object-assign/",
       "<rootDir>/node_modules/prop-types/",
-      "<rootDir>/node_modules/react-addons-test-utils/",
       "<rootDir>/node_modules/react-dom/",
       "<rootDir>/node_modules/react-static-container/",
       "<rootDir>/node_modules/react/"

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -27,7 +27,7 @@ const babelOptions = getBabelOptions({
     'ReactDOM': 'react-dom',
     'ReactDOMServer': 'react-dom/server',
     'ReactTestRenderer': 'react-test-renderer',
-    'ReactTestUtils': 'react-addons-test-utils',
+    'ReactTestUtils': 'react-dom/test-utils',
     'StaticContainer.react': 'react-static-container',
   },
   plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,7 +1527,7 @@ fbjs-scripts@0.7.1:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@0.8.12, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@0.8.12, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -3467,13 +3467,6 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-addons-test-utils@^15.5.1:
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.5.1.tgz#e0d258cda2a122ad0dff69f838260d0c3958f5f7"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
 
 react-dom@^15.5.4:
   version "15.5.4"


### PR DESCRIPTION
This was causing a lot of warnings in tests.

Test Plan:
run the tests