### PR TITLE
Relax constraint of unique file names in Relay Modern

### DIFF
--- a/packages/relay-compiler/codegen/FindGraphQLTags.js
+++ b/packages/relay-compiler/codegen/FindGraphQLTags.js
@@ -259,17 +259,17 @@ function validateTemplate(template, moduleName, keyName, filePath, loc) {
     );
     const definitionName = def.name.value;
     if (def.kind === 'OperationDefinition') {
-      const operationNameParts = definitionName.match(
-        /^(.*)(Mutation|Query|Subscription)$/,
-      );
-      invariant(
-        operationNameParts && definitionName.startsWith(moduleName),
-        'FindGraphQLTags: Operation names in graphql tags must be prefixed ' +
-          'with the module name and end in "Mutation", "Query", or ' +
-          '"Subscription". Got `%s` in module `%s`.',
-        definitionName,
-        moduleName,
-      );
+      // const operationNameParts = definitionName.match(
+      //   /^(.*)(Mutation|Query|Subscription)$/,
+      // );
+      // invariant(
+      //   operationNameParts && definitionName.startsWith(moduleName),
+      //   'FindGraphQLTags: Operation names in graphql tags must be prefixed ' +
+      //     'with the module name and end in "Mutation", "Query", or ' +
+      //     '"Subscription". Got `%s` in module `%s`.',
+      //   definitionName,
+      //   moduleName,
+      // );
     } else if (def.kind === 'FragmentDefinition') {
       if (keyName) {
         invariant(
@@ -278,14 +278,6 @@ function validateTemplate(template, moduleName, keyName, filePath, loc) {
             '`<ModuleName>_<propName>`. Got `%s`, expected `%s`.',
           definitionName,
           moduleName + '_' + keyName,
-        );
-      } else {
-        invariant(
-          definitionName.startsWith(moduleName),
-          'FindGraphQLTags: Fragment names in graphql tags must be prefixed ' +
-            'with the module name. Got `%s` in module `%s`.',
-          definitionName,
-          moduleName,
         );
       }
     }

--- a/packages/relay-compiler/codegen/__tests__/FindGraphQLTags-test.js
+++ b/packages/relay-compiler/codegen/__tests__/FindGraphQLTags-test.js
@@ -273,9 +273,7 @@ describe('FindGraphQLTags', () => {
     // });
 
     it('parses queries when query name is different from module name', () => {
-      expect(
-        find('graphql`query NotModuleName { me { id } }`;')
-      ).toEqual([
+      expect(find('graphql`query NotModuleName { me { id } }`;')).toEqual([
         {
           tag: 'graphql',
           template: 'query NotModuleName { me { id } }',
@@ -353,7 +351,7 @@ describe('FindGraphQLTags', () => {
 
     it('parses top-level fragments with valid names', () => {
       expect(
-        find('graphql`fragment NotModuleName on User { name }`;')
+        find('graphql`fragment NotModuleName on User { name }`;'),
       ).toEqual([
         {
           tag: 'graphql',

--- a/packages/relay-compiler/codegen/__tests__/FindGraphQLTags-test.js
+++ b/packages/relay-compiler/codegen/__tests__/FindGraphQLTags-test.js
@@ -264,12 +264,23 @@ describe('FindGraphQLTags', () => {
   });
 
   describe('query name validation', () => {
-    it('throws for invalid query names', () => {
-      expect(() => find('graphql`query NotModuleName { me { id } }`;')).toThrow(
-        'FindGraphQLTags: Operation names in graphql tags must be prefixed with ' +
-          'the module name and end in "Mutation", "Query", or "Subscription". ' +
-          'Got `NotModuleName` in module `FindGraphQLTags`.',
-      );
+    // it('throws for invalid query names', () => {
+    //   expect(() => find('graphql`query NotModuleName { me { id } }`;')).toThrow(
+    //     'FindGraphQLTags: Operation names in graphql tags must be prefixed with ' +
+    //       'the module name and end in "Mutation", "Query", or "Subscription". ' +
+    //       'Got `NotModuleName` in module `FindGraphQLTags`.',
+    //   );
+    // });
+
+    it('parses queries when query name is different from module name', () => {
+      expect(
+        find('graphql`query NotModuleName { me { id } }`;')
+      ).toEqual([
+        {
+          tag: 'graphql',
+          template: 'query NotModuleName { me { id } }',
+        },
+      ]);
     });
 
     it('parses queries with valid names', () => {
@@ -330,17 +341,26 @@ describe('FindGraphQLTags', () => {
       ]);
     });
 
-    it('throws for invalid top-level fragment names', () => {
-      expect(() =>
-        find('graphql`fragment NotModuleName on User { name }`;'),
-      ).toThrow(
-        'FindGraphQLTags: Fragment names in graphql tags ' +
-          'must be prefixed with the module name. Got ' +
-          '`NotModuleName` in module `FindGraphQLTags`.',
-      );
-    });
+    // it('throws for invalid top-level fragment names', () => {
+    //   expect(() =>
+    //     find('graphql`fragment NotModuleName on User { name }`;'),
+    //   ).toThrow(
+    //     'FindGraphQLTags: Fragment names in graphql tags ' +
+    //       'must be prefixed with the module name. Got ' +
+    //       '`NotModuleName` in module `FindGraphQLTags`.',
+    //   );
+    // });
 
     it('parses top-level fragments with valid names', () => {
+      expect(
+        find('graphql`fragment NotModuleName on User { name }`;')
+      ).toEqual([
+        {
+          tag: 'graphql',
+          template: 'fragment NotModuleName on User { name }',
+        },
+      ]);
+
       expect(
         find('graphql`fragment FindGraphQLTags on User { name }`;'),
       ).toEqual([

--- a/packages/relay-compiler/graphql-compiler/core/ASTCache.js
+++ b/packages/relay-compiler/graphql-compiler/core/ASTCache.js
@@ -27,11 +27,20 @@ class ASTCache {
   _baseDir: string;
   _parse: ParseFn;
 
-  static validateDocument(doc: DocumentNode, relPath: string, fragments: ImmutableMap<string, string>, operations: ImmutableMap<string, string>) {
+  static validateDocument(
+    doc: DocumentNode,
+    relPath: string,
+    fragments: ImmutableMap<string, string>,
+    operations: ImmutableMap<string, string>,
+  ) {
     let existingFragments = fragments;
     let existingOperations = operations;
-    const fragmentsInFile = doc.definitions.filter(def => def.kind === 'FragmentDefinition')
-    const operationsInFile = doc.definitions.filter(def => def.kind === 'OperationDefinition')
+    const fragmentsInFile = doc.definitions.filter(
+      def => def.kind === 'FragmentDefinition',
+    );
+    const operationsInFile = doc.definitions.filter(
+      def => def.kind === 'OperationDefinition',
+    );
     fragmentsInFile.forEach(fragmentInFile => {
       const fragmentName = fragmentInFile.name.value;
       const existingFragmentPath = existingFragments.get(fragmentName);
@@ -40,7 +49,7 @@ class ASTCache {
         'duplicate fragment %s for Containers at paths: %s, %s',
         fragmentName,
         relPath,
-        existingFragmentPath
+        existingFragmentPath,
       );
       existingFragments = existingFragments.set(fragmentName, relPath);
     });
@@ -52,12 +61,12 @@ class ASTCache {
         'duplicate operation %s for Containers at paths: %s, %s',
         operationName,
         relPath,
-        existingOperationPath
+        existingOperationPath,
       );
       existingOperations = existingOperations.set(operationName, relPath);
     });
 
-    return { fragments: existingFragments, operations: existingOperations };
+    return {fragments: existingFragments, operations: existingOperations};
   }
 
   constructor(config: {baseDir: string, parse: ParseFn}) {
@@ -90,7 +99,12 @@ class ASTCache {
         return;
       }
 
-      const result = ASTCache.validateDocument(doc, file.relPath, fragments, operations);
+      const result = ASTCache.validateDocument(
+        doc,
+        file.relPath,
+        fragments,
+        operations,
+      );
       fragments = result.fragments;
       operations = result.operations;
 

--- a/packages/relay-compiler/graphql-compiler/core/__tests__/ASTCache-test.js
+++ b/packages/relay-compiler/graphql-compiler/core/__tests__/ASTCache-test.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @format
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+const ASTCache = require('ASTCache');
+const ImmutableMap = require('immutable').Map;
+
+const existingFragments = ImmutableMap({ ExistingFragmentName: 'some/path' });
+const existingOperations = ImmutableMap({ ExistingQueryName: 'some/path' });
+
+describe('ASTCache', () => {
+  describe('document validation', () => {
+    it('returns updated fragments for valid fragment names', () => {
+      const document = {
+        definitions: [
+          {
+            kind: 'FragmentDefinition',
+            name: {
+              value: 'SomeFragmentName',
+            }
+          }
+        ]
+      };
+      const result = ASTCache.validateDocument(document, 'path/to/document', existingFragments, existingOperations);
+      expect(result.fragments).toEqual(existingFragments.set('SomeFragmentName', 'path/to/document'));
+      expect(result.operations).toBe(ImmutableMap(existingOperations));
+    });
+
+    it('returns updated operations for valid operation names', () => {
+      const document = {
+        definitions: [
+          {
+            kind: 'OperationDefinition',
+            name: {
+              value: 'SomeQueryName',
+            }
+          }
+        ]
+      };
+      const result = ASTCache.validateDocument(document, 'path/to/document', existingFragments, existingOperations);
+      expect(result.operations).toEqual(existingOperations.set('SomeQueryName', 'path/to/document'));
+      expect(result.fragments).toBe(ImmutableMap(existingFragments));
+    });
+
+    it('throws for already existing fragment names', () => {
+      const document = {
+        definitions: [
+          {
+            kind: 'FragmentDefinition',
+            name: {
+              value: 'ExistingFragmentName',
+            }
+          }
+        ]
+      };
+
+      expect(() => ASTCache.validateDocument(
+        document,
+        'path/to/document',
+        existingFragments,
+        existingOperations
+      )).toThrow();
+    });
+
+    it('throws for duplicate fragment names in document', () => {
+      const document = {
+        definitions: [
+          {
+            kind: 'FragmentDefinition',
+            name: {
+              value: 'NewFragmentName',
+            }
+          },
+          {
+            kind: 'FragmentDefinition',
+            name: {
+              value: 'NewFragmentName',
+            }
+          }
+        ]
+      };
+
+      expect(() => ASTCache.validateDocument(
+        document,
+        'path/to/document',
+        existingFragments,
+        existingOperations
+      )).toThrow();
+    });
+
+    it('throws for already existing operation names', () => {
+      const document = {
+        definitions: [
+          {
+            kind: 'OperationDefinition',
+            name: {
+              value: 'ExistingQueryName',
+            }
+          }
+        ]
+      };
+
+      expect(() => ASTCache.validateDocument(
+        document,
+        'path/to/document',
+        existingFragments,
+        existingOperations
+      )).toThrow();
+    });
+
+    it('throws for duplicate operation names in document', () => {
+      const document = {
+        definitions: [
+          {
+            kind: 'OperationDefinition',
+            name: {
+              value: 'NewQueryName',
+            }
+          },
+          {
+            kind: 'OperationDefinition',
+            name: {
+              value: 'NewQueryName',
+            }
+          }
+        ]
+      };
+
+      expect(() => ASTCache.validateDocument(
+        document,
+        'path/to/document',
+        existingFragments,
+        existingOperations
+      )).toThrow();
+    });
+  });
+});

--- a/packages/relay-compiler/graphql-compiler/core/__tests__/ASTCache-test.js
+++ b/packages/relay-compiler/graphql-compiler/core/__tests__/ASTCache-test.js
@@ -15,8 +15,8 @@
 const ASTCache = require('ASTCache');
 const ImmutableMap = require('immutable').Map;
 
-const existingFragments = ImmutableMap({ ExistingFragmentName: 'some/path' });
-const existingOperations = ImmutableMap({ ExistingQueryName: 'some/path' });
+const existingFragments = ImmutableMap({ExistingFragmentName: 'some/path'});
+const existingOperations = ImmutableMap({ExistingQueryName: 'some/path'});
 
 describe('ASTCache', () => {
   describe('document validation', () => {
@@ -27,12 +27,19 @@ describe('ASTCache', () => {
             kind: 'FragmentDefinition',
             name: {
               value: 'SomeFragmentName',
-            }
-          }
-        ]
+            },
+          },
+        ],
       };
-      const result = ASTCache.validateDocument(document, 'path/to/document', existingFragments, existingOperations);
-      expect(result.fragments).toEqual(existingFragments.set('SomeFragmentName', 'path/to/document'));
+      const result = ASTCache.validateDocument(
+        document,
+        'path/to/document',
+        existingFragments,
+        existingOperations,
+      );
+      expect(result.fragments).toEqual(
+        existingFragments.set('SomeFragmentName', 'path/to/document'),
+      );
       expect(result.operations).toBe(ImmutableMap(existingOperations));
     });
 
@@ -43,12 +50,19 @@ describe('ASTCache', () => {
             kind: 'OperationDefinition',
             name: {
               value: 'SomeQueryName',
-            }
-          }
-        ]
+            },
+          },
+        ],
       };
-      const result = ASTCache.validateDocument(document, 'path/to/document', existingFragments, existingOperations);
-      expect(result.operations).toEqual(existingOperations.set('SomeQueryName', 'path/to/document'));
+      const result = ASTCache.validateDocument(
+        document,
+        'path/to/document',
+        existingFragments,
+        existingOperations,
+      );
+      expect(result.operations).toEqual(
+        existingOperations.set('SomeQueryName', 'path/to/document'),
+      );
       expect(result.fragments).toBe(ImmutableMap(existingFragments));
     });
 
@@ -59,17 +73,19 @@ describe('ASTCache', () => {
             kind: 'FragmentDefinition',
             name: {
               value: 'ExistingFragmentName',
-            }
-          }
-        ]
+            },
+          },
+        ],
       };
 
-      expect(() => ASTCache.validateDocument(
-        document,
-        'path/to/document',
-        existingFragments,
-        existingOperations
-      )).toThrow();
+      expect(() =>
+        ASTCache.validateDocument(
+          document,
+          'path/to/document',
+          existingFragments,
+          existingOperations,
+        ),
+      ).toThrow();
     });
 
     it('throws for duplicate fragment names in document', () => {
@@ -79,23 +95,25 @@ describe('ASTCache', () => {
             kind: 'FragmentDefinition',
             name: {
               value: 'NewFragmentName',
-            }
+            },
           },
           {
             kind: 'FragmentDefinition',
             name: {
               value: 'NewFragmentName',
-            }
-          }
-        ]
+            },
+          },
+        ],
       };
 
-      expect(() => ASTCache.validateDocument(
-        document,
-        'path/to/document',
-        existingFragments,
-        existingOperations
-      )).toThrow();
+      expect(() =>
+        ASTCache.validateDocument(
+          document,
+          'path/to/document',
+          existingFragments,
+          existingOperations,
+        ),
+      ).toThrow();
     });
 
     it('throws for already existing operation names', () => {
@@ -105,17 +123,19 @@ describe('ASTCache', () => {
             kind: 'OperationDefinition',
             name: {
               value: 'ExistingQueryName',
-            }
-          }
-        ]
+            },
+          },
+        ],
       };
 
-      expect(() => ASTCache.validateDocument(
-        document,
-        'path/to/document',
-        existingFragments,
-        existingOperations
-      )).toThrow();
+      expect(() =>
+        ASTCache.validateDocument(
+          document,
+          'path/to/document',
+          existingFragments,
+          existingOperations,
+        ),
+      ).toThrow();
     });
 
     it('throws for duplicate operation names in document', () => {
@@ -125,23 +145,25 @@ describe('ASTCache', () => {
             kind: 'OperationDefinition',
             name: {
               value: 'NewQueryName',
-            }
+            },
           },
           {
             kind: 'OperationDefinition',
             name: {
               value: 'NewQueryName',
-            }
-          }
-        ]
+            },
+          },
+        ],
       };
 
-      expect(() => ASTCache.validateDocument(
-        document,
-        'path/to/document',
-        existingFragments,
-        existingOperations
-      )).toThrow();
+      expect(() =>
+        ASTCache.validateDocument(
+          document,
+          'path/to/document',
+          existingFragments,
+          existingOperations,
+        ),
+      ).toThrow();
     });
   });
 });


### PR DESCRIPTION
See #2093 

- Allow fragment and operation names to be different from their modules names.
- Ensure that all fragment and operation names are unique.

Only the Relay Modern part seems to be missing, as these changes are not specific for Relay Modern. This is why I only commented the constraining parts out.

How can we use these rules only on Relay Modern?