### PR TITLE
Correct prop reference in PaginationContainer

### DIFF
--- a/docs/modern/PaginationContainer.md
+++ b/docs/modern/PaginationContainer.md
@@ -81,7 +81,7 @@ class Feed extends React.Component {
   render() {
     return (
       <div>
-        {this.props.viewer.feed.edges.map(
+        {this.props.user.feed.edges.map(
           edge => <Story story={edge.node} key={edge.node.id} />
         )}
         <button


### PR DESCRIPTION
If I'm understanding the query correctly:

```graphql
query: graphql`
    query FeedPaginationQuery(
    $count: Int!
    $cursor: String
    $orderby: String!
) {
    user {
        # You could reference the fragment defined previously.
        ...Feed_user
    }
}
```

...the prop should be `user` not `viewer`.