### PR TITLE
docs: fix link for `react-relay-network-modern`

### DIFF
--- a/docs/Modern-NetworkLayer.md
+++ b/docs/Modern-NetworkLayer.md
@@ -126,4 +126,4 @@ export default environment;
 ```
 
 ## Custom open-source implementations
-**[react-relay-network-modern](https://github.com/nodkz/react-relay-network-modern)** on [npm](https://www.npmjs.com/package/react-relay-network-modern) - is a Network Layer for Relay Modern which has built-in highly customizable middlewares for commonly used scenarios: batching query requests, caching, authentication, request retrying, logging. Moreover, you may write your own middlewares with custom logic.
+**[react-relay-network-modern](https://github.com/relay-tools/react-relay-network-modern)** on [npm](https://www.npmjs.com/package/react-relay-network-modern) - is a Network Layer for Relay Modern which has built-in highly customizable middlewares for commonly used scenarios: batching query requests, caching, authentication, request retrying, logging. Moreover, you may write your own middlewares with custom logic.


### PR DESCRIPTION
It was moved to `relay-tools` organization.