### PR TITLE
Allow configuring file extension for files generated by RelayFileWriter

### DIFF
--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -49,6 +49,7 @@ export type ValidationRule = (context: ValidationContext) => any;
 
 export type WriterConfig = {
   baseDir: string,
+  fileExtension?: string,
   compilerTransforms: RelayCompilerTransforms,
   customScalars: ScalarTypeMapping,
   formatModule: FormatModule,
@@ -243,6 +244,8 @@ class RelayFileWriter implements FileWriterInterface {
           )
         : null;
 
+      const fileExtension = this._config.fileExtension ? this._config.fileExtension : '.js';
+
       try {
         await Promise.all(
           artifacts.map(async node => {
@@ -280,6 +283,7 @@ class RelayFileWriter implements FileWriterInterface {
 
             await writeRelayGeneratedFile(
               getGeneratedDirectory(node.name),
+              fileExtension,
               node,
               formatModule,
               flowTypes,

--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -45,6 +45,7 @@ export type FormatModule = ({|
 
 async function writeRelayGeneratedFile(
   codegenDir: CodegenDirectory,
+  fileExtension: string,
   generatedNode: GeneratedNode,
   formatModule: FormatModule,
   flowText: string,
@@ -57,7 +58,7 @@ async function writeRelayGeneratedFile(
   const persistQuery = _persistQuery;
   const moduleName = generatedNode.name + '.graphql';
   const platformName = platform ? moduleName + '.' + platform : moduleName;
-  const filename = platformName + '.js';
+  const filename = platformName + fileExtension;
   const flowTypeName =
     generatedNode.kind === RelayConcreteNode.FRAGMENT
       ? 'ConcreteFragment'


### PR DESCRIPTION
This allows configuring the file extension of the files written by RelayFileWriter.

I'm in the process of trying to create a version of `relay-compiler` that can parse and generate typescript files. Overall the experience is quite smooth, but I'd especially like to not have reimplement the entire `writeRelayGeneratedFile` module.

If you are happy with these sort of small pull requests to open up the package for more extensions I'll be making some more (exposing some more modules through the `RelayCompilerPublic` file, etc.)
  