### PR TITLE
Add CircleCI config for website deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2
+jobs:
+  deploy-website:
+    working_directory: ~/relay
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - website-node-modules-{{ checksum "website/yarn.lock" }}
+            - website-node-modules-
+      - run: |
+          cd website
+          yarn --no-progress
+      - save_cache:
+          key: website-node-modules-{{ checksum "website/yarn.lock" }}
+          paths:
+            - website/node_modules
+      - deploy:
+          command: |
+            git config --global user.email "relay-bot@users.noreply.github.com"
+            git config --global user.name "Relay Bot"
+            echo "machine github.com login relay-bot password $GITHUB_TOKEN" > ~/.netrc
+            cd website && yarn install && GIT_USER=relay-bot yarn run publish-gh-pages
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - deploy-website:
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
This is pretty hacky and copied together, but worked to deploy on my user account.

What probably needs fixing is configuration that only master is deployed as I saw circle run on the gh-pages branch.

We might also want to update the user name to some bot or something?