### PR TITLE
Makes flow generated '%future added value' for enums optional

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -94,6 +94,7 @@ async function run(options: {
   watch?: ?boolean,
   validate: boolean,
   quiet: boolean,
+  strictFlowTypes: boolean,
 }) {
   const schemaPath = path.resolve(process.cwd(), options.schema);
   if (!fs.existsSync(schemaPath)) {
@@ -163,7 +164,7 @@ Ensure that one such file exists in ${srcDir} or its parents.
   };
   const writerConfigs = {
     js: {
-      getWriter: getRelayFileWriter(srcDir),
+      getWriter: getRelayFileWriter(srcDir, options.strictFlowTypes),
       isGeneratedFile: (filePath: string) =>
         filePath.endsWith('.js') && filePath.includes('__generated__'),
       parser: 'js',
@@ -194,7 +195,7 @@ Ensure that one such file exists in ${srcDir} or its parents.
   }
 }
 
-function getRelayFileWriter(baseDir: string) {
+function getRelayFileWriter(baseDir: string, strictFlowTypes: boolean) {
   return ({
     onlyValidate,
     schema,
@@ -218,6 +219,7 @@ function getRelayFileWriter(baseDir: string) {
         inputFieldWhiteListForFlow: [],
         schemaExtensions,
         useHaste: false,
+        strictFlowTypes,
       },
       onlyValidate,
       schema,
@@ -332,6 +334,12 @@ const argv = yargs
         'Looks for pending changes and exits with non-zero code instead of ' +
         'writing to disk',
       type: 'boolean',
+      default: false,
+    },
+    strictFlowTypes: {
+      describe:
+        'Generate flow types that more closely match the schema. This should be avoided ' +
+        'if the GraphQL server can change enum values without updating its schema',
       default: false,
     },
   })

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -63,6 +63,7 @@ export type WriterConfig = {
   platform?: string,
   relayRuntimeModule?: string,
   schemaExtensions: Array<string>,
+  strictFlowTypes: boolean,
   useHaste: boolean,
   // Haste style module that exports flow types for GraphQL enums.
   // TODO(T22422153) support non-haste environments
@@ -280,6 +281,7 @@ class RelayFileWriter implements FileWriterInterface {
               inputFieldWhiteList: this._config.inputFieldWhiteListForFlow,
               relayRuntimeModule,
               useHaste: this._config.useHaste,
+              strictFlowTypes: this._config.strictFlowTypes,
             });
 
             const sourceHash = Profiler.run('hashGraphQL', () =>

--- a/packages/relay-compiler/core/RelayFlowGenerator.js
+++ b/packages/relay-compiler/core/RelayFlowGenerator.js
@@ -55,6 +55,7 @@ type Options = {|
   +existingFragmentNames: Set<string>,
   +inputFieldWhiteList: $ReadOnlyArray<string>,
   +relayRuntimeModule: string,
+  +strictFlowTypes: boolean,
 |};
 
 export type State = {|
@@ -235,6 +236,7 @@ function createVisitor(options: Options) {
     usedEnums: {},
     usedFragments: new Set(),
     useHaste: options.useHaste,
+    strictFlowTypes: options.strictFlowTypes,
   };
 
   return {
@@ -423,7 +425,11 @@ function getFragmentImports(state: State) {
   return imports;
 }
 
-function getEnumDefinitions({enumsHasteModule, usedEnums}: State) {
+function getEnumDefinitions({
+  enumsHasteModule,
+  usedEnums,
+  strictFlowTypes,
+}: State) {
   const enumNames = Object.keys(usedEnums).sort();
   if (enumNames.length === 0) {
     return [];
@@ -434,7 +440,9 @@ function getEnumDefinitions({enumsHasteModule, usedEnums}: State) {
   return enumNames.map(name => {
     const values = usedEnums[name].getValues().map(({value}) => value);
     values.sort();
-    values.push('%future added value');
+    if (!strictFlowTypes) {
+      values.push('%future added value');
+    }
     return exportType(
       name,
       t.unionTypeAnnotation(


### PR DESCRIPTION
As suggested by @leebyron in #2351, this adds an option to the `relay-compiler`  so it doesn't add `%future added value` to each GraphQL generated enum. My reasoning is that you might have a strict control over your GraphQL service, so you'd have to handle any future value by rerunning the compiler, with the new version of the schema.

I'm not totally convinced by the name `strictFlowTypes`, but I don't really have much better now. My thought between this name is that the option would be a generic option that configures the generated flow types, and would not be specifically to enums.

Regarding test cases, I'm not sure of how I should tackle that, since the only tests are snapshots, and there are no tests with different configurations of the `RelayFlowGenerator`. I could however try to make that happen if you'd like! 