### PR TITLE
Upgrade prettier to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "jest": "NODE_ENV=test jest \"$@\"",
     "lint": "eslint .",
     "prepublish": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && npm run build",
-    "prettier": "find . -name node_modules -prune -or -name '*.js' -print | xargs grep -l '@format' | xargs prettier --single-quote --trailing-comma all --no-bracket-spacing --jsx-bracket-same-line --parser flow --write",
+    "prettier": "find . -name node_modules -prune -or -name dist -prune -or -name '*.js' -print | xargs prettier --write",
     "test": "f() { EXIT=0; npm run typecheck || EXIT=$?; npm run test-dependencies || EXIT=$?; npm run jest \"$@\" || EXIT=$?; exit $EXIT; }; f",
     "test-dependencies": "node ./scripts/testDependencies.js",
     "typecheck": "flow check"
@@ -60,7 +60,7 @@
     "iterall": "1.0.3",
     "jest": "^21.0.1",
     "object-assign": "4.1.1",
-    "prettier": "1.5.2",
+    "prettier": "^1.7.0",
     "prop-types": "^15.5.8",
     "react": "16.0.0-beta.5",
     "react-dom": "16.0.0-beta.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,9 +4077,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.2.tgz#7ea0751da27b93bfb6cecfcec509994f52d83bb3"
+prettier@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
 
 pretty-format@^21.1.0:
   version "21.1.0"


### PR DESCRIPTION
This also allows us to drop the command line flags by using the prettier config inside `package.json`.