### PR TITLE
expose formatGeneratedModule publicly

### DIFF
--- a/packages/relay-compiler/RelayCompilerPublic.js
+++ b/packages/relay-compiler/RelayCompilerPublic.js
@@ -20,6 +20,7 @@ const RelayFileIRParser = require('RelayFileIRParser');
 const RelayFileWriter = require('RelayFileWriter');
 const RelayIRTransforms = require('RelayIRTransforms');
 const RelayMultiReporter = require('RelayMultiReporter');
+const formatGeneratedModule = require('formatGeneratedModule');
 
 export type {CompileResult} from 'RelayCodegenTypes';
 export type {ParserConfig, WriterConfig} from 'RelayCodegenRunner';
@@ -32,4 +33,5 @@ module.exports = {
   IRTransforms: RelayIRTransforms,
   MultiReporter: RelayMultiReporter,
   Runner: RelayCodegenRunner,
+  formatGeneratedModule,
 };


### PR DESCRIPTION
Fixes https://github.com/facebook/relay/issues/1927

@wincent This will export `formatGeneratedModule` as discussed in https://github.com/facebook/relay/pull/1846#issuecomment-324109320. I exported it in `relay-compiler` (as opposed to `graphql-compiler`) since that is where it is currently located.