### PR TITLE
Always generate union types for inline fragment selections

### DIFF
--- a/packages/relay-compiler/core/RelayFlowGenerator.js
+++ b/packages/relay-compiler/core/RelayFlowGenerator.js
@@ -130,14 +130,7 @@ function selectionsToBabel(selections, state: State, refTypeName?: string) {
 
   const types = [];
 
-  if (
-    Object.keys(byConcreteType).length &&
-    onlySelectsTypename(Array.from(baseFields.values())) &&
-    (hasTypenameSelection(Array.from(baseFields.values())) ||
-      Object.keys(byConcreteType).every(type =>
-        hasTypenameSelection(byConcreteType[type]),
-      ))
-  ) {
+  if (Object.keys(byConcreteType).length > 0) {
     for (const concreteType in byConcreteType) {
       types.push(
         groupRefs([
@@ -163,12 +156,7 @@ function selectionsToBabel(selections, state: State, refTypeName?: string) {
     for (const concreteType in byConcreteType) {
       selectionMap = mergeSelections(
         selectionMap,
-        selectionsToMap(
-          byConcreteType[concreteType].map(sel => ({
-            ...sel,
-            conditional: true,
-          })),
-        ),
+        selectionsToMap(byConcreteType[concreteType]),
       );
     }
     const selectionMapValues = groupRefs(Array.from(selectionMap.values())).map(

--- a/packages/relay-compiler/core/__tests__/__snapshots__/RelayFlowGenerator-test.js.snap
+++ b/packages/relay-compiler/core/__tests__/__snapshots__/RelayFlowGenerator-test.js.snap
@@ -66,7 +66,7 @@ type UserFrag1$ref = any;
 type UserFrag2$ref = any;
 import type { FragmentReference } from 'relay-runtime';
 export opaque type FragmentSpread$ref: FragmentReference = FragmentReference;
-export type FragmentSpread = {|
+export type FragmentSpread = ({|
   +id: string,
   +justFrag: ?{|
     +__fragments: PictureFragment$ref,
@@ -77,7 +77,12 @@ export type FragmentSpread = {|
   |},
   +__fragments: (OtherFragment$ref & UserFrag1$ref & UserFrag2$ref),
   +$refType: FragmentSpread$ref,
-|};
+|} | {|
+  // This will never be '%other', but we need some
+  // value in case none of the concrete values match.
+  +__typename: '%other',
+  +$refType: FragmentSpread$ref,
+|});
 
 type PageFragment$ref = any;
 import type { FragmentReference } from 'relay-runtime';
@@ -165,28 +170,43 @@ fragment InlineFragmentKitchenSink on Story {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 import type { FragmentReference } from 'relay-runtime';
 export opaque type InlineFragment$ref: FragmentReference = FragmentReference;
-export type InlineFragment = {|
+export type InlineFragment = ({|
   +id: string,
   +name?: ?string,
-  +message?: ?{|
+  +message: ?{|
     +text: ?string,
   |},
   +$refType: InlineFragment$ref,
-|};
+|} | {|
+  // This will never be '%other', but we need some
+  // value in case none of the concrete values match.
+  +__typename: '%other',
+  +$refType: InlineFragment$ref,
+|});
 
 import type { FragmentReference } from 'relay-runtime';
 export opaque type InlineFragmentWithOverlappingFields$ref: FragmentReference = FragmentReference;
-export type InlineFragmentWithOverlappingFields = {|
-  +hometown?: ?{|
+export type InlineFragmentWithOverlappingFields = ({|
+  +hometown: ?{|
     +id: string,
     +name: ?string,
-    +message?: ?{|
+  |},
+  +$refType: InlineFragmentWithOverlappingFields$ref,
+|} | {|
+  +name: ?string,
+  +hometown: ?{|
+    +id: string,
+    +message: ?{|
       +text: ?string,
     |},
   |},
-  +name?: ?string,
   +$refType: InlineFragmentWithOverlappingFields$ref,
-|};
+|} | {|
+  // This will never be '%other', but we need some
+  // value in case none of the concrete values match.
+  +__typename: '%other',
+  +$refType: InlineFragmentWithOverlappingFields$ref,
+|});
 
 import type { FragmentReference } from 'relay-runtime';
 export opaque type InlineFragmentConditionalID$ref: FragmentReference = FragmentReference;
@@ -200,16 +220,20 @@ type SomeFragment$ref = any;
 import type { FragmentReference } from 'relay-runtime';
 export opaque type InlineFragmentKitchenSink$ref: FragmentReference = FragmentReference;
 export type InlineFragmentKitchenSink = {|
-  +actor: ?{|
+  +actor: ?({|
     +id: string,
     +profilePicture: ?{|
       +uri: ?string,
       +width?: ?number,
       +height?: ?number,
     |},
-    +name?: ?string,
+    +name: ?string,
     +__fragments: SomeFragment$ref,
-  |},
+  |} | {|
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    +__typename: '%other',
+  |}),
   +$refType: InlineFragmentKitchenSink$ref,
 |};
 `;
@@ -569,25 +593,38 @@ export type TypenameOutside = ({|
 
 import type { FragmentReference } from 'relay-runtime';
 export opaque type TypenameOutsideWithAbstractType$ref: FragmentReference = FragmentReference;
-export type TypenameOutsideWithAbstractType = {|
-  +__typename: string,
+export type TypenameOutsideWithAbstractType = ({|
+  +__typename: 'User',
   +username?: ?string,
   +address?: ?{|
     +city: ?string,
     +country: ?string,
-    +street?: ?string,
   |},
-  +firstName?: ?string,
+  +firstName: ?string,
+  +address: ?{|
+    +street: ?string,
+    +city: ?string,
+  |},
   +$refType: TypenameOutsideWithAbstractType$ref,
-|};
+|} | {|
+  // This will never be '%other', but we need some
+  // value in case none of the concrete values match.
+  +__typename: '%other',
+  +$refType: TypenameOutsideWithAbstractType$ref,
+|});
 
 import type { FragmentReference } from 'relay-runtime';
 export opaque type TypenameWithoutSpreads$ref: FragmentReference = FragmentReference;
-export type TypenameWithoutSpreads = {|
+export type TypenameWithoutSpreads = ({|
   +firstName: ?string,
   +__typename: 'User',
   +$refType: TypenameWithoutSpreads$ref,
-|};
+|} | {|
+  // This will never be '%other', but we need some
+  // value in case none of the concrete values match.
+  +__typename: '%other',
+  +$refType: TypenameWithoutSpreads$ref,
+|});
 
 import type { FragmentReference } from 'relay-runtime';
 export opaque type TypenameWithoutSpreadsAbstractType$ref: FragmentReference = FragmentReference;
@@ -599,13 +636,22 @@ export type TypenameWithoutSpreadsAbstractType = {|
 
 import type { FragmentReference } from 'relay-runtime';
 export opaque type TypenameWithCommonSelections$ref: FragmentReference = FragmentReference;
-export type TypenameWithCommonSelections = {|
-  +__typename: string,
+export type TypenameWithCommonSelections = ({|
+  +__typename: 'User',
   +name: ?string,
-  +firstName?: ?string,
-  +username?: ?string,
+  +firstName: ?string,
   +$refType: TypenameWithCommonSelections$ref,
-|};
+|} | {|
+  +__typename: 'Page',
+  +name: ?string,
+  +username: ?string,
+  +$refType: TypenameWithCommonSelections$ref,
+|} | {|
+  // This will never be '%other', but we need some
+  // value in case none of the concrete values match.
+  +__typename: '%other',
+  +$refType: TypenameWithCommonSelections$ref,
+|});
 `;
 
 exports[`RelayFlowGenerator matches expected output: unmasked-fragment-spreads.graphql 1`] = `


### PR DESCRIPTION
### Overview

Removes an undocumented behaviour which generated different compiled flowtypes based on the presence of the `__typename` key selection.

I opened this PR in relation to issue #2039, which I opened a few months ago.

### Details

My team is working with relay modern and generated flowtypes at some scale in a rewrite of our API layer.  We find that the merged, optional key format output is never more desirable than union types.  Merging keys always results in a large quantity of redundant null checks, and makes it much harder for developers to identify the real, possible failure conditions.

Thanks to @kassens we've been selecting the `__typename` key in every fragment spread, which can force our preferred output.

However, there are a few downsides with this approach:

1. It gets confusing
    * In some more complicated fragment compositions, it can get very confusing trying to work out why relay has decided to prefer one output format vs the other.
1. It's not documented
    * New developers on the team have no insight into why we are selecting this key, nor how to get the desired type output.
1. It has bugs
    * There are some conditions, which I can try to isolate if desired, under which it seems to be impossible to convince relay to output a union type.

### Open Questions

This will probably be a breaking change for any users relying on relay's generated flow types.  It might be good to think about a migration strategy, or an opt-in toggle here.  I'm open to suggestions.