### PR TITLE
Update Modern-PaginationContainer.md

### DIFF
--- a/docs/Modern-PaginationContainer.md
+++ b/docs/Modern-PaginationContainer.md
@@ -63,7 +63,7 @@ fragment Feed_user on User {
     after: $cursor
     orderby: $orderBy
     search_term: $searchTerm
-  ) @connection(key: "Feed_feed", filters: ['searchTerm']) {
+  ) @connection(key: "Feed_feed", filters: ["searchTerm"]) {
     edges {
       node {
         id,


### PR DESCRIPTION
Filter names in a connection fragment's `filters` field are specified by double-quotes instead of single-quotes