### PR TITLE
[package] Make `jest --watch` work with React 16.

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "roots": [
       "<rootDir>/node_modules/fbjs/lib/",
       "<rootDir>/node_modules/fbjs-scripts/jest",
-      "<rootDir>/node_modules/react/lib/",
       "<rootDir>/packages/"
     ],
     "setupFiles": [


### PR DESCRIPTION
The `react/lib` directory no longer exists and that breaks watchman.