### PR TITLE
Send last fetched vars to refetchVariables() in RefetchContainer

### DIFF
--- a/packages/react-relay/modern/ReactRelayRefetchContainer.js
+++ b/packages/react-relay/modern/ReactRelayRefetchContainer.js
@@ -333,7 +333,7 @@ function createContainerWithFragments<
       );
       let fetchVariables =
         typeof refetchVariables === 'function'
-          ? refetchVariables(this._getFragmentVariables())
+          ? refetchVariables(this.state.localVariables || this._getFragmentVariables())
           : refetchVariables;
       fetchVariables = {...rootVariables, ...fetchVariables};
       const fragmentVariables = renderVariables

--- a/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
+++ b/packages/react-relay/modern/__tests__/ReactRelayRefetchContainer-test.js
@@ -752,6 +752,49 @@ describe('ReactRelayRefetchContainer', () => {
       expect(relayContext.variables).toEqual(refetchVariables);
     });
 
+    it('passes last fetched variables to refetchVariables()', () => {
+      expect.assertions(1);
+
+      const refetchVariables = {
+        cond: false,
+        id: '4',
+      };
+      refetch(refetchVariables, null, jest.fn());
+
+      environment.mock.resolve(UserQuery, {
+        data: {
+          node: {
+            id: '4',
+            __typename: 'User',
+            name: 'Zuck',
+          },
+        },
+      });
+
+      // expects given id to be '4' and returns '44'
+      const refetchVariables2 = ({
+        cond,
+        id,
+      }) => ({
+        cond,
+        id: id + '4',
+      });
+      refetch(refetchVariables2, null, jest.fn());
+
+      environment.mock.resolve(UserQuery, {
+        data: {
+          node: {
+            id: '44',
+            __typename: 'User',
+            name: 'Zuck',
+          },
+        },
+      });
+
+      // new context after successful refetch
+      expect(relayContext.variables.id).toEqual('44');
+    });
+
     it('does not update variables on failure', () => {
       expect.assertions(4);
       expect(render.mock.calls.length).toBe(1);


### PR DESCRIPTION
We currently advertises that refetchVariables, when it is a function,
receives the last queried variables, but it does not. This commit fixes it.

Fixes #2506