### PR TITLE
Update link to Babel plugin ordering

### DIFF
--- a/docs/Introduction-InstallationAndSetup.md
+++ b/docs/Introduction-InstallationAndSetup.md
@@ -31,7 +31,7 @@ Add `"relay"` to the list of plugins your `.babelrc` file:
 
 Please note that the `"relay"` plugin should run before other plugins or
 presets to ensure the `graphql` template literals are correctly transformed. See
-Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#plugin-preset-ordering).
+Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#pluginpreset-ordering).
 
 See the [Migration Setup](./migration-setup.html) guide if upgrading an existing Relay app.
 


### PR DESCRIPTION
Seems like the anchor at https://babeljs.io/docs/plugins/ has changed.