### PR TITLE
Docs: Update APICheatsheet for this.props.relay.refetch

### DIFF
--- a/docs/modern/APICheatsheet.md
+++ b/docs/modern/APICheatsheet.md
@@ -51,7 +51,7 @@ Classic: `this.props.relay.forceFetch()`
 
 Modern: `this.props.relay.refetchConnection(...)` in a Pagination Container
 
-or: `this.props.relay.refetch({}, callback, {force: true})` in a Refetch Container
+or: `this.props.relay.refetch({}, {}, callback, {force: true})` in a Refetch Container
 
 ### To commit a mutation
 


### PR DESCRIPTION
Seems that the arguments of `this.props.relay.refetch` in the API Cheatsheet is outdated and may confuse people (#2000). Just a small change on this 😃