### PR TITLE
Update to QueryRenderer docs

### DIFF
--- a/docs/Modern-QueryRenderer.md
+++ b/docs/Modern-QueryRenderer.md
@@ -13,6 +13,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 * `environment`: The [Relay Environment](./relay-environment.html)
 * `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat.html), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
+* `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 * `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables is passed, the `QueryRenderer` will re-fetch the query.
 * `render`: Function of type `({error, props}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.
   * `props`: Object containing data obtained from the query; the shape of this object will match the shape of the query. If this object is not defined, it means that the data is still being fetched.


### PR DESCRIPTION
QueryRenderer props can include a cacheConfig. I'm not sure of the proper place to go into details about what can be included on the cahceConfig object, but it would be nice to include reference here.