### PR TITLE
fix(Connections.md): document startCursor/endCursor

### DIFF
--- a/website/spec/Connections.md
+++ b/website/spec/Connections.md
@@ -307,7 +307,8 @@ The server must provide a type called `PageInfo`.
 ## Fields
 
 `PageInfo` must contain fields `hasPreviousPage` and `hasNextPage`, both
-of which return non-null booleans.
+of which return non-null booleans.  It must also contain fields `startCursor`
+and `endCursor`, both of which return non-null opaque strings.
 
 `hasPreviousPage` is used to indicate whether more edges exist prior to the set
 defined by the clients arguments. If the client is paginating with 
@@ -343,6 +344,14 @@ NOTE When both `first` and `last` are included, both of the fields should be set
 according to the above algorithms, but their meaning as it relates to pagination
 becomes unclear. This is among the reasons that pagination with both `first` and
 `last` is discouraged.
+
+`startCursor` and `endCursor` must be the cursors corresponding to the first and
+last nodes in `edges`, respectively.
+
+NOTE Relay Legacy did not define `startCursor` and `endCursor`, and relied on
+selecting the `cursor` of each edge; Relay Modern began selecting
+`startCursor` and `endCursor` instead to save bandwidth (since it doesn't use any
+cursors in between).
 
 ## Introspection
 
@@ -393,6 +402,28 @@ returns
             "kind": "NON_NULL",
             "ofType": {
               "name": "Boolean",
+              "kind": "SCALAR"
+            }
+          }
+        },
+        {
+          "name": "startCursor",
+          "type": {
+            "name": null,
+            "kind": "NON_NULL",
+            "ofType": {
+              "name": "String",
+              "kind": "SCALAR"
+            }
+          }
+        },
+        {
+          "name": "endCursor",
+          "type": {
+            "name": null,
+            "kind": "NON_NULL",
+            "ofType": {
+              "name": "String",
               "kind": "SCALAR"
             }
           }


### PR DESCRIPTION
fix #1930 

Someone should check the veracity of my assumption:
> NOTE Relay Legacy did not define `startCursor` and `endCursor`, and relied on
selecting the `cursor` of each edge; Relay Modern began selecting
`startCursor` and `endCursor` instead to save bandwidth (since it doesn't use any
cursors in between).
