### PR TITLE
RFC: Support subscriptions and TTL in QueryRenderer

### DIFF
--- a/packages/react-relay/modern/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/modern/ReactRelayQueryRenderer.js
@@ -103,9 +103,9 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
     super(props, context);
 
     const handleDataChange = ({
-                                error,
-                                snapshot,
-                              }: {
+      error,
+      snapshot,
+    }: {
       error?: Error,
       snapshot?: Snapshot,
     }): void => {
@@ -162,7 +162,6 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
       prevState.prevPropsEnvironment !== nextProps.environment ||
       !areEqual(prevState.prevPropsVariables, nextProps.variables)
     ) {
-
       return {
         prevQuery: nextProps.query,
         prevPropsEnvironment: nextProps.environment,


### PR DESCRIPTION
## Background
The queryFetcher in v1.5.0 is _really_ great. It separates the fetching concern from the query renderer component. Now that it is in place, the stage is set for subscriptions, TTLs, and subscription-based TTLs.

### Scenario 1: Subscription-backed queries
Let's say I have a query that gets the Like count for a post and a subscription that keeps the Like count updated.
In this scenario, as long as that subscription is active, I never need to rerun the query. It is powered by a subscription.
By default, when the component is unmounted, the query should be GC'd and the subscription should be unsubscribed _if it is not being used anywhere else in the app_.
For efficiency gains, we may want to cache a query even after it's been unmounted. For example, imagine a `/stories` route that queries 100 stories. When a user navigates away from `/stories`, there is a 90% chance they will return within 2 minutes. In this case, it's cheaper to maintain that active subscription than it is to GC & requery.

### Scenario 2: Infrequently updated data
Let's say the data I'm working with is valid for 5 minutes from the time of initial query. Therefore, to avoid a requery, I should hold onto that query data for 5 minutes because they may revisit the route within 5 mins.

## How it works
The QueryRenderer takes in an additional 2 arg: `subscriptions` and `subParams`. `subscriptions` is an array of functions that will be passed the environment and `subParams`. The existing `cacheConfig` now also accepts a `ttl`. If there are no subscriptions & no TTL, the QueryRenderer acts like normal. If either are passed in, the QueryFetcher will not dispose of the data until the subscription becomes inactive or the TTL expires.
It is necessary to build these args into the QueryRenderer to get access to the queryFetcher and know when the component has been unmounted. However, it is not the job of the QueryRenderer to manage subscriptions, so a light touch is needed.
There is a many-to-many relationship between queries and subscriptions. If a client is kicked out of 1 subscription by the server, we need to invalidate all associated queryFetchers. If the client navigates away from a query, then the associated subscriptions need to be flagged for possible unsubscription. To reduce coupling, I made QueryRenderer handle all the TTL logic and call 2 user-defined methods in the extended environment or `SubscriptionManager`: 
- `registerQuery`: called when a query will begin using a subscription
- `unregisterQuery`:  called when a query stops using a subscrption

 ## Example subscription manager
Similar to the `subscribeFn` that is passed into `Network.create`, managing subscription the 2 aforementioned methods should be user defined; however, as best practices emerge, adopting a reasonable default may be worthwhile. Big picture, `registerQuery` should start the subscription if it hasn't been started already. `unregisterQuery` should stop the subscription & unsubscribe if it is no longer being used. To keep track of what components use what subscriptions, a basic ledger can be implemented with these 3 keys:
- `queryKey`: The unique identifier for this query & variables
- `subKey`: The unique identifier for this subscription & variables
- `queryFetcher`: a way to GC the query data

I've been using this technique in production for the last few months (although the queryFetcher makes it _much_ cleaner!) Here are my methods for reference: 

```js
  registerQuery = async (queryKey, subscriptions, subParams, queryVariables, queryFetcher) => {
    const subConfigs = subscriptions.map((subCreator) => subCreator(this, queryVariables, subParams));
    const subscriptionClient = await this.ensureSubscriptionClient();
    if (!subscriptionClient) return;
    const newQuerySubs = subConfigs.map((config) => {
      const {subscription, variables = {}} = config;
      const {name} = subscription();
      const subKey = JSON.stringify({name, variables});
      requestSubscription(this, config);
      return {
        subKey,
        queryKey,
        queryFetcher
      };
    });

    this.querySubscriptions.push(...newQuerySubs);
  };

unregisterQuery = (maybeQueryKeys) => {
    const queryKeys = Array.isArray(maybeQueryKeys) ? maybeQueryKeys : [maybeQueryKeys];

    // for each query that is no longer 100% supported, find the subs that power them
    const peerSubs = this.querySubscriptions.filter(({queryKey}) => queryKeys.includes(queryKey));

    // get a unique list of the subs to release & maybe unsub
    const peerSubKeys = Array.from(new Set(peerSubs.map(({subKey}) => subKey)));

    peerSubKeys.forEach((subKey) => {
      // for each peerSubKey, see if there exists a query that is not affected.
      const unaffectedQuery = this.querySubscriptions.find((qs) => qs.subKey === subKey && !queryKeys.includes(qs.queryKey));
      if (!unaffectedQuery) {
        this.subscriptions[subKey].client.unsubscribe();
      }
    });

    this.querySubscriptions = this.querySubscriptions.filter((qs) => {
      return !peerSubKeys.includes(qs.subKey) || !queryKeys.includes(qs.queryKey);
    });
  };
```

