### PR TITLE
Remove new string methods from runtime code

### DIFF
--- a/packages/react-relay/classic/store/RelayRecord.js
+++ b/packages/react-relay/classic/store/RelayRecord.js
@@ -106,7 +106,7 @@ const RelayRecord = {
   * that's understood by the server as well.
   */
   isClientID(dataID: string): boolean {
-    return dataID.startsWith('client:');
+    return dataID.indexOf('client:') === 0;
   },
 
   isMetadataKey(key: string): boolean {

--- a/packages/react-relay/classic/traversal/printRelayOSSQuery.js
+++ b/packages/react-relay/classic/traversal/printRelayOSSQuery.js
@@ -218,7 +218,7 @@ function printVariableDefinitions({variableMap}: PrinterState): string {
 }
 
 function printNonNullType(type: string): string {
-  if (type.endsWith('!')) {
+  if (type[type.length - 1] === '!') {
     return type;
   }
   return type + '!';

--- a/packages/relay-runtime/store/RelayConcreteVariables.js
+++ b/packages/relay-runtime/store/RelayConcreteVariables.js
@@ -82,7 +82,7 @@ function getOperationVariables(
     operationVariables[def.name] = value;
     if (__DEV__) {
       warning(
-        value != null || !def.type.endsWith('!'),
+        value != null || def.type[def.type.length - 1] !== '!',
         'RelayConcreteVariables: Expected a value for non-nullable variable ' +
           '`$%s: %s` on operation `%s`, got `%s`. Make sure you supply a ' +
           'value for all non-nullable arguments.',

--- a/packages/relay-runtime/store/RelayRecordSourceInspector.js
+++ b/packages/relay-runtime/store/RelayRecordSourceInspector.js
@@ -71,7 +71,7 @@ class RelayRecordSourceInspector {
   getNodes(): Array<RecordSummary> {
     const nodes = [];
     this._source.getRecordIDs().forEach(dataID => {
-      if (dataID.startsWith('client:')) {
+      if (dataID.indexOf('client:') === 0) {
         return;
       }
       const record = this._source.get(dataID);

--- a/packages/relay-runtime/store/generateRelayClientID.js
+++ b/packages/relay-runtime/store/generateRelayClientID.js
@@ -26,7 +26,7 @@ function generateRelayClientID(
   if (index != null) {
     key += ':' + index;
   }
-  if (!key.startsWith(PREFIX)) {
+  if (key.indexOf(PREFIX) !== 0) {
     key = PREFIX + key;
   }
   return key;


### PR DESCRIPTION
This just complicates the polyfill story and is trivial to replace with ES5-compatible code.

Fixes #1894