### PR TITLE
Update doc block to use pageInfo field names

### DIFF
--- a/packages/react-relay/modern/ReactRelayPaginationContainer.js
+++ b/packages/react-relay/modern/ReactRelayPaginationContainer.js
@@ -150,9 +150,11 @@ export type ConnectionData = {
  *     user: graphql`fragment FriendsFragment on User {
  *       friends(after: $afterCursor first: $count) @connection {
  *         edges { ... }
- *         page_info {
- *           end_cursor
- *           has_next_page
+ *         pageInfo {
+ *           startCursor 
+ *           endCursor
+ *           hasNextPage
+ *           hasPreviousPage
  *         }
  *       }
  *     }`,


### PR DESCRIPTION
`page_info` throws an error, as do the non-camelcase fields present in this block, because they are not present in the connection schema. Pagination containers are already hard to figure out without concrete examples, we should at least make the pseudo-code (mostly) runnable if copy-pasta'd.