### PR TITLE
Fix CI for node < 8

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -61,9 +61,11 @@ module.exports = {
   getCacheKey: createCacheKeyFunction([
     __filename,
     testSchemaPath,
+    // We cannot have trailing commas in this file for node < 8
+    // prettier-ignore
     path.join(
       path.dirname(require.resolve('babel-preset-fbjs')),
-      'package.json',
+      'package.json'
     ),
     path.join(__dirname, '..', 'getBabelOptions.js'),
   ]),


### PR DESCRIPTION
Thanks @alloy for noticing that https://github.com/facebook/relay/commit/0d24a725c7ad5e2414e755c5ab47850fb85b824c broke CI.  The reason is that node < 8 does not support trailing commas for function calls which prettier adds in our configuration. This should fix it.