### PR TITLE
Fix exit code for reporter errors

### DIFF
--- a/packages/relay-compiler/graphql-compiler/reporters/RelayConsoleReporter.js
+++ b/packages/relay-compiler/graphql-compiler/reporters/RelayConsoleReporter.js
@@ -25,6 +25,7 @@ class RelayConsoleReporter implements RelayReporter {
   }
 
   reportError(caughtLocation: string, error: Error): void {
+    process.exitCode = 1;
     process.stdout.write(chalk.red('ERROR:' + '\n' + error.message + '\n'));
     if (this._verbose) {
       const frames = error.stack.match(/^ {4}at .*$/gm);


### PR DESCRIPTION
Fixes https://github.com/facebook/relay/issues/2036

See bug for description of issue

This PR uses [`process.exitCode`](https://nodejs.org/api/process.html#process_process_exitcode) which doesn't immediately terminate the process but defines the code that it'll use when it exits at a later time