### PR TITLE
Look for `compat` schema file relative to Babel source root

### DIFF
--- a/packages/babel-plugin-relay/compileRelayQLTag.js
+++ b/packages/babel-plugin-relay/compileRelayQLTag.js
@@ -37,7 +37,7 @@ function compileRelayQLTag(
   state: BabelState,
 ): Object {
   try {
-    const fileOpts = state.file && state.file.opts;
+    const fileOpts = state.file && state.file.opts || {};
     const transformer = getClassicTransformer(schemaProvider, state.opts || {}, fileOpts);
     return transformer.transform(t, quasi, {
       documentName,

--- a/packages/babel-plugin-relay/compileRelayQLTag.js
+++ b/packages/babel-plugin-relay/compileRelayQLTag.js
@@ -37,7 +37,7 @@ function compileRelayQLTag(
   state: BabelState,
 ): Object {
   try {
-    const transformer = getClassicTransformer(schemaProvider, state.opts || {});
+    const transformer = getClassicTransformer(schemaProvider, state.opts || {}, state.file.opts);
     return transformer.transform(t, quasi, {
       documentName,
       propName,

--- a/packages/babel-plugin-relay/compileRelayQLTag.js
+++ b/packages/babel-plugin-relay/compileRelayQLTag.js
@@ -37,7 +37,8 @@ function compileRelayQLTag(
   state: BabelState,
 ): Object {
   try {
-    const transformer = getClassicTransformer(schemaProvider, state.opts || {}, state.file.opts);
+    const fileOpts = state.file && state.file.opts;
+    const transformer = getClassicTransformer(schemaProvider, state.opts || {}, fileOpts);
     return transformer.transform(t, quasi, {
       documentName,
       propName,

--- a/packages/babel-plugin-relay/getClassicTransformer.js
+++ b/packages/babel-plugin-relay/getClassicTransformer.js
@@ -32,7 +32,7 @@ type ClassicTransformerOpts = {
 };
 
 type BabelFileOpts = {
-  moduleRoot?: string,
+  sourceRoot?: string,
 };
 
 /**
@@ -65,7 +65,7 @@ function getSchema(schemaProvider: GraphQLSchemaProvider, fileOptions: BabelFile
     typeof schemaProvider === 'function' ? schemaProvider() : schemaProvider;
   const introspection =
     typeof schemaReference === 'string'
-      ? getSchemaIntrospection(schemaReference, fileOptions.moduleRoot)
+      ? getSchemaIntrospection(schemaReference, fileOptions.sourceRoot)
       : schemaReference;
   if (introspection.__schema) {
     return buildClientSchema((introspection: any));

--- a/packages/babel-plugin-relay/getClassicTransformer.js
+++ b/packages/babel-plugin-relay/getClassicTransformer.js
@@ -31,6 +31,10 @@ type ClassicTransformerOpts = {
   validator?: Validator<any>,
 };
 
+type BabelFileOpts = {
+  moduleRoot?: string,
+};
+
 /**
  * Caches based on the provided schema. Typically this means only one instance
  * of the RelayQLTransformer will be created, however in some circumstances
@@ -40,10 +44,11 @@ const classicTransformerCache = new Map();
 function getClassicTransformer(
   schemaProvider: GraphQLSchemaProvider,
   options: ClassicTransformerOpts,
+  fileOptions: BabelFileOpts,
 ): RelayQLTransformer {
   let classicTransformer = classicTransformerCache.get(schemaProvider);
   if (!classicTransformer) {
-    const schema = getSchema(schemaProvider);
+    const schema = getSchema(schemaProvider, fileOptions);
     classicTransformer = new RelayQLTransformer(schema, {
       inputArgumentName: options.inputArgumentName,
       snakeCase: Boolean(options.snakeCase),
@@ -55,12 +60,12 @@ function getClassicTransformer(
   return classicTransformer;
 }
 
-function getSchema(schemaProvider: GraphQLSchemaProvider): GraphQLSchema {
+function getSchema(schemaProvider: GraphQLSchemaProvider, fileOptions: BabelFileOpts): GraphQLSchema {
   const schemaReference =
     typeof schemaProvider === 'function' ? schemaProvider() : schemaProvider;
   const introspection =
     typeof schemaReference === 'string'
-      ? getSchemaIntrospection(schemaReference)
+      ? getSchemaIntrospection(schemaReference, fileOptions.moduleRoot)
       : schemaReference;
   if (introspection.__schema) {
     return buildClientSchema((introspection: any));

--- a/packages/babel-plugin-relay/getSchemaIntrospection.js
+++ b/packages/babel-plugin-relay/getSchemaIntrospection.js
@@ -20,7 +20,7 @@ const {parse} = require('graphql');
 
 function getSchemaIntrospection(schemaPath: string, basePath: ?string) {
   try {
-    let fullSchemaPath = path.join(process.cwd(), schemaPath);
+    let fullSchemaPath = schemaPath;
     if (!fs.existsSync(fullSchemaPath) && basePath) {
       fullSchemaPath = path.join(basePath, schemaPath);
     }

--- a/packages/babel-plugin-relay/getSchemaIntrospection.js
+++ b/packages/babel-plugin-relay/getSchemaIntrospection.js
@@ -13,13 +13,18 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 
 const {SCHEMA_EXTENSION} = require('./GraphQLRelayDirective');
 const {parse} = require('graphql');
 
-function getSchemaIntrospection(schemaPath: string) {
+function getSchemaIntrospection(schemaPath: string, basePath: ?string) {
   try {
-    const source = fs.readFileSync(schemaPath, 'utf8');
+    let fullSchemaPath = schemaPath;
+    if (!path.isAbsolute(fullSchemaPath) && basePath) {
+      fullSchemaPath = path.join(basePath, schemaPath);
+    }
+    const source = fs.readFileSync(fullSchemaPath, 'utf8');
     if (source[0] === '{') {
       return JSON.parse(source);
     }

--- a/packages/babel-plugin-relay/getSchemaIntrospection.js
+++ b/packages/babel-plugin-relay/getSchemaIntrospection.js
@@ -20,8 +20,8 @@ const {parse} = require('graphql');
 
 function getSchemaIntrospection(schemaPath: string, basePath: ?string) {
   try {
-    let fullSchemaPath = schemaPath;
-    if (!path.isAbsolute(fullSchemaPath) && basePath) {
+    let fullSchemaPath = path.join(process.cwd(), schemaPath);
+    if (!fs.existsSync(fullSchemaPath) && basePath) {
       fullSchemaPath = path.join(basePath, schemaPath);
     }
     const source = fs.readFileSync(fullSchemaPath, 'utf8');


### PR DESCRIPTION
Currently the schema specified in the Babel config is opened relative to the current working directory; this changes the behavior so that if the file is not found, we additionally look relative to Babel's ~module~ source root.

Fixes facebook/relay#1755