### PR TITLE
Remove unnecessary arguments to relay compiler

### DIFF
--- a/docs/Introduction-InstallationAndSetup.md
+++ b/docs/Introduction-InstallationAndSetup.md
@@ -68,7 +68,7 @@ yarn run relay
 Alternatively, you can pass the `--watch` option to watch for file changes in your source code and automatically re-generate the compiled artifacts (**Note:** Requires [watchman](https://facebook.github.io/watchman) to be installed):
 
 ```sh
-yarn run relay -- --watch
+yarn run relay --watch
 ```
 
 


### PR DESCRIPTION
Extra `--` arguments on relay-compiler. Even the command line says to execute `yarn run relay --watch`. Note no error comes while using the extra characters.