### PR TITLE
Remove the `clientMutationId` requirement by creating a new root id for each executed mutation

### DIFF
--- a/packages/react-relay/classic/environment/RelayCombinedEnvironmentTypes.js
+++ b/packages/react-relay/classic/environment/RelayCombinedEnvironmentTypes.js
@@ -231,6 +231,7 @@ export interface CUnstableEnvironmentCore<
     request: TRequest,
     variables: Variables,
     operation?: TOperation,
+    dataID?: DataID,
   ) => COperationSelector<TNode, TRequest>;
 
   /**

--- a/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
@@ -139,10 +139,10 @@ class RelayRecordSourceProxy implements RecordSourceProxy {
     return this._proxies[dataID];
   }
 
-  getRoot(): RecordProxy {
-    let root = this.get(ROOT_ID);
+  getRoot(dataID: DataID = ROOT_ID): RecordProxy {
+    let root = this.get(dataID);
     if (!root) {
-      root = this.create(ROOT_ID, ROOT_TYPE);
+      root = this.create(dataID, ROOT_TYPE);
     }
     invariant(
       root && root.getType() === ROOT_TYPE,

--- a/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
@@ -54,7 +54,7 @@ class RelayRecordSourceSelectorProxy implements RecordSourceSelectorProxy {
   }
 
   getRoot(): RecordProxy {
-    return this.__recordSource.getRoot();
+    return this.__recordSource.getRoot(this._readSelector.dataID);
   }
 
   _getRootField(

--- a/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
+++ b/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
@@ -106,14 +106,14 @@ describe('Configs: NODE_DELETE', () => {
     ];
     const optimisticUpdater = jest.fn();
     const updater = jest.fn();
+    const operationSelector = createOperationSelector(FeedbackCommentQuery, {});
+    environment.commitPayload(operationSelector, payload);
     const snapshot = store.lookup({
       dataID: ROOT_ID,
       node: FeedbackCommentQuery.fragment,
       variables: {},
     });
     const callback = jest.fn();
-    const operationSelector = createOperationSelector(FeedbackCommentQuery, {});
-    environment.commitPayload(operationSelector, payload);
     store.subscribe(snapshot, callback);
     commitRelayModernMutation(environment, {
       configs,
@@ -547,13 +547,13 @@ describe('Configs: RANGE_ADD', () => {
         edgeName: 'feedbackCommentEdge',
       },
     ];
+    const operationSelector = createOperationSelector(CommentQuery, {});
+    environment.commitPayload(operationSelector, payload);
     const snapshot = store.lookup({
       dataID: ROOT_ID,
       node: CommentQuery.fragment,
       variables: {},
     });
-    const operationSelector = createOperationSelector(CommentQuery, {});
-    environment.commitPayload(operationSelector, payload);
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
       configs,
@@ -757,13 +757,13 @@ describe('Configs: RANGE_ADD', () => {
         edgeName: 'feedbackCommentEdge',
       },
     ];
+    const operationSelector = createOperationSelector(CommentQuery, {});
+    environment.commitPayload(operationSelector, payload);
     const snapshot = store.lookup({
       dataID: ROOT_ID,
       node: CommentQuery.fragment,
       variables: {},
     });
-    const operationSelector = createOperationSelector(CommentQuery, {});
-    environment.commitPayload(operationSelector, payload);
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
       configs,

--- a/packages/relay-runtime/mutations/commitRelayModernMutation.js
+++ b/packages/relay-runtime/mutations/commitRelayModernMutation.js
@@ -48,6 +48,7 @@ function commitRelayModernMutation<T>(
     'commitRelayModernMutation: expect `environment` to be an instance of ' +
       '`RelayModernEnvironment`.',
   );
+  const mutationUid = nextMutationUid();
   const {createOperationSelector, getRequest} = environment.unstable_internal;
   const mutation = getRequest(config.mutation);
   if (mutation.operationKind !== 'mutation') {
@@ -55,7 +56,7 @@ function commitRelayModernMutation<T>(
   }
   let {optimisticResponse, optimisticUpdater, updater} = config;
   const {configs, onError, variables, uploadables} = config;
-  const operation = createOperationSelector(mutation, variables);
+  const operation = createOperationSelector(mutation, variables, undefined, mutationUid);
   // TODO: remove this check after we fix flow.
   if (typeof optimisticResponse === 'function') {
     optimisticResponse = optimisticResponse();
@@ -108,6 +109,13 @@ function commitRelayModernMutation<T>(
       },
       onError,
     });
+}
+
+
+let mutationUidCounter = 0;
+const mutationUidPrefix = Math.random().toString();
+function nextMutationUid() {
+  return mutationUidPrefix + mutationUidCounter++;
 }
 
 module.exports = commitRelayModernMutation;

--- a/packages/relay-runtime/mutations/commitRelayModernMutation.js
+++ b/packages/relay-runtime/mutations/commitRelayModernMutation.js
@@ -113,7 +113,7 @@ function commitRelayModernMutation<T>(
 
 
 let mutationUidCounter = 0;
-const mutationUidPrefix = Math.random().toString();
+const mutationUidPrefix = 'mutationRoot';
 function nextMutationUid() {
   return mutationUidPrefix + mutationUidCounter++;
 }

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -197,7 +197,7 @@ class RelayModernEnvironment implements Environment {
       .execute(operation.node, operation.variables, cacheConfig || {})
       .do({
         next: executePayload => {
-          const responsePayload = normalizePayload(executePayload);
+          const responsePayload = normalizePayload(executePayload, operation);
           const {source, fieldPayloads, deferrableSelections} = responsePayload;
           for (const selectionKey of deferrableSelections || new Set()) {
             this._deferrableSelections.add(selectionKey);
@@ -303,7 +303,7 @@ class RelayModernEnvironment implements Environment {
           }
           this._publishQueue.commitPayload(
             operation,
-            normalizePayload(payload),
+            normalizePayload(payload, operation),
             updater,
           );
           this._publishQueue.run();

--- a/packages/relay-runtime/store/RelayModernOperationSelector.js
+++ b/packages/relay-runtime/store/RelayModernOperationSelector.js
@@ -16,7 +16,7 @@ const RelayConcreteNode = require('RelayConcreteNode');
 const {getOperationVariables} = require('RelayConcreteVariables');
 const {ROOT_ID} = require('RelayStoreUtils');
 
-import type {Variables} from '../util/RelayRuntimeTypes';
+import type {Variables, DataID} from '../util/RelayRuntimeTypes';
 import type {RequestNode, ConcreteOperation} from 'RelayConcreteNode';
 import type {OperationSelector} from 'RelayStoreTypes';
 
@@ -30,6 +30,7 @@ function createOperationSelector(
   request: RequestNode,
   variables: Variables,
   operationFromBatch?: ConcreteOperation,
+  dataID: DataID = ROOT_ID,
 ): OperationSelector {
   const operation =
     operationFromBatch ||
@@ -38,7 +39,6 @@ function createOperationSelector(
       : request.operation);
 
   const operationVariables = getOperationVariables(operation, variables);
-  const dataID = ROOT_ID;
   return {
     fragment: {
       dataID,

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -186,7 +186,7 @@ export interface RecordSourceProxy {
   create(dataID: DataID, typeName: string): RecordProxy;
   delete(dataID: DataID): void;
   get(dataID: DataID): ?RecordProxy;
-  getRoot(): RecordProxy;
+  getRoot(dataID?: DataID): RecordProxy;
 }
 
 /**

--- a/packages/relay-runtime/store/normalizePayload.js
+++ b/packages/relay-runtime/store/normalizePayload.js
@@ -15,18 +15,19 @@ const RelayError = require('RelayError');
 
 const normalizeRelayPayload = require('normalizeRelayPayload');
 
-const {ROOT_ID} = require('RelayStoreUtils');
-
 import type {ExecutePayload} from 'RelayNetworkTypes';
-import type {RelayResponsePayload} from 'RelayStoreTypes';
+import type {RelayResponsePayload, OperationSelector} from 'RelayStoreTypes';
 
-function normalizePayload(payload: ExecutePayload): RelayResponsePayload {
+function normalizePayload(
+  payload: ExecutePayload,
+  operationSelector: OperationSelector,
+): RelayResponsePayload {
   const {operation, variables, response} = payload;
   const {data, errors} = response;
   if (data != null) {
     return normalizeRelayPayload(
       {
-        dataID: ROOT_ID,
+        dataID: operationSelector.root.dataID,
         node: operation,
         variables,
       },

--- a/packages/relay-runtime/store/normalizeRelayPayload.js
+++ b/packages/relay-runtime/store/normalizeRelayPayload.js
@@ -15,7 +15,7 @@ const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
 const RelayModernRecord = require('RelayModernRecord');
 const RelayResponseNormalizer = require('RelayResponseNormalizer');
 
-const {ROOT_ID, ROOT_TYPE} = require('RelayStoreUtils');
+const {ROOT_TYPE} = require('RelayStoreUtils');
 
 import type {PayloadData, PayloadError} from 'RelayNetworkTypes';
 import type {NormalizationOptions} from 'RelayResponseNormalizer';

--- a/packages/relay-runtime/store/normalizeRelayPayload.js
+++ b/packages/relay-runtime/store/normalizeRelayPayload.js
@@ -28,7 +28,7 @@ function normalizeRelayPayload(
   options: NormalizationOptions = {handleStrippedNulls: false},
 ): RelayResponsePayload {
   const source = new RelayInMemoryRecordSource();
-  source.set(ROOT_ID, RelayModernRecord.create(ROOT_ID, ROOT_TYPE));
+  source.set(selector.dataID, RelayModernRecord.create(selector.dataID, ROOT_TYPE));
   const {
     fieldPayloads,
     deferrableSelections,


### PR DESCRIPTION
Fixes #1734
Fixes #2333 
Fixes #825

Related to https://github.com/relayjs/relay-examples/issues/30
When a mutation is executed, it's payload is added to the store using a key of the serialized arguments. In the Todo Modern example this looks like this:

```js
{
  'client:root:addTodo(input:{"text":"a"})': { ... } // added by mutation response
  'client:VXNlcjptZQ==:__TodoList_todos_connection': {
    edges: [
      __refs: [
        'client:VXNlcjptZQ==:__TodoList_todos_connection:edges:0',
        'client:VXNlcjptZQ==:__TodoList_todos_connection:edges:1',
        'client:root:addTodo(input:{"text":"a"}):todoEdge', // added by mutation imperative updater function
      ]
    ]
  }
}
```

If you execute a second `addTodo` mutation with the same arguments, the `client:root:addTodo(input:{"text":"a"})` field in the store will get overwritten with the second mutation and the store will look like this:

```js
{
  'client:root:addTodo(input:{"text":"a"})': { ... }
  'client:VXNlcjptZQ==:__TodoList_todos_connection': {
    edges: [
      __refs: [
        'client:VXNlcjptZQ==:__TodoList_todos_connection:edges:0',
        'client:VXNlcjptZQ==:__TodoList_todos_connection:edges:1',
        'client:root:addTodo(input:{"text":"a"}):todoEdge',
        'client:root:addTodo(input:{"text":"a"}):todoEdge',
      ]
    ]
  }
}
```

When React renders the data, you will have the latter `todo` in the connection array twice and will likely get an error along the lines of `Encountered two children with the same key, <id>. Child keys must be unique; when two children share a key, only the first child will be used`.

This was [fixed in relay-examples](https://github.com/relayjs/relay-examples/commit/ed955945ca5158ac34ed8ce703ae0cc7cb3e38e7#diff-4b42725e6eb503f56da8e3f637e9a4e3) by adding a `clientMutationId` to the mutation arguments. I don't think this is ideal since
1. it requires the developer to manually add this to each mutation
2. it places an additional constraint on the GraphQL schema to support this field.

The approach I took to fix this, was to use a new root `dataID` (instead of the static `client:root`) for results on each mutation. This will namespace results from each mutation so they can never overwrite one another. 

With these changes, the relay store now looks like this after completing the same series of mutations:

```js
{
  'client:mutationRoot0:addTodo(input:{"text":"a"})': { ... },
  'client:mutationRoot1:addTodo(input:{"text":"a"})': { ... },
  'client:VXNlcjptZQ==:__TodoList_todos_connection': {
    edges: [
      __refs: [
        'client:VXNlcjptZQ==:__TodoList_todos_connection:edges:0',
        'client:VXNlcjptZQ==:__TodoList_todos_connection:edges:1',
        'client:mutationRoot0:addTodo(input:{"text":"a"}):todoEdge',
        'client:mutationRoot1:addTodo(input:{"text":"a"}):todoEdge'
      ]
    ]
  }
}
```

I tested this and it works to solve this issue, but I'm unsure if there could be any unintended consequences by this change.