### PR TITLE
Moving eslint-config-fbjs to devDependencies in package.json

### DIFF
--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -22,7 +22,6 @@
     "babel-types": "6.25.0",
     "babylon": "6.18.0",
     "chalk": "^1.1.3",
-    "eslint-config-fbjs": "^1.1.1",
     "fast-glob": "^1.0.1",
     "fb-watchman": "^2.0.0",
     "fbjs": "^0.8.1",
@@ -31,5 +30,8 @@
     "relay-runtime": "1.2.0",
     "signedsource": "^1.0.0",
     "yargs": "^7.0.2"
+  },
+  "devDependencies": {
+    "eslint-config-fbjs": "^1.1.1"
   }
 }

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -30,8 +30,5 @@
     "relay-runtime": "1.2.0",
     "signedsource": "^1.0.0",
     "yargs": "^7.0.2"
-  },
-  "devDependencies": {
-    "eslint-config-fbjs": "^1.1.1"
   }
 }


### PR DESCRIPTION
Having ``eslint-config-fbjs`` listed within ``dependencies`` in the package.json file causes ``npm install`` warnings for ESLint users with ``relay-compiler`` listed as a dependency.

This resolves this issue, yet allows Relay devs to still use the ESLint rules.
<img width="758" alt="screen shot 2017-08-28 at 11 12 24 am" src="https://user-images.githubusercontent.com/16157429/29782339-d627f40c-8be1-11e7-813b-b8256cddaa60.png">
