### PR TITLE
Remove deprecated forwarding flag for yarn --watch

### DIFF
--- a/docs/modern/Introduction.md
+++ b/docs/modern/Introduction.md
@@ -45,7 +45,7 @@ Run the Relay Compiler after making changes to any GraphQL in your Relay applica
 "relay": "relay-compiler --src ./src --schema path/schema.graphql"
 ```
 
-Then after making edits to your application files, just run `yarn run relay` to generate new files, or `yarn run relay -- --watch` to run the compiler as a long-lived process which automatically generates new files whenever you save.
+Then after making edits to your application files, just run `yarn run relay` to generate new files, or `yarn run relay --watch` to run the compiler as a long-lived process which automatically generates new files whenever you save.
 
 
 ## JavaScript environment requirements


### PR DESCRIPTION
`warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.`

That's the message I got from Yarn. Anyone using Yarn v1 + doesn't need the additional `--` to forward to the `--watch` portion of the yarn relay script.