### PR TITLE
[modern] ReactRelayQueryRenderer: Change readyState to getDefaultState value after retry

### DIFF
--- a/packages/react-relay/modern/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/modern/ReactRelayQueryRenderer.js
@@ -205,6 +205,8 @@ class ReactRelayQueryRenderer extends React.Component {
         error,
         props: null,
         retry: () => {
+          const readyState = getDefaultState();
+          this.setState({readyState});
           this._fetch(operation, cacheConfig);
         },
       };

--- a/packages/react-relay/modern/__tests__/ReactRelayQueryRenderer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayQueryRenderer-test.js
@@ -627,7 +627,7 @@ describe('ReactRelayQueryRenderer', () => {
     });
 
     it('refetch the query if `retry`', async () => {
-      expect.assertions(4);
+      expect.assertions(7);
       render.mockClear();
       const error = new Error('network fails');
       await environment.mock.reject(TestQuery, error);
@@ -636,6 +636,13 @@ describe('ReactRelayQueryRenderer', () => {
 
       render.mockClear();
       readyState.retry();
+      expect({
+        error: null,
+        props: null,
+        retry: null,
+      }).toBeRendered();
+
+      render.mockClear();
       const response = {
         data: {
           node: {


### PR DESCRIPTION
As exemplified in the [QueryRenderer documentation](https://github.com/facebook/relay/blob/b4b086a8ce0005d1d13af4a96112d5c6d87f3e4c/docs/modern/QueryRenderer.md#L33-L40), the `render` method receives `error` and `props` as arguments, and the component is supposed to show an error screen, a loading screen or the component based on those properties.

If `error` isn't `null`, show the error; if `props` isn't `null`, show the component; otherwise, show the loading.

However, after calling the `retry()` function, the `error` argument isn't passed again as `null`. This way, the component can't know if it is loading or the same error has just occurred again.

With this patch, `retry()` changes the value of `readyState` to the same as the initial value: all values set to `null`, telling the component that it is loading.