### PR TITLE
Add prettier config file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "requirePragma": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": false,
+  "jsxBracketSameLine": true,
+  "parser": "flow"
+}


### PR DESCRIPTION
Prettier 1.6 now supports config files, makes it a lot easier when working with multiple projects with different configs. 1.7 also adds pragma support so only files with @format are formatted.

We could eventually remove parameters from the prettier script but that would also require updating the version of prettier to 1.6+ and don't want to do that in this PR since it will change a bunch of files if some formating changed in those newer versions.

Used the dotfile since I don't mind a million dotfiles and rather not add stuff we almost never care about in package.json.