### PR TITLE
Use commonjs imports in relay-runtime

### DIFF
--- a/packages/relay-runtime/RelayRuntime.js
+++ b/packages/relay-runtime/RelayRuntime.js
@@ -11,30 +11,30 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
-const RelayConnectionHandler = require('RelayConnectionHandler');
-const RelayConnectionInterface = require('RelayConnectionInterface');
-const RelayCore = require('RelayCore');
-const RelayDeclarativeMutationConfig = require('RelayDeclarativeMutationConfig');
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayMarkSweepStore = require('RelayMarkSweepStore');
-const RelayModernEnvironment = require('RelayModernEnvironment');
-const RelayModernGraphQLTag = require('RelayModernGraphQLTag');
-const RelayNetwork = require('RelayNetwork');
-const RelayObservable = require('RelayObservable');
-const RelayProfiler = require('RelayProfiler');
-const RelayQueryResponseCache = require('RelayQueryResponseCache');
-const RelayStoreUtils = require('RelayStoreUtils');
-const RelayViewerHandler = require('RelayViewerHandler');
+const RelayConcreteNode = require('./util/RelayConcreteNode');
+const RelayConnectionHandler = require('./handlers/connection/RelayConnectionHandler');
+const RelayConnectionInterface = require('./handlers/connection/RelayConnectionInterface');
+const RelayCore = require('./store/RelayCore');
+const RelayDeclarativeMutationConfig = require('./mutations/RelayDeclarativeMutationConfig');
+const RelayInMemoryRecordSource = require('./store/RelayInMemoryRecordSource');
+const RelayMarkSweepStore = require('./store/RelayMarkSweepStore');
+const RelayModernEnvironment = require('./store/RelayModernEnvironment');
+const RelayModernGraphQLTag = require('./query/RelayModernGraphQLTag');
+const RelayNetwork = require('./network/RelayNetwork');
+const RelayObservable = require('./network/RelayObservable');
+const RelayProfiler = require('./util/RelayProfiler');
+const RelayQueryResponseCache = require('./network/RelayQueryResponseCache');
+const RelayStoreUtils = require('./store/RelayStoreUtils');
+const RelayViewerHandler = require('./handlers/viewer/RelayViewerHandler');
 
-const applyRelayModernOptimisticMutation = require('applyRelayModernOptimisticMutation');
-const commitLocalUpdate = require('commitLocalUpdate');
-const commitRelayModernMutation = require('commitRelayModernMutation');
-const fetchRelayModernQuery = require('fetchRelayModernQuery');
-const isRelayModernEnvironment = require('isRelayModernEnvironment');
-const recycleNodesInto = require('recycleNodesInto');
+const applyRelayModernOptimisticMutation = require('./mutations/applyRelayModernOptimisticMutation');
+const commitLocalUpdate = require('./mutations/commitLocalUpdate');
+const commitRelayModernMutation = require('./mutations/commitRelayModernMutation');
+const fetchRelayModernQuery = require('./query/fetchRelayModernQuery');
+const isRelayModernEnvironment = require('./store/isRelayModernEnvironment');
+const recycleNodesInto = require('./util/recycleNodesInto');
 const requestRelaySubscription = require('./subscription/requestRelaySubscription');
-const simpleClone = require('simpleClone');
+const simpleClone = require('./util/simpleClone');
 
 export type {
   GraphQLSubscriptionConfig,
@@ -53,27 +53,27 @@ export type {
   ConcreteOperation,
   ConcreteFragment,
   RequestNode,
-} from 'RelayConcreteNode';
-export type {ConnectionMetadata} from 'RelayConnectionHandler';
-export type {EdgeRecord, PageInfo} from 'RelayConnectionInterface';
+} from './util/RelayConcreteNode';
+export type {ConnectionMetadata} from './handlers/connection/RelayConnectionHandler';
+export type {EdgeRecord, PageInfo} from './handlers/connection/RelayConnectionInterface';
 export type {
   DeclarativeMutationConfig,
   MutationType,
   RangeOperation,
-} from 'RelayDeclarativeMutationConfig';
-export type {GraphQLTaggedNode} from 'RelayModernGraphQLTag';
+} from './mutations/RelayDeclarativeMutationConfig';
+export type {GraphQLTaggedNode} from './query/RelayModernGraphQLTag';
 export type {
   GraphQLResponse,
   PayloadError,
   UploadableMap,
-} from 'RelayNetworkTypes';
+} from './network/RelayNetworkTypes';
 export type {
   ObservableFromValue,
   Observer,
   Subscribable,
   Subscription,
-} from 'RelayObservable';
-export type {RecordState} from 'RelayRecordState';
+} from './network/RelayObservable';
+export type {RecordState} from './store/RelayRecordState';
 export type {
   Environment as IEnvironment,
   FragmentMap,
@@ -83,11 +83,11 @@ export type {
   Selector,
   SelectorStoreUpdater,
   Snapshot,
-} from 'RelayStoreTypes';
+} from './store/RelayStoreTypes';
 export type {
   OptimisticMutationConfig,
-} from 'applyRelayModernOptimisticMutation';
-export type {MutationConfig} from 'commitRelayModernMutation';
+} from './mutations/applyRelayModernOptimisticMutation';
+export type {MutationConfig} from './mutations/commitRelayModernMutation';
 
 // As early as possible, check for the existence of the JavaScript globals which
 // Relay Runtime relies upon, and produce a clear message if they do not exist.

--- a/packages/relay-runtime/handlers/RelayDefaultHandlerProvider.js
+++ b/packages/relay-runtime/handlers/RelayDefaultHandlerProvider.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayDefaultHandlerProvider
  * @flow
  * @format
  */

--- a/packages/relay-runtime/handlers/RelayDefaultHandlerProvider.js
+++ b/packages/relay-runtime/handlers/RelayDefaultHandlerProvider.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-const RelayConnectionHandler = require('RelayConnectionHandler');
-const RelayViewerHandler = require('RelayViewerHandler');
+const RelayConnectionHandler = require('./connection/RelayConnectionHandler');
+const RelayViewerHandler = require('./viewer/RelayViewerHandler');
 
 const invariant = require('invariant');
 
