### PR TITLE
add include/exclude options to compiler

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -43,15 +43,17 @@ const {
 
 import type {GraphQLSchema} from 'graphql';
 
-function buildWatchExpression(options: {extensions: Array<string>}) {
+function buildWatchExpression(options: {
+  extensions: Array<string>,
+  include: Array<string>,
+  exclude: Array<string>,
+}) {
   return [
     'allof',
     ['type', 'f'],
     ['anyof', ...options.extensions.map(ext => ['suffix', ext])],
-    ['not', ['match', '**/node_modules/**', 'wholename']],
-    ['not', ['match', '**/__mocks__/**', 'wholename']],
-    ['not', ['match', '**/__tests__/**', 'wholename']],
-    ['not', ['match', '**/__generated__/**', 'wholename']],
+    ['anyof', ...options.include.map(include => ['match', include, 'wholename'])],
+    ...options.exclude.map(exclude => ['not', ['match', exclude, 'wholename']])
   ];
 }
 
@@ -61,6 +63,8 @@ async function run(options: {
   schema: string,
   src: string,
   extensions: Array<string>,
+  include: Array<string>,
+  exclude: Array<string>,
   verbose: boolean,
   watch?: ?boolean,
 }) {
@@ -197,6 +201,23 @@ const argv = yargs
     src: {
       describe: 'Root directory of application code',
       demandOption: true,
+      type: 'string',
+    },
+    include: {
+      array: true,
+      default: ['**'],
+      describe: 'directories to include under src',
+      type: 'string',
+    },
+    exclude: {
+      array: true,
+      default: [
+        '**/node_modules/**',
+        '**/__mocks__/**',
+        '**/__tests__/**',
+        '**/__generated__/**',
+      ],
+      describe: 'directories to ignore under src',
       type: 'string',
     },
     extensions: {


### PR DESCRIPTION
It would be nice to be a little more flexible with the search paths for `relay-compiler`. As of https://github.com/facebook/relay/pull/1686 `relay-compiler` ignores node_modules. We have several Relay apps that share common components through node_modules and need a way to tell the compiler which ones to search. This change will let us add several more specific search paths and override the setting to ignore node_modules.

I was careful to do this in a way that is not a breaking change.