### PR TITLE
ISSUE-2042: Update «fast-glob» package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-react": "7.3.0",
     "eslint-plugin-relay": "0.0.19",
     "event-stream": "3.3.4",
-    "fast-glob": "^1.0.1",
+    "fast-glob": "^2.0.0",
     "fb-watchman": "^2.0.0",
     "fbjs": "^0.8.14",
     "fbjs-scripts": "0.7.1",

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -78,8 +78,6 @@ function getFilepathsFromGlob(
   const glob = require('fast-glob');
   return glob.sync(patterns, {
     cwd: baseDir,
-    bashNative: [],
-    onlyFiles: true,
     ignore: exclude,
   });
 }

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -23,7 +23,7 @@
     "babel-types": "^6.24.1",
     "babylon": "^6.18.0",
     "chalk": "^1.1.1",
-    "fast-glob": "^1.0.1",
+    "fast-glob": "^2.0.0",
     "fb-watchman": "^2.0.0",
     "fbjs": "^0.8.14",
     "graphql": "^0.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1997,14 +1997,14 @@ fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
-fast-glob@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-1.0.1.tgz#30f9b1120fd57a7f172364a6458fbdbd98187b3c"
+fast-glob@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.0.2.tgz#985f01d251ddb045f42af0ca59ade9b9bff87725"
   dependencies:
-    bash-glob "^1.0.1"
-    glob-parent "^3.1.0"
-    micromatch "^3.0.3"
-    readdir-enhanced "^1.5.2"
+    glob-parent "3.1.0"
+    merge2 "1.2.1"
+    micromatch "3.1.5"
+    readdir-enhanced "2.2.0"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### Links

  * https://github.com/facebook/relay/issues/2042
  * https://github.com/mrmlnc/fast-glob/issues/23

#### What is?

  * Fix for #2042. Now works fine with more then 500 000 entries (maybe more – more I have not tried).
  * Also this is a [new release of `fast-glob` package](https://github.com/mrmlnc/fast-glob/releases/tag/2.0.0), which became even faster and more stable.

#### Some lines

  * If you want exclude `node_modules` directory you can use `**/node_modules` pattern ([documentation](https://github.com/mrmlnc/fast-glob#how-to-exclude-directory-from-reading)).

Sorry for the problems from #2042.  