### PR TITLE
Don't break in compat mode when root field is not named Query

### DIFF
--- a/packages/babel-plugin-relay/createClassicNode.js
+++ b/packages/babel-plugin-relay/createClassicNode.js
@@ -319,13 +319,25 @@ function createFragmentForOperation(t, path, operation, state) {
   );
   switch (operation.operation) {
     case 'query':
-      type = transformer.schema.getQueryType().name;
+      const queryType = transformer.schema.getQueryType();
+      if (!queryType) {
+        throw new Error('Schema does not contain a root query type.');
+      }
+      type = queryType.name;
       break;
     case 'mutation':
-      type = transformer.schema.getMutationType().name;
+      const mutationType = transformer.schema.getMutationType();
+      if (!mutationType) {
+        throw new Error('Schema does not contain a root mutation type.');
+      }
+      type = mutationType.name;
       break;
     case 'subscription':
-      type = transformer.schema.getSubscriptionType().name;
+      const subscriptionType = transformer.schema.getSubscriptionType();
+      if (!subscriptionType) {
+        throw new Error('Schema does not contain a root subscription type.');
+      }
+      type = subscriptionType.name;
       break;
     default:
       throw new Error(

--- a/packages/react-relay/classic/store/RelayStoreConstants.js
+++ b/packages/react-relay/classic/store/RelayStoreConstants.js
@@ -20,12 +20,6 @@
  */
 const ROOT_ID = 'client:root';
 
-/**
- * The type of the root record.
- */
-const ROOT_TYPE = 'Query';
-
 module.exports = {
-  ROOT_ID,
-  ROOT_TYPE,
+  ROOT_ID
 };

--- a/packages/react-relay/classic/store/RelayStoreData.js
+++ b/packages/react-relay/classic/store/RelayStoreData.js
@@ -73,7 +73,7 @@ import type {
 
 const {CLIENT_MUTATION_ID} = RelayConnectionInterface;
 const {ID, ID_TYPE, NODE, NODE_TYPE, TYPENAME} = RelayNodeInterface;
-const {ROOT_ID, ROOT_TYPE} = require('RelayStoreConstants');
+const {ROOT_ID} = require('RelayStoreConstants');
 const {EXISTENT} = RelayClassicRecordState;
 
 const idField = RelayQuery.Field.build({
@@ -350,7 +350,7 @@ class RelayStoreData {
 
       // Ensure the root record exists
       const path = RelayQueryPath.getRootRecordPath();
-      recordWriter.putRecord(ROOT_ID, ROOT_TYPE, path);
+      recordWriter.putRecord(ROOT_ID, query.getType(), path);
       if (this._queuedStore.getRecordState(ROOT_ID) !== EXISTENT) {
         changeTracker.createID(ROOT_ID);
       } else {


### PR DESCRIPTION
Fixes https://github.com/facebook/relay/issues/1667 and https://github.com/facebook/relay/issues/1624

I tested using this branch of the example repo: https://github.com/relayjs/relay-examples/compare/master...robrichard:custom-query-name?expand=1

@kassens 