### PR TITLE
Changing field name in ThinkingInGraphQL docs

### DIFF
--- a/docs/PrinciplesAndArchitecture-ThinkingInGraphQL.md
+++ b/docs/PrinciplesAndArchitecture-ThinkingInGraphQL.md
@@ -183,7 +183,7 @@ Consider rendering the text and comments of a story along with the corresponding
 
 ```
 query {
-  node(id: "1") {
+  story(id: "1") {
     text,
     author { name, photo },
     comments {


### PR DESCRIPTION
In the Data/View Consistency section of the Thinking in GraphQL page the query refers to a node field but the caching and previous query examples indicate that the field should be `story`. 

Here is the query before the change:
```graphql
query {
  node(id: "1") {
    text,
    author { name, photo },
    comments {
      text,
      author { name, photo }
    }
  }
}
```
And here is how the query should be: 
```graphql
query {
  story(id: "1") {
    text,
    author { name, photo },
    comments {
      text,
      author { name, photo }
    }
  }
}
```
 