### PR TITLE
Add prettier-ignore to generated files

### DIFF
--- a/packages/relay-compiler/codegen/formatGeneratedModule.js
+++ b/packages/relay-compiler/codegen/formatGeneratedModule.js
@@ -39,6 +39,7 @@ ${flowText || ''}
 
 ${docTextComment}
 const node/*: ${documentType}*/ = ${concreteText};
+// prettier-ignore
 (node/*: any*/).hash = '${sourceHash}';
 module.exports = node;
 `;


### PR DESCRIPTION
When prettier is run on the generated files, it removes the parenthesis resulting in flow failing.

Adding the prettier-ignore comment skip formatting of this line.

Fixes #2426 

Test Plan:
https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAKKEAmcD0AqJAAgEMoBPPHASgDoALYgZzsIF5CByAEmEYgFcATmDgAJJnQC+HANwAdKApw5CAB0FwYMAJZxBAWm0BzDBoXosuAiXKVaDZm048+QkeObSZIADQgIqjrQjMigxIKCEADuAArhCCEoxABuENqYviAARoLEYADWmgDKqnnaUEbIMIL8cH7ljHowMblGALbEyABmxAA2jX4AVowAHgBCuQXFxG1wADLlcN19AyClgo2CyNnEWWS90Jnq5TAA6ukwdMgAHAAMfuoQjae5qtvqcJvJS34aAI78bQaFrEdqdJA9fp1ECNNraKo1aGMcpGXpwACK-Ag8GWUL8MF250wl2QACZ8bltL0UQBhCBtDrbDBQH4gfiNAAqu0SkMakkkQA