### PR TITLE
add option to `relay-compiler` to be quiet

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -92,6 +92,7 @@ async function run(options: {
   watchman: boolean,
   watch?: ?boolean,
   validate: boolean,
+  quiet: boolean,
 }) {
   const schemaPath = path.resolve(process.cwd(), options.schema);
   if (!fs.existsSync(schemaPath)) {
@@ -118,8 +119,11 @@ Ensure that one such file exists in ${srcDir} or its parents.
     `.trim(),
     );
   }
+  if (options.verbose && options.quiet) {
+    throw new Error('I can\'t be quiet and verbose at the same time');
+  }
 
-  const reporter = new ConsoleReporter({verbose: options.verbose});
+  const reporter = new ConsoleReporter({verbose: options.verbose, quiet: options.quiet});
 
   const useWatchman = options.watchman && (await WatchmanClient.isAvailable());
 
@@ -273,6 +277,10 @@ const argv = yargs
     verbose: {
       describe: 'More verbose logging',
       type: 'boolean',
+    },
+    quiet: {
+      describe: 'No output to stdout',
+      type: 'boolean'
     },
     watchman: {
       describe: 'Use watchman when not in watch mode',

--- a/packages/relay-compiler/graphql-compiler/codegen/CodegenRunner.js
+++ b/packages/relay-compiler/graphql-compiler/codegen/CodegenRunner.js
@@ -242,7 +242,7 @@ class CodegenRunner {
     return Profiler.asyncContext('CodegenRunner.write', async () => {
       try {
         // eslint-disable-next-line no-console
-        console.log('\nWriting %s', writerName);
+        this._reporter.reportMessage(`\nWriting ${writerName}`);
         const {
           getWriter,
           parser,
@@ -361,12 +361,10 @@ class CodegenRunner {
         } catch (error) {
           this._reporter.reportError('CodegenRunner.watch', error);
         }
-        // eslint-disable-next-line no-console
-        console.log('Watching for changes to %s...', parserName);
+        this._reporter.reportMessage(`Watching for changes to ${parserName}...`);
       },
     );
-    // eslint-disable-next-line no-console
-    console.log('Watching for changes to %s...', parserName);
+    this._reporter.reportMessage(`Watching for changes to ${parserName}...`);
   }
 }
 

--- a/packages/relay-compiler/graphql-compiler/reporters/GraphQLConsoleReporter.js
+++ b/packages/relay-compiler/graphql-compiler/reporters/GraphQLConsoleReporter.js
@@ -17,13 +17,21 @@ import type {GraphQLReporter} from './GraphQLReporter';
 
 class GraphQLConsoleReporter implements GraphQLReporter {
   _verbose: boolean;
+  _quiet: boolean;
 
-  constructor(options: {verbose: boolean}) {
+  constructor(options: {verbose: boolean, quiet: boolean}) {
     this._verbose = options.verbose;
+    this._quiet = options.quiet;
+  }
+
+  reportMessage(message: string): void {
+    if (!this._quiet) {
+      process.stdout.write(message + '\n');
+    }
   }
 
   reportTime(name: string, ms: number): void {
-    if (this._verbose) {
+    if (this._verbose && !this.quiet) {
       const time =
         ms === 0
           ? chalk.gray(' <1ms')
@@ -35,15 +43,17 @@ class GraphQLConsoleReporter implements GraphQLReporter {
   }
 
   reportError(caughtLocation: string, error: Error): void {
-    process.stdout.write(chalk.red('ERROR:\n' + error.message + '\n'));
-    if (this._verbose) {
-      const frames = error.stack.match(/^ {4}at .*$/gm);
-      if (frames) {
-        process.stdout.write(
-          chalk.gray(
-            'From: ' + caughtLocation + '\n' + frames.join('\n') + '\n',
-          ),
-        );
+    if (!this._quiet) {
+      process.stdout.write(chalk.red('ERROR:\n' + error.message + '\n'));
+      if (this._verbose) {
+        const frames = error.stack.match(/^ {4}at .*$/gm);
+        if (frames) {
+          process.stdout.write(
+            chalk.gray(
+              'From: ' + caughtLocation + '\n' + frames.join('\n') + '\n',
+            ),
+          );
+        }
       }
     }
   }

--- a/packages/relay-compiler/graphql-compiler/reporters/GraphQLMultiReporter.js
+++ b/packages/relay-compiler/graphql-compiler/reporters/GraphQLMultiReporter.js
@@ -20,6 +20,12 @@ class GraphQLMultiReporter implements GraphQLReporter {
     this._reporters = reporters;
   }
 
+  reportMessage(message: string): void {
+    this._reporters.forEach(reporter => {
+      reporter.reportMessage(message);
+    });
+  }
+
   reportTime(name: string, ms: number): void {
     this._reporters.forEach(reporter => {
       reporter.reportTime(name, ms);

--- a/packages/relay-compiler/graphql-compiler/reporters/GraphQLReporter.js
+++ b/packages/relay-compiler/graphql-compiler/reporters/GraphQLReporter.js
@@ -12,6 +12,7 @@
 'use strict';
 
 export interface GraphQLReporter {
+  reportMessage(message: string): void,
   reportTime(name: string, ms: number): void,
   reportError(caughtLocation: string, error: Error): void,
 }


### PR DESCRIPTION
I have a project where I'm using [`relay-compiler-webpack`](https://github.com/danielholmes/relay-compiler-webpack-plugin) and am looking for ways for it to be a bit more quiet.

This patch removes the `console.log` calls from `CodeGenRunner.js` and replaces them with calls to a new method on the reporter `reportMessage` that checks the `quiet` option passed from the bin script before outputting to `stdout`.

Now I couldn't really test this since I couldn't get the build working so I would apprciate any help with that. I ran `npm run build` with `NODE_ENV` set to `production` so I could get the `bins` task to run since I was going to link the package into my project to see it working.

<details>

<summary>Build output</summary>

```
> relay@1.4.1 build /Users/koddsson/koddsson/relay
> gulp

[15:21:01] Using gulpfile ~/koddsson/relay/gulpfile.js
[15:21:01] Starting 'default'...
[15:21:01] Starting 'clean'...
[15:21:01] Finished 'clean' after 242 ms
[15:21:01] Starting 'copy-files'...
[15:21:01] Starting 'modules'...
[15:21:07] Finished 'copy-files' after 5.28 s

events.js:136
      throw er; // Unhandled 'error' event
      ^
Error: /Users/koddsson/koddsson/relay/packages/relay-compiler/node_modules/signal-exit/index.js: Cannot assign to a require(...) alias, EE. Line: 10.
    at PluginPass.Identifier (/Users/koddsson/koddsson/relay/node_modules/babel-preset-fbjs/plugins/inline-requires.js:119:17)
    at newFn (/Users/koddsson/koddsson/relay/node_modules/babel-traverse/lib/visitors.js:276:21)
    at NodePath._call (/Users/koddsson/koddsson/relay/node_modules/babel-traverse/lib/path/context.js:76:18)
    at NodePath.call (/Users/koddsson/koddsson/relay/node_modules/babel-traverse/lib/path/context.js:48:17)
    at NodePath.visit (/Users/koddsson/koddsson/relay/node_modules/babel-traverse/lib/path/context.js:105:12)
    at TraversalContext.visitQueue (/Users/koddsson/koddsson/relay/node_modules/babel-traverse/lib/context.js:150:16)
    at TraversalContext.visitSingle (/Users/koddsson/koddsson/relay/node_modules/babel-traverse/lib/context.js:108:19)
    at TraversalContext.visit (/Users/koddsson/koddsson/relay/node_modules/babel-traverse/lib/context.js:192:19)
    at Function.traverse.node (/Users/koddsson/koddsson/relay/node_modules/babel-traverse/lib/index.js:114:17)
    at NodePath.visit (/Users/koddsson/koddsson/relay/node_modules/babel-traverse/lib/path/context.js:115:19)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! relay@1.4.1 build: `gulp`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the relay@1.4.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/koddsson/.npm/_logs/2017-11-21T15_21_38_405Z-debug.log
```

</details>

