### PR TITLE
support scalar handles in data loader

### DIFF
--- a/packages/relay-runtime/store/DataChecker.js
+++ b/packages/relay-runtime/store/DataChecker.js
@@ -277,6 +277,7 @@ class DataChecker {
           this._traverseSelections(selection.selections, dataID);
           break;
         case SCALAR_HANDLE:
+          break;
         case FRAGMENT_SPREAD:
           invariant(
             false,


### PR DESCRIPTION
Currently, the ~~data loader~~ `DataChecker` does not support scalar handles. 


## Reproduction
1. Set `dataFrom: 'STORE_THEN_NETWORK'` in the queryFetcher
2. Run a query like the following:

```js
query RideBikes {
  foo {
    bar @__clientField(handle: "handleBars")
  }
}
```
