### PR TITLE
Throw better error for missing idType

### DIFF
--- a/packages/relay-compiler/transforms/RelayGenerateIDFieldTransform.js
+++ b/packages/relay-compiler/transforms/RelayGenerateIDFieldTransform.js
@@ -17,6 +17,7 @@ const {
   assertCompositeType,
   assertLeafType,
 } = require('graphql');
+const invariant = require('invariant');
 const {
   CompilerContext,
   SchemaUtils,
@@ -49,7 +50,10 @@ type State = {
 function relayGenerateIDFieldTransform(
   context: CompilerContext,
 ): CompilerContext {
-  const idType = assertLeafType(context.serverSchema.getType(ID_TYPE));
+  let idType = context.serverSchema.getType(ID_TYPE);
+  invariant(idType, 'Schema does not contain an id field on any types');
+  // reassigning avoids flow error, would love to hear thoughts on this
+  idType = assertLeafType(idType);
   const idField: ScalarField = {
     kind: 'ScalarField',
     alias: (null: ?string),


### PR DESCRIPTION
Related to #2281 

A better error message for the situation i ran into would have helped me figure out my mistake much faster. This just checks to see if there is no id field defined in the schema (returns undefined) and if so throws a different error message instead of asserting that 'undefined' is a leaf type (Which is most certainly is not). 