### PR TITLE
[Modern] Update refetchContainer example in documentation

### DIFF
--- a/docs/modern/RefetchContainer.md
+++ b/docs/modern/RefetchContainer.md
@@ -119,7 +119,8 @@ export default createRefetchContainer(
           totalCount
           edges {
             node {
-              ...Stories
+              id
+              ...Story_story
             }
           }
         }


### PR DESCRIPTION
Perhaps I failed to see how refetchRender would be used for pagination, and you'll notice in this example I'm proposing that I did not use that here. 

The Relay documentation does not actively broadcast an easy solution to handling offset-based pagination as the PaginationContainer is specifically targeting the case of infinite cursor-based pagination. After much research and tinkering I've used the component state and a refetchContainer to implement offset-based pagination in Relay. For me this solution works very well.

I've taken the script I wrote for my application and modified it to utilize aspects of the existing example. The changes I've made simply make this a more complete implementation of a common case that others are likely to struggle to solve.

Additional changes possibly to consider would be not using ES6 syntax and changing naming conventions as FeedStories in itself does imply a more continuous pagination feed. But I won't get hung up on semantics here. I just hope the maintainers will consider this modification to the documentation.