### PR TITLE
[docs] Fix broken URL in classic docs

### DIFF
--- a/website/versioned_docs/version-classic/Classic-APIReference-QL.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-QL.md
@@ -49,7 +49,7 @@ Fragments can be composed in one of two ways:
 
 ### Container.getFragment()
 
-Composing the fragments of child components is discussed in detail in the [Containers Guide](guides-containers.html), but here's a quick example:
+Composing the fragments of child components is discussed in detail in the [Containers Guide](classic-guides-containers.html), but here's a quick example:
 
 ```{5}
 Relay.createContainer(Foo, {


### PR DESCRIPTION
Fixes broken url by adding `classic-` prefix.

Similar to this [issue](https://github.com/facebook/relay/pull/2396) and the same problem probably exists in several places throughout the docs.