### PR TITLE
Field is accessible also when @include(if: false)

### DIFF
--- a/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
@@ -717,7 +717,7 @@ describe('ReactRelayRefetchContainer', () => {
         },
       });
       expect(render.mock.calls.length).toBe(2);
-      expect(render.mock.calls[1][0].user.name).toBe(undefined);
+      expect(render.mock.calls[1][0].user.name).toBe('Zuck');
     });
 
     it('updates context with the results of new variables', () => {

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -116,10 +116,7 @@ class RelayReader {
           this._readLink(selection, record, data);
         }
       } else if (selection.kind === CONDITION) {
-        const conditionValue = this._getVariableValue(selection.condition);
-        if (conditionValue === selection.passingValue) {
-          this._traverseSelections(selection.selections, record, data);
-        }
+        this._traverseSelections(selection.selections, record, data);
       } else if (selection.kind === INLINE_FRAGMENT) {
         const typeName = RelayModernRecord.getType(record);
         if (typeName != null && typeName === selection.type) {


### PR DESCRIPTION
Addressing #2103 

What happens is simply that for @include(if: false) field gets skipped while reading even though the previous value is still in the store.

This change solves my problem, but not sure if this is the right thing to do anymore. Depends on point of view. 

Argument for it is: @include(if: false) says that field should be skipped in the request, therefore just should not be refetched and old value should be still accessible.
Argument against is: having in sync `variables` and values getting from the store provides clear overview of current state, without considering past. Which is what we all kind of like on react.

I am bit inclined to keep it as it is and find some other approach for my use case. What you think?

 