### PR TITLE
(RelayModernEnvironment) Verify can normalizePayload before `do`

### DIFF
--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -193,6 +193,10 @@ class RelayModernEnvironment implements Environment {
     let optimisticResponse;
     return this._network
       .execute(operation.node, operation.variables, cacheConfig || {})
+      .map(executePayload => {
+        normalizePayload(executePayload);
+        return executePayload;
+      })
       .do({
         next: executePayload => {
           const responsePayload = normalizePayload(executePayload);


### PR DESCRIPTION
Fixes #2385

I suspect there's a much nicer solution to this, but I thought it was worth starting somewhere.

I'm also not sure how to add test assertions to highlight the behaviour, but this does demonstrate a working fix.