### PR TITLE
Allow literals in @arguments

### DIFF
--- a/packages/graphql-compiler/core/GraphQLParser.js
+++ b/packages/graphql-compiler/core/GraphQLParser.js
@@ -546,19 +546,15 @@ class GraphQLParser {
     if (argumentDirectives.length) {
       args = (argumentDirectives[0].arguments || []).map(arg => {
         const argValue = arg.value;
-        invariant(
-          argValue.kind === 'Variable',
-          'GraphQLParser: All @arguments() args must be variables, got %s. ' +
-            'Source: %s.',
-          argValue.kind,
-          this._getErrorContext(),
-        );
 
         return {
           kind: 'Argument',
           metadata: null,
           name: getName(arg),
-          value: this._transformVariable(argValue),
+          value:
+            argValue.kind === 'Variable'
+              ? this._transformVariable(argValue)
+              : this._transformValue(arg.value, null),
           type: null, // TODO: can't get type until referenced fragment is defined
         };
       });

--- a/packages/graphql-compiler/core/__tests__/GraphQLParser-test.js
+++ b/packages/graphql-compiler/core/__tests__/GraphQLParser-test.js
@@ -101,3 +101,12 @@ it('should error when parsing fragment that references undeclared variables are 
     /Variable `\\$id` was used in locations expecting the conflicting types `ID` and `Int`/,
   );
 });
