### PR TITLE
Fix remove_range examples not being strings

### DIFF
--- a/docs/Modern-Mutations.md
+++ b/docs/Modern-Mutations.md
@@ -229,10 +229,10 @@ const configs = [{
   type: 'RANGE_DELETE',
   parentID: 'todoId',
   connectionKeys: [{
-    key: RemoveTags_tags,
+    key: 'RemoveTags_tags',
   }],
   pathToConnection: ['todo', 'tags'],
-  deletedIDFieldName: removedTagId
+  deletedIDFieldName: 'removedTagId'
 }];
 ```
 


### PR DESCRIPTION
Pretty sure this was just an oversight in the original doc and was meant to include string quotes