### PR TITLE
Export root id on public api

### DIFF
--- a/packages/react-relay/modern/ReactRelayPublic.js
+++ b/packages/react-relay/modern/ReactRelayPublic.js
@@ -16,6 +16,14 @@ const ReactRelayQueryRenderer = require('./ReactRelayQueryRenderer');
 const ReactRelayRefetchContainer = require('./ReactRelayRefetchContainer');
 const RelayRuntime = require('relay-runtime');
 
+/**
+ * An id used for the root of the graph, corresponding to the "Query" type.
+ * Conceptually, root fields in queries can be viewed as normal fields on a
+ * synthesized root record.
+ */
+
+export const ROOT_ID = 'client:root';
+
 export type {
   RelayPaginationProp,
   RelayProp,


### PR DESCRIPTION
This is useful to update a connection that haves `Query` as it's parent. Like [here](https://github.com/facebook/relay/issues/2157).

Hence, I don't know if this is the best way to do it.