### PR TITLE
[Bug Fix: Relay Compiler] Don’t break on functions sharing names with object prototype methods

### DIFF
--- a/packages/relay-compiler/codegen/FindGraphQLTags.js
+++ b/packages/relay-compiler/codegen/FindGraphQLTags.js
@@ -176,11 +176,11 @@ function memoizedFind(
   );
 }
 
-const CREATE_CONTAINER_FUNCTIONS = {
-  createFragmentContainer: true,
-  createPaginationContainer: true,
-  createRefetchContainer: true,
-};
+const CREATE_CONTAINER_FUNCTIONS = Object.create(null, {
+  createFragmentContainer: {value: true},
+  createPaginationContainer: {value: true},
+  createRefetchContainer: {value: true},
+});
 
 const IGNORED_KEYS = {
   comments: true,

--- a/packages/relay-compiler/codegen/__tests__/FindGraphQLTags-test.js
+++ b/packages/relay-compiler/codegen/__tests__/FindGraphQLTags-test.js
@@ -90,6 +90,14 @@ describe('FindGraphQLTags', () => {
         `),
       ).toEqual(['fragment FindGraphQLTags on User { id }']);
     });
+    it('parses JS with functions sharing names with object prototype methods', () => {
+      expect(
+        find(`
+          toString();
+          foo(graphql\`fragment FindGraphQLTags on User { id }\`);
+        `),
+      ).toEqual(['fragment FindGraphQLTags on User { id }']);
+    });
   });
 
   describe('query validation', () => {


### PR DESCRIPTION
Reopened from https://github.com/facebook/relay/pull/2060 with a test case to prevent regressions.