### PR TITLE
add error for missing string.startsWith

### DIFF
--- a/docs/modern/Introduction.md
+++ b/docs/modern/Introduction.md
@@ -67,6 +67,7 @@ require('core-js/es6/map');
 require('core-js/es6/set');
 require('core-js/es6/promise');
 require('core-js/es6/object');
+require('core-js/es6/string');
 
 require('./myRelayApplication');
 ```

--- a/packages/relay-runtime/RelayRuntime.js
+++ b/packages/relay-runtime/RelayRuntime.js
@@ -42,10 +42,13 @@ if (__DEV__) {
     typeof Map !== 'function' ||
     typeof Set !== 'function' ||
     typeof Promise !== 'function' ||
-    typeof Object.assign !== 'function'
+    typeof Object.assign !== 'function' ||
+    typeof String.prototype.startsWith !== 'function' ||
+    typeof String.prototype.endsWith !== 'function'
   ) {
     throw new Error(
-      'relay-runtime requires Map, Set, Promise, and Object.assign to exist. ' +
+      'relay-runtime requires Map, Set, Promise, Object.assign, ' +
+        'String.prototype.startsWith/endsWith to exist. ' +
         'Use a polyfill to provide these for older browsers.',
     );
   }


### PR DESCRIPTION
@leebyron Relay Runtime also requires a polyfill for String.prototype.startsWith/endsWith which is not supported in Safari <9 or IE11. This is required even for v1.0.0 which does not include https://github.com/facebook/relay/commit/3daedb2af1ab3baf67c61ad27afd7d8bd60aa59c.