### PR TITLE
 GraphQLIRVisitor: visit ObjectValue and ObjectFieldValue

### DIFF
--- a/packages/graphql-compiler/core/GraphQLIRVisitor.js
+++ b/packages/graphql-compiler/core/GraphQLIRVisitor.js
@@ -41,6 +41,8 @@ const NodeKeys = {
   LinkedField: ['args', 'directives', 'selections'],
   Literal: [],
   LocalArgumentDefinition: [],
+  ObjectValue: [`fields`],
+  ObjectFieldValue: [`value`],
   Request: ['root'],
   Root: ['argumentDefinitions', 'directives', 'selections'],
   RootArgumentDefinition: [],

--- a/packages/relay-compiler/codegen/__tests__/__snapshots__/RelayCodeGenerator-test.js.snap
+++ b/packages/relay-compiler/codegen/__tests__/__snapshots__/RelayCodeGenerator-test.js.snap
@@ -175,9 +175,9 @@ Invariant Violation: RelayCodeGenerator: Complex argument values (Lists or Input
       "name": "date",
       "value": {
         "kind": "Variable",
-        "metadata": null,
+        "name": "date",
         "variableName": "date",
-        "type": "String"
+        "type": null
       }
     }
   ]

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/StripUnusedVariablesTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/StripUnusedVariablesTransform-test.js.snap
@@ -44,6 +44,14 @@ fragment NestedTwoLevels on User {
   }
 }
 
+query TestQuery3(
+  $usedInInputObject: String!
+) {
+  items(filter: { date: $usedInInputObject }) {
+    date
+  }
+}
+
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 fragment TestFragment on Actor {
   id @skip(if: $usedInDirective)
@@ -77,6 +85,14 @@ fragment NestedOneLevel on User {
 fragment NestedTwoLevels on User {
   profile_picture(scale: $usedInNested) {
     uri
+  }
+}
+
+query TestQuery3(
+  $usedInInputObject: String!
+) {
+  items(filter: {date: $usedInInputObject}) {
+    date
   }
 }
 

--- a/packages/relay-compiler/transforms/__tests__/fixtures/strip-unused-variables-transform/kitchen-sink.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/strip-unused-variables-transform/kitchen-sink.graphql
@@ -39,3 +39,11 @@ fragment NestedTwoLevels on User {
     uri
   }
 }
+
+query TestQuery3(
+  $usedInInputObject: String!
+) {
+  items(filter: { date: $usedInInputObject }) {
+    date
+  }
+}


### PR DESCRIPTION
This fixes variables used in InputObject not being detected in `StripUnusedVariablesTransform.js` and therefore being stripped from resulting query.

Before this:
```gql
query TestQuery3(
  $usedInInputObject: String!
) {
  items(filter: { date: $usedInInputObject }) {
    date
  }
}
```

Would be compiled to (missing query argument declaration)
```gql
query TestQuery3 {
  items(filter: {date: $usedInInputObject}) {
    date
  }
}
````

I'm not familiar with codegen part, so please advise on how to deal with how my change affected it (see RelayCodeGenerator-test.js.snap change).