### PR TITLE
Bump graphql dependency to ^0.13.0

### DIFF
--- a/packages/babel-plugin-relay/package.json
+++ b/packages/babel-plugin-relay/package.json
@@ -17,6 +17,6 @@
     "babel-types": "^6.24.1"
   },
   "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0"
+    "graphql": "^0.13.0"
   }
 }

--- a/packages/graphql-compiler/package.json
+++ b/packages/graphql-compiler/package.json
@@ -10,6 +10,6 @@
     "immutable": "~3.7.6"
   },
   "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0"
+    "graphql": "^0.13.0"
   }
 }

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -33,6 +33,6 @@
     "yargs": "^9.0.0"
   },
   "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0"
+    "graphql": "^0.13.0"
   }
 }

--- a/packages/relay-test-utils/package.json
+++ b/packages/relay-test-utils/package.json
@@ -18,7 +18,7 @@
     "relay-compiler": "1.6.0"
   },
   "peerDependencies": {
-    "graphql": "^0.12.0 || ^0.13.0"
+    "graphql": "^0.13.0"
   },
   "haste_commonjs": true
 }


### PR DESCRIPTION
At some point we broke support for graphql 0.12.x (see #2428). It might not be a difficult fix to get it working again, but since we don't have a regression test and graphql@0.13 has been out for a while, I propose just removing 0.12 support.

Fixes #2428.