### PR TITLE
Fix bug where RelayModernFragmentSpecResolver was not resolving data correctly

### DIFF
--- a/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
+++ b/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
@@ -287,6 +287,9 @@ class SelectorListResolver {
           nextData.push(nextItem);
         }
       }
+      if (!nextData && this._resolvers.length !== prevData.length) {
+        nextData = prevData.slice(0, this._resolvers.length);
+      }
       this._data = nextData || prevData;
       this._stale = false;
     }

--- a/packages/relay-runtime/store/__tests__/RelayModernFragmentSpecResolver-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernFragmentSpecResolver-test.js
@@ -465,6 +465,39 @@ describe('RelayModernFragmentSpecResolver', () => {
       });
     });
 
+    it('resolves fragment data when the item at the end of the array is removed', () => {
+      const resolver = new RelayModernFragmentSpecResolver(
+        context,
+        {user: UsersFragment},
+        {user: [zuck, beast]},
+        jest.fn(),
+      );
+
+      expect(resolver.resolve()).toEqual({
+        user: [
+          {
+            id: '4',
+            name: 'Zuck',
+          },
+          {
+            id: 'beast',
+            name: 'Beast',
+          },
+        ],
+      });
+
+      resolver.setProps({user: [zuck]});
+
+      expect(resolver.resolve()).toEqual({
+        user: [
+          {
+            id: '4',
+            name: 'Zuck',
+          },
+        ],
+      });
+    });
+
     it('disposes subscriptions', () => {
       const callback = jest.fn();
       const resolver = new RelayModernFragmentSpecResolver(


### PR DESCRIPTION
Fixes #1750
Fixes #1904 

The RelayModernFragmentSpecResolver was not resolving data correctly when the item at end of the array passed in props was removed.

i.e. given that my fragment is resolving data for `[zuck, beast]`, when this changes to `[zuck]`, the resolved data should reflect this. Previously it was returning the existing data as it was not checking if the length of the resolvers was not equal to the previous data length.

Does this need to be fixed in classic too?