### PR TITLE
Fix example instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ The [relay-examples](https://github.com/relayjs/relay-examples) repository conta
 
 ```
 git clone https://github.com/relayjs/relay-examples.git
-cd relay-examples/todo && npm install
+cd relay-examples/todo
+npm install
+npm run build
 npm start
 ```
 


### PR DESCRIPTION
The proposed instructions don't work. You can try them :-)

Related issue (closed by author but not actually solved): https://github.com/relayjs/relay-examples/issues/44

This fixes the instructions to also run the compiler.