### PR TITLE
[relay-compiler] resolve module names for files named *.js.flow

### DIFF
--- a/packages/relay-compiler/util/__tests__/getModuleName-test.js
+++ b/packages/relay-compiler/util/__tests__/getModuleName-test.js
@@ -18,9 +18,11 @@ const getModuleName = require('getModuleName');
 
 test('getModuleName', () => {
   expect(getModuleName('/path/Button.js')).toBe('Button');
+  expect(getModuleName('/path/Button.js.flow')).toBe('Button');
   expect(getModuleName('/path/Slider.ios.js')).toBe('Slider');
   expect(getModuleName('/path/Typescript.ts')).toBe('Typescript');
   expect(getModuleName('/path/button/index.js')).toBe('button');
+  expect(getModuleName('/path/button/index.js.flow')).toBe('button');
   expect(getModuleName('/path/foo-bar/index.js')).toBe('fooBar');
   expect(getModuleName('/path/foo-bar-baz.js')).toBe('fooBarBaz');
   expect(getModuleName('/path/non-numeric-end-.js')).toBe('nonNumericEnd');

--- a/packages/relay-compiler/util/getModuleName.js
+++ b/packages/relay-compiler/util/getModuleName.js
@@ -16,7 +16,13 @@
 const path = require('path');
 
 function getModuleName(filePath: string): string {
-  const filename = path.basename(filePath, path.extname(filePath));
+  // index.js -> index
+  // index.js.flow -> index.js
+  let filename = path.basename(filePath, path.extname(filePath));
+
+  // index.js -> index (when extension has multiple segments)
+  filename = filename.replace(/(?:\.\w+)+/, '');
+
   // /path/to/button/index.js -> button
   let moduleName = filename === 'index'
     ? path.basename(path.dirname(filePath))


### PR DESCRIPTION
In the case where users custom compile with base documents parsed from node_module library shadow files (full context here: https://github.com/facebook/relay/issues/1897#issuecomment-309560870), we need to be able to resolve both standard one-part extensions e.g. `*.js` as well as `*.js.flow`.

Continuation of #1901