### PR TITLE
Replace references to deprecated React.createClass

### DIFF
--- a/packages/react-relay/classic/container/__tests__/RelayContainer-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayContainer-test.js
@@ -51,7 +51,9 @@ describe('RelayContainer', function() {
       render.mock.calls[render.mock.calls.length - 1].props = this.props;
       return <div />;
     });
-    MockComponent = React.createClass({render});
+    MockComponent = class MockComponent extends React.Component {
+      render = render;
+    };
     MockContainer = Relay.createContainer(MockComponent, {
       fragments: {
         foo: jest.fn(() => Relay.QL`fragment on Node{id,name}`),
@@ -176,7 +178,11 @@ describe('RelayContainer', function() {
     });
 
     it('creates query for a container with fragments', () => {
-      const anotherComponent = React.createClass({render: () => null});
+      class AnotherComponent extends React.Component {
+        render() {
+          return null;
+        }
+      }
       const MockProfile = Relay.createContainer(MockComponent, {
         fragments: {
           user: () => Relay.QL`
@@ -188,7 +194,7 @@ describe('RelayContainer', function() {
           `,
         },
       });
-      const MockProfileLink = Relay.createContainer(anotherComponent, {
+      const MockProfileLink = Relay.createContainer(AnotherComponent, {
         fragments: {
           user: () => Relay.QL`
             fragment on Actor {
@@ -202,19 +208,19 @@ describe('RelayContainer', function() {
       expect(fragment).toEqualQueryNode(
         getNode(
           Relay.QL`
-        fragment on Actor {
-          id
-          __typename
-          name
-          ${Relay.QL`
             fragment on Actor {
-              id,
-              __typename,
-              url,
+              id
+              __typename
+              name
+              ${Relay.QL`
+                fragment on Actor {
+                  id,
+                  __typename,
+                  url,
+                }
+              `},
             }
-          `},
-        }
-      `,
+          `,
         ),
       );
     });
@@ -1085,10 +1091,10 @@ describe('RelayContainer', function() {
     render = jest.fn(() => <div />);
     const shouldComponentUpdate = jest.fn();
 
-    const MockFastComponent = React.createClass({
-      render,
-      shouldComponentUpdate,
-    });
+    class MockFastComponent extends React.Component {
+      render = render;
+      shouldComponentUpdate = shouldComponentUpdate;
+    }
 
     const MockFastContainer = Relay.createContainer(MockFastComponent, {
       fragments: {

--- a/packages/react-relay/classic/container/__tests__/RelayContainer_Component-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayContainer_Component-test.js
@@ -31,9 +31,11 @@ describe('RelayContainer', function() {
   beforeEach(function() {
     jest.resetModules();
 
-    MockComponent = React.createClass({
-      render: jest.fn(() => <div />),
-    });
+    MockComponent = class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    };
 
     mockCreateContainer = component => {
       MockContainer = Relay.createContainer(component, {

--- a/packages/react-relay/classic/container/__tests__/RelayContainer_setVariables-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayContainer_setVariables-test.js
@@ -50,7 +50,9 @@ describe('RelayContainer.setVariables', function() {
     prepareVariables = jest.fn((variables, route) => variables);
 
     // Make RQLTransform ignore this call.
-    MockComponent = React.createClass({render});
+    MockComponent = class MockComponent extends React.Component {
+      render = render;
+    };
     const createContainer = Relay.createContainer;
     MockContainer = createContainer(MockComponent, {
       fragments: {
@@ -494,7 +496,9 @@ describe('RelayContainer.setVariables', function() {
       );
 
       // Make RQLTransform ignore this call.
-      MockComponent = React.createClass({render});
+      class MockComponent extends React.Component {
+        render = render;
+      }
       const createContainer = Relay.createContainer;
       MockContainer = createContainer(MockComponent, {
         fragments: {

--- a/packages/react-relay/classic/container/__tests__/RelayRenderer_abort-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayRenderer_abort-test.js
@@ -29,7 +29,11 @@ describe('RelayRenderer.abort', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    const MockComponent = React.createClass({render: () => <div />});
+    class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
     MockContainer = Relay.createContainer(MockComponent, {
       fragments: {},
     });

--- a/packages/react-relay/classic/container/__tests__/RelayRenderer_onReadyStateChange-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayRenderer_onReadyStateChange-test.js
@@ -34,7 +34,11 @@ describe('RelayRenderer.onReadyStateChange', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    const MockComponent = React.createClass({render: () => <div />});
+    class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
     MockContainer = Relay.createContainer(MockComponent, {
       fragments: {},
     });

--- a/packages/react-relay/classic/container/__tests__/RelayRenderer_render-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayRenderer_render-test.js
@@ -47,7 +47,11 @@ describe('RelayRenderer.render', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    const MockComponent = React.createClass({render: () => <div />});
+    class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
     MockContainer = Relay.createContainer(MockComponent, {
       fragments: {},
     });

--- a/packages/react-relay/classic/container/__tests__/RelayRenderer_renderArgs-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayRenderer_renderArgs-test.js
@@ -34,7 +34,11 @@ describe('RelayRenderer.renderArgs', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    const MockComponent = React.createClass({render: () => <div />});
+    class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
     MockContainer = Relay.createContainer(MockComponent, {
       fragments: {},
     });

--- a/packages/react-relay/classic/container/__tests__/RelayRenderer_requests-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayRenderer_requests-test.js
@@ -35,7 +35,11 @@ describe('RelayRenderer', function() {
   beforeEach(() => {
     jest.resetModules();
 
-    const MockComponent = React.createClass({render: () => <div />});
+    class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
     MockContainer = Relay.createContainer(MockComponent, {
       fragments: {},
     });
@@ -87,7 +91,11 @@ describe('RelayRenderer', function() {
   });
 
   it('primes new queries when `Component` changes', () => {
-    const AnotherComponent = React.createClass({render: () => <div />});
+    class AnotherComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
     const AnotherContainer = Relay.createContainer(AnotherComponent, {
       fragments: {},
     });

--- a/packages/react-relay/classic/container/__tests__/RelayRenderer_server-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayRenderer_server-test.js
@@ -32,7 +32,11 @@ describe('RelayRenderer', function() {
   beforeEach(() => {
     jest.resetModules();
 
-    const MockComponent = React.createClass({render: () => <div />});
+    class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
     MockContainer = Relay.createContainer(MockComponent, {
       fragments: {},
     });

--- a/packages/react-relay/classic/container/__tests__/RelayRenderer_validation-test.js
+++ b/packages/react-relay/classic/container/__tests__/RelayRenderer_validation-test.js
@@ -37,7 +37,11 @@ describe('RelayRenderer.validation', () => {
     jest.resetModules();
     jasmine.addMatchers(RelayTestUtils.matchers);
 
-    MockComponent = React.createClass({render: () => <div />});
+    MockComponent = class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    };
     MockContainer = Relay.createContainer(MockComponent, {
       fragments: {},
     });

--- a/packages/react-relay/classic/container/__tests__/isRelayContainer-test.js
+++ b/packages/react-relay/classic/container/__tests__/isRelayContainer-test.js
@@ -22,9 +22,11 @@ describe('isRelayContainer', function() {
   beforeEach(function() {
     jest.resetModules();
 
-    MockComponent = React.createClass({
-      render: () => <div />,
-    });
+    class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
 
     MockContainer = Relay.createContainer(MockComponent, {
       fragments: {},

--- a/packages/react-relay/classic/query/__tests__/buildRQL-test.js
+++ b/packages/react-relay/classic/query/__tests__/buildRQL-test.js
@@ -32,12 +32,11 @@ describe('buildRQL', () => {
   let MockContainer;
 
   beforeEach(() => {
-    const render = jest.fn(function() {
-      // Make it easier to expect prop values.
-      render.mock.calls[render.mock.calls.length - 1].props = this.props;
-      return <div />;
-    });
-    MockComponent = React.createClass({render});
+    class MockComponent extends React.Component {
+      render() {
+        return <div />;
+      }
+    }
     MockContainer = Relay.createContainer(MockComponent, {
       initialVariables: {
         size: null,


### PR DESCRIPTION
This was causing a lot of warnings in the tests. Let's move towards the future.
I left one test with the current `createClass` call that was testing that these components are handled correctly. This can be upgraded separately.

Test Plan:
run the jest tests