### PR TITLE
Allow connection records with no filter calls to invoke getRangeBehavior

### DIFF
--- a/packages/react-relay/classic/traversal/writeRelayUpdatePayload.js
+++ b/packages/react-relay/classic/traversal/writeRelayUpdatePayload.js
@@ -388,7 +388,7 @@ function addRangeNode(
 ) {
   const store = writer.getRecordStore();
   const recordWriter = writer.getRecordWriter();
-  const filterCalls = store.getRangeFilterCalls(connectionID);
+  const filterCalls = store.getRangeFilterCalls(connectionID) || [];
   const rangeBehavior = getRangeBehavior(config.rangeBehaviors, filterCalls);
 
   // no range behavior specified for this combination of filter calls

--- a/packages/react-relay/classic/traversal/writeRelayUpdatePayload.js
+++ b/packages/react-relay/classic/traversal/writeRelayUpdatePayload.js
@@ -389,9 +389,7 @@ function addRangeNode(
   const store = writer.getRecordStore();
   const recordWriter = writer.getRecordWriter();
   const filterCalls = store.getRangeFilterCalls(connectionID);
-  const rangeBehavior = filterCalls
-    ? getRangeBehavior(config.rangeBehaviors, filterCalls)
-    : null;
+  const rangeBehavior = getRangeBehavior(config.rangeBehaviors, filterCalls);
 
   // no range behavior specified for this combination of filter calls
   if (!rangeBehavior) {


### PR DESCRIPTION
If a connection record has no filter calls, we are never able to invoke `getRangeBehavior` when handling `RANGE_ADD` from a mutation

I have a use case where I've set `rangeBehavior` to a function that returns `'prepend'` to all calls, regardless of arguments. This in conjunction with the fact that we fetch connections just for connection fields (`total`) in some places, without fetching edges.

It would be nice if all connection records could call getRangeBehavior regardless

<img width="1243" alt="screen shot 2018-04-05 at 6 02 11 pm" src="https://user-images.githubusercontent.com/2374625/38398869-961a8f60-38fb-11e8-831b-3ef9c637e4dc.png">

