### PR TITLE
Make compatible with React Native 0.45

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,7 @@ const babelOptions = require('./scripts/getBabelOptions')({
     'React': 'react',
     'ReactDOM': 'react-dom',
     'ReactNative': 'react-native',
+    'ReactNative/Libraries/Renderer/src/renderers/native/ReactNative': 'react-native/Libraries/Renderer/src/renderers/native/ReactNative',
     'RelayRuntime': 'relay-runtime',
     'signedsource': 'signedsource',
     'StaticContainer.react': 'react-static-container',

--- a/packages/react-relay/classic/tools/relayUnstableBatchedUpdates.native.js
+++ b/packages/react-relay/classic/tools/relayUnstableBatchedUpdates.native.js
@@ -13,5 +13,13 @@
 'use strict';
 
 const ReactNative = require('ReactNative');
+let batchedUpdates = undefined;
 
-module.exports = ReactNative.unstable_batchedUpdates;
+if (ReactNative.unstable_batchedUpdates) {
+  batchedUpdates = ReactNative.unstable_batchedUpdates;
+} else {
+  const Renderer = require('ReactNative/Libraries/Renderer/src/renderers/native/ReactNative');
+  batchedUpdates = Renderer.unstable_batchedUpdates;
+}
+
+module.exports = batchedUpdates;

--- a/packages/react-relay/classic/tools/relayUnstableBatchedUpdates.native.js
+++ b/packages/react-relay/classic/tools/relayUnstableBatchedUpdates.native.js
@@ -13,13 +13,8 @@
 'use strict';
 
 const ReactNative = require('ReactNative');
-let batchedUpdates = undefined;
 
-if (ReactNative.unstable_batchedUpdates) {
-  batchedUpdates = ReactNative.unstable_batchedUpdates;
-} else {
-  const Renderer = require('ReactNative/Libraries/Renderer/src/renderers/native/ReactNative');
-  batchedUpdates = Renderer.unstable_batchedUpdates;
-}
-
-module.exports = batchedUpdates;
+module.exports =
+  ReactNative.unstable_batchedUpdates ||
+  require('ReactNative/Libraries/Renderer/src/renderers/native/ReactNative')
+    .unstable_batchedUpdates;


### PR DESCRIPTION
Fixes #1866.

The `unstable_batchedUpdates` function is no longer available from the root module, but instead has to be fetched from the renderer shim, which in turn gets it from the correct renderer (stack vs fiber).