### PR TITLE
Remove @providesModule from all modules

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,10 +17,26 @@ node_modules/fbjs/flow/lib
 
 [options]
 module.system=haste
+module.system.haste.use_name_reducers=true
+# keep the following in sync with server/haste/hasteImpl.js
+# get basename
+module.system.haste.name_reducers='^.*/\([a-zA-Z0-9$_.-]+\.js\(\.flow\)?\)$' -> '\1'
+# strip .js or .js.flow suffix
+module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
+# strip .ios suffix
+module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
+module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'
+module.system.haste.name_reducers='^\(.*\)\.native$' -> '\1'
+module.system.haste.paths.blacklist=.*/__tests__/.*
+module.system.haste.paths.blacklist=.*/__mocks__/.*
+module.system.haste.paths.blacklist=<PROJECT_ROOT>/packages/react-relay/.*
+module.system.haste.paths.blacklist=<PROJECT_ROOT>/packages/babel-plugin-relay/invariant.js
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/packages/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/fbjs/lib/.*
+
 module.name_mapper='^ReactDOM$' -> 'react-dom'
 ; TODO(T25740028) once we're fully on babylon 7, we can remove this hack.
 module.name_mapper='^metro-babylon7$' -> 'babylon'
-module.system.haste.paths.blacklist=<PROJECT_ROOT>/packages/react-relay/.*
 
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable

