### PR TITLE
docs(Introduction): add info about extensions parameter for compiler

### DIFF
--- a/docs/Introduction-InstallationAndSetup.md
+++ b/docs/Introduction-InstallationAndSetup.md
@@ -51,6 +51,14 @@ This installs the bin script `relay-compiler` in your node_modules folder. It's 
 }
 ```
 
+or if you are using jsx:
+
+```js
+"scripts": {
+  "relay": "relay-compiler --src ./src --schema path/schema.graphql --extensions js jsx"
+}
+```
+
 Then, after making edits to your application files, just run the `relay` script to generate new compiled artifacts:
 
 ```sh


### PR DESCRIPTION
Added info about extension parameter for `relay-compiler`. It took me a couple of days to figure out why my `relay-compiler` doesn't work. As turns out it was because of lack of `--extensions` flag in `relay-compiler` command so I decided to add one to docs for others who may stumble upon the same problem.