### PR TITLE
Add a recursive input type to compiler test schema

### DIFF
--- a/packages/relay-compiler/core/RelayFlowGenerator.js
+++ b/packages/relay-compiler/core/RelayFlowGenerator.js
@@ -42,6 +42,12 @@ export type ScalarTypeMapping = {
 };
 
 const printBabel = ast => babelGenerator(ast).code;
+const {getInputObjectSCCs} = require('getSCCsFromFlowContextDocument');
+
+function whiteListRecursiveTypes(node: Root) {
+  const sccs = getInputObjectSCCs(node);
+  return Array.prototype.concat.apply([], sccs);
+}
 
 function generate(
   node: Root | Fragment,
@@ -51,10 +57,13 @@ function generate(
   const defaultedCustomScalars = customScalars || {};
   const output = [];
   if (node.kind === 'Root' && node.operation !== 'query') {
+    const whiteList = inputFieldWhiteList
+      ? [...inputFieldWhiteList, ...whiteListRecursiveTypes(node)]
+      : whiteListRecursiveTypes(node);
     const inputAST = generateInputVariablesType(
       node,
       defaultedCustomScalars,
-      inputFieldWhiteList,
+      whiteList,
     );
     output.push(printBabel(inputAST));
   }

--- a/packages/relay-compiler/core/getSCCsFromFlowContextDocument.js
+++ b/packages/relay-compiler/core/getSCCsFromFlowContextDocument.js
@@ -41,7 +41,7 @@ function baseInputObjects(type: GraphQLInputType) {
   return Object.keys(fields)
     .map(k => fields[k])
     .filter(
-      field => baseInputType(field.type) instanceof GraphQLInputObjectType,
+      field => getRawType(field.type) instanceof GraphQLInputObjectType,
     );
 }
 

--- a/packages/relay-compiler/core/getSCCsFromFlowContextDocument.js
+++ b/packages/relay-compiler/core/getSCCsFromFlowContextDocument.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule getSCCsFromFlowContextDocument
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+const {getRawType} = require('GraphQLSchemaUtils');
+const {
+  GraphQLInputType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+} = require('graphql');
+
+import type {Root} from 'GraphQLIR';
+
+function flatten(arr) {
+  return arr ? Array.prototype.concat.apply([], arr) : arr;
+}
+
+function inputObjectType(type: GraphQLInputType): GraphQLInputObjectType {
+  const baseType = getRawType(type);
+  if (!(baseType instanceof GraphQLInputObjectType))
+    throw new Error(
+      `${type.toString()} does not contain a GraphQLInputObjectType`,
+    );
+  return baseType;
+}
+
+function baseInputObjects(type: GraphQLInputType) {
+  const fields = inputObjectType(type).getFields();
+  return Object.keys(fields)
+    .map(k => fields[k])
+    .filter(
+      field => baseInputType(field.type) instanceof GraphQLInputObjectType,
+    );
+}
+
+function buildInputObjectGraph(graph, input) {
+  const k = input.name;
+  if (graph.hasOwnProperty(k)) return graph;
+  const updated = {
+    ...graph,
+    [k]: baseInputObjects(input.type).map(obj => obj.name),
+  };
+  return baseInputObjects(input.type).reduce(buildInputObjectGraph, updated);
+}
+
+function getInputObjectGraph(node: Root) {
+  return flatten(
+    node.argumentDefinitions
+      .filter(arg => getRawType(arg.type) instanceof GraphQLInputObjectType)
+      .map(arg => baseInputObjects(arg.type)),
+  ).reduce(buildInputObjectGraph, {});
+}
+
+function transposeGraph(graph) {
+  const transposed = Object.keys(graph).reduce(
+    (g, k) => Object.assign(g, {[k]: []}),
+    {},
+  );
+  Object.keys(graph).forEach(k => {
+    graph[k].forEach(node => {
+      transposed[node].push(k);
+    });
+  });
+  return transposed;
+}
+
+function initVisited(graph) {
+  return Object.keys(graph).reduce(
+    (v, k) => Object.assign(v, {[k]: false}),
+    {},
+  );
+}
+
+function graphDFS(graph, key, visited, cb) {
+  visited[key] = true;
+  graph[key].forEach(node => {
+    if (!visited[node]) graphDFS(graph, node, visited, cb);
+    cb(node);
+  });
+}
+
+function graphOrderNodes(graph) {
+  const visited = initVisited(graph);
+  const orderedNodes = [];
+  Object.keys(graph).forEach(k => {
+    if (!visited[k])
+      graphDFS(graph, k, visited, node => {
+        orderedNodes.push(node);
+      });
+  });
+  return orderedNodes;
+}
+
+function graphSCCs(graph, orderedNodes) {
+  const visited = initVisited(graph);
+  const sccs = [[]];
+  orderedNodes.reverse().forEach(k => {
+    if (!visited[k]) {
+      graphDFS(graph, k, visited, node => {
+        sccs[sccs.length - 1].push(node);
+      });
+      sccs.push([]);
+    }
+  });
+  return sccs;
+}
+
+function getInputObjectSCCs(node: Root) {
+  const graph = getInputObjectGraph(node);
+  const orderedNodes = graphOrderNodes(graph);
+  const transposed = transposeGraph(graph);
+  return graphSCCs(transposed, orderedNodes).filter(arr => arr.length);
+}
+
+module.exports = {
+  getInputObjectSCCs,
+};

--- a/packages/relay-compiler/testutils/testschema.graphql
+++ b/packages/relay-compiler/testutils/testschema.graphql
@@ -91,6 +91,12 @@ input ApplicationRequestDeleteAllInput {
 input CommentCreateInput {
   clientMutationId: String
   feedbackId: ID
+  feedback: CommentfeedbackFeedback
+}
+
+input CommentfeedbackFeedback {
+  commentsIds: [ID!]
+  comments: [CommentCreateInput!]
 }
 
 input CommentCreateSubscriptionInput {


### PR DESCRIPTION
Adding a mutation with recursive inputs breaks two tests in the relay compiler: `RelayFlowGenerator-test` and `printFlowTypes-test`. It causes the call stack to exceed its max as the code tries to recursively generate flow types for the input objects. See issue https://github.com/facebook/relay/issues/1740 Where someone said that a pull request with a failing test case would be helpful

The two function calls exceeding the stack seem to be here.
https://github.com/facebook/relay/blob/95319d19c2027661efd400eea3137ba7b6885431/packages/relay-compiler/core/RelayFlowGenerator.js#L452
https://github.com/facebook/relay/blob/95319d19c2027661efd400eea3137ba7b6885431/packages/relay-compiler/codegen/flowtype/transformInputObjectToIR.js#L50

I was able to add a base case to the recursive function in the `RelayFlowGenerator` to get it to generate types for recursive inputs but it also resulted in huge, and unpredictable generated mutations. At first I thought, instead of just disallowing recursive definitions at certain levels it might be possible to label the recursive definition as a separate type to reflect what the actual schema looks like and so the generated mutation would look something like this
```
type CommentVariables = {|
  clientMutationId?: ?string;
  feedbackId?: ?string;
  feedback?: ?{|
    commentsIds: ?$ReadOnlyArray<string>;
    comments: ?$ReadOnlyArray<CommentVariables>
  |};
|};
export type CommentCreateMutationVariables = {|
  input: CommentVariables;
  first?: ?number;
  orderBy?: ?$ReadOnlyArray<string>;
|};
```
But I saw a commit in the log of the RelayFlowGenerator that explained generating types for inner objects resulted in naming conflicts.