### PR TITLE
Add support for NullValue ast kind to RelayParser._transformValue()

### DIFF
--- a/packages/relay-compiler/core/__tests__/fixtures/parser/null-values.golden.json
+++ b/packages/relay-compiler/core/__tests__/fixtures/parser/null-values.golden.json
@@ -1,0 +1,47 @@
+[
+  {
+    "kind": "Root",
+    "operation": "query",
+    "metadata": null,
+    "name": "NullValuesQuery",
+    "argumentDefinitions": [],
+    "directives": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "args": [
+          {
+            "kind": "Argument",
+            "metadata": null,
+            "name": "filter",
+            "value": {
+              "kind": "Literal",
+              "metadata": null,
+              "value": {
+                "date": null
+              }
+            },
+            "type": "ItemFilterInput"
+          }
+        ],
+        "directives": [],
+        "metadata": null,
+        "name": "items",
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "args": [],
+            "directives": [],
+            "metadata": null,
+            "name": "date",
+            "type": "String"
+          }
+        ],
+        "type": "ItemFilterResult"
+      }
+    ],
+    "type": "Query"
+  }
+]

--- a/packages/relay-compiler/core/__tests__/fixtures/parser/null-values.input.rql
+++ b/packages/relay-compiler/core/__tests__/fixtures/parser/null-values.input.rql
@@ -1,0 +1,5 @@
+query NullValuesQuery {
+  items(filter: { date: null }) {
+    date
+  }
+}

--- a/packages/relay-compiler/graphql-compiler/core/RelayParser.js
+++ b/packages/relay-compiler/graphql-compiler/core/RelayParser.js
@@ -793,6 +793,12 @@ class RelayParser {
             items,
           };
         }
+      case 'NullValue':
+        return {
+          kind: 'Literal',
+          metadata: null,
+          value: null,
+        };
       case 'ObjectValue':
         const literalObject = {};
         const fields = [];

--- a/packages/relay-compiler/testutils/testschema.graphql
+++ b/packages/relay-compiler/testutils/testschema.graphql
@@ -8,6 +8,7 @@ type Query {
   checkinSearchQuery(query: CheckinSearchInput): CheckinSearchResult
   defaultSettings: Settings,
   route(waypoints: [WayPoint!]!): Route
+  items(filter: ItemFilterInput): ItemFilterResult
   maybeNode: MaybeNode
   neverNode: NeverNode
   me: User
@@ -688,6 +689,14 @@ input StoryCommentSearchInput {
   text: String
   limit: Int
   offset: Int
+}
+
+type ItemFilterResult {
+  date: String
+}
+
+input ItemFilterInput {
+  date: String
 }
 
 type Viewer {


### PR DESCRIPTION
Hi there! This patch is the result of debugging gatsbyjs/gatsby#1689. It seems like the switch statement inside of `RelayParser._transformValue()` was missing a case for `NullValue`, so queries which contained a `null` literal would throw an error.

Adding a case fixes the downstream issue that some folks have experienced with Gatsby, but I'm not sure if there's a better way to solve this problem.