### PR TITLE
Fix typo in code example in Thinking in Relay doc

### DIFF
--- a/docs/PrinciplesAndArchitecture-ThinkingInRelay.md
+++ b/docs/PrinciplesAndArchitecture-ThinkingInRelay.md
@@ -72,7 +72,7 @@ ReactDOM.render(
     variables={{
       storyID: '123',
     }}
-    render={(props, error) {
+    render={(props, error) => {
       if (error) {
         return <ErrorView />;
       } else if (props) {


### PR DESCRIPTION
```graphql
query Doc($page: "thinking-in-relay") {
  example {
    StoryContainer
  }
}
```