### PR TITLE
Update CI to node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ cache: yarn
 
 matrix:
   include:
-  - node_js: '9'
+  - node_js: '10'
     env: TEST=1
   - node_js: '8'
     env: TEST=1
   - node_js: '6'
     env: TEST=1
-  - node_js: '8'
+  - node_js: '10'
     env: TYPECHECK=1
-  - node_js: '8'
+  - node_js: '10'
     env: LINT=1
 
 script:


### PR DESCRIPTION
Node 9 is close to its end of life and being replaced by version 10.

https://github.com/nodejs/Release#release-schedule