### PR TITLE
[discussion] Change optimistic/server update ordering

### DIFF
--- a/packages/relay-runtime/store/RelayModernQueryExecutor.js
+++ b/packages/relay-runtime/store/RelayModernQueryExecutor.js
@@ -256,10 +256,6 @@ class Executor {
   }
 
   _processResponse(response: GraphQLResponseWithData): void {
-    if (this._optimisticUpdate !== null) {
-      this._publishQueue.revertUpdate(this._optimisticUpdate);
-      this._optimisticUpdate = null;
-    }
     const payload = normalizeResponse(
       response,
       this._operation.root,
@@ -269,7 +265,8 @@ class Executor {
     this._incrementalPlaceholders.clear();
     this._source.clear();
     this._processPayloadFollowups(payload);
-    this._publishQueue.commitPayload(this._operation, payload, this._updater);
+    this._publishQueue.commitPayload(this._operation, payload, this._updater, this._optimisticUpdate);
+    this._optimisticUpdate = null;
     this._publishQueue.run();
   }
 

--- a/packages/relay-runtime/store/RelayPublishQueue.js
+++ b/packages/relay-runtime/store/RelayPublishQueue.js
@@ -142,7 +142,11 @@ class RelayPublishQueue implements PublishQueue {
     operation: OperationDescriptor,
     {fieldPayloads, source}: RelayResponsePayload,
     updater?: ?SelectorStoreUpdater,
+    optimisticUpdate?: OptimisticUpdate | null
   ): void {
+    if (optimisticUpdate) {
+      this.revertUpdate(optimisticUpdate);
+    }
     this._pendingBackupRebase = true;
     this._pendingData.add({
       kind: 'payload',


### PR DESCRIPTION
tl;dr My app shouldn't break just because someone has slow internet.

Relay's PublishQueue has a race condition built into it.
Let's take an example from a test that was passing, but definitely should not have been:

```js
      const increaseVolumeUpdater = {
        storeUpdater: storeProxy => {
          const amp = storeProxy.get('84872');
          amp.setValue(amp.getValue('volume') + 1, 'volume');
        },
      };

      const setVolumeTo10Updater = storeProxy => {
        const amp = storeProxy.get('84872');
        amp.setValue(10, 'volume');
      };

queue.applyUpdate(increaseVolumeUpdater);
queue.commitUpdate(setVolumeTo10Updater);
```
As written, one would expect the volume to be increased by 1, and then set to 10.
In the test, it is set to 10 and then increased to 11.
That's pretty awful. I called `increase` back when the volume was 3, now it's not safe to call. What if the max safe volume is 10? Broken app.

This is because internally, the publish queue runs all committed updates first, then all client updates, then optimistic updates. Here's a list of problems with that:
- Not linearizable. if 2 mutations go out, the first MUST return before the 2nd or your app can break. see #2481 for proof.
- Your server updates don't have access to the current state (any optimistic updates or client updates that were run after it was sent).
- Your client updates don't have access to optimistic updates, at best causing extra renders, at worst, causing errors. <-- This is how i discovered the error. My app broke when latency increased.
- Your optimistic updates are run when they shouldn't be, requiring all your safety checks to occur inside the optimistic updater instead of before the mutation is called.

This is the same approach used in operational transformations, databases, and even in the world of redux (https://github.com/mattkrick/redux-optimistic-ui).

fixes #2481