### PR TITLE
Move parts of CONTRIBUTING to ISSUE_TEMPLATE

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,18 +36,6 @@ In order to accept your pull request, we need you to submit a CLA. You only need
 
 ## Bugs & Questions
 
-### Questions regarding how to use Relay and/or GraphQL
-
-We want to keep signal strong in the GitHub issue tracker – to make sure that it remains the best place to track issues that affect the development of Relay.
-
-If you have a question on how to use Relay, please [post it to Stack Overflow](https://stackoverflow.com/questions/ask?tags=relayjs) with the tag [#relayjs](http://stackoverflow.com/questions/tagged/relayjs).
-
-### Reporting issues with Relay
-
-We will be using GitHub Issues for our public bugs. We will keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new issue, make sure an issue for your problem doesn't already exist.
-
-The best way to get your bug fixed is to provide a reduced test case. Please provide a public repository with a runnable example.
-
 ### Security bugs
 
 Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe disclosure of security bugs. With that in mind, please do not file public issues; go through the process outlined on that page.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+# Creating issues for Relay
+
+## Questions regarding how to use Relay and/or GraphQL
+
+We want to keep signal strong in the GitHub issue tracker – to make sure that it remains the best place to track issues that affect the development of Relay.
+
+If you have a question on how to use Relay, please [post it to Stack Overflow](https://stackoverflow.com/questions/ask?tags=relayjs) with the tag [#relayjs](http://stackoverflow.com/questions/tagged/relayjs).
+
+## Reporting issues with Relay
+
+We will be using GitHub Issues for our public bugs. We will keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new issue, make sure an issue for your problem doesn't already exist.
+
+The best way to get your bug fixed is to provide a reduced test case. To make reproduction simple for you, and set-up simple for Relay's maintainers, you can use Glitch:
+https://glitch.com/edit/#!/remix/relay-starter-kit
+
+You can also provide a public repository with a runnable example.
+
+## Security bugs
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe disclosure of security bugs. With that in mind, please do not file public issues; go through the process outlined on that page.
+
+## How to Get in Touch
+
+* Discord - [#relay](https://discord.gg/0ZcbPKXt5bX40xsQ) on [Reactiflux](https://www.reactiflux.com/)
+* Stack Overflow - [#relayjs](https://stackoverflow.com/questions/tagged/relayjs)


### PR DESCRIPTION
I noticed that a lot of questions that are better suited for SO are coming in here. So maybe by using GitHub's `ISSUE_TEMPLATE` we can circumvent that.

Also I found it a bit tedious that one can't simply create a jsfiddle to recreate a problem with Relay, so I changed `relay-starter-kit` a bit to make it work with Glitch and included a link to it in the `ISSUE_TEMPLATE`.

Lmkwyt :)