### PR TITLE
[Bug Fix: Relay Compiler] Incorrectly parses functions that match Object prototype function names as Create Container Funcs

### DIFF
--- a/packages/relay-compiler/codegen/FindGraphQLTags.js
+++ b/packages/relay-compiler/codegen/FindGraphQLTags.js
@@ -179,11 +179,11 @@ function memoizedFind(
   });
 }
 
-const CREATE_CONTAINER_FUNCTIONS = {
-  createFragmentContainer: true,
-  createPaginationContainer: true,
-  createRefetchContainer: true,
-};
+const CREATE_CONTAINER_FUNCTIONS = Object.create(null, {
+  createFragmentContainer: {value: true},
+  createPaginationContainer: {value: true},
+  createRefetchContainer: {value: true}
+});
 
 const IDENTIFIERS = {
   graphql: true,


### PR DESCRIPTION
In the event that the relay-compiler is parsing a file which has function calls that match Object.prototype methods these functions will be included in parsing and expected to have arguments matching the Create Container functions which should only include the following:

- createFragmentContainer
- createPaginationContainer
- createRefetchContainer

For example, see this example file which would exhibit this error: https://github.com/robrichard/relay-compiler-error/blob/master/src/index.js

```
toString();

const foo = graphql`
	fragment src on Post {
		id
	}
`;
```

Relay compiler would currently fail with the following error:

```
TypeError: Cannot read property 'type' of undefined
    at CallExpression (/XXX/node_modules/relay-compiler/lib/FindGraphQLTags.js:41:20)
```

This fix ensures CREATE_CONTAINER_FUNCTIONS is an object created without a prototype.