+
+it('should transform fragments with @arguments', () => {
+  const text = `fragment TestFragment on Query {
+    viewer {
+      ...MyFragment_viewer @arguments(foo: "bar")
+    }
+  }`;
+  expect(() => GraphQLParser.parse(RelayTestSchema, text)).not.toThrowError();
+});

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
@@ -91,6 +91,69 @@ fragment Profile_4CNNX6 on User {
 
 `;
 
+exports[`RelayApplyFragmentArgumentTransform matches expected output: literal-argument.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query TestQuery(
+  $id: ID!
+) {
+  node(id: $id) {
+    id
+    ...Profile @arguments(pictureSize: [128])
+    friends(first: 10) {
+      edges {
+        node {
+          ...Profile @arguments(pictureSize: [256])
+        }
+      }
+    }
+  }
+}
+
+fragment Profile on User @argumentDefinitions(
+  pictureSize: {type: "[Int]", nonNull: true}
+) {
+  id
+  name
+  profilePicture(size: $pictureSize) {
+    uri
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+query TestQuery(
+  $id: ID!
+) {
+  node(id: $id) {
+    id
+    ...Profile_17y1Ti
+    friends(first: 10) {
+      edges {
+        node {
+          ...Profile_1tVpuC
+        }
+      }
+    }
+  }
+}
+
+fragment Profile_17y1Ti on User {
+  id
+  name
+  profilePicture(size: [128]) {
+    uri
+  }
+}
+
+fragment Profile_1tVpuC on User {
+  id
+  name
+  profilePicture(size: [256]) {
+    uri
+  }
+}
+
+`;
+
 exports[`RelayApplyFragmentArgumentTransform matches expected output: merges-identical-fragments.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 query TestQuery($id: ID!, $pictureSize: [Int] = [128]) {

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
@@ -211,3 +211,67 @@ fragment ProfileFriends on User {
 }
 
 `;
+
+exports[`RelayApplyFragmentArgumentTransform matches expected output: merges-identical-fragments-literals.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query TestQuery($id: ID!, $pictureSize: [Int] = [64]) {
+  node(id: $id) {
+    id
+    globalSize: profilePicture(size: $pictureSize) {
+      uri
+    }
+    ...Profile @arguments(pictureSize: [128])
+    ...ProfileFriends
+  }
+}
+
+fragment ProfileFriends on User {
+  friends(first: 10) {
+    edges {
+      node {
+        ...Profile @arguments(pictureSize: [128])
+      }
+    }
+  }
+}
+
+fragment Profile on User @argumentDefinitions(
+  pictureSize: {type: "[Int]", nonNull: true}
+) {
+  profilePicture(size: $pictureSize) {
+    uri
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+query TestQuery(
+  $id: ID!
+  $pictureSize: [Int] = [64]
+) {
+  node(id: $id) {
+    id
+    globalSize: profilePicture(size: $pictureSize) {
+      uri
+    }
+    ...Profile_17y1Ti
+    ...ProfileFriends
+  }
+}
+
+fragment Profile_17y1Ti on User {
+  profilePicture(size: [128]) {
+    uri
+  }
+}
+
+fragment ProfileFriends on User {
+  friends(first: 10) {
+    edges {
+      node {
+        ...Profile_17y1Ti
+      }
+    }
+  }
+}
+
+`;

--- a/packages/relay-compiler/transforms/__tests__/fixtures/apply-fragment-argument-transform/literal-argument.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/apply-fragment-argument-transform/literal-argument.graphql
@@ -1,0 +1,25 @@
+query TestQuery(
+  $id: ID!
+) {
+  node(id: $id) {
+    id
+    ...Profile @arguments(pictureSize: [128])
+    friends(first: 10) {
+      edges {
+        node {
+          ...Profile @arguments(pictureSize: [256])
+        }
+      }
+    }
+  }
+}
+
+fragment Profile on User @argumentDefinitions(
+  pictureSize: {type: "[Int]", nonNull: true}
+) {
+  id
+  name
+  profilePicture(size: $pictureSize) {
+    uri
+  }
+}

--- a/packages/relay-compiler/transforms/__tests__/fixtures/apply-fragment-argument-transform/merges-identical-fragments-literals.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/apply-fragment-argument-transform/merges-identical-fragments-literals.graphql
@@ -1,0 +1,28 @@
+query TestQuery($id: ID!, $pictureSize: [Int] = [64]) {
+  node(id: $id) {
+    id
+    globalSize: profilePicture(size: $pictureSize) {
+      uri
+    }
+    ...Profile @arguments(pictureSize: [128])
+    ...ProfileFriends
+  }
+}
+
+fragment ProfileFriends on User {
+  friends(first: 10) {
+    edges {
+      node {
+        ...Profile @arguments(pictureSize: [128])
+      }
+    }
+  }
+}
+
+fragment Profile on User @argumentDefinitions(
+  pictureSize: {type: "[Int]", nonNull: true}
+) {
+  profilePicture(size: $pictureSize) {
+    uri
+  }
+}


### PR DESCRIPTION
Sometimes it would be nice to use a fragments that has `@argumentDefinitions` defined with a known static value. This could be done by passing a literal to `@arguments` as in this example:

```graphql
query TestQuery($id: ID!) {
  node(id: $id) {
    id
    ...Profile @arguments(pictureSize: [128])
  }
}

fragment Profile on User @argumentDefinitions(
  pictureSize: {type: "[Int]", nonNull: true}
) {
  id
  name
  profilePicture(size: $pictureSize) {
    uri
  }
}
```

However, this will cause `relay-compiler` to throw an error `All @arguments() args must be variables.` One solution is to define a new global variable on the query, but this has the downside of polluting the query with more globals. Alternatively, the following workaround could also be used:

```graphql
query TestQuery($id: ID!) {
  node(id: $id) {
    id
    ...ProfileWrapper
  }
}

fragment ProfileWrapper on User @argumentDefinitions(
  pictureSize: {type: "[Int]", defaultValue: [128]}
) {
  ...Profile @arguments(pictureSize: $pictureSize)
}


fragment Profile on User @argumentDefinitions(
  pictureSize: {type: "[Int]"}
) {
  id
  name
  profilePicture(size: $pictureSize) {
    uri
  }
}
```

It would reduce a lot of boilerplate to allow literals directly in `@arguments`. This PR removed the invariant that prevents literals and adds new test cases to verify behavior.