### PR TITLE
Cleanup deps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -260,9 +260,7 @@ gulp.task('modules', function() {
       gulp
         .src([
           '*' + PACKAGES + '/' + build.package + '/**/*.js',
-          '*' + PACKAGES + '/react-relay/classic/tools/*.js',
-          '*' + PACKAGES + '/react-relay/classic/util/*.js',
-          '*' + PACKAGES + '/relay-runtime/util/*.js',
+          // '*' + PACKAGES + '/relay-runtime/util/*.js',
           '!' + PACKAGES + '/**/__tests__/**/*.js',
           '!' + PACKAGES + '/**/__mocks__/**/*.js',
         ])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -260,7 +260,6 @@ gulp.task('modules', function() {
       gulp
         .src([
           '*' + PACKAGES + '/' + build.package + '/**/*.js',
-          // '*' + PACKAGES + '/relay-runtime/util/*.js',
           '!' + PACKAGES + '/**/__tests__/**/*.js',
           '!' + PACKAGES + '/**/__mocks__/**/*.js',
         ])

--- a/packages/react-relay/classic/container/RelayContainerComparators.js
+++ b/packages/react-relay/classic/container/RelayContainerComparators.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const isScalarAndEqual = require('isScalarAndEqual');
+const {isScalarAndEqual} = require('RelayRuntime');
 
 /**
  * Compares `objectA` and `objectB` using the provided `isEqual` function.

--- a/packages/react-relay/classic/environment/RelayFragmentSpecResolver.js
+++ b/packages/react-relay/classic/environment/RelayFragmentSpecResolver.js
@@ -12,7 +12,7 @@
 
 const forEachObject = require('forEachObject');
 const invariant = require('invariant');
-const isScalarAndEqual = require('isScalarAndEqual');
+const {isScalarAndEqual} = require('RelayRuntime');
 
 const {areEqualSelectors, getSelectorsFromObject} = require('./RelaySelector');
 

--- a/packages/react-relay/classic/store/RelayEnvironment.js
+++ b/packages/react-relay/classic/store/RelayEnvironment.js
@@ -20,14 +20,13 @@ const RelayQueryRequest = require('../network/RelayQueryRequest');
 const RelayStoreData = require('./RelayStoreData');
 const RelayVariables = require('../query/RelayVariables');
 
-const deepFreeze = require('deepFreeze');
 const forEachRootCallArg = require('../query/forEachRootCallArg');
 const generateForceIndex = require('../legacy/store/generateForceIndex');
 const readRelayQueryData = require('./readRelayQueryData');
 const relayUnstableBatchedUpdates = require('../tools/relayUnstableBatchedUpdates');
 const warning = require('warning');
 
-const {Observable, recycleNodesInto} = require('RelayRuntime');
+const {Observable, deepFreeze, recycleNodesInto} = require('RelayRuntime');
 
 import type {
   Environment,

--- a/packages/react-relay/classic/store/__tests__/RelayStoreData_cacheManager-test.js
+++ b/packages/react-relay/classic/store/__tests__/RelayStoreData_cacheManager-test.js
@@ -15,11 +15,14 @@ jest.mock('../../legacy/store/generateClientID');
 require('configureForRelayOSS');
 
 const Relay = require('../../RelayPublic');
-const {ConnectionInterface} = require('RelayRuntime');
 const RelayMockCacheManager = require('RelayMockCacheManager');
 const RelayStoreData = require('../RelayStoreData');
 const RelayTestUtils = require('RelayTestUtils');
-const {RangeOperations, MutationTypes} = require('RelayRuntime');
+const {
+  ConnectionInterface,
+  RangeOperations,
+  MutationTypes,
+} = require('RelayRuntime');
 
 const transformRelayQueryPayload = require('../../traversal/transformRelayQueryPayload');
 

--- a/packages/react-relay/classic/traversal/writeRelayUpdatePayload.js
+++ b/packages/react-relay/classic/traversal/writeRelayUpdatePayload.js
@@ -22,9 +22,9 @@ const getRangeBehavior = require('../mutation/getRangeBehavior');
 const invariant = require('invariant');
 const warning = require('warning');
 
-const {MutationTypes} = require('RelayRuntime');
 const {
   ConnectionInterface,
+  MutationTypes,
   RangeOperations,
   RelayProfiler,
 } = require('RelayRuntime');

--- a/packages/react-relay/modern/ReactRelayFragmentContainer.js
+++ b/packages/react-relay/modern/ReactRelayFragmentContainer.js
@@ -15,7 +15,6 @@ const RelayPropTypes = require('../classic/container/RelayPropTypes');
 
 const areEqual = require('areEqual');
 const buildReactRelayContainer = require('./buildReactRelayContainer');
-const isScalarAndEqual = require('isScalarAndEqual');
 const warning = require('warning');
 
 const {
@@ -24,7 +23,7 @@ const {
 } = require('../classic/container/RelayContainerUtils');
 const {assertRelayContext} = require('../classic/environment/RelayContext');
 const {profileContainer} = require('./ReactRelayContainerProfiler');
-const {RelayProfiler} = require('RelayRuntime');
+const {RelayProfiler, isScalarAndEqual} = require('RelayRuntime');
 
 import type {FragmentSpecResolver} from '../classic/environment/RelayCombinedEnvironmentTypes';
 import type {RelayEnvironmentInterface as ClassicEnvironment} from '../classic/store/RelayEnvironment';

--- a/packages/react-relay/modern/ReactRelayPaginationContainer.js
+++ b/packages/react-relay/modern/ReactRelayPaginationContainer.js
@@ -17,7 +17,6 @@ const RelayPropTypes = require('../classic/container/RelayPropTypes');
 const areEqual = require('areEqual');
 const buildReactRelayContainer = require('./buildReactRelayContainer');
 const invariant = require('invariant');
-const isScalarAndEqual = require('isScalarAndEqual');
 const nullthrows = require('nullthrows');
 const warning = require('warning');
 
@@ -31,6 +30,7 @@ const {
   ConnectionInterface,
   RelayProfiler,
   Observable,
+  isScalarAndEqual,
 } = require('RelayRuntime');
 
 import type {FragmentSpecResolver} from '../classic/environment/RelayCombinedEnvironmentTypes';

--- a/packages/react-relay/modern/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/modern/ReactRelayQueryRenderer.js
@@ -15,7 +15,8 @@ const ReactRelayQueryFetcher = require('./ReactRelayQueryFetcher');
 const RelayPropTypes = require('../classic/container/RelayPropTypes');
 
 const areEqual = require('areEqual');
-const deepFreeze = require('deepFreeze');
+
+const {deepFreeze} = require('RelayRuntime');
 
 import type {RelayEnvironmentInterface as ClassicEnvironment} from '../classic/store/RelayEnvironment';
 import type {

--- a/packages/react-relay/modern/ReactRelayRefetchContainer.js
+++ b/packages/react-relay/modern/ReactRelayRefetchContainer.js
@@ -16,7 +16,6 @@ const RelayPropTypes = require('../classic/container/RelayPropTypes');
 
 const areEqual = require('areEqual');
 const buildReactRelayContainer = require('./buildReactRelayContainer');
-const isScalarAndEqual = require('isScalarAndEqual');
 
 const {
   getComponentName,
@@ -24,7 +23,7 @@ const {
 } = require('../classic/container/RelayContainerUtils');
 const {assertRelayContext} = require('../classic/environment/RelayContext');
 const {profileContainer} = require('./ReactRelayContainerProfiler');
-const {Observable, RelayProfiler} = require('RelayRuntime');
+const {Observable, RelayProfiler, isScalarAndEqual} = require('RelayRuntime');
 
 import type {FragmentSpecResolver} from '../classic/environment/RelayCombinedEnvironmentTypes';
 import type {RelayEnvironmentInterface as ClassicEnvironment} from '../classic/store/RelayEnvironment';

--- a/packages/relay-compiler/codegen/RelayCodeGenerator.js
+++ b/packages/relay-compiler/codegen/RelayCodeGenerator.js
@@ -12,10 +12,8 @@
 'use strict';
 
 const invariant = require('invariant');
-// TODO T21875029 ../../relay-runtime/util/stableCopy
-const stableCopy = require('stableCopy');
 
-const {getStorageKey} = require('RelayRuntime');
+const {getStorageKey, stableCopy} = require('RelayRuntime');
 const {GraphQLList} = require('graphql');
 const {IRVisitor, SchemaUtils} = require('graphql-compiler');
 

--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -11,8 +11,7 @@
 
 'use strict';
 
-// TODO T21875029 ../../relay-runtime/util/RelayConcreteNode
-const RelayConcreteNode = require('RelayConcreteNode');
+const {RelayConcreteNode} = require('RelayRuntime');
 
 const crypto = require('crypto');
 const dedupeJSONStringify = require('dedupeJSONStringify');

--- a/packages/relay-compiler/handlers/viewer/RelayViewerHandleTransform.js
+++ b/packages/relay-compiler/handlers/viewer/RelayViewerHandleTransform.js
@@ -11,8 +11,7 @@
 
 'use strict';
 
-// TODO T21875029 ../../../relay-runtime/util/RelayDefaultHandleKey
-const {DEFAULT_HANDLE_KEY} = require('RelayDefaultHandleKey');
+const {DEFAULT_HANDLE_KEY} = require('RelayRuntime');
 const {GraphQLObjectType} = require('graphql');
 const {IRTransformer, SchemaUtils} = require('graphql-compiler');
 

--- a/packages/relay-compiler/transforms/RelayFieldHandleTransform.js
+++ b/packages/relay-compiler/transforms/RelayFieldHandleTransform.js
@@ -11,11 +11,10 @@
 
 'use strict';
 
-// TODO T21875029 ../../relay-runtime/util/getRelayHandleKey
-const getRelayHandleKey = require('getRelayHandleKey');
 const invariant = require('invariant');
 
 const {CompilerContext, IRTransformer} = require('graphql-compiler');
+const {getRelayHandleKey} = require('RelayRuntime');
 
 import type {Field} from 'graphql-compiler';
 

--- a/packages/relay-runtime/RelayRuntime.js
+++ b/packages/relay-runtime/RelayRuntime.js
@@ -32,6 +32,7 @@ const commitLocalUpdate = require('commitLocalUpdate');
 const commitRelayModernMutation = require('commitRelayModernMutation');
 const deepFreeze = require('deepFreeze');
 const fetchRelayModernQuery = require('fetchRelayModernQuery');
+const getRelayHandleKey = require('getRelayHandleKey');
 const isRelayModernEnvironment = require('isRelayModernEnvironment');
 const isScalarAndEqual = require('isScalarAndEqual');
 const recycleNodesInto = require('recycleNodesInto');
@@ -161,6 +162,7 @@ module.exports = {
 
   // INTERNAL-ONLY: These exports might be removed at any point.
   deepFreeze: deepFreeze,
+  getRelayHandleKey: getRelayHandleKey,
   isScalarAndEqual: isScalarAndEqual,
   recycleNodesInto: recycleNodesInto,
   simpleClone: simpleClone,

--- a/packages/relay-runtime/RelayRuntime.js
+++ b/packages/relay-runtime/RelayRuntime.js
@@ -32,6 +32,7 @@ const commitLocalUpdate = require('commitLocalUpdate');
 const commitRelayModernMutation = require('commitRelayModernMutation');
 const fetchRelayModernQuery = require('fetchRelayModernQuery');
 const isRelayModernEnvironment = require('isRelayModernEnvironment');
+const isScalarAndEqual = require('isScalarAndEqual');
 const recycleNodesInto = require('recycleNodesInto');
 const requestRelaySubscription = require('requestRelaySubscription');
 const simpleClone = require('simpleClone');
@@ -162,4 +163,5 @@ module.exports = {
   simpleClone: simpleClone,
   ROOT_ID: RelayStoreUtils.ROOT_ID,
   RelayConcreteNode: RelayConcreteNode,
+  isScalarAndEqual: isScalarAndEqual,
 };

--- a/packages/relay-runtime/RelayRuntime.js
+++ b/packages/relay-runtime/RelayRuntime.js
@@ -30,6 +30,7 @@ const RelayViewerHandler = require('RelayViewerHandler');
 const applyRelayModernOptimisticMutation = require('applyRelayModernOptimisticMutation');
 const commitLocalUpdate = require('commitLocalUpdate');
 const commitRelayModernMutation = require('commitRelayModernMutation');
+const deepFreeze = require('deepFreeze');
 const fetchRelayModernQuery = require('fetchRelayModernQuery');
 const isRelayModernEnvironment = require('isRelayModernEnvironment');
 const isScalarAndEqual = require('isScalarAndEqual');
@@ -157,11 +158,11 @@ module.exports = {
   // Utilities
   RelayProfiler: RelayProfiler,
 
-  // TODO T22766889 remove cross-cell imports of internal modules
-  // INTERNAL-ONLY: these WILL be removed from this API in the next release
+  // INTERNAL-ONLY: These exports might be removed at any point.
+  deepFreeze: deepFreeze,
+  isScalarAndEqual: isScalarAndEqual,
   recycleNodesInto: recycleNodesInto,
   simpleClone: simpleClone,
   ROOT_ID: RelayStoreUtils.ROOT_ID,
   RelayConcreteNode: RelayConcreteNode,
-  isScalarAndEqual: isScalarAndEqual,
 };

--- a/packages/relay-runtime/RelayRuntime.js
+++ b/packages/relay-runtime/RelayRuntime.js
@@ -16,6 +16,7 @@ const RelayConnectionHandler = require('RelayConnectionHandler');
 const RelayConnectionInterface = require('RelayConnectionInterface');
 const RelayCore = require('RelayCore');
 const RelayDeclarativeMutationConfig = require('RelayDeclarativeMutationConfig');
+const RelayDefaultHandleKey = require('RelayDefaultHandleKey');
 const RelayInMemoryRecordSource = require('RelayInMemoryRecordSource');
 const RelayMarkSweepStore = require('RelayMarkSweepStore');
 const RelayModernEnvironment = require('RelayModernEnvironment');
@@ -161,12 +162,14 @@ module.exports = {
   RelayProfiler: RelayProfiler,
 
   // INTERNAL-ONLY: These exports might be removed at any point.
+  RelayConcreteNode: RelayConcreteNode,
+  DEFAULT_HANDLE_KEY: RelayDefaultHandleKey.DEFAULT_HANDLE_KEY,
+  ROOT_ID: RelayStoreUtils.ROOT_ID,
+
   deepFreeze: deepFreeze,
   getRelayHandleKey: getRelayHandleKey,
   isScalarAndEqual: isScalarAndEqual,
   recycleNodesInto: recycleNodesInto,
   simpleClone: simpleClone,
   stableCopy: stableCopy,
-  ROOT_ID: RelayStoreUtils.ROOT_ID,
-  RelayConcreteNode: RelayConcreteNode,
 };

--- a/packages/relay-runtime/RelayRuntime.js
+++ b/packages/relay-runtime/RelayRuntime.js
@@ -37,6 +37,7 @@ const isScalarAndEqual = require('isScalarAndEqual');
 const recycleNodesInto = require('recycleNodesInto');
 const requestRelaySubscription = require('requestRelaySubscription');
 const simpleClone = require('simpleClone');
+const stableCopy = require('stableCopy');
 
 export type {
   CacheConfig,
@@ -163,6 +164,7 @@ module.exports = {
   isScalarAndEqual: isScalarAndEqual,
   recycleNodesInto: recycleNodesInto,
   simpleClone: simpleClone,
+  stableCopy: stableCopy,
   ROOT_ID: RelayStoreUtils.ROOT_ID,
   RelayConcreteNode: RelayConcreteNode,
 };


### PR DESCRIPTION
This cleans up some dependencies that weren't following module boundaries correctly. As a result we copied a couple of directories into every module we published. With this PR, we stop doing that and as a result have a total of over 100 fewer files imported (these are no longer in the dist folder):

```
relay-runtime/lib/relayUnstableBatchedUpdates.native.js
relay-runtime/lib/isCompatibleRelayFragmentType.js
relay-runtime/lib/RelayInternalTypes.js
relay-runtime/lib/testEditDistance.js
relay-runtime/lib/throwFailedPromise.js
relay-runtime/lib/RelayTaskQueue.js
relay-runtime/lib/relayUnstableBatchedUpdates.js
relay-runtime/lib/RelayInternals.js
relay-runtime/lib/RelayQueryCaching.js
relay-runtime/lib/RelayShallowMock.js
relay-runtime/lib/dedent.js
relay-runtime/lib/RelayNetworkDebug.js
relay-runtime/lib/RelayMockRenderer.js
relay-runtime/lib/RelayTypes.js
react-relay/lib/recycleNodesInto.js
react-relay/lib/isScalarAndEqual.js
react-relay/lib/RelayProfiler.js
react-relay/lib/stableCopy.js
react-relay/lib/deepFreeze.js
react-relay/lib/RelayConcreteNode.js
react-relay/lib/simpleClone.js
react-relay/lib/RelayDefaultHandleKey.js
react-relay/lib/RelayRuntimeTypes.js
react-relay/lib/isPromise.js
react-relay/lib/getRelayHandleKey.js
react-relay/lib/RelayError.js
relay-compiler/lib/recycleNodesInto.js
relay-compiler/lib/isScalarAndEqual.js
relay-compiler/lib/RelayProfiler.js
relay-compiler/lib/stableCopy.js
relay-compiler/lib/relayUnstableBatchedUpdates.native.js
relay-compiler/lib/isCompatibleRelayFragmentType.js
relay-compiler/lib/RelayInternalTypes.js
relay-compiler/lib/testEditDistance.js
relay-compiler/lib/deepFreeze.js
relay-compiler/lib/throwFailedPromise.js
relay-compiler/lib/RelayConcreteNode.js
relay-compiler/lib/RelayTaskQueue.js
relay-compiler/lib/relayUnstableBatchedUpdates.js
relay-compiler/lib/RelayInternals.js
relay-compiler/lib/RelayQueryCaching.js
relay-compiler/lib/simpleClone.js
relay-compiler/lib/RelayDefaultHandleKey.js
relay-compiler/lib/RelayRuntimeTypes.js
relay-compiler/lib/isPromise.js
relay-compiler/lib/getRelayHandleKey.js
relay-compiler/lib/RelayShallowMock.js
relay-compiler/lib/RelayError.js
relay-compiler/lib/dedent.js
relay-compiler/lib/RelayNetworkDebug.js
relay-compiler/lib/RelayMockRenderer.js
relay-compiler/lib/RelayTypes.js
babel-plugin-relay/lib/recycleNodesInto.js
babel-plugin-relay/lib/isScalarAndEqual.js
babel-plugin-relay/lib/RelayProfiler.js
babel-plugin-relay/lib/stableCopy.js
babel-plugin-relay/lib/relayUnstableBatchedUpdates.native.js
babel-plugin-relay/lib/isCompatibleRelayFragmentType.js
babel-plugin-relay/lib/RelayInternalTypes.js
babel-plugin-relay/lib/testEditDistance.js
babel-plugin-relay/lib/deepFreeze.js
babel-plugin-relay/lib/throwFailedPromise.js
babel-plugin-relay/lib/RelayConcreteNode.js
babel-plugin-relay/lib/RelayTaskQueue.js
babel-plugin-relay/lib/relayUnstableBatchedUpdates.js
babel-plugin-relay/lib/RelayInternals.js
babel-plugin-relay/lib/RelayQueryCaching.js
babel-plugin-relay/lib/simpleClone.js
babel-plugin-relay/lib/RelayDefaultHandleKey.js
babel-plugin-relay/lib/RelayRuntimeTypes.js
babel-plugin-relay/lib/isPromise.js
babel-plugin-relay/lib/getRelayHandleKey.js
babel-plugin-relay/lib/RelayShallowMock.js
babel-plugin-relay/lib/RelayError.js
babel-plugin-relay/lib/dedent.js
babel-plugin-relay/lib/RelayNetworkDebug.js
babel-plugin-relay/lib/RelayMockRenderer.js
babel-plugin-relay/lib/RelayTypes.js
relay-test-utils/lib/recycleNodesInto.js
relay-test-utils/lib/isScalarAndEqual.js
relay-test-utils/lib/RelayProfiler.js
relay-test-utils/lib/stableCopy.js
relay-test-utils/lib/relayUnstableBatchedUpdates.native.js
relay-test-utils/lib/isCompatibleRelayFragmentType.js
relay-test-utils/lib/RelayInternalTypes.js
relay-test-utils/lib/testEditDistance.js
relay-test-utils/lib/deepFreeze.js
relay-test-utils/lib/throwFailedPromise.js
relay-test-utils/lib/RelayConcreteNode.js
relay-test-utils/lib/RelayTaskQueue.js
relay-test-utils/lib/relayUnstableBatchedUpdates.js
relay-test-utils/lib/RelayInternals.js
relay-test-utils/lib/RelayQueryCaching.js
relay-test-utils/lib/simpleClone.js
relay-test-utils/lib/RelayDefaultHandleKey.js
relay-test-utils/lib/RelayRuntimeTypes.js
relay-test-utils/lib/isPromise.js
relay-test-utils/lib/getRelayHandleKey.js
relay-test-utils/lib/RelayShallowMock.js
relay-test-utils/lib/RelayError.js
relay-test-utils/lib/dedent.js
relay-test-utils/lib/RelayNetworkDebug.js
relay-test-utils/lib/RelayMockRenderer.js
relay-test-utils/lib/RelayTypes.js
```