### PR TITLE
Update <OperationType> to inline code

### DIFF
--- a/docs/Modern-QueryRenderer.md
+++ b/docs/Modern-QueryRenderer.md
@@ -39,4 +39,4 @@ const {
 
 ### Query Naming Convention
 
-To enable [compatibility mode](./relay-compat.html), `relay-compiler` enforces a simple naming convention for your queries. Queries must be named as `<FileName><OperationType>`, where "<OperationType>" is one of "Query", "Mutation", or "Subscription". The query above is named `ExampleQuery` so should be placed in `Example.js`.
+To enable [compatibility mode](./relay-compat.html), `relay-compiler` enforces a simple naming convention for your queries. Queries must be named as `<FileName><OperationType>`, where `<OperationType>` is one of "Query", "Mutation", or "Subscription". The query above is named `ExampleQuery` so should be placed in `Example.js`.


### PR DESCRIPTION
Add back-ticks to `<OperationType>` so that is not interpreted as an HTML tag.

<img width="228" alt="screen shot 2017-12-03 at 9 51 03 pm" src="https://user-images.githubusercontent.com/1153686/33534589-628bf8f4-d876-11e7-9627-9c620c932e01.png">
