### PR TITLE
RFC: Teach compiler `--persist` option

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -75,10 +75,9 @@ async function run(options: {
   if (persistModule && !fs.existsSync(persistModule)) {
     throw new Error(`--persist path does not exist: ${persistModule}.`);
   }
-  // Using eval here to prevent webpack from trying to rewrite the require and
-  // failing.
-  const persistQuery = persistModule &&
-    eval(`require(${JSON.stringify(persistModule)})`);
+  // Need to hide the `require` here to prevent webpack from rewriting
+  // it and failing.
+  const persistQuery = persistModule && global['require'](persistModule);
   if (options.watch && !hasWatchmanRootFile(srcDir)) {
     throw new Error(
       `

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -77,7 +77,7 @@ async function run(options: {
   }
   // Need to hide the `require` here to prevent webpack from rewriting
   // it and failing.
-  const persistQuery = persistModule && global['require'](persistModule);
+  const persistQuery = persistModule && __non_webpack_require__(persistModule);
   if (options.watch && !hasWatchmanRootFile(srcDir)) {
     throw new Error(
       `

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -44,7 +44,7 @@ export type WriterConfig = {
   compilerTransforms: CompilerTransforms,
   generateExtraFiles?: GenerateExtraFiles,
   outputDir?: string,
-  persistQuery?: (text: string) => Promise<string>,
+  persistQuery?: ?(text: string) => Promise<string>,
   platform?: string,
   fragmentsWithLegacyFlowTypes?: Set<string>,
   schemaExtensions: Array<string>,


### PR DESCRIPTION
Sample usage:

    relay-compiler --src ./src --schema schema.graphql --persist scripts/persistQuery.js

Where `persistQuery.js` looks like this:

```
function persistQuery(text) {
  var id = someLogicToPersistQueryText(text);
  return Promise.resolve(id);
}
```

The alternative in the absence of this option is to copy-paste the entire `RelayCompilerBin` implementation just to override that bit.

Note that webpack makes this ghastly — necessitating the use of `eval` — because it wants to rewrite the `require` of the passed in module, which of course fails because it is dynamic. Google search turns up a bunch of results like this one lamenting the situation:

https://stackoverflow.com/questions/30575060/require-js-files-dynamically-on-runtime-using-webpack

Apparently it's better in webpack 2.