### PR TITLE
Fix false warning when end/startCursor is null because no edges are returned

### DIFF
--- a/packages/react-relay/modern/ReactRelayPaginationContainer.js
+++ b/packages/react-relay/modern/ReactRelayPaginationContainer.js
@@ -512,6 +512,9 @@ function createContainerWithFragments<
           : pageInfo[HAS_PREV_PAGE];
       const cursor =
         direction === FORWARD ? pageInfo[END_CURSOR] : pageInfo[START_CURSOR];
+      if (edges.length === 0 && cursor == null) {
+        return null;
+      }
       if (typeof hasMore !== 'boolean' || typeof cursor !== 'string') {
         warning(
           false,


### PR DESCRIPTION
This allows null (or other values, don't think we need to check for that) for start or end cursor when edges is an empty array.

`graphql-relay-js` returns null for endCursor and startCursor when creating a connection from an empty array so it makes sense we support this.

Fixes #1852