### PR TITLE
Fix CI for node 6

### DIFF
--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -4,8 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
- * @format
+ * @noformat
  */
 
 'use strict';
@@ -17,7 +16,7 @@ module.exports = function(options) {
       moduleMap: {},
       plugins: [],
     },
-    options,
+    options
   );
 
   const fbjsPreset = require('babel-preset-fbjs/configure')({


### PR DESCRIPTION
This file is executed without transforms so we can't have trailing commas in function calls until we drop node 6.