### PR TITLE
docs(NetworkLayer): add custom open-source implementations

### DIFF
--- a/docs/modern/NetworkLayer.md
+++ b/docs/modern/NetworkLayer.md
@@ -50,3 +50,9 @@ const environment = new Environment({
 ```
 
 Note that this is a basic example to help you get started. This example could be extended with additional features such as request/response caching (enabled e.g. when `cacheConfig.force` is false) and uploading form data for mutations (the `uploadables` parameter).
+
+### Custom open-source implementations
+
+- **[react-relay-network-modern](https://github.com/nodkz/react-relay-network-modern)** on [npm](https://www.npmjs.com/package/react-relay-network-modern)
+
+  Network Layer for Relay Modern which has built-in highly customizable middlewares for commonly used scenarios: batching query requests, caching, authentication, request retrying, logging. Moreover, you may write your own middlewares with custom logic.


### PR DESCRIPTION
[react-relay-network-modern](https://github.com/nodkz/react-relay-network-modern) was rewritten from scratch for Relay Modern. It has almost identical options and plugins which have previous [Network Layer for Relay Classic](https://github.com/nodkz/react-relay-network-layer). So in most cases, it is a drop-in replacement for users which migrates from Classic to Modern. It has a clear code, tests, and covered by flowtype.