### PR TITLE
Allow compatible variable types with `@relay(mask: true)` 

### DIFF
--- a/packages/relay-compiler/transforms/RelayMaskTransform.js
+++ b/packages/relay-compiler/transforms/RelayMaskTransform.js
@@ -20,6 +20,8 @@ const {
   isEquivalentType,
 } = require('graphql-compiler');
 
+const {GraphQLNonNull} = require('graphql');
+
 import type {
   Fragment,
   FragmentSpread,
@@ -145,10 +147,21 @@ function areSameArgumentDefinitions(
   argDef1: ArgumentDefinition,
   argDef2: ArgumentDefinition,
 ) {
+
+  let typeOrSubType1 = argDef1.type;
+  if (argDef1.type instanceof GraphQLNonNull) {
+    typeOrSubType1 = argDef1.type.ofType;
+  }
+
+  let typeOrSubType2 = argDef2.type;
+  if (argDef2.type instanceof GraphQLNonNull) {
+    typeOrSubType2 = argDef2.type.ofType;
+  }
+
   return (
     argDef1.kind === argDef2.kind &&
     argDef1.name === argDef2.name &&
-    isEquivalentType(argDef1.type, argDef2.type) &&
+    isEquivalentType(typeOrSubType1, typeOrSubType2) &&
     // Only LocalArgumentDefinition defines defaultValue
     (argDef1: any).defaultValue === (argDef2: any).defaultValue
   );

--- a/packages/relay-compiler/transforms/__tests__/RelayMaskTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/RelayMaskTransform-test.js
@@ -42,4 +42,21 @@ describe('RelayMaskTransform', () => {
         .join('\n');
     },
   );
+
+  generateTestsFromFixtures(
+    `${__dirname}/fixtures/relay-mask-transform-mixed-null`,
+    text => {
+      const {definitions} = parseGraphQLText(schema, text);
+      return new GraphQLCompilerContext(RelayTestSchema, schema)
+        .addAll(definitions)
+        .applyTransforms([
+          // Requires Relay directive transform first.
+          RelayRelayDirectiveTransform.transform,
+          RelayMaskTransform.transform,
+        ])
+        .documents()
+        .map(doc => GraphQLIRPrinter.print(doc))
+        .join('\n');
+    },
+  );
 });

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
@@ -73,6 +73,22 @@ fragment ParentFragment on Query {
   ...NonNullFieldFragment @relay(mask: false)
 }
 
+fragment FragmentWithField on Query {
+  ...NullableFieldFragment @relay(mask: false)
+  ...NonNullFieldFragment @relay(mask: false)
+  node(id: $id) {
+    id
+  }
+}
+
+fragment FragmentWithNullField on Query {
+  ...NullableFieldFragment @relay(mask: false)
+  ...NonNullFieldFragment @relay(mask: false)
+  node_id_required(id: $id) {
+    id
+  }
+}
+
 fragment NullableFieldFragment on Query {
   node(id: $id) {
     id
@@ -97,6 +113,38 @@ fragment ParentFragment on Query {
     node_id_required(id: $id) {
       id
     }
+  }
+}
+
+fragment FragmentWithField on Query {
+  ... on Query {
+    node(id: $id) {
+      id
+    }
+  }
+  ... on Query {
+    node_id_required(id: $id) {
+      id
+    }
+  }
+  node(id: $id) {
+    id
+  }
+}
+
+fragment FragmentWithNullField on Query {
+  ... on Query {
+    node(id: $id) {
+      id
+    }
+  }
+  ... on Query {
+    node_id_required(id: $id) {
+      id
+    }
+  }
+  node_id_required(id: $id) {
+    id
   }
 }
 

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
@@ -65,3 +65,51 @@ fragment AnotherRecursiveFragment on Image {
 }
 
 `;
+
+exports[`RelayMaskTransform matches expected output: relay-mask-transform-mixed-null.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+fragment ParentFragment on Query {
+  ...NullableFieldFragment @relay(mask: false)
+  ...NonNullFieldFragment @relay(mask: false)
+}
+
+fragment NullableFieldFragment on Query {
+  node(id: $id) {
+    id
+  }
+}
+
+fragment NonNullFieldFragment on Query {
+  node_id_required(id: $id) {
+    id
+  }
+}
+
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+fragment ParentFragment on Query {
+  ... on Query {
+    node(id: $id) {
+      id
+    }
+  }
+  ... on Query {
+    node_id_required(id: $id) {
+      id
+    }
+  }
+}
+
+fragment NullableFieldFragment on Query {
+  node(id: $id) {
+    id
+  }
+}
+
+fragment NonNullFieldFragment on Query {
+  node_id_required(id: $id) {
+    id
+  }
+}
+
+`;

--- a/packages/relay-compiler/transforms/__tests__/fixtures/relay-mask-transform-mixed-null/relay-mask-transform-mixed-null.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/relay-mask-transform-mixed-null/relay-mask-transform-mixed-null.graphql
@@ -1,0 +1,17 @@
+fragment ParentFragment on Query {
+  ...NullableFieldFragment @relay(mask: false)
+  ...NonNullFieldFragment @relay(mask: false)
+}
+
+fragment NullableFieldFragment on Query {
+  node(id: $id) {
+    id
+  }
+}
+
+fragment NonNullFieldFragment on Query {
+  node_id_required(id: $id) {
+    id
+  }
+}
+

--- a/packages/relay-compiler/transforms/__tests__/fixtures/relay-mask-transform-mixed-null/relay-mask-transform-mixed-null.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/relay-mask-transform-mixed-null/relay-mask-transform-mixed-null.graphql
@@ -3,6 +3,22 @@ fragment ParentFragment on Query {
   ...NonNullFieldFragment @relay(mask: false)
 }
 
+fragment FragmentWithField on Query {
+  ...NullableFieldFragment @relay(mask: false)
+  ...NonNullFieldFragment @relay(mask: false)
+  node(id: $id) {
+    id
+  }
+}
+
+fragment FragmentWithNullField on Query {
+  ...NullableFieldFragment @relay(mask: false)
+  ...NonNullFieldFragment @relay(mask: false)
+  node_id_required(id: $id) {
+    id
+  }
+}
+
 fragment NullableFieldFragment on Query {
   node(id: $id) {
     id


### PR DESCRIPTION
Fixes #2358 

See https://github.com/facebook/relay/issues/2358 for details and an example.

I think this is safe to remove this. If the variables are actually not compatible it will be caught by the GraphQL validation step.