### PR TITLE
Track fragments on connections that yield no edges

### DIFF
--- a/packages/react-relay/classic/traversal/diffRelayQuery.js
+++ b/packages/react-relay/classic/traversal/diffRelayQuery.js
@@ -628,6 +628,11 @@ class RelayDiffQueryBuilder {
     // to be tracked as-is.
     if (hasSplitQueries) {
       trackedNode = field;
+    } else if (filteredEdges.length === 0) {
+      // if the connection does not have any edges, then we must track the
+      // entire field since there's no tracking details generated from
+      // enumerating the edges.
+      trackedNode = field;
     }
 
     return {


### PR DESCRIPTION
Like connections that return `null`, tracking the fragment is necessary in order to properly generate future queries that affect the connection since traversal of the edges is not generating details on split queries and tracking those individually.

Here's [a bit of code that demonstrates what problem this is solving](https://gist.github.com/wbyoung/f4ef16828ea1f4b0071bcf3eb27335e5) that runs against a simple backend w/ the idea of a `List` model that has an `owner` among other fields. Hopefully the idea of the schema that it's running against and the code itself is pretty self explanatory. This is intended to demonstrate the issue w/ a minimal amount of code — in reality this situation came up when changing between different components/queries being rendered as the user navigates between pages in an app.