-import type {Handler} from 'RelayStoreTypes';
+import type {Handler} from '../store/RelayStoreTypes';
 export type HandlerProvider = (name: string) => ?Handler;
 
 function RelayDefaultHandlerProvider(handle: string): Handler {

--- a/packages/relay-runtime/handlers/connection/RelayConnectionHandler.js
+++ b/packages/relay-runtime/handlers/connection/RelayConnectionHandler.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-const RelayConnectionInterface = require('RelayConnectionInterface');
+const RelayConnectionInterface = require('./RelayConnectionInterface');
 
-const generateRelayClientID = require('generateRelayClientID');
-const getRelayHandleKey = require('getRelayHandleKey');
+const generateRelayClientID = require('../../store/generateRelayClientID');
+const getRelayHandleKey = require('../../util/getRelayHandleKey');
 const invariant = require('invariant');
 const warning = require('warning');
 
@@ -23,7 +23,7 @@ import type {
   HandleFieldPayload,
   RecordProxy,
   RecordSourceProxy,
-} from 'RelayStoreTypes';
+} from '../../store/RelayStoreTypes';
 
 export type ConnectionMetadata = {
   path: ?Array<string>,

--- a/packages/relay-runtime/handlers/connection/RelayConnectionInterface.js
+++ b/packages/relay-runtime/handlers/connection/RelayConnectionInterface.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayConnectionInterface
  * @flow
  * @format
  */

--- a/packages/relay-runtime/handlers/connection/__tests__/RelayConnectionHandler-test.js
+++ b/packages/relay-runtime/handlers/connection/__tests__/RelayConnectionHandler-test.js
@@ -12,18 +12,18 @@
 
 require('configureForRelayOSS');
 
-const RelayConnectionHandler = require('RelayConnectionHandler');
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayMarkSweepStore = require('RelayMarkSweepStore');
-const RelayRecordSourceMutator = require('RelayRecordSourceMutator');
-const RelayRecordSourceProxy = require('RelayRecordSourceProxy');
-const RelayResponseNormalizer = require('RelayResponseNormalizer');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayConnectionHandler = require('../RelayConnectionHandler');
+const RelayInMemoryRecordSource = require('../../../store/RelayInMemoryRecordSource');
+const RelayMarkSweepStore = require('../../../store/RelayMarkSweepStore');
+const RelayRecordSourceMutator = require('../../../mutations/RelayRecordSourceMutator');
+const RelayRecordSourceProxy = require('../../../mutations/RelayRecordSourceProxy');
+const RelayResponseNormalizer = require('../../../store/RelayResponseNormalizer');
+const RelayStoreUtils = require('../../../store/RelayStoreUtils');
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const RelayConnectionInterface = require('RelayConnectionInterface');
+const RelayConnectionInterface = require('../RelayConnectionInterface');
 
-const getRelayHandleKey = require('getRelayHandleKey');
-const simpleClone = require('simpleClone');
+const getRelayHandleKey = require('../../../util/getRelayHandleKey');
+const simpleClone = require('../../../util/simpleClone');
 
 const {
   ID_KEY,

--- a/packages/relay-runtime/handlers/viewer/RelayViewerHandler.js
+++ b/packages/relay-runtime/handlers/viewer/RelayViewerHandler.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const generateRelayClientID = require('generateRelayClientID');
+const generateRelayClientID = require('../../store/generateRelayClientID');
 
-const {ROOT_ID} = require('RelayStoreUtils');
+const {ROOT_ID} = require('../../store/RelayStoreUtils');
 
-import type {HandleFieldPayload, RecordSourceProxy} from 'RelayStoreTypes';
+import type {HandleFieldPayload, RecordSourceProxy} from '../../store/RelayStoreTypes';
 
 const VIEWER_ID = generateRelayClientID(ROOT_ID, 'viewer');
 const VIEWER_TYPE = 'Viewer';

--- a/packages/relay-runtime/handlers/viewer/RelayViewerHandler.js
+++ b/packages/relay-runtime/handlers/viewer/RelayViewerHandler.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayViewerHandler
  * @flow
  * @format
  */

--- a/packages/relay-runtime/handlers/viewer/__tests__/RelayViewerHandler-test.js
+++ b/packages/relay-runtime/handlers/viewer/__tests__/RelayViewerHandler-test.js
@@ -10,16 +10,16 @@
 
 'use strict';
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayModernRecord = require('RelayModernRecord');
+const RelayInMemoryRecordSource = require('../../../store/RelayInMemoryRecordSource');
+const RelayModernRecord = require('../../../store/RelayModernRecord');
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const RelayRecordSourceMutator = require('RelayRecordSourceMutator');
-const RelayRecordSourceProxy = require('RelayRecordSourceProxy');
-const RelayStoreUtils = require('RelayStoreUtils');
-const RelayViewerHandler = require('RelayViewerHandler');
+const RelayRecordSourceMutator = require('../../../mutations/RelayRecordSourceMutator');
+const RelayRecordSourceProxy = require('../../../mutations/RelayRecordSourceProxy');
+const RelayStoreUtils = require('../../../store/RelayStoreUtils');
+const RelayViewerHandler = require('../RelayViewerHandler');
 
-const generateRelayClientID = require('generateRelayClientID');
-const getRelayHandleKey = require('getRelayHandleKey');
+const generateRelayClientID = require('../../../store/generateRelayClientID');
+const getRelayHandleKey = require('../../../util/getRelayHandleKey');
 
 const {ID_KEY, REF_KEY, ROOT_ID, ROOT_TYPE, TYPENAME_KEY} = RelayStoreUtils;
 

--- a/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
+++ b/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-const RelayConnectionHandler = require('RelayConnectionHandler');
+const RelayConnectionHandler = require('../handlers/connection/RelayConnectionHandler');
 
 const warning = require('warning');
 
 import type {DataID, Variables} from '../util/RelayRuntimeTypes';
-import type {RequestNode} from 'RelayConcreteNode';
+import type {RequestNode} from '../util/RelayConcreteNode';
 import type {
   RecordSourceSelectorProxy,
   SelectorStoreUpdater,
-} from 'RelayStoreTypes';
+} from '../store/RelayStoreTypes';
 import type {SelectorData} from 'react-relay/classic/environment/RelayCombinedEnvironmentTypes';
 import type {RelayConcreteNode} from 'react-relay/classic/query/RelayQL';
 

--- a/packages/relay-runtime/mutations/RelayRecordProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordProxy.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-const generateRelayClientID = require('generateRelayClientID');
+const generateRelayClientID = require('../store/generateRelayClientID');
 const invariant = require('invariant');
 
-const {getStableStorageKey} = require('RelayStoreUtils');
+const {getStableStorageKey} = require('../store/RelayStoreUtils');
 
-import type RelayRecordSourceMutator from 'RelayRecordSourceMutator';
-import type RelayRecordSourceProxy from 'RelayRecordSourceProxy';
-import type {DataID} from 'RelayRuntime';
-import type {RecordProxy} from 'RelayStoreTypes';
-import type {Arguments} from 'RelayStoreUtils';
+import type RelayRecordSourceMutator from './RelayRecordSourceMutator';
+import type RelayRecordSourceProxy from './RelayRecordSourceProxy';
+import type {DataID} from '../RelayRuntime';
+import type {RecordProxy} from '../store/RelayStoreTypes';
+import type {Arguments} from '../store/RelayStoreUtils';
 
 /**
  * @internal

--- a/packages/relay-runtime/mutations/RelayRecordProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordProxy.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordProxy
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/RelayRecordSourceMutator.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceMutator.js
@@ -11,19 +11,19 @@
 
 'use strict';
 
-const RelayModernRecord = require('RelayModernRecord');
+const RelayModernRecord = require('../store/RelayModernRecord');
 
 const invariant = require('invariant');
 
-const {EXISTENT} = require('RelayRecordState');
+const {EXISTENT} = require('../store/RelayRecordState');
 const {
   UNPUBLISH_FIELD_SENTINEL,
   UNPUBLISH_RECORD_SENTINEL,
-} = require('RelayStoreUtils');
+} = require('../store/RelayStoreUtils');
 
 import type {DataID} from '../util/RelayRuntimeTypes';
-import type {RecordState} from 'RelayRecordState';
-import type {MutableRecordSource, RecordSource} from 'RelayStoreTypes';
+import type {RecordState} from '../store/RelayRecordState';
+import type {MutableRecordSource, RecordSource} from '../store/RelayStoreTypes';
 import type {Record} from 'react-relay/classic/environment/RelayCombinedEnvironmentTypes';
 
 /**

--- a/packages/relay-runtime/mutations/RelayRecordSourceMutator.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceMutator.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordSourceMutator
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordSourceProxy
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
@@ -11,19 +11,19 @@
 
 'use strict';
 
-const RelayModernRecord = require('RelayModernRecord');
-const RelayRecordProxy = require('RelayRecordProxy');
-const RelayRecordSourceSelectorProxy = require('RelayRecordSourceSelectorProxy');
+const RelayModernRecord = require('../store/RelayModernRecord');
+const RelayRecordProxy = require('./RelayRecordProxy');
+const RelayRecordSourceSelectorProxy = require('./RelayRecordSourceSelectorProxy');
 
 const invariant = require('invariant');
-const normalizeRelayPayload = require('normalizeRelayPayload');
+const normalizeRelayPayload = require('../store/normalizeRelayPayload');
 
-const {EXISTENT, NONEXISTENT} = require('RelayRecordState');
-const {ROOT_ID, ROOT_TYPE} = require('RelayStoreUtils');
+const {EXISTENT, NONEXISTENT} = require('../store/RelayRecordState');
+const {ROOT_ID, ROOT_TYPE} = require('../store/RelayStoreUtils');
 
 import type {DataID} from '../util/RelayRuntimeTypes';
-import type {HandlerProvider} from 'RelayDefaultHandlerProvider';
-import type RelayRecordSourceMutator from 'RelayRecordSourceMutator';
+import type {HandlerProvider} from '../handlers/RelayDefaultHandlerProvider';
+import type RelayRecordSourceMutator from './RelayRecordSourceMutator';
 import type {
   HandleFieldPayload,
   RecordSource,
@@ -31,7 +31,7 @@ import type {
   RecordSourceProxy,
   RecordSourceSelectorProxy,
   OperationSelector,
-} from 'RelayStoreTypes';
+} from '../store/RelayStoreTypes';
 
 /**
  * @internal

--- a/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordSourceSelectorProxy
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
@@ -13,16 +13,16 @@
 
 const invariant = require('invariant');
 
-const {getStorageKey} = require('RelayStoreUtils');
+const {getStorageKey} = require('../store/RelayStoreUtils');
 
 import type {DataID} from '../util/RelayRuntimeTypes';
-import type {ConcreteLinkedField} from 'RelayConcreteNode';
+import type {ConcreteLinkedField} from '../util/RelayConcreteNode';
 import type {
   RecordProxy,
   Selector,
   RecordSourceProxy,
   RecordSourceSelectorProxy,
-} from 'RelayStoreTypes';
+} from '../store/RelayStoreTypes';
 
 /**
  * @internal

--- a/packages/relay-runtime/mutations/__tests__/RelayRecordSourceMutator-test.js
+++ b/packages/relay-runtime/mutations/__tests__/RelayRecordSourceMutator-test.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
+const RelayInMemoryRecordSource = require('../../store/RelayInMemoryRecordSource');
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const RelayRecordSourceMutator = require('RelayRecordSourceMutator');
-const RelayRecordState = require('RelayRecordState');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayRecordSourceMutator = require('../RelayRecordSourceMutator');
+const RelayRecordState = require('../../store/RelayRecordState');
+const RelayStoreUtils = require('../../store/RelayStoreUtils');
 
-const simpleClone = require('simpleClone');
+const simpleClone = require('../../util/simpleClone');
 
 const {
   ID_KEY,

--- a/packages/relay-runtime/mutations/__tests__/RelayRecordSourceProxy-test.js
+++ b/packages/relay-runtime/mutations/__tests__/RelayRecordSourceProxy-test.js
@@ -10,16 +10,16 @@
 
 'use strict';
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
+const RelayInMemoryRecordSource = require('../../store/RelayInMemoryRecordSource');
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const RelayRecordProxy = require('RelayRecordProxy');
-const RelayRecordSourceMutator = require('RelayRecordSourceMutator');
-const RelayRecordSourceProxy = require('RelayRecordSourceProxy');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayRecordProxy = require('../RelayRecordProxy');
+const RelayRecordSourceMutator = require('../RelayRecordSourceMutator');
+const RelayRecordSourceProxy = require('../RelayRecordSourceProxy');
+const RelayStoreUtils = require('../../store/RelayStoreUtils');
 
-const simpleClone = require('simpleClone');
+const simpleClone = require('../../util/simpleClone');
 
-const {createOperationSelector} = require('RelayModernOperationSelector');
+const {createOperationSelector} = require('../../store/RelayModernOperationSelector');
 
 const {
   ID_KEY,

--- a/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
+++ b/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-const commitRelayModernMutation = require('commitRelayModernMutation');
+const commitRelayModernMutation = require('../commitRelayModernMutation');
 
 const {createMockEnvironment} = require('RelayModernMockEnvironment');
-const {createOperationSelector} = require('RelayModernOperationSelector');
+const {createOperationSelector} = require('../../store/RelayModernOperationSelector');
 const {generateAndCompile} = require('RelayModernTestUtils');
-const {ROOT_ID} = require('RelayStoreUtils');
+const {ROOT_ID} = require('../../store/RelayStoreUtils');
 const {commitMutation} = require('react-relay/modern/ReactRelayPublic');
 
 describe('Configs: NODE_DELETE', () => {

--- a/packages/relay-runtime/mutations/applyRelayModernOptimisticMutation.js
+++ b/packages/relay-runtime/mutations/applyRelayModernOptimisticMutation.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule applyRelayModernOptimisticMutation
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/applyRelayModernOptimisticMutation.js
+++ b/packages/relay-runtime/mutations/applyRelayModernOptimisticMutation.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-const RelayDeclarativeMutationConfig = require('RelayDeclarativeMutationConfig');
+const RelayDeclarativeMutationConfig = require('./RelayDeclarativeMutationConfig');
 
 const invariant = require('invariant');
-const isRelayModernEnvironment = require('isRelayModernEnvironment');
+const isRelayModernEnvironment = require('../store/isRelayModernEnvironment');
 
 import type {Disposable, Variables} from '../util/RelayRuntimeTypes';
-import type {DeclarativeMutationConfig} from 'RelayDeclarativeMutationConfig';
-import type {GraphQLTaggedNode} from 'RelayModernGraphQLTag';
-import type {Environment, SelectorStoreUpdater} from 'RelayStoreTypes';
+import type {DeclarativeMutationConfig} from './RelayDeclarativeMutationConfig';
+import type {GraphQLTaggedNode} from '../query/RelayModernGraphQLTag';
+import type {Environment, SelectorStoreUpdater} from '../store/RelayStoreTypes';
 
 export type OptimisticMutationConfig = {|
   configs?: ?Array<DeclarativeMutationConfig>,

--- a/packages/relay-runtime/mutations/commitLocalUpdate.js
+++ b/packages/relay-runtime/mutations/commitLocalUpdate.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule commitLocalUpdate
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/commitLocalUpdate.js
+++ b/packages/relay-runtime/mutations/commitLocalUpdate.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-import type {StoreUpdater, Environment} from 'RelayStoreTypes';
+import type {StoreUpdater, Environment} from '../store/RelayStoreTypes';
 
 function commitLocalUpdate(
   environment: Environment,

--- a/packages/relay-runtime/mutations/commitRelayModernMutation.js
+++ b/packages/relay-runtime/mutations/commitRelayModernMutation.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule commitRelayModernMutation
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/commitRelayModernMutation.js
+++ b/packages/relay-runtime/mutations/commitRelayModernMutation.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-const RelayDeclarativeMutationConfig = require('RelayDeclarativeMutationConfig');
+const RelayDeclarativeMutationConfig = require('./RelayDeclarativeMutationConfig');
 
 const invariant = require('invariant');
-const isRelayModernEnvironment = require('isRelayModernEnvironment');
+const isRelayModernEnvironment = require('../store/isRelayModernEnvironment');
 const warning = require('warning');
 
 import type {Disposable, Variables} from '../util/RelayRuntimeTypes';
-import type {DeclarativeMutationConfig} from 'RelayDeclarativeMutationConfig';
-import type {GraphQLTaggedNode} from 'RelayModernGraphQLTag';
-import type {PayloadError, UploadableMap} from 'RelayNetworkTypes';
-import type {Environment, SelectorStoreUpdater} from 'RelayStoreTypes';
+import type {DeclarativeMutationConfig} from './RelayDeclarativeMutationConfig';
+import type {GraphQLTaggedNode} from '../query/RelayModernGraphQLTag';
+import type {PayloadError, UploadableMap} from '../network/RelayNetworkTypes';
+import type {Environment, SelectorStoreUpdater} from '../store/RelayStoreTypes';
 
 export type MutationConfig<T> = {|
   configs?: Array<DeclarativeMutationConfig>,

--- a/packages/relay-runtime/network/ConvertToExecuteFunction.js
+++ b/packages/relay-runtime/network/ConvertToExecuteFunction.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ConvertToExecuteFunction
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/ConvertToExecuteFunction.js
+++ b/packages/relay-runtime/network/ConvertToExecuteFunction.js
@@ -11,20 +11,20 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
-const RelayObservable = require('RelayObservable');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
+const RelayObservable = require('./RelayObservable');
 
 const warning = require('warning');
 
 import type {Variables} from '../util/RelayRuntimeTypes';
-import type {RequestNode} from 'RelayConcreteNode';
+import type {RequestNode} from '../util/RelayConcreteNode';
 import type {
   ExecuteFunction,
   ExecutePayload,
   FetchFunction,
   GraphQLResponse,
   SubscribeFunction,
-} from 'RelayNetworkTypes';
+} from './RelayNetworkTypes';
 
 /**
  * Converts a FetchFunction into an ExecuteFunction for use by RelayNetwork.

--- a/packages/relay-runtime/network/RelayNetwork.js
+++ b/packages/relay-runtime/network/RelayNetwork.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayNetwork
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayNetwork.js
+++ b/packages/relay-runtime/network/RelayNetwork.js
@@ -11,21 +11,21 @@
 
 'use strict';
 
-const RelayObservable = require('RelayObservable');
+const RelayObservable = require('./RelayObservable');
 
 const invariant = require('invariant');
 
-const {convertFetch, convertSubscribe} = require('ConvertToExecuteFunction');
+const {convertFetch, convertSubscribe} = require('./ConvertToExecuteFunction');
 
 import type {CacheConfig, Variables} from '../util/RelayRuntimeTypes';
-import type {RequestNode} from 'RelayConcreteNode';
+import type {RequestNode} from '../util/RelayConcreteNode';
 import type {
   FetchFunction,
   Network,
   ExecutePayload,
   SubscribeFunction,
   UploadableMap,
-} from 'RelayNetworkTypes';
+} from './RelayNetworkTypes';
 
 /**
  * Creates an implementation of the `Network` interface defined in

--- a/packages/relay-runtime/network/RelayNetworkLogger.js
+++ b/packages/relay-runtime/network/RelayNetworkLogger.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayNetworkLogger
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayNetworkLogger.js
+++ b/packages/relay-runtime/network/RelayNetworkLogger.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const RelayNetworkLoggerTransaction = require('RelayNetworkLoggerTransaction');
+const RelayNetworkLoggerTransaction = require('./RelayNetworkLoggerTransaction');
 
-const createRelayNetworkLogger = require('createRelayNetworkLogger');
+const createRelayNetworkLogger = require('./createRelayNetworkLogger');
 
 module.exports = createRelayNetworkLogger(RelayNetworkLoggerTransaction);

--- a/packages/relay-runtime/network/RelayNetworkLoggerTransaction.js
+++ b/packages/relay-runtime/network/RelayNetworkLoggerTransaction.js
@@ -14,8 +14,8 @@
 const invariant = require('invariant');
 
 import type {CacheConfig, Variables} from '../util/RelayRuntimeTypes';
-import type {RequestNode} from 'RelayConcreteNode';
-import type {ExecutePayload, UploadableMap} from 'RelayNetworkTypes';
+import type {RequestNode} from '../util/RelayConcreteNode';
+import type {ExecutePayload, UploadableMap} from './RelayNetworkTypes';
 
 let queryID = 1;
 

--- a/packages/relay-runtime/network/RelayNetworkLoggerTransaction.js
+++ b/packages/relay-runtime/network/RelayNetworkLoggerTransaction.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayNetworkLoggerTransaction
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayNetworkTypes.js
+++ b/packages/relay-runtime/network/RelayNetworkTypes.js
@@ -16,8 +16,8 @@ import type {
   Disposable,
   Variables,
 } from '../util/RelayRuntimeTypes';
-import type {ConcreteOperation, RequestNode} from 'RelayConcreteNode';
-import type RelayObservable, {ObservableFromValue} from 'RelayObservable';
+import type {ConcreteOperation, RequestNode} from '../util/RelayConcreteNode';
+import type RelayObservable, {ObservableFromValue} from './RelayObservable';
 
 /**
  * An interface for fetching the data for one or more (possibly interdependent)

--- a/packages/relay-runtime/network/RelayObservable.js
+++ b/packages/relay-runtime/network/RelayObservable.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-const isPromise = require('isPromise');
+const isPromise = require('../util/isPromise');
 
 import type {Disposable} from '../util/RelayRuntimeTypes';
-import type {LegacyObserver} from 'RelayNetworkTypes';
+import type {LegacyObserver} from './RelayNetworkTypes';
 
 /**
  * A Subscription object is returned from .subscribe(), which can be

--- a/packages/relay-runtime/network/RelayQueryResponseCache.js
+++ b/packages/relay-runtime/network/RelayQueryResponseCache.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayQueryResponseCache
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayQueryResponseCache.js
+++ b/packages/relay-runtime/network/RelayQueryResponseCache.js
@@ -12,10 +12,10 @@
 'use strict';
 
 const invariant = require('invariant');
-const stableCopy = require('stableCopy');
+const stableCopy = require('../util/stableCopy');
 
 import type {Variables} from '../util/RelayRuntimeTypes';
-import type {GraphQLResponse} from 'RelayNetworkTypes';
+import type {GraphQLResponse} from './RelayNetworkTypes';
 
 type Response = {
   fetchTime: number,

--- a/packages/relay-runtime/network/__tests__/RelayObservable-test.js
+++ b/packages/relay-runtime/network/__tests__/RelayObservable-test.js
@@ -12,7 +12,7 @@
 
 require('configureForRelayOSS');
 
-const RelayObservable = require('RelayObservable');
+const RelayObservable = require('../RelayObservable');
 
 jest.useFakeTimers();
 

--- a/packages/relay-runtime/network/__tests__/RelayQueryResponseCache-test.js
+++ b/packages/relay-runtime/network/__tests__/RelayQueryResponseCache-test.js
@@ -12,7 +12,7 @@
 
 require('configureForRelayOSS');
 
-const RelayQueryResponseCache = require('RelayQueryResponseCache');
+const RelayQueryResponseCache = require('../RelayQueryResponseCache');
 
 describe('RelayQueryResponseCache', () => {
   let dateNow;

--- a/packages/relay-runtime/network/createRelayNetworkLogger.js
+++ b/packages/relay-runtime/network/createRelayNetworkLogger.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule createRelayNetworkLogger
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/createRelayNetworkLogger.js
+++ b/packages/relay-runtime/network/createRelayNetworkLogger.js
@@ -11,18 +11,18 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
 
-const {convertFetch, convertSubscribe} = require('ConvertToExecuteFunction');
+const {convertFetch, convertSubscribe} = require('./ConvertToExecuteFunction');
 
 import type {Variables} from '../util/RelayRuntimeTypes';
-import type {ConcreteRequest} from 'RelayConcreteNode';
-import type {IRelayNetworkLoggerTransaction} from 'RelayNetworkLoggerTransaction';
+import type {ConcreteRequest} from '../util/RelayConcreteNode';
+import type {IRelayNetworkLoggerTransaction} from './RelayNetworkLoggerTransaction';
 import type {
   ExecuteFunction,
   FetchFunction,
   SubscribeFunction,
-} from 'RelayNetworkTypes';
+} from './RelayNetworkTypes';
 
 export type GraphiQLPrinter = (
   request: ConcreteRequest,

--- a/packages/relay-runtime/query/RelayModernGraphQLTag.js
+++ b/packages/relay-runtime/query/RelayModernGraphQLTag.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernGraphQLTag
  * @flow
  * @format
  */

--- a/packages/relay-runtime/query/RelayModernGraphQLTag.js
+++ b/packages/relay-runtime/query/RelayModernGraphQLTag.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
 
 const invariant = require('invariant');
 
-import type {ConcreteFragment, RequestNode} from 'RelayConcreteNode';
+import type {ConcreteFragment, RequestNode} from '../util/RelayConcreteNode';
 import type {
   ConcreteFragmentDefinition,
   ConcreteOperationDefinition,

--- a/packages/relay-runtime/query/__tests__/fetchRelayModernQuery-test.js
+++ b/packages/relay-runtime/query/__tests__/fetchRelayModernQuery-test.js
@@ -12,10 +12,10 @@
 
 const RelayModernTestUtils = require('RelayModernTestUtils');
 
-const fetchRelayModernQuery = require('fetchRelayModernQuery');
+const fetchRelayModernQuery = require('../fetchRelayModernQuery');
 
 const {createMockEnvironment} = require('RelayModernMockEnvironment');
-const {createOperationSelector} = require('RelayModernOperationSelector');
+const {createOperationSelector} = require('../../store/RelayModernOperationSelector');
 
 describe('fetchRelayModernQuery', () => {
   const {generateAndCompile} = RelayModernTestUtils;

--- a/packages/relay-runtime/query/fetchRelayModernQuery.js
+++ b/packages/relay-runtime/query/fetchRelayModernQuery.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule fetchRelayModernQuery
  * @flow
  * @format
  */

--- a/packages/relay-runtime/query/fetchRelayModernQuery.js
+++ b/packages/relay-runtime/query/fetchRelayModernQuery.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
 
 const invariant = require('invariant');
 
 import type {CacheConfig, Variables} from '../util/RelayRuntimeTypes';
-import type {GraphQLTaggedNode} from 'RelayModernGraphQLTag';
+import type {GraphQLTaggedNode} from './RelayModernGraphQLTag';
 
 /**
  * A helper function to fetch the results of a query. Note that results for

--- a/packages/relay-runtime/store/RelayConcreteVariables.js
+++ b/packages/relay-runtime/store/RelayConcreteVariables.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayConcreteVariables
  * @format
  */
 

--- a/packages/relay-runtime/store/RelayConcreteVariables.js
+++ b/packages/relay-runtime/store/RelayConcreteVariables.js
@@ -15,7 +15,7 @@ const invariant = require('invariant');
 const warning = require('warning');
 
 import type {Variables} from '../util/RelayRuntimeTypes';
-import type {ConcreteOperation, ConcreteFragment} from 'RelayConcreteNode';
+import type {ConcreteOperation, ConcreteFragment} from '../util/RelayConcreteNode';
 
 /**
  * Determines the variables that are in scope for a fragment given the variables

--- a/packages/relay-runtime/store/RelayCore.js
+++ b/packages/relay-runtime/store/RelayCore.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayCore
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayCore.js
+++ b/packages/relay-runtime/store/RelayCore.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-const RelayModernFragmentSpecResolver = require('RelayModernFragmentSpecResolver');
+const RelayModernFragmentSpecResolver = require('./RelayModernFragmentSpecResolver');
 
 const warning = require('warning');
 
-const {getFragment, getRequest} = require('RelayModernGraphQLTag');
-const {createOperationSelector} = require('RelayModernOperationSelector');
+const {getFragment, getRequest} = require('../query/RelayModernGraphQLTag');
+const {createOperationSelector} = require('./RelayModernOperationSelector');
 const {
   areEqualSelectors,
   getDataIDsFromObject,
@@ -24,9 +24,9 @@ const {
   getSelectorList,
   getSelectorsFromObject,
   getVariablesFromObject,
-} = require('RelayModernSelector');
+} = require('./RelayModernSelector');
 
-import type {FragmentMap, RelayContext} from 'RelayStoreTypes';
+import type {FragmentMap, RelayContext} from './RelayStoreTypes';
 import type {
   FragmentSpecResolver,
   Props,

--- a/packages/relay-runtime/store/RelayDataLoader.js
+++ b/packages/relay-runtime/store/RelayDataLoader.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayDataLoader
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayDataLoader.js
+++ b/packages/relay-runtime/store/RelayDataLoader.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
-const RelayRecordSourceMutator = require('RelayRecordSourceMutator');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
+const RelayRecordSourceMutator = require('../mutations/RelayRecordSourceMutator');
+const RelayStoreUtils = require('./RelayStoreUtils');
 
-const cloneRelayHandleSourceField = require('cloneRelayHandleSourceField');
+const cloneRelayHandleSourceField = require('./cloneRelayHandleSourceField');
 const invariant = require('invariant');
 
-const {EXISTENT, UNKNOWN} = require('RelayRecordState');
+const {EXISTENT, UNKNOWN} = require('./RelayRecordState');
 
 import type {DataID, Variables} from '../util/RelayRuntimeTypes';
 import type {
@@ -27,13 +27,13 @@ import type {
   ConcreteScalarField,
   ConcreteSelection,
   ConcreteField,
-} from 'RelayConcreteNode';
+} from '../util/RelayConcreteNode';
 import type {
   MissingFieldHandler,
   MutableRecordSource,
   RecordSource,
   Selector,
-} from 'RelayStoreTypes';
+} from './RelayStoreTypes';
 import type {Record} from 'react-relay/classic/environment/RelayCombinedEnvironmentTypes';
 
 const {

--- a/packages/relay-runtime/store/RelayInMemoryRecordSource.js
+++ b/packages/relay-runtime/store/RelayInMemoryRecordSource.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const RelayRecordState = require('RelayRecordState');
+const RelayRecordState = require('./RelayRecordState');
 
 import type {DataID} from '../util/RelayRuntimeTypes';
-import type {RecordState} from 'RelayRecordState';
-import type {MutableRecordSource} from 'RelayStoreTypes';
+import type {RecordState} from './RelayRecordState';
+import type {MutableRecordSource} from './RelayStoreTypes';
 import type {
   Record,
   RecordMap,

--- a/packages/relay-runtime/store/RelayInMemoryRecordSource.js
+++ b/packages/relay-runtime/store/RelayInMemoryRecordSource.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayInMemoryRecordSource
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayMarkSweepStore.js
+++ b/packages/relay-runtime/store/RelayMarkSweepStore.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayMarkSweepStore
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayMarkSweepStore.js
+++ b/packages/relay-runtime/store/RelayMarkSweepStore.js
@@ -11,18 +11,18 @@
 
 'use strict';
 
-const RelayDataLoader = require('RelayDataLoader');
-const RelayModernRecord = require('RelayModernRecord');
-const RelayProfiler = require('RelayProfiler');
-const RelayReader = require('RelayReader');
-const RelayReferenceMarker = require('RelayReferenceMarker');
+const RelayDataLoader = require('./RelayDataLoader');
+const RelayModernRecord = require('./RelayModernRecord');
+const RelayProfiler = require('../util/RelayProfiler');
+const RelayReader = require('./RelayReader');
+const RelayReferenceMarker = require('./RelayReferenceMarker');
 
-const deepFreeze = require('deepFreeze');
-const hasOverlappingIDs = require('hasOverlappingIDs');
-const recycleNodesInto = require('recycleNodesInto');
+const deepFreeze = require('../util/deepFreeze');
+const hasOverlappingIDs = require('./hasOverlappingIDs');
+const recycleNodesInto = require('../util/recycleNodesInto');
 const resolveImmediate = require('resolveImmediate');
 
-const {UNPUBLISH_RECORD_SENTINEL} = require('RelayStoreUtils');
+const {UNPUBLISH_RECORD_SENTINEL} = require('./RelayStoreUtils');
 
 import type {Disposable} from '../util/RelayRuntimeTypes';
 import type {
@@ -32,7 +32,7 @@ import type {
   Snapshot,
   Store,
   UpdatedRecords,
-} from 'RelayStoreTypes';
+} from './RelayStoreTypes';
 
 type Subscription = {
   callback: (snapshot: Snapshot) => void,

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -11,29 +11,29 @@
 
 'use strict';
 
-const RelayCore = require('RelayCore');
-const RelayDefaultHandlerProvider = require('RelayDefaultHandlerProvider');
-const RelayPublishQueue = require('RelayPublishQueue');
+const RelayCore = require('./RelayCore');
+const RelayDefaultHandlerProvider = require('../handlers/RelayDefaultHandlerProvider');
+const RelayPublishQueue = require('./RelayPublishQueue');
 
-const deferrableFragmentKey = require('deferrableFragmentKey');
+const deferrableFragmentKey = require('./deferrableFragmentKey');
 const invariant = require('invariant');
-const normalizePayload = require('normalizePayload');
-const normalizeRelayPayload = require('normalizeRelayPayload');
+const normalizePayload = require('./normalizePayload');
+const normalizeRelayPayload = require('./normalizeRelayPayload');
 const warning = require('warning');
 
-const {getOperationVariables} = require('RelayConcreteVariables');
-const {createOperationSelector} = require('RelayModernOperationSelector');
+const {getOperationVariables} = require('./RelayConcreteVariables');
+const {createOperationSelector} = require('./RelayModernOperationSelector');
 
 import type {CacheConfig, Disposable} from '../util/RelayRuntimeTypes';
-import type {HandlerProvider} from 'RelayDefaultHandlerProvider';
+import type {HandlerProvider} from '../handlers/RelayDefaultHandlerProvider';
 import type {
   ExecutePayload,
   Network,
   PayloadData,
   PayloadError,
   UploadableMap,
-} from 'RelayNetworkTypes';
-import type RelayObservable from 'RelayObservable';
+} from '../network/RelayNetworkTypes';
+import type RelayObservable from '../network/RelayObservable';
 import type {
   Environment,
   OperationSelector,
@@ -44,7 +44,7 @@ import type {
   Store,
   StoreUpdater,
   UnstableEnvironmentCore,
-} from 'RelayStoreTypes';
+} from './RelayStoreTypes';
 
 export type EnvironmentConfig = {
   configName?: string,

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernEnvironment
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
+++ b/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernFragmentSpecResolver
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
+++ b/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
@@ -12,12 +12,12 @@
 'use strict';
 
 const invariant = require('invariant');
-const isScalarAndEqual = require('isScalarAndEqual');
+const isScalarAndEqual = require('../util/isScalarAndEqual');
 
 const {
   areEqualSelectors,
   getSelectorsFromObject,
-} = require('RelayModernSelector');
+} = require('./RelayModernSelector');
 
 import type {Disposable, Variables} from '../util/RelayRuntimeTypes';
 import type {
@@ -26,7 +26,7 @@ import type {
   RelayContext,
   Selector,
   Snapshot,
-} from 'RelayStoreTypes';
+} from './RelayStoreTypes';
 import type {
   FragmentSpecResolver,
   FragmentSpecResults,

--- a/packages/relay-runtime/store/RelayModernOperationSelector.js
+++ b/packages/relay-runtime/store/RelayModernOperationSelector.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
 
-const {getOperationVariables} = require('RelayConcreteVariables');
-const {ROOT_ID} = require('RelayStoreUtils');
+const {getOperationVariables} = require('./RelayConcreteVariables');
+const {ROOT_ID} = require('./RelayStoreUtils');
 
 import type {Variables} from '../util/RelayRuntimeTypes';
-import type {RequestNode, ConcreteOperation} from 'RelayConcreteNode';
-import type {OperationSelector} from 'RelayStoreTypes';
+import type {RequestNode, ConcreteOperation} from '../util/RelayConcreteNode';
+import type {OperationSelector} from './RelayStoreTypes';
 
 /**
  * Creates an instance of the `OperationSelector` type defined in

--- a/packages/relay-runtime/store/RelayModernOperationSelector.js
+++ b/packages/relay-runtime/store/RelayModernOperationSelector.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernOperationSelector
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernRecord.js
+++ b/packages/relay-runtime/store/RelayModernRecord.js
@@ -12,7 +12,7 @@
 'use strict';
 
 const areEqual = require('areEqual');
-const deepFreeze = require('deepFreeze');
+const deepFreeze = require('../util/deepFreeze');
 const invariant = require('invariant');
 
 const {
@@ -21,7 +21,7 @@ const {
   REFS_KEY,
   TYPENAME_KEY,
   UNPUBLISH_FIELD_SENTINEL,
-} = require('RelayStoreUtils');
+} = require('./RelayStoreUtils');
 
 import type {DataID} from '../util/RelayRuntimeTypes';
 import type {Record} from 'react-relay/classic/environment/RelayCombinedEnvironmentTypes';

--- a/packages/relay-runtime/store/RelayModernRecord.js
+++ b/packages/relay-runtime/store/RelayModernRecord.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernRecord
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernSelector.js
+++ b/packages/relay-runtime/store/RelayModernSelector.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernSelector
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernSelector.js
+++ b/packages/relay-runtime/store/RelayModernSelector.js
@@ -15,12 +15,12 @@ const areEqual = require('areEqual');
 const invariant = require('invariant');
 const warning = require('warning');
 
-const {getFragmentVariables} = require('RelayConcreteVariables');
-const {FRAGMENTS_KEY, ID_KEY} = require('RelayStoreUtils');
+const {getFragmentVariables} = require('./RelayConcreteVariables');
+const {FRAGMENTS_KEY, ID_KEY} = require('./RelayStoreUtils');
 
 import type {DataID, Variables} from '../util/RelayRuntimeTypes';
-import type {ConcreteFragment} from 'RelayConcreteNode';
-import type {Selector} from 'RelayStoreTypes';
+import type {ConcreteFragment} from '../util/RelayConcreteNode';
+import type {Selector} from './RelayStoreTypes';
 
 /**
  * @public

--- a/packages/relay-runtime/store/RelayPublishQueue.js
+++ b/packages/relay-runtime/store/RelayPublishQueue.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayReader = require('RelayReader');
-const RelayRecordSourceMutator = require('RelayRecordSourceMutator');
-const RelayRecordSourceProxy = require('RelayRecordSourceProxy');
-const RelayRecordSourceSelectorProxy = require('RelayRecordSourceSelectorProxy');
+const RelayInMemoryRecordSource = require('./RelayInMemoryRecordSource');
+const RelayReader = require('./RelayReader');
+const RelayRecordSourceMutator = require('../mutations/RelayRecordSourceMutator');
+const RelayRecordSourceProxy = require('../mutations/RelayRecordSourceProxy');
+const RelayRecordSourceSelectorProxy = require('../mutations/RelayRecordSourceSelectorProxy');
 
 const invariant = require('invariant');
-const normalizeRelayPayload = require('normalizeRelayPayload');
+const normalizeRelayPayload = require('./normalizeRelayPayload');
 
-import type {HandlerProvider} from 'RelayDefaultHandlerProvider';
+import type {HandlerProvider} from '../handlers/RelayDefaultHandlerProvider';
 import type {
   HandleFieldPayload,
   MutableRecordSource,
@@ -31,7 +31,7 @@ import type {
   StoreUpdater,
   RecordSource,
   RelayResponsePayload,
-} from 'RelayStoreTypes';
+} from './RelayStoreTypes';
 import type {SelectorData} from 'react-relay/classic/environment/RelayCombinedEnvironmentTypes';
 
 type Payload = {
@@ -321,7 +321,7 @@ class RelayPublishQueue {
 function lookupSelector(source, selector): ?SelectorData {
   const selectorData = RelayReader.read(source, selector).data;
   if (__DEV__) {
-    const deepFreeze = require('deepFreeze');
+    const deepFreeze = require('../util/deepFreeze');
     if (selectorData) {
       deepFreeze(selectorData);
     }

--- a/packages/relay-runtime/store/RelayPublishQueue.js
+++ b/packages/relay-runtime/store/RelayPublishQueue.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayPublishQueue
  * @format
  */
 

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayReader
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
-const RelayModernRecord = require('RelayModernRecord');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
+const RelayModernRecord = require('./RelayModernRecord');
+const RelayStoreUtils = require('./RelayStoreUtils');
 
 const invariant = require('invariant');
 
@@ -26,8 +26,8 @@ import type {
   ConcreteScalarField,
   ConcreteSelection,
   ConcreteSelectableNode,
-} from 'RelayConcreteNode';
-import type {RecordSource, Selector, Snapshot} from 'RelayStoreTypes';
+} from '../util/RelayConcreteNode';
+import type {RecordSource, Selector, Snapshot} from './RelayStoreTypes';
 import type {
   Record,
   SelectorData,

--- a/packages/relay-runtime/store/RelayRecordState.js
+++ b/packages/relay-runtime/store/RelayRecordState.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordState
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayReferenceMarker.js
+++ b/packages/relay-runtime/store/RelayReferenceMarker.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayReferenceMarker
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayReferenceMarker.js
+++ b/packages/relay-runtime/store/RelayReferenceMarker.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
-const RelayModernRecord = require('RelayModernRecord');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
+const RelayModernRecord = require('./RelayModernRecord');
+const RelayStoreUtils = require('./RelayStoreUtils');
 
-const cloneRelayHandleSourceField = require('cloneRelayHandleSourceField');
+const cloneRelayHandleSourceField = require('./cloneRelayHandleSourceField');
 const invariant = require('invariant');
 
 import type {DataID, Variables} from '../util/RelayRuntimeTypes';
@@ -23,8 +23,8 @@ import type {
   ConcreteLinkedField,
   ConcreteNode,
   ConcreteSelection,
-} from 'RelayConcreteNode';
-import type {RecordSource, Selector} from 'RelayStoreTypes';
+} from '../util/RelayConcreteNode';
+import type {RecordSource, Selector} from './RelayStoreTypes';
 import type {Record} from 'react-relay/classic/environment/RelayCombinedEnvironmentTypes';
 
 const {

--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
-const RelayModernRecord = require('RelayModernRecord');
-const RelayProfiler = require('RelayProfiler');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
+const RelayModernRecord = require('./RelayModernRecord');
+const RelayProfiler = require('../util/RelayProfiler');
 
-const deferrableFragmentKey = require('deferrableFragmentKey');
-const generateRelayClientID = require('generateRelayClientID');
+const deferrableFragmentKey = require('./deferrableFragmentKey');
+const generateRelayClientID = require('./generateRelayClientID');
 const invariant = require('invariant');
 const warning = require('warning');
 
@@ -25,21 +25,21 @@ const {
   getHandleStorageKey,
   getStorageKey,
   TYPENAME_KEY,
-} = require('RelayStoreUtils');
+} = require('./RelayStoreUtils');
 
 import type {DataID, Variables} from '../util/RelayRuntimeTypes';
 import type {
   ConcreteField,
   ConcreteLinkedField,
   ConcreteNode,
-} from 'RelayConcreteNode';
-import type {PayloadData} from 'RelayNetworkTypes';
+} from '../util/RelayConcreteNode';
+import type {PayloadData} from '../network/RelayNetworkTypes';
 import type {
   DeferrableSelections,
   HandleFieldPayload,
   MutableRecordSource,
   Selector,
-} from 'RelayStoreTypes';
+} from './RelayStoreTypes';
 import type {Record} from 'react-relay/classic/environment/RelayCombinedEnvironmentTypes';
 
 const {

--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayResponseNormalizer
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayStoreTypes
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -19,16 +19,16 @@ import type {
   ConcreteSelectableNode,
   RequestNode,
   ConcreteOperation,
-} from 'RelayConcreteNode';
-import type {GraphQLTaggedNode} from 'RelayModernGraphQLTag';
+} from '../util/RelayConcreteNode';
+import type {GraphQLTaggedNode} from '../query/RelayModernGraphQLTag';
 import type {
   ExecutePayload,
   PayloadError,
   UploadableMap,
-} from 'RelayNetworkTypes';
-import type {PayloadData} from 'RelayNetworkTypes';
-import type RelayObservable from 'RelayObservable';
-import type {RecordState} from 'RelayRecordState';
+} from '../network/RelayNetworkTypes';
+import type {PayloadData} from '../network/RelayNetworkTypes';
+import type RelayObservable from '../network/RelayObservable';
+import type {RecordState} from './RelayRecordState';
 import type {
   CEnvironment,
   CFragmentMap,

--- a/packages/relay-runtime/store/RelayStoreUtils.js
+++ b/packages/relay-runtime/store/RelayStoreUtils.js
@@ -11,18 +11,18 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
 
-const getRelayHandleKey = require('getRelayHandleKey');
+const getRelayHandleKey = require('../util/getRelayHandleKey');
 const invariant = require('invariant');
-const stableCopy = require('stableCopy');
+const stableCopy = require('../util/stableCopy');
 
 import type {Variables} from '../util/RelayRuntimeTypes';
 import type {
   ConcreteArgument,
   ConcreteField,
   ConcreteHandle,
-} from 'RelayConcreteNode';
+} from '../util/RelayConcreteNode';
 
 export type Arguments = {[argName: string]: mixed};
 

