### PR TITLE
v1.2.0-rc1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relay",
   "description": "A framework for building data-driven React applications.",
-  "version": "1.1.0",
+  "version": "1.2.0-rc1",
   "license": "BSD-3-Clause",
   "homepage": "https://facebook.github.io/relay/",
   "bugs": "https://github.com/facebook/relay/issues",

--- a/packages/babel-plugin-relay/package.json
+++ b/packages/babel-plugin-relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-relay",
   "description": "A Babel Plugin for use with Relay applications.",
-  "version": "1.1.0",
+  "version": "1.2.0-rc1",
   "keywords": [
     "graphql",
     "relay",

--- a/packages/react-relay/package.json
+++ b/packages/react-relay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-relay",
   "description": "A framework for building GraphQL-driven React applications.",
-  "version": "1.1.0",
+  "version": "1.2.0-rc1",
   "keywords": [
     "graphql",
     "relay",

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relay-compiler",
   "description": "A compiler tool for building GraphQL-driven applications.",
-  "version": "1.1.0",
+  "version": "1.2.0-rc1",
   "keywords": [
     "graphql",
     "relay"

--- a/packages/relay-runtime/package.json
+++ b/packages/relay-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relay-runtime",
   "description": "A core runtime for building GraphQL-driven applications.",
-  "version": "1.1.0",
+  "version": "1.2.0-rc1",
   "keywords": [
     "graphql",
     "relay"


### PR DESCRIPTION
Changelog up to 7e1065fd6ea2cbc5e3468029ac2f0ab3b7daf418

# New

- Experimental `@inline` directive to inline fragments verbatim for use in utility functions (1b19ee0fb536fd9b28d25fd7b02801256870d68c)
- The compiler now supports `--exclude` and `--include` for more control over what files are parsed (94c8b203a95b1366b4034459d1c594e092de92ee)
- PaginationContainer can now refetch with new variables, useful for server filtered, paginated lists (6bc91271f31e5e268784be516ed6c3190d82c89f)

# Fixed

- Relay context is set correctly inside pagination containers (@pranaygp, b09bba4512971dc4463cb3fa78cb29c27ba59304)
- Fixed an issue where fragments didn't update correctly when the last item of a plural field was deleted (08336c63c59e9fb8ca398cb019a11e1250c38c61)
- Fixed a bug where query files weren't re-generated if only the flow type changed (697c6ee908602e230cec91f4742f700ea6fd5fc1)

# Improved

- Faster parsing in the compiler by caching the extracted `graphql` tags (7e1065fd6ea2cbc5e3468029ac2f0ab3b7daf418)
- Improved error handling in the compiler (cb7680fff2116e27ffa813a1b486afe713f08c89)
- The callback to `loadMore` and `refetch` of the pagination and refetch container is now consistently called after render (e316b6e70c06f03dc4a1160342f1f7c73dc59b20)
- The compiler now parses `.js.flow` files (3e0266c649e993e704f07bb8484cae8938112a71)
- A new warning on pagination container helps avoid bugs (3fe68c8ba24532b8b2fe3ad6fe5d679186a183e0)
- Better error when unknown directories are inside the generated output directories (9766201c92e546af8f015f62bd68b277d888d5a2)
- Line numbers of parse errors are now correct (ca15340cb4ece8063ec393eb3d37c7792ad6d9d5)
- Updated graphql dependency to `^0.10.5` (beba4077be30c80327d41dc4871c09c4a9bdabb5)
