### PR TITLE
relay-compiler hangs when watchman is installed

### DIFF
--- a/packages/relay-compiler/graphql-compiler/core/RelayWatchmanClient.js
+++ b/packages/relay-compiler/graphql-compiler/core/RelayWatchmanClient.js
@@ -20,8 +20,20 @@ class RelayWatchmanClient {
   static isAvailable(): Promise<boolean> {
     return new Promise(resolve => {
       const client = new RelayWatchmanClient();
-      client.on('error', () => resolve(false));
-      client.hasCapability('relative_root').then(resolve, () => resolve(false));
+      client.on('error', () => {
+        resolve(false);
+        client.end();
+      });
+      client.hasCapability('relative_root').then(
+        hasRelativeRoot => {
+          resolve(hasRelativeRoot);
+          client.end();
+        },
+        () => {
+          resolve(false);
+          client.end();
+        },
+      );
     });
   }
 


### PR DESCRIPTION
Hey @leebyron, I noticed after https://github.com/facebook/relay/pull/1966 was merged the code was amended to create a watchman client solely for purposes of testing if watchman is available. Unfortunately this client is never closed so the process will hang indefinitely. 