--- a/packages/relay-runtime/store/__tests__/RelayConcreteVariables-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayConcreteVariables-test.js
@@ -15,7 +15,7 @@ const RelayModernTestUtils = require('RelayModernTestUtils');
 const {
   getFragmentVariables,
   getOperationVariables,
-} = require('RelayConcreteVariables');
+} = require('../RelayConcreteVariables');
 
 describe('RelayConcreteVariables', () => {
   const {generateAndCompile} = RelayModernTestUtils;

--- a/packages/relay-runtime/store/__tests__/RelayCore-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayCore-test.js
@@ -15,7 +15,7 @@ jest.mock('warning');
 const RelayTestUtils = require('RelayTestUtils');
 const {generateAndCompile} = require('RelayModernTestUtils');
 
-const {createFragmentSpecResolver} = require('RelayCore');
+const {createFragmentSpecResolver} = require('../RelayCore');
 
 describe('RelayCore', () => {
   describe('createFragmentSpecResolver', () => {

--- a/packages/relay-runtime/store/__tests__/RelayDataLoader-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayDataLoader-test.js
@@ -13,12 +13,12 @@
 
 jest.mock('generateClientID');
 
-const RelayDataLoader = require('RelayDataLoader');
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayStoreUtils = require('RelayStoreUtils');
-const RelayModernRecord = require('RelayModernRecord');
+const RelayDataLoader = require('../RelayDataLoader');
+const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
+const RelayStoreUtils = require('../RelayStoreUtils');
+const RelayModernRecord = require('../RelayModernRecord');
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const getRelayHandleKey = require('getRelayHandleKey');
+const getRelayHandleKey = require('../../util/getRelayHandleKey');
 
 const {check} = RelayDataLoader;
 const {ROOT_ID} = RelayStoreUtils;

--- a/packages/relay-runtime/store/__tests__/RelayMarkSweepStore-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayMarkSweepStore-test.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayMarkSweepStore = require('RelayMarkSweepStore');
-const RelayModernRecord = require('RelayModernRecord');
+const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
+const RelayMarkSweepStore = require('../RelayMarkSweepStore');
+const RelayModernRecord = require('../RelayModernRecord');
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayStoreUtils = require('../RelayStoreUtils');
 
-const simpleClone = require('simpleClone');
+const simpleClone = require('../../util/simpleClone');
 
 const {REF_KEY, ROOT_ID, ROOT_TYPE} = RelayStoreUtils;
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-test.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayMarkSweepStore = require('RelayMarkSweepStore');
-const RelayModernEnvironment = require('RelayModernEnvironment');
+const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
+const RelayMarkSweepStore = require('../RelayMarkSweepStore');
+const RelayModernEnvironment = require('../RelayModernEnvironment');
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const RelayNetwork = require('RelayNetwork');
-const RelayObservable = require('RelayObservable');
+const RelayNetwork = require('../../network/RelayNetwork');
+const RelayObservable = require('../../network/RelayObservable');
 
-const {createOperationSelector} = require('RelayModernOperationSelector');
-const {ROOT_ID} = require('RelayStoreUtils');
+const {createOperationSelector} = require('../RelayModernOperationSelector');
+const {ROOT_ID} = require('../RelayStoreUtils');
 
 describe('RelayModernEnvironment', () => {
   const {generateAndCompile} = RelayModernTestUtils;

--- a/packages/relay-runtime/store/__tests__/RelayModernFragmentSpecResolver-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernFragmentSpecResolver-test.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-const RelayModernFragmentSpecResolver = require('RelayModernFragmentSpecResolver');
+const RelayModernFragmentSpecResolver = require('../RelayModernFragmentSpecResolver');
 const RelayModernTestUtils = require('RelayModernTestUtils');
 
 const {createMockEnvironment} = require('RelayModernMockEnvironment');
-const {createOperationSelector} = require('RelayModernOperationSelector');
-const {ROOT_ID} = require('RelayStoreUtils');
+const {createOperationSelector} = require('../RelayModernOperationSelector');
+const {ROOT_ID} = require('../RelayStoreUtils');
 
 describe('RelayModernFragmentSpecResolver', () => {
   let UserFragment;

--- a/packages/relay-runtime/store/__tests__/RelayModernRecord-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernRecord-test.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const RelayModernRecord = require('RelayModernRecord');
+const RelayModernRecord = require('../RelayModernRecord');
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayStoreUtils = require('../RelayStoreUtils');
 
-const deepFreeze = require('deepFreeze');
+const deepFreeze = require('../../util/deepFreeze');
 
 const {ID_KEY, REF_KEY, REFS_KEY, TYPENAME_KEY} = RelayStoreUtils;
 

--- a/packages/relay-runtime/store/__tests__/RelayModernSelector-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernSelector-test.js
@@ -19,9 +19,9 @@ const {
   getSelectorList,
   getSelectorsFromObject,
   getVariablesFromObject,
-} = require('RelayModernSelector');
+} = require('../RelayModernSelector');
 const {createMockEnvironment} = require('RelayModernMockEnvironment');
-const {ROOT_ID} = require('RelayStoreUtils');
+const {ROOT_ID} = require('../RelayStoreUtils');
 const RelayModernTestUtils = require('RelayModernTestUtils');
 
 describe('RelayModernSelector', () => {

--- a/packages/relay-runtime/store/__tests__/RelayPublishQueue-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayPublishQueue-test.js
@@ -10,18 +10,18 @@
 
 'use strict';
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayMarkSweepStore = require('RelayMarkSweepStore');
-const RelayModernRecord = require('RelayModernRecord');
+const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
+const RelayMarkSweepStore = require('../RelayMarkSweepStore');
+const RelayModernRecord = require('../RelayModernRecord');
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const RelayPublishQueue = require('RelayPublishQueue');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayPublishQueue = require('../RelayPublishQueue');
+const RelayStoreUtils = require('../RelayStoreUtils');
 
-const getRelayHandleKey = require('getRelayHandleKey');
+const getRelayHandleKey = require('../../util/getRelayHandleKey');
 const invariant = require('invariant');
-const simpleClone = require('simpleClone');
+const simpleClone = require('../../util/simpleClone');
 
-const {createOperationSelector} = require('RelayModernOperationSelector');
+const {createOperationSelector} = require('../RelayModernOperationSelector');
 
 const {ID_KEY, REF_KEY, ROOT_ID, ROOT_TYPE, TYPENAME_KEY} = RelayStoreUtils;
 

--- a/packages/relay-runtime/store/__tests__/RelayReader-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-test.js
@@ -12,9 +12,9 @@
 
 jest.mock('generateClientID');
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayReader = require('RelayReader');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
+const RelayReader = require('../RelayReader');
+const RelayStoreUtils = require('../RelayStoreUtils');
 const RelayModernTestUtils = require('RelayModernTestUtils');
 
 const {read} = RelayReader;

--- a/packages/relay-runtime/store/__tests__/RelayReferenceMarker-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReferenceMarker-test.js
@@ -12,9 +12,9 @@
 
 jest.mock('generateClientID');
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayReferenceMarker = require('RelayReferenceMarker');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
+const RelayReferenceMarker = require('../RelayReferenceMarker');
+const RelayStoreUtils = require('../RelayStoreUtils');
 const RelayModernTestUtils = require('RelayModernTestUtils');
 const Set = require('Set');
 

--- a/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
@@ -12,10 +12,10 @@
 
 jest.mock('generateClientID');
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayModernRecord = require('RelayModernRecord');
-const {normalize} = require('RelayResponseNormalizer');
-const {ROOT_ID, ROOT_TYPE} = require('RelayStoreUtils');
+const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
+const RelayModernRecord = require('../RelayModernRecord');
+const {normalize} = require('../RelayResponseNormalizer');
+const {ROOT_ID, ROOT_TYPE} = require('../RelayStoreUtils');
 const RelayModernTestUtils = require('RelayModernTestUtils');
 
 describe('RelayResponseNormalizer', () => {

--- a/packages/relay-runtime/store/__tests__/RelayStoreUtils-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayStoreUtils-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const RelayModernTestUtils = require('RelayModernTestUtils');
-const RelayStoreUtils = require('RelayStoreUtils');
+const RelayStoreUtils = require('../RelayStoreUtils');
 
 const {generateAndCompile} = RelayModernTestUtils;
 

--- a/packages/relay-runtime/store/__tests__/cloneRelayHandleSourceField-test.js
+++ b/packages/relay-runtime/store/__tests__/cloneRelayHandleSourceField-test.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
+const RelayConcreteNode = require('../../util/RelayConcreteNode');
 const RelayModernTestUtils = require('RelayModernTestUtils');
 
-const cloneRelayHandleSourceField = require('cloneRelayHandleSourceField');
-const getRelayHandleKey = require('getRelayHandleKey');
+const cloneRelayHandleSourceField = require('../cloneRelayHandleSourceField');
+const getRelayHandleKey = require('../../util/getRelayHandleKey');
 
 const {generateWithTransforms, matchers} = RelayModernTestUtils;
 const {LINKED_FIELD, LINKED_HANDLE} = RelayConcreteNode;

--- a/packages/relay-runtime/store/__tests__/isRelayModernEnvironment-test.js
+++ b/packages/relay-runtime/store/__tests__/isRelayModernEnvironment-test.js
@@ -11,11 +11,11 @@
 'use strict';
 
 const RelayEnvironment = require('react-relay/classic/store/RelayEnvironment');
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayMarkSweepStore = require('RelayMarkSweepStore');
-const RelayModernEnvironment = require('RelayModernEnvironment');
+const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
+const RelayMarkSweepStore = require('../RelayMarkSweepStore');
+const RelayModernEnvironment = require('../RelayModernEnvironment');
 
-const isRelayModernEnvironment = require('isRelayModernEnvironment');
+const isRelayModernEnvironment = require('../isRelayModernEnvironment');
 
 describe('isRelayModernEnvironment()', () => {
   it('returns true for `RelayModernEnvironment` instances', () => {

--- a/packages/relay-runtime/store/cloneRelayHandleSourceField.js
+++ b/packages/relay-runtime/store/cloneRelayHandleSourceField.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule cloneRelayHandleSourceField
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/cloneRelayHandleSourceField.js
+++ b/packages/relay-runtime/store/cloneRelayHandleSourceField.js
@@ -11,19 +11,19 @@
 
 'use strict';
 
-const RelayConcreteNode = require('RelayConcreteNode');
+const RelayConcreteNode = require('../util/RelayConcreteNode');
 
 const areEqual = require('areEqual');
 const invariant = require('invariant');
 
-const {getHandleStorageKey} = require('RelayStoreUtils');
+const {getHandleStorageKey} = require('./RelayStoreUtils');
 
 import type {Variables} from '../util/RelayRuntimeTypes';
 import type {
   ConcreteLinkedField,
   ConcreteLinkedHandle,
   ConcreteSelection,
-} from 'RelayConcreteNode';
+} from '../util/RelayConcreteNode';
 
 const {LINKED_FIELD} = RelayConcreteNode;
 

--- a/packages/relay-runtime/store/deferrableFragmentKey.js
+++ b/packages/relay-runtime/store/deferrableFragmentKey.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule deferrableFragmentKey
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/generateRelayClientID.js
+++ b/packages/relay-runtime/store/generateRelayClientID.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule generateRelayClientID
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/hasOverlappingIDs.js
+++ b/packages/relay-runtime/store/hasOverlappingIDs.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule hasOverlappingIDs
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/hasOverlappingIDs.js
+++ b/packages/relay-runtime/store/hasOverlappingIDs.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-import type {UpdatedRecords, Snapshot} from 'RelayStoreTypes';
+import type {UpdatedRecords, Snapshot} from './RelayStoreTypes';
 
 function hasOverlappingIDs(
   snapshot: Snapshot,

--- a/packages/relay-runtime/store/isRelayModernEnvironment.js
+++ b/packages/relay-runtime/store/isRelayModernEnvironment.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule isRelayModernEnvironment
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/normalizePayload.js
+++ b/packages/relay-runtime/store/normalizePayload.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule normalizePayload
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/normalizePayload.js
+++ b/packages/relay-runtime/store/normalizePayload.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-const RelayError = require('RelayError');
+const RelayError = require('../util/RelayError');
 
-const normalizeRelayPayload = require('normalizeRelayPayload');
+const normalizeRelayPayload = require('./normalizeRelayPayload');
 
-const {ROOT_ID} = require('RelayStoreUtils');
+const {ROOT_ID} = require('./RelayStoreUtils');
 
-import type {ExecutePayload} from 'RelayNetworkTypes';
-import type {RelayResponsePayload} from 'RelayStoreTypes';
+import type {ExecutePayload} from '../network/RelayNetworkTypes';
+import type {RelayResponsePayload} from './RelayStoreTypes';
 
 function normalizePayload(payload: ExecutePayload): RelayResponsePayload {
   const {operation, variables, response} = payload;

--- a/packages/relay-runtime/store/normalizeRelayPayload.js
+++ b/packages/relay-runtime/store/normalizeRelayPayload.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
-const RelayModernRecord = require('RelayModernRecord');
-const RelayResponseNormalizer = require('RelayResponseNormalizer');
+const RelayInMemoryRecordSource = require('./RelayInMemoryRecordSource');
+const RelayModernRecord = require('./RelayModernRecord');
+const RelayResponseNormalizer = require('./RelayResponseNormalizer');
 
-const {ROOT_ID, ROOT_TYPE} = require('RelayStoreUtils');
+const {ROOT_ID, ROOT_TYPE} = require('./RelayStoreUtils');
 
-import type {PayloadData, PayloadError} from 'RelayNetworkTypes';
-import type {NormalizationOptions} from 'RelayResponseNormalizer';
-import type {RelayResponsePayload, Selector} from 'RelayStoreTypes';
+import type {PayloadData, PayloadError} from '../network/RelayNetworkTypes';
+import type {NormalizationOptions} from './RelayResponseNormalizer';
+import type {RelayResponsePayload, Selector} from './RelayStoreTypes';
 
 function normalizeRelayPayload(
   selector: Selector,

--- a/packages/relay-runtime/store/normalizeRelayPayload.js
+++ b/packages/relay-runtime/store/normalizeRelayPayload.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule normalizeRelayPayload
  * @flow
  * @format
  */

--- a/packages/relay-runtime/subscription/__tests__/requestRelaySubscription-test.js
+++ b/packages/relay-runtime/subscription/__tests__/requestRelaySubscription-test.js
@@ -14,9 +14,9 @@
 const requestRelaySubscription = require('../requestRelaySubscription');
 
 const {createMockEnvironment} = require('RelayModernMockEnvironment');
-const {createOperationSelector} = require('RelayModernOperationSelector');
+const {createOperationSelector} = require('../../store/RelayModernOperationSelector');
 const {generateAndCompile} = require('RelayModernTestUtils');
-const {ROOT_ID} = require('RelayStoreUtils');
+const {ROOT_ID} = require('../../store/RelayStoreUtils');
 
 describe('requestRelaySubscription-test', () => {
   it('Config: `RANGE_ADD`', () => {

--- a/packages/relay-runtime/subscription/requestRelaySubscription.js
+++ b/packages/relay-runtime/subscription/requestRelaySubscription.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const RelayDeclarativeMutationConfig = require('RelayDeclarativeMutationConfig');
+const RelayDeclarativeMutationConfig = require('../mutations/RelayDeclarativeMutationConfig');
 
 const warning = require('warning');
 
 import type {Disposable} from '../util/RelayRuntimeTypes';
 import type {Variables} from '../util/RelayRuntimeTypes';
-import type {DeclarativeMutationConfig} from 'RelayDeclarativeMutationConfig';
-import type {GraphQLTaggedNode} from 'RelayModernGraphQLTag';
-import type {Environment, SelectorStoreUpdater} from 'RelayStoreTypes';
+import type {DeclarativeMutationConfig} from '../mutations/RelayDeclarativeMutationConfig';
+import type {GraphQLTaggedNode} from '../query/RelayModernGraphQLTag';
+import type {Environment, SelectorStoreUpdater} from '../store/RelayStoreTypes';
 
 export type GraphQLSubscriptionConfig = {|
   configs?: Array<DeclarativeMutationConfig>,

--- a/packages/relay-runtime/util/__tests__/RelayProfiler-test.js
+++ b/packages/relay-runtime/util/__tests__/RelayProfiler-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const RelayProfiler = require('RelayProfiler');
+const RelayProfiler = require('../RelayProfiler');
 
 describe('RelayProfiler', function() {
   const DEV = __DEV__;

--- a/packages/relay-runtime/util/__tests__/stableCopy-test.js
+++ b/packages/relay-runtime/util/__tests__/stableCopy-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const stableCopy = require('stableCopy');
+const stableCopy = require('../stableCopy');
 
 describe('stableCopy', () => {
   it('returns non-objects', () => {

--- a/packages/relay-runtime/util/getRelayHandleKey.js
+++ b/packages/relay-runtime/util/getRelayHandleKey.js
@@ -13,7 +13,7 @@
 
 const invariant = require('invariant');
 
-const {DEFAULT_HANDLE_KEY} = require('RelayDefaultHandleKey');
+const {DEFAULT_HANDLE_KEY} = require('./RelayDefaultHandleKey');
 
 /**
  * @internal


### PR DESCRIPTION
Doing the same that was done in https://github.com/facebook/relay/commit/97f24f8ebe80ebfd849db8e88f8449bfc9f9f5eb for react-relay in relay-runtime.

This is part of the first step in https://github.com/facebook/relay/issues/1590#issuecomment-372484579.

I left the `@providesModule` in the files in `relay-runtime/util/*.js` and a few others that used directly in the other packages. I can address that in the next PR by exporting them in `RelayRuntime.js`. I didn't want this one to get bigger than it already is.