--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
     "parser": "flow"
   },
   "jest": {
+    "haste": {
+      "hasteImplModulePath": "<rootDir>/scripts/jest/hasteImpl.js"
+    },
     "modulePathIgnorePatterns": [
       "<rootDir>/lib/",
       "<rootDir>/node_modules/(?!(fbjs/lib/|react/lib/|fbjs-scripts/jest))"

--- a/packages/babel-plugin-relay/BabelPluginRelay.js
+++ b/packages/babel-plugin-relay/BabelPluginRelay.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule BabelPluginRelay
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/compileGraphQLTag.js
+++ b/packages/babel-plugin-relay/compileGraphQLTag.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule compileGraphQLTag
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/compileRelayQLTag.js
+++ b/packages/babel-plugin-relay/compileRelayQLTag.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule compileRelayQLTag
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/createClassicNode.js
+++ b/packages/babel-plugin-relay/createClassicNode.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule createClassicNode
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/createCompatNode.js
+++ b/packages/babel-plugin-relay/createCompatNode.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule createCompatNode
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/createModernNode.js
+++ b/packages/babel-plugin-relay/createModernNode.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule createModernNode
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/createTransformError.js
+++ b/packages/babel-plugin-relay/createTransformError.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule createTransformError
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/getClassicTransformer.js
+++ b/packages/babel-plugin-relay/getClassicTransformer.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule getClassicTransformer
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/getDocumentName.js
+++ b/packages/babel-plugin-relay/getDocumentName.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule getDocumentName
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/getFragmentNameParts.js
+++ b/packages/babel-plugin-relay/getFragmentNameParts.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule getFragmentNameParts
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/getValidGraphQLTag.js
+++ b/packages/babel-plugin-relay/getValidGraphQLTag.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule getValidGraphQLTag
  * @flow
  * @format
  */

--- a/packages/babel-plugin-relay/getValidRelayQLTag.js
+++ b/packages/babel-plugin-relay/getValidRelayQLTag.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule getValidRelayQLTag
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/GraphQLCompilerPublic.js
+++ b/packages/graphql-compiler/GraphQLCompilerPublic.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule GraphQLCompilerPublic
  * @format
  */
 

--- a/packages/graphql-compiler/codegen/CodegenDirectory.js
+++ b/packages/graphql-compiler/codegen/CodegenDirectory.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule CodegenDirectory
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/codegen/CodegenRunner.js
+++ b/packages/graphql-compiler/codegen/CodegenRunner.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule CodegenRunner
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/codegen/CodegenTypes.js
+++ b/packages/graphql-compiler/codegen/CodegenTypes.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule CodegenTypes
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/codegen/CodegenWatcher.js
+++ b/packages/graphql-compiler/codegen/CodegenWatcher.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule CodegenWatcher
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/codegen/SourceControl.js
+++ b/packages/graphql-compiler/codegen/SourceControl.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule SourceControl
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/ASTCache.js
+++ b/packages/graphql-compiler/core/ASTCache.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ASTCache
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/ASTConvert.js
+++ b/packages/graphql-compiler/core/ASTConvert.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ASTConvert
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/DotGraphQLParser.js
+++ b/packages/graphql-compiler/core/DotGraphQLParser.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule DotGraphQLParser
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/GraphQLCompilerContext.js
+++ b/packages/graphql-compiler/core/GraphQLCompilerContext.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule GraphQLCompilerContext
  * @format
  */
 

--- a/packages/graphql-compiler/core/GraphQLCompilerProfiler.js
+++ b/packages/graphql-compiler/core/GraphQLCompilerProfiler.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLCompilerProfiler
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/GraphQLCompilerUserError.js
+++ b/packages/graphql-compiler/core/GraphQLCompilerUserError.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLCompilerUserError
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/GraphQLIR.js
+++ b/packages/graphql-compiler/core/GraphQLIR.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLIR
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/GraphQLIRPrinter.js
+++ b/packages/graphql-compiler/core/GraphQLIRPrinter.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule GraphQLIRPrinter
  * @format
  */
 

--- a/packages/graphql-compiler/core/GraphQLIRTransformer.js
+++ b/packages/graphql-compiler/core/GraphQLIRTransformer.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLIRTransformer
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/GraphQLIRTransforms.js
+++ b/packages/graphql-compiler/core/GraphQLIRTransforms.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLIRTransforms
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/GraphQLIRVisitor.js
+++ b/packages/graphql-compiler/core/GraphQLIRVisitor.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLIRVisitor
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/GraphQLParser.js
+++ b/packages/graphql-compiler/core/GraphQLParser.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLParser
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/GraphQLSchemaUtils.js
+++ b/packages/graphql-compiler/core/GraphQLSchemaUtils.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLSchemaUtils
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/GraphQLValidator.js
+++ b/packages/graphql-compiler/core/GraphQLValidator.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule GraphQLValidator
  * @format
  */
 

--- a/packages/graphql-compiler/core/GraphQLWatchmanClient.js
+++ b/packages/graphql-compiler/core/GraphQLWatchmanClient.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLWatchmanClient
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/filterContextForNode.js
+++ b/packages/graphql-compiler/core/filterContextForNode.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule filterContextForNode
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/getIdentifierForArgumentValue.js
+++ b/packages/graphql-compiler/core/getIdentifierForArgumentValue.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule getIdentifierForArgumentValue
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/getIdentifierForSelection.js
+++ b/packages/graphql-compiler/core/getIdentifierForSelection.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule getIdentifierForSelection
  * @format
  */
 

--- a/packages/graphql-compiler/core/getLiteralArgumentValues.js
+++ b/packages/graphql-compiler/core/getLiteralArgumentValues.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule getLiteralArgumentValues
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/core/isEquivalentType.js
+++ b/packages/graphql-compiler/core/isEquivalentType.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule isEquivalentType
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/reporters/GraphQLConsoleReporter.js
+++ b/packages/graphql-compiler/reporters/GraphQLConsoleReporter.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLConsoleReporter
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/reporters/GraphQLMultiReporter.js
+++ b/packages/graphql-compiler/reporters/GraphQLMultiReporter.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLMultiReporter
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/reporters/GraphQLReporter.js
+++ b/packages/graphql-compiler/reporters/GraphQLReporter.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule GraphQLReporter
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/transforms/FilterDirectivesTransform.js
+++ b/packages/graphql-compiler/transforms/FilterDirectivesTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule FilterDirectivesTransform
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/transforms/FlattenTransform.js
+++ b/packages/graphql-compiler/transforms/FlattenTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule FlattenTransform
  * @format
  * @flow
  */

--- a/packages/graphql-compiler/transforms/InlineFragmentsTransform.js
+++ b/packages/graphql-compiler/transforms/InlineFragmentsTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule InlineFragmentsTransform
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/transforms/SkipClientFieldTransform.js
+++ b/packages/graphql-compiler/transforms/SkipClientFieldTransform.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule SkipClientFieldTransform
  * @format
  */
 

--- a/packages/graphql-compiler/transforms/SkipRedundantNodesTransform.js
+++ b/packages/graphql-compiler/transforms/SkipRedundantNodesTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule SkipRedundantNodesTransform
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/transforms/SkipUnreachableNodeTransform.js
+++ b/packages/graphql-compiler/transforms/SkipUnreachableNodeTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule SkipUnreachableNodeTransform
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/transforms/StripUnusedVariablesTransform.js
+++ b/packages/graphql-compiler/transforms/StripUnusedVariablesTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule StripUnusedVariablesTransform
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/util/DefaultHandleKey.js
+++ b/packages/graphql-compiler/util/DefaultHandleKey.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule DefaultHandleKey
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/util/areEqualOSS.js
+++ b/packages/graphql-compiler/util/areEqualOSS.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule areEqualOSS
  * @flow
  * @format
  */

--- a/packages/graphql-compiler/util/nullthrowsOSS.js
+++ b/packages/graphql-compiler/util/nullthrowsOSS.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule nullthrowsOSS
  * @flow
  * @format
  */

--- a/packages/relay-compiler/RelayCompilerPublic.js
+++ b/packages/relay-compiler/RelayCompilerPublic.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayCompilerPublic
  * @format
  */
 

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayCompilerBin
  * @format
  */
 

--- a/packages/relay-compiler/codegen/FindGraphQLTags.js
+++ b/packages/relay-compiler/codegen/FindGraphQLTags.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule FindGraphQLTags
  * @flow
  * @format
  */

--- a/packages/relay-compiler/codegen/RelayCodeGenerator.js
+++ b/packages/relay-compiler/codegen/RelayCodeGenerator.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayCodeGenerator
  * @flow
  * @format
  */

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayFileWriter
  * @flow
  * @format
  */

--- a/packages/relay-compiler/codegen/compileRelayArtifacts.js
+++ b/packages/relay-compiler/codegen/compileRelayArtifacts.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule compileRelayArtifacts
  * @flow
  * @format
  */

--- a/packages/relay-compiler/codegen/deepMergeAssignments.js
+++ b/packages/relay-compiler/codegen/deepMergeAssignments.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule deepMergeAssignments
  * @flow
  * @format
  */

--- a/packages/relay-compiler/codegen/formatGeneratedModule.js
+++ b/packages/relay-compiler/codegen/formatGeneratedModule.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule formatGeneratedModule
  * @flow
  * @format
  */

--- a/packages/relay-compiler/codegen/requestsForOperation.js
+++ b/packages/relay-compiler/codegen/requestsForOperation.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule requestsForOperation
  * @flow
  * @format
  */

--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule writeRelayGeneratedFile
  * @flow
  * @format
  */

--- a/packages/relay-compiler/core/RelayCompilerScope.js
+++ b/packages/relay-compiler/core/RelayCompilerScope.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayCompilerScope
  * @flow
  * @format
  */

--- a/packages/relay-compiler/core/RelayFlowBabelFactories.js
+++ b/packages/relay-compiler/core/RelayFlowBabelFactories.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayFlowBabelFactories
  * @flow
  * @format
  */

--- a/packages/relay-compiler/core/RelayFlowGenerator.js
+++ b/packages/relay-compiler/core/RelayFlowGenerator.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayFlowGenerator
  * @flow
  * @format
  */

--- a/packages/relay-compiler/core/RelayFlowTypeTransformers.js
+++ b/packages/relay-compiler/core/RelayFlowTypeTransformers.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayFlowTypeTransformers
  * @flow
  * @format
  */

--- a/packages/relay-compiler/core/RelayGraphQLEnumsGenerator.js
+++ b/packages/relay-compiler/core/RelayGraphQLEnumsGenerator.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayGraphQLEnumsGenerator
  * @flow
  * @format
  */
@@ -44,7 +43,6 @@ function writeForSchema(
     '/**\n' +
     licenseHeader.map(line => ` * ${line}\n`).join('') +
     ' *\n' +
-    ` * @providesModule ${moduleName}\n` +
     ` * ${SignedSource.getSigningToken()}\n` +
     ' * @flow\n' +
     ' */\n' +

--- a/packages/relay-compiler/core/RelayIRTransforms.js
+++ b/packages/relay-compiler/core/RelayIRTransforms.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayIRTransforms
  * @flow
  * @format
  */

--- a/packages/relay-compiler/core/RelayJSModuleParser.js
+++ b/packages/relay-compiler/core/RelayJSModuleParser.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayJSModuleParser
  * @flow
  * @format
  */

--- a/packages/relay-compiler/core/RelayParser.js
+++ b/packages/relay-compiler/core/RelayParser.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayParser
  * @flow
  * @format
  */

--- a/packages/relay-compiler/core/RelayValidator.js
+++ b/packages/relay-compiler/core/RelayValidator.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayValidator
  * @format
  */
 

--- a/packages/relay-compiler/handlers/connection/RelayConnectionConstants.js
+++ b/packages/relay-compiler/handlers/connection/RelayConnectionConstants.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayConnectionConstants
  * @flow
  * @format
  */

--- a/packages/relay-compiler/handlers/connection/RelayConnectionTransform.js
+++ b/packages/relay-compiler/handlers/connection/RelayConnectionTransform.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayConnectionTransform
  * @format
  */
 

--- a/packages/relay-compiler/handlers/viewer/RelayViewerHandleTransform.js
+++ b/packages/relay-compiler/handlers/viewer/RelayViewerHandleTransform.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayViewerHandleTransform
  * @format
  */
 

--- a/packages/relay-compiler/transforms/RelayApplyFragmentArgumentTransform.js
+++ b/packages/relay-compiler/transforms/RelayApplyFragmentArgumentTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayApplyFragmentArgumentTransform
  * @flow
  * @format
  */

--- a/packages/relay-compiler/transforms/RelayDeferrableFragmentTransform.js
+++ b/packages/relay-compiler/transforms/RelayDeferrableFragmentTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayDeferrableFragmentTransform
  * @flow
  * @format
  */

--- a/packages/relay-compiler/transforms/RelayFieldHandleTransform.js
+++ b/packages/relay-compiler/transforms/RelayFieldHandleTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayFieldHandleTransform
  * @flow
  * @format
  */

--- a/packages/relay-compiler/transforms/RelayGenerateIDFieldTransform.js
+++ b/packages/relay-compiler/transforms/RelayGenerateIDFieldTransform.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayGenerateIDFieldTransform
  * @format
  */
 

--- a/packages/relay-compiler/transforms/RelayGenerateTypeNameTransform.js
+++ b/packages/relay-compiler/transforms/RelayGenerateTypeNameTransform.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayGenerateTypeNameTransform
  * @format
  */
 

--- a/packages/relay-compiler/transforms/RelayMaskTransform.js
+++ b/packages/relay-compiler/transforms/RelayMaskTransform.js
@@ -6,7 +6,6 @@
  *
  * All rights reserved.
  *
- * @providesModule RelayMaskTransform
  * @flow
  * @format
  */

--- a/packages/relay-compiler/transforms/RelayRelayDirectiveTransform.js
+++ b/packages/relay-compiler/transforms/RelayRelayDirectiveTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRelayDirectiveTransform
  * @flow
  * @format
  */

--- a/packages/relay-compiler/transforms/RelaySkipHandleFieldTransform.js
+++ b/packages/relay-compiler/transforms/RelaySkipHandleFieldTransform.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelaySkipHandleFieldTransform
  * @flow
  * @format
  */

--- a/packages/relay-compiler/transforms/RelayTransformUtils.js
+++ b/packages/relay-compiler/transforms/RelayTransformUtils.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayTransformUtils
  * @format
  */
 

--- a/packages/relay-compiler/util/RelayCompilerCache.js
+++ b/packages/relay-compiler/util/RelayCompilerCache.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayCompilerCache
  * @flow
  * @format
  */

--- a/packages/relay-compiler/util/dedupeJSONStringify.js
+++ b/packages/relay-compiler/util/dedupeJSONStringify.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule dedupeJSONStringify
  * @flow
  * @format
  */

--- a/packages/relay-compiler/util/getModuleName.js
+++ b/packages/relay-compiler/util/getModuleName.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule getModuleName
  * @flow
  * @format
  */

--- a/packages/relay-compiler/util/murmurHash.js
+++ b/packages/relay-compiler/util/murmurHash.js
@@ -6,7 +6,6 @@
  *
  * Based on implementations by Gary Court and Austin Appleby, 2011, MIT.
  *
- * @providesModule murmurHash
  * @flow
  * @format
  */

--- a/packages/relay-runtime/RelayRuntime.js
+++ b/packages/relay-runtime/RelayRuntime.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRuntime
  * @flow
  * @format
  */

--- a/packages/relay-runtime/handlers/RelayDefaultHandlerProvider.js
+++ b/packages/relay-runtime/handlers/RelayDefaultHandlerProvider.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayDefaultHandlerProvider
  * @flow
  * @format
  */

--- a/packages/relay-runtime/handlers/connection/RelayConnectionHandler.js
+++ b/packages/relay-runtime/handlers/connection/RelayConnectionHandler.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayConnectionHandler
  * @flow
  * @format
  */

--- a/packages/relay-runtime/handlers/connection/RelayConnectionInterface.js
+++ b/packages/relay-runtime/handlers/connection/RelayConnectionInterface.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayConnectionInterface
  * @flow
  * @format
  */

--- a/packages/relay-runtime/handlers/viewer/RelayViewerHandler.js
+++ b/packages/relay-runtime/handlers/viewer/RelayViewerHandler.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayViewerHandler
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
+++ b/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayDeclarativeMutationConfig
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/RelayRecordProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordProxy.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordProxy
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/RelayRecordSourceMutator.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceMutator.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordSourceMutator
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordSourceProxy
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordSourceSelectorProxy
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/applyRelayModernOptimisticMutation.js
+++ b/packages/relay-runtime/mutations/applyRelayModernOptimisticMutation.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule applyRelayModernOptimisticMutation
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/commitLocalUpdate.js
+++ b/packages/relay-runtime/mutations/commitLocalUpdate.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule commitLocalUpdate
  * @flow
  * @format
  */

--- a/packages/relay-runtime/mutations/commitRelayModernMutation.js
+++ b/packages/relay-runtime/mutations/commitRelayModernMutation.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule commitRelayModernMutation
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/ConvertToExecuteFunction.js
+++ b/packages/relay-runtime/network/ConvertToExecuteFunction.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule ConvertToExecuteFunction
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayNetwork.js
+++ b/packages/relay-runtime/network/RelayNetwork.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayNetwork
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayNetworkLogger.js
+++ b/packages/relay-runtime/network/RelayNetworkLogger.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayNetworkLogger
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayNetworkLoggerTransaction.js
+++ b/packages/relay-runtime/network/RelayNetworkLoggerTransaction.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayNetworkLoggerTransaction
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayNetworkTypes.js
+++ b/packages/relay-runtime/network/RelayNetworkTypes.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayNetworkTypes
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayObservable.js
+++ b/packages/relay-runtime/network/RelayObservable.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayObservable
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/RelayQueryResponseCache.js
+++ b/packages/relay-runtime/network/RelayQueryResponseCache.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayQueryResponseCache
  * @flow
  * @format
  */

--- a/packages/relay-runtime/network/createRelayNetworkLogger.js
+++ b/packages/relay-runtime/network/createRelayNetworkLogger.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule createRelayNetworkLogger
  * @flow
  * @format
  */

--- a/packages/relay-runtime/query/RelayModernGraphQLTag.js
+++ b/packages/relay-runtime/query/RelayModernGraphQLTag.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernGraphQLTag
  * @flow
  * @format
  */

--- a/packages/relay-runtime/query/fetchRelayModernQuery.js
+++ b/packages/relay-runtime/query/fetchRelayModernQuery.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule fetchRelayModernQuery
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayConcreteVariables.js
+++ b/packages/relay-runtime/store/RelayConcreteVariables.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayConcreteVariables
  * @format
  */
 

--- a/packages/relay-runtime/store/RelayCore.js
+++ b/packages/relay-runtime/store/RelayCore.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayCore
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayDataLoader.js
+++ b/packages/relay-runtime/store/RelayDataLoader.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayDataLoader
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayInMemoryRecordSource.js
+++ b/packages/relay-runtime/store/RelayInMemoryRecordSource.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayInMemoryRecordSource
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayMarkSweepStore.js
+++ b/packages/relay-runtime/store/RelayMarkSweepStore.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayMarkSweepStore
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernEnvironment
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
+++ b/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernFragmentSpecResolver
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernOperationSelector.js
+++ b/packages/relay-runtime/store/RelayModernOperationSelector.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernOperationSelector
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernRecord.js
+++ b/packages/relay-runtime/store/RelayModernRecord.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernRecord
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayModernSelector.js
+++ b/packages/relay-runtime/store/RelayModernSelector.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernSelector
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayPublishQueue.js
+++ b/packages/relay-runtime/store/RelayPublishQueue.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule RelayPublishQueue
  * @format
  */
 

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayReader
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayRecordState.js
+++ b/packages/relay-runtime/store/RelayRecordState.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRecordState
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayReferenceMarker.js
+++ b/packages/relay-runtime/store/RelayReferenceMarker.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayReferenceMarker
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayResponseNormalizer
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayStoreTypes
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/RelayStoreUtils.js
+++ b/packages/relay-runtime/store/RelayStoreUtils.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayStoreUtils
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/cloneRelayHandleSourceField.js
+++ b/packages/relay-runtime/store/cloneRelayHandleSourceField.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule cloneRelayHandleSourceField
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/deferrableFragmentKey.js
+++ b/packages/relay-runtime/store/deferrableFragmentKey.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule deferrableFragmentKey
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/generateRelayClientID.js
+++ b/packages/relay-runtime/store/generateRelayClientID.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule generateRelayClientID
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/hasOverlappingIDs.js
+++ b/packages/relay-runtime/store/hasOverlappingIDs.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule hasOverlappingIDs
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/isRelayModernEnvironment.js
+++ b/packages/relay-runtime/store/isRelayModernEnvironment.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule isRelayModernEnvironment
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/normalizePayload.js
+++ b/packages/relay-runtime/store/normalizePayload.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule normalizePayload
  * @flow
  * @format
  */

--- a/packages/relay-runtime/store/normalizeRelayPayload.js
+++ b/packages/relay-runtime/store/normalizeRelayPayload.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule normalizeRelayPayload
  * @flow
  * @format
  */

--- a/packages/relay-runtime/subscription/requestRelaySubscription.js
+++ b/packages/relay-runtime/subscription/requestRelaySubscription.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule requestRelaySubscription
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/RelayConcreteNode.js
+++ b/packages/relay-runtime/util/RelayConcreteNode.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayConcreteNode
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/RelayDefaultHandleKey.js
+++ b/packages/relay-runtime/util/RelayDefaultHandleKey.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayDefaultHandleKey
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/RelayError.js
+++ b/packages/relay-runtime/util/RelayError.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayError
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/RelayProfiler.js
+++ b/packages/relay-runtime/util/RelayProfiler.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayProfiler
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/RelayRuntimeTypes.js
+++ b/packages/relay-runtime/util/RelayRuntimeTypes.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayRuntimeTypes
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/deepFreeze.js
+++ b/packages/relay-runtime/util/deepFreeze.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule deepFreeze
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/getRelayHandleKey.js
+++ b/packages/relay-runtime/util/getRelayHandleKey.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule getRelayHandleKey
  * @format
  */
 

--- a/packages/relay-runtime/util/isPromise.js
+++ b/packages/relay-runtime/util/isPromise.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule isPromise
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/isScalarAndEqual.js
+++ b/packages/relay-runtime/util/isScalarAndEqual.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule isScalarAndEqual
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/recycleNodesInto.js
+++ b/packages/relay-runtime/util/recycleNodesInto.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule recycleNodesInto
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/simpleClone.js
+++ b/packages/relay-runtime/util/simpleClone.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule simpleClone
  * @flow
  * @format
  */

--- a/packages/relay-runtime/util/stableCopy.js
+++ b/packages/relay-runtime/util/stableCopy.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule stableCopy
  * @flow
  * @format
  */

--- a/packages/relay-test-utils/RelayModernMockEnvironment.js
+++ b/packages/relay-test-utils/RelayModernMockEnvironment.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernMockEnvironment
  * @format
  */
 

--- a/packages/relay-test-utils/RelayModernTestUtils.js
+++ b/packages/relay-test-utils/RelayModernTestUtils.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayModernTestUtils
  * @format
  */
 

--- a/packages/relay-test-utils/RelayTestSchema.js
+++ b/packages/relay-test-utils/RelayTestSchema.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayTestSchema
  * @flow
  * @format
  */

--- a/packages/relay-test-utils/RelayTestSchemaPath.js
+++ b/packages/relay-test-utils/RelayTestSchemaPath.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule RelayTestSchemaPath
  * @flow
  * @format
  */

--- a/packages/relay-test-utils/RelayTestUtilsPublic.js
+++ b/packages/relay-test-utils/RelayTestUtilsPublic.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @providesModule RelayTestUtilsPublic
  */
 
 'use strict';

--- a/packages/relay-test-utils/parseGraphQLText.js
+++ b/packages/relay-test-utils/parseGraphQLText.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule parseGraphQLText
  * @flow
  * @format
  */

--- a/scripts/jest/hasteImpl.js
+++ b/scripts/jest/hasteImpl.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+const BLACKLISTED_PATTERNS/*: Array<RegExp>*/ = [
+  /.*\/__(mocks|tests)__\/.*/,
+  /^packages\/babel-plugin-relay\/invariant\.js/,
+];
+
+const WHITELISTED_PREFIXES/*: Array<string>*/ = [
+  'packages'
+];
+
+const NAME_REDUCERS/*: Array<[RegExp, string]>*/ = [
+  // extract basename
+  [/^(?:.*\/)?([a-zA-Z0-9$_.-]+)$/, '$1'],
+  // strip .js/.js.flow suffix
+  [/^(.*)\.js(\.flow)?$/, '$1'],
+  // strip .android/.ios/.native/.web suffix
+  [/^(.*)\.(android|ios|native|web)$/, '$1'],
+];
+
+const haste = {
+  /*
+   * @return {string|void} hasteName for module at filePath; or undefined if
+   *                       filePath is not a haste module
+   */
+  getHasteName(
+    filePath/*: string*/,
+    sourceCode/* : ?string*/
+  )/*: (string | void)*/ {
+    if (!isHastePath(filePath)) {
+      return undefined;
+    }
+
+    const hasteName = NAME_REDUCERS.reduce(
+      (name, [pattern, replacement]) => name.replace(pattern, replacement),
+      filePath
+    );
+
+    return hasteName;
+  },
+};
+
+function isHastePath(filePath/*: string*/)/*: bool*/ {
+  if (!filePath.endsWith('.js') && !filePath.endsWith('.js.flow')) {
+    return false;
+  }
+
+  if (!filePath.startsWith(ROOT)) {
+    return false;
+  }
+
+  filePath = filePath.substr(ROOT.length + 1);
+  if (BLACKLISTED_PATTERNS.some(pattern => pattern.test(filePath))) {
+    return false;
+  }
+  return WHITELISTED_PREFIXES.some(prefix => filePath.startsWith(prefix));
+}
+
+module.exports = haste;


### PR DESCRIPTION
This PR removes the need for having the `@providesModule` tags in all the modules in the repository.

It configures Flow and Jest to get the module names from the filenames (`packages/babel-plugin-relay/getValidGraphQLTag.js` => `getValidGraphQLTag`)

Test plan:

* Checked the Flow configuration by running flow on the project root (no errors):

```
yarn flow
```

* Checked the Jest configuration by running the tests with a clean cache:

```
yarn jest --clearCache && yarn test
```