### PR TITLE
Update node versions for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache: yarn
 
 matrix:
   include:
-  - node_js: '8'
+  - node_js: '9'
     env: TEST=1
-  - node_js: '7'
+  - node_js: '8'
     env: TEST=1
   - node_js: '6'
     env: TEST=1


### PR DESCRIPTION
Removes Node 7 and adds Node 9 to reflect the current supported versions
on https://github.com/nodejs/Release#release-schedule