### PR TITLE
Re-sync with internal repository

### DIFF
--- a/packages/relay-experimental/helpers/__tests__/fetchQuery_UNSTABLE-test.js
+++ b/packages/relay-experimental/helpers/__tests__/fetchQuery_UNSTABLE-test.js
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+const {fetchQuery_UNSTABLE} = require('../fetchQuery_UNSTABLE');
+const {createMockEnvironment} = require('RelayModernMockEnvironment');
+const {generateAndCompile} = require('RelayModernTestUtils');
+
+describe('fetchQuery_UNSTABLE', () => {
+  let query;
+  let environment;
+  let retained = [];
+  const response = {
+    data: {
+      node: {
+        __typename: 'User',
+        id: '4',
+        name: 'Zuck',
+      },
+    },
+  };
+  beforeEach(() => {
+    retained = [];
+    environment = createMockEnvironment();
+    environment.retain.mockImplementation(obj => {
+      retained.push(obj);
+      return {
+        dispose: () => {
+          retained = retained.filter(o => o !== obj);
+        },
+      };
+    });
+    query = generateAndCompile(
+      `query TestQuery($id: ID!) {
+          node(id: $id) {
+            id
+          }
+        }
+      `,
+    ).TestQuery;
+  });
+
+  test('fetches request and retains data correctly', () => {
+    let calledObserver = false;
+    const observer = {
+      complete: () => {
+        calledObserver = true;
+        expect(retained.length).toEqual(1);
+      },
+    };
+    const disposable = fetchQuery_UNSTABLE({
+      environment,
+      query,
+      variables: {id: '4'},
+      observer,
+    });
+    environment.mock.nextValue(query, response);
+    environment.mock.complete(query);
+    disposable.dispose();
+    expect(calledObserver).toEqual(true);
+    expect(retained.length).toEqual(0);
+  });
+
+  test('unsubscribes and releases data when request is disposed', () => {
+    let calledNext = false;
+    let calledUnsubscribe = false;
+    const observer = {
+      next: () => {
+        calledNext = true;
+        expect(retained.length).toEqual(1);
+      },
+      unsubscribe: () => {
+        calledUnsubscribe = true;
+        expect(retained.length).toEqual(0);
+      },
+    };
+    const disposable = fetchQuery_UNSTABLE({
+      environment,
+      query,
+      variables: {id: '4'},
+      observer,
+    });
+    environment.mock.nextValue(query, response);
+    disposable.dispose();
+    expect(calledNext).toEqual(true);
+    expect(calledUnsubscribe).toEqual(true);
+  });
+
+  describe('when making a request that is already in flight', () => {
+    it('doesnt dedupe requests if using different environments', () => {
+      const environment2 = createMockEnvironment();
+      let calledObserver1 = false;
+      const observer1 = {
+        complete: () => {
+          calledObserver1 = true;
+        },
+      };
+      const observer2 = {
+        complete: () => {
+          expect(calledObserver1).toEqual(true);
+        },
+      };
+      const disposable1 = fetchQuery_UNSTABLE({
+        environment,
+        query,
+        variables: {id: '4'},
+        observer: observer1,
+      });
+      const disposable2 = fetchQuery_UNSTABLE({
+        environment: environment2,
+        query,
+        variables: {id: '4'},
+        observer: observer2,
+      });
+      environment.mock.nextValue(query, response);
+      environment2.mock.nextValue(query, response);
+      environment.mock.complete(query);
+      environment2.mock.complete(query);
+      disposable1.dispose();
+      disposable2.dispose();
+      expect(environment.execute).toHaveBeenCalledTimes(1);
+      expect(environment2.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('dedupes request and notifies all observers', () => {
+      let calledObserver1 = false;
+      let calledObserver2 = false;
+      const observer1 = {
+        complete: () => {
+          calledObserver1 = true;
+        },
+      };
+      const observer2 = {
+        complete: () => {
+          calledObserver2 = true;
+        },
+      };
+      const disposable1 = fetchQuery_UNSTABLE({
+        environment,
+        query,
+        variables: {id: '4'},
+        observer: observer1,
+      });
+      const disposable2 = fetchQuery_UNSTABLE({
+        environment,
+        query,
+        variables: {id: '4'},
+        observer: observer2,
+      });
+      environment.mock.nextValue(query, response);
+      environment.mock.complete(query);
+      disposable1.dispose();
+      disposable2.dispose();
+      expect(environment.execute).toHaveBeenCalledTimes(1);
+      expect(calledObserver1).toEqual(true);
+      expect(calledObserver2).toEqual(true);
+    });
+
+    it('dedupes request and notifies observers of events that were missed', () => {
+      let observer1Payload = null;
+      let calledObserver1Complete = false;
+      let observer2Payload = null;
+      let calledObserver2Complete = false;
+      const observer1 = {
+        next: payload => {
+          observer1Payload = payload;
+        },
+        complete: () => {
+          calledObserver1Complete = true;
+        },
+      };
+      const observer2 = {
+        next: payload => {
+          observer2Payload = payload;
+        },
+        complete: () => {
+          calledObserver2Complete = true;
+        },
+      };
+      const disposable1 = fetchQuery_UNSTABLE({
+        environment,
+        query,
+        variables: {id: '4'},
+        observer: observer1,
+      });
+      environment.mock.nextValue(query, response);
+      const disposable2 = fetchQuery_UNSTABLE({
+        environment,
+        query,
+        variables: {id: '4'},
+        observer: observer2,
+      });
+      environment.mock.complete(query);
+      disposable1.dispose();
+      disposable2.dispose();
+      expect(environment.execute).toHaveBeenCalledTimes(1);
+      expect(observer1Payload).not.toEqual(null);
+      expect(observer2Payload).not.toEqual(null);
+      expect(observer1Payload).toEqual(observer2Payload);
+      expect(calledObserver1Complete).toEqual(true);
+      expect(calledObserver2Complete).toEqual(true);
+    });
+
+    test('disposes of data and unsubscribes from request until last observer is disposed of', () => {
+      let unsubscribedObserver1 = false;
+      let unsubscribedObserver2 = false;
+      const observer1 = {
+        unsubscribe: () => {
+          unsubscribedObserver1 = true;
+        },
+      };
+      const observer2 = {
+        unsubscribe: () => {
+          unsubscribedObserver2 = true;
+        },
+      };
+      const disposable1 = fetchQuery_UNSTABLE({
+        environment,
+        query,
+        variables: {id: '4'},
+        observer: observer1,
+      });
+      const disposable2 = fetchQuery_UNSTABLE({
+        environment,
+        query,
+        variables: {id: '4'},
+        observer: observer2,
+      });
+      environment.mock.nextValue(query, response);
+      expect(unsubscribedObserver1).toEqual(false);
+      expect(unsubscribedObserver2).toEqual(false);
+      expect(retained.length).toEqual(1);
+      disposable1.dispose();
+      expect(unsubscribedObserver1).toEqual(false);
+      expect(unsubscribedObserver2).toEqual(false);
+      expect(retained.length).toEqual(1);
+      disposable2.dispose();
+      expect(unsubscribedObserver1).toEqual(true);
+      expect(unsubscribedObserver2).toEqual(true);
+      expect(retained.length).toEqual(0);
+      expect(environment.execute).toHaveBeenCalledTimes(1);
+    });
+
+    test('disposes of data until last observer is disposed of even after request completes', () => {
+      let calledObserver1 = false;
+      let calledObserver2 = false;
+      const observer1 = {
+        complete: () => {
+          calledObserver1 = true;
+        },
+      };
+      const observer2 = {
+        complete: () => {
+          calledObserver2 = true;
+        },
+      };
+      const disposable1 = fetchQuery_UNSTABLE({
+        environment,
+        query,
+        variables: {id: '4'},
+        observer: observer1,
+      });
+      const disposable2 = fetchQuery_UNSTABLE({
+        environment,
+        query,
+        variables: {id: '4'},
+        observer: observer2,
+      });
+      environment.mock.nextValue(query, response);
+      environment.mock.complete(query);
+      expect(calledObserver1).toEqual(true);
+      expect(calledObserver2).toEqual(true);
+      expect(retained.length).toEqual(1);
+      disposable1.dispose();
+      expect(retained.length).toEqual(1);
+      disposable2.dispose();
+      expect(retained.length).toEqual(0);
+      expect(environment.execute).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/relay-experimental/helpers/checkQuery_UNSTABLE.js
+++ b/packages/relay-experimental/helpers/checkQuery_UNSTABLE.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const invariant = require('invariant');
+
+import type {GraphQLTaggedNode, IEnvironment, Variables} from 'relay-runtime';
+
+/**
+ * Checks if a query is fully available locally in the Relay Store
+ */
+function checkQuery_UNSTABLE(
+  environment: IEnvironment,
+  gqlNode: GraphQLTaggedNode,
+  variables: Variables,
+): boolean {
+  const {
+    getRequest,
+    isRequest,
+    createOperationSelector,
+  } = environment.unstable_internal;
+  invariant(
+    isRequest(gqlNode),
+    'checkQuery_UNSTABLE: Expected graphql node to be a query',
+  );
+  const queryNode = getRequest(gqlNode);
+  const operation = createOperationSelector(queryNode, variables);
+  return environment.check(operation.root);
+}
+
+module.exports = checkQuery_UNSTABLE;

--- a/packages/relay-experimental/helpers/fetchQuery_UNSTABLE.js
+++ b/packages/relay-experimental/helpers/fetchQuery_UNSTABLE.js
@@ -1,0 +1,362 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const getRequestKey_UNSTABLE = require('./getRequestKey_UNSTABLE');
+const invariant = require('invariant');
+
+import type {
+  ExecutePayload,
+  Observer,
+  Subscription,
+  GraphQLTaggedNode,
+  IEnvironment,
+  CacheConfig,
+  Disposable,
+  OperationType,
+  Variables,
+} from 'relay-runtime';
+
+type ObserverEvent = {|
+  event: 'start' | 'next' | 'error' | 'complete' | 'unsubscribe',
+  data?: mixed,
+|};
+
+type RequestCacheEntry = {|
+  subscription: Subscription,
+  receivedEvents: Array<ObserverEvent>,
+  observers: Array<Observer<ExecutePayload>>,
+|};
+
+type ReferencesCacheEntry = {|
+  count: number,
+  references: Array<Disposable>,
+|};
+
+const requestsByEnvironment: Map<
+  IEnvironment,
+  Map<string, RequestCacheEntry>,
+> = new Map();
+const referencesByEnvironment: Map<
+  IEnvironment,
+  Map<string, ReferencesCacheEntry>,
+> = new Map();
+
+/**
+ * Facilitates fetching a query given its variables and an environment, while
+ * retaining data for the query and de-duping identical requests that are
+ * _in-flight_.
+ *
+ * Observing a request:
+ * ====================
+ * fetchQuery_UNSTABLE takes an Observer which you can use to observe network
+ * responses and other events like errors or when the request is complete:
+ *
+ * ```
+ * fetchQuery_UNSTABLE(environment, query, variables, {
+ *   // Called when network requests starts
+ *   start: (subsctiption) => {},
+ *
+ *   // Called after a payload is received and written to the local store
+ *   next: (payload) => {},
+ *
+ *   // Called when network requests errors
+ *   error: (error) => {},
+ *
+ *   // Called when network requests fully completes
+ *   complete: () => {},
+ *
+ *   // Called when network request is unsubscribed
+ *   unsubscribe: (subscription) => {},
+ * });
+ * ```
+ *
+ * In-flight request de-duping:
+ * ============================
+ * By default, calling fetchQuery_UNSTABLE multiple times with the same
+ * environment, query and variables will not initiate a new request if a request
+ * for those same parameters is already in flight.
+ *
+ * A request is marked in-flight from the moment it starts until the moment it
+ * fully completes, regardless of error or successful completion.
+ *
+ * NOTE: If the request completes _synchronously_, calling fetchQuery_UNSTABLE
+ * a second time with the same arguments in the same tick will _NOT_ de-dupe
+ * the request given that it will no longer be in-flight.
+ *
+ *
+ * Data Retention:
+ * ===============
+ * This function will _retain_ data for the given query and variables on the
+ * provided Relay environment; this means that it prevent that data from being
+ * garbage collected (i.e. deleted) from the Relay store.
+ * In order to release the data, the will return a Disposable which can be used to
+ * dispose of the retained data:
+ *
+ * ```
+ * const disposable = fetchQuery_UNSTABLE(...);
+ *
+ * // After calling this, the data might be garbage collected (i.e. deleted)
+ * // from the Relay local store
+ * diposable.dispose();
+ * ```
+ */
+function fetchQuery_UNSTABLE<TQuery: OperationType>(args: {|
+  environment: IEnvironment,
+  query: GraphQLTaggedNode,
+  variables: $ElementType<TQuery, 'variables'>,
+  observer?: Observer<ExecutePayload>,
+  networkLayerCacheConfig?: CacheConfig,
+|}): Disposable {
+  const {
+    environment,
+    query,
+    variables,
+    observer,
+    networkLayerCacheConfig,
+  } = args;
+  const {createOperationSelector, getRequest} = environment.unstable_internal;
+  const queryNode = getRequest(query);
+  invariant(
+    queryNode.operationKind === 'query',
+    'fetchQuery_UNSTABLE: Expected query operation',
+  );
+  const requestCache = getRequestCache(environment);
+  const referencesCache = getReferencesCache(environment);
+  const operation = createOperationSelector(queryNode, variables);
+  const cacheKey = getRequestKey_UNSTABLE(queryNode, variables);
+  const cachedRequest = requestCache.get(cacheKey);
+  const cachedReferences = referencesCache.get(cacheKey);
+
+  if (cachedReferences) {
+    referencesCache.set(cacheKey, {
+      ...cachedReferences,
+      count: cachedReferences.count + 1,
+    });
+  } else {
+    referencesCache.set(cacheKey, {
+      references: [],
+      count: 1,
+    });
+  }
+
+  if (cachedRequest) {
+    // We manage observers manually due to the lack of an RxJS Subject abstraction
+    // (https://fburl.com/s6m56gim)
+    const observers =
+      observer && !cachedRequest.observers.find(o => o === observer)
+        ? [...cachedRequest.observers, observer]
+        : cachedRequest.observers;
+
+    if (observer) {
+      cachedRequest.receivedEvents.forEach(observerEvent => {
+        const {data} = observerEvent;
+        // eslint-disable-next-line lint/flow-no-fixme
+        const eventHandler: $FlowFixMe = observer[observerEvent.event];
+        if (data !== undefined) {
+          eventHandler && eventHandler(data);
+        } else {
+          eventHandler && eventHandler();
+        }
+      });
+    }
+    requestCache.set(cacheKey, {
+      ...cachedRequest,
+      observers,
+    });
+  } else {
+    environment
+      .execute({operation, cacheConfig: networkLayerCacheConfig})
+      .map(payload => {
+        const operationForPayload = createOperationSelector(
+          operation.node,
+          payload.variables,
+          payload.operation,
+        );
+        const cached = referencesCache.get(cacheKey);
+        invariant(
+          cached != null,
+          'fetchQuery_UNSTABLE: Expected references to be cached',
+        );
+        cached.references.push(environment.retain(operationForPayload.root));
+        return payload;
+      })
+      .finally(() => {
+        requestCache.delete(cacheKey);
+      })
+      .subscribe({
+        start: subscription => {
+          requestCache.set(cacheKey, {
+            subscription: subscription,
+            observers: observer ? [observer] : [],
+            receivedEvents: [],
+          });
+          addReceivedEvent(requestCache, cacheKey, {
+            event: 'start',
+            data: subscription,
+          });
+          getCachedObservers(requestCache, cacheKey).forEach(
+            o => o.start && o.start(subscription),
+          );
+        },
+        next: payload => {
+          addReceivedEvent(requestCache, cacheKey, {
+            event: 'next',
+            data: payload,
+          });
+          getCachedObservers(requestCache, cacheKey).forEach(
+            o => o.next && o.next(payload),
+          );
+        },
+        error: error => {
+          addReceivedEvent(requestCache, cacheKey, {
+            event: 'error',
+            data: error,
+          });
+          getCachedObservers(requestCache, cacheKey).forEach(
+            o => o.error && o.error(error),
+          );
+        },
+        complete: () => {
+          addReceivedEvent(requestCache, cacheKey, {
+            event: 'complete',
+          });
+          getCachedObservers(requestCache, cacheKey).forEach(
+            o => o.complete && o.complete(),
+          );
+        },
+        unsubscribe: subscription => {
+          addReceivedEvent(requestCache, cacheKey, {
+            event: 'unsubscribe',
+            data: subscription,
+          });
+          getCachedObservers(requestCache, cacheKey).forEach(
+            o => o.unsubscribe && o.unsubscribe(subscription),
+          );
+        },
+      });
+  }
+
+  return {
+    dispose: () => {
+      const cachedRefs = referencesCache.get(cacheKey);
+      invariant(
+        cachedRefs != null,
+        'fetchQuery_UNSTABLE: Expected references to be cached',
+      );
+      const {count, references} = cachedRefs;
+      if (count === 1) {
+        references.forEach(r => r.dispose());
+        referencesCache.delete(cacheKey);
+
+        const cachedReq = requestCache.get(cacheKey);
+        if (cachedReq) {
+          cachedReq.subscription.unsubscribe();
+        }
+      } else {
+        referencesCache.set(cacheKey, {
+          references,
+          count: Math.max(0, count - 1),
+        });
+      }
+    },
+  };
+}
+
+/**
+ * If a request is in flight for the given query, variables and environment,
+ * this function will return a Promise that will resolve when that request has
+ * completed and the data has been saved to the store.
+ * If no request is in flight, null will be returned
+ */
+function getPromiseForQueryRequest_UNSTABLE(args: {|
+  environment: IEnvironment,
+  query: GraphQLTaggedNode,
+  variables: Variables,
+|}): Promise<void> | null {
+  const {environment, query, variables} = args;
+  const {getRequest} = environment.unstable_internal;
+  const queryNode = getRequest(query);
+  const requestCache = getRequestCache(environment);
+  const cacheKey = getRequestKey_UNSTABLE(queryNode, variables);
+  const cachedRequest = requestCache.get(cacheKey);
+  if (cachedRequest == null) {
+    return null;
+  }
+  return new Promise(resolve => {
+    fetchQuery_UNSTABLE({
+      environment,
+      query,
+      variables,
+      observer: {
+        complete: resolve,
+      },
+    });
+  });
+}
+
+function addReceivedEvent(
+  requestCache: Map<string, RequestCacheEntry>,
+  cacheKey: string,
+  observerEvent: ObserverEvent,
+) {
+  const cached = requestCache.get(cacheKey);
+  invariant(
+    cached != null,
+    'fetchQuery_UNSTABLE: Expected request to be cached',
+  );
+  const receivedEvents = [...cached.receivedEvents, observerEvent];
+  requestCache.set(cacheKey, {
+    ...cached,
+    receivedEvents,
+  });
+}
+
+function getRequestCache(
+  environment: IEnvironment,
+): Map<string, RequestCacheEntry> {
+  const cached = requestsByEnvironment.get(environment);
+  if (cached != null) {
+    return cached;
+  }
+  const requestCache = new Map();
+  requestsByEnvironment.set(environment, requestCache);
+  return requestCache;
+}
+
+function getReferencesCache(
+  environment: IEnvironment,
+): Map<string, ReferencesCacheEntry> {
+  const cached = referencesByEnvironment.get(environment);
+  if (cached != null) {
+    return cached;
+  }
+  const referencesCache = new Map();
+  referencesByEnvironment.set(environment, referencesCache);
+  return referencesCache;
+}
+
+function getCachedObservers(
+  requestCache: Map<string, RequestCacheEntry>,
+  cacheKey: string,
+): Array<Observer<ExecutePayload>> {
+  const cached = requestCache.get(cacheKey);
+  invariant(
+    cached != null,
+    'fetchQuery_UNSTABLE: Expected request to be cached',
+  );
+  return cached.observers;
+}
+
+module.exports = {
+  fetchQuery_UNSTABLE,
+  getPromiseForQueryRequest_UNSTABLE,
+};

--- a/packages/relay-experimental/helpers/getRequestKey_UNSTABLE.js
+++ b/packages/relay-experimental/helpers/getRequestKey_UNSTABLE.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {RequestNode, Variables} from 'relay-runtime';
+
+function getRequestKey_UNSTABLE(
+  requestNode: RequestNode,
+  variables: Variables,
+) {
+  let queryKey = '';
+  if (requestNode.kind === 'BatchRequest') {
+    queryKey = JSON.stringify({
+      id: requestNode.requests.map(req =>
+        String(req.id != null ? req.id : req.text),
+      ),
+    });
+  } else {
+    const requestID =
+      requestNode.id != null ? requestNode.id : requestNode.text;
+    queryKey = String(requestID);
+  }
+  return queryKey + JSON.stringify(variables);
+}
+
+module.exports = getRequestKey_UNSTABLE;

--- a/packages/relay-experimental/helpers/readQuery_UNSTABLE.js
+++ b/packages/relay-experimental/helpers/readQuery_UNSTABLE.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const invariant = require('invariant');
+
+import type {
+  GraphQLTaggedNode,
+  IEnvironment,
+  Snapshot,
+  Variables,
+} from 'relay-runtime';
+
+/**
+ * Reads a query from the local Relay Store.
+ * Returns the Snapshot which contains the data result for the query.
+ */
+function readQuery_UNSTABLE(
+  environment: IEnvironment,
+  gqlNode: GraphQLTaggedNode,
+  variables: Variables,
+): Snapshot {
+  const {
+    getRequest,
+    isRequest,
+    createOperationSelector,
+  } = environment.unstable_internal;
+  invariant(
+    isRequest(gqlNode),
+    'readQuery_UNSTABLE: Expected graphql node to be a query',
+  );
+  const queryNode = getRequest(gqlNode);
+  const operation = createOperationSelector(queryNode, variables);
+  return environment.lookup(operation.fragment);
+}
+
+module.exports = readQuery_UNSTABLE;

--- a/packages/relay-experimental/helpers/retainQuery_UNSTABLE.js
+++ b/packages/relay-experimental/helpers/retainQuery_UNSTABLE.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {
+  GraphQLTaggedNode,
+  IEnvironment,
+  OperationType,
+} from 'relay-runtime';
+
+function retainQuery_UNSTABLE<TQuery: OperationType>(
+  environment: IEnvironment,
+  query: GraphQLTaggedNode,
+  variables: $ElementType<TQuery, 'variables'>,
+) {
+  const {createOperationSelector, getRequest} = environment.unstable_internal;
+  const queryRequestNode = getRequest(query);
+  const operation = createOperationSelector(queryRequestNode, variables);
+  return environment.retain(operation.root);
+}
+
+module.exports = retainQuery_UNSTABLE;

--- a/packages/relay-experimental/index.js
+++ b/packages/relay-experimental/index.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+const checkQuery_UNSTABLE = require('./helpers/checkQuery_UNSTABLE');
+const getRequestKey_UNSTABLE = require('./helpers/getRequestKey_UNSTABLE');
+const readQuery_UNSTABLE = require('./helpers/readQuery_UNSTABLE');
+const retainQuery_UNSTABLE = require('./helpers/retainQuery_UNSTABLE');
+
+const {
+  fetchQuery_UNSTABLE,
+  getPromiseForQueryRequest_UNSTABLE,
+} = require('./helpers/fetchQuery_UNSTABLE');
+
+module.exports = {
+  checkQuery_UNSTABLE: checkQuery_UNSTABLE,
+  fetchQuery_UNSTABLE: fetchQuery_UNSTABLE,
+  getPromiseForQueryRequest_UNSTABLE: getPromiseForQueryRequest_UNSTABLE,
+  getRequestKey_UNSTABLE: getRequestKey_UNSTABLE,
+  readQuery_UNSTABLE: readQuery_UNSTABLE,
+  retainQuery_UNSTABLE: retainQuery_UNSTABLE,
+};

--- a/packages/relay-experimental/package.json
+++ b/packages/relay-experimental/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "relay-experimental",
+  "description": "Contains unstable, experimental code",
+  "version": "1.7.0-rc.1",
+  "keywords": [
+    "graphql",
+    "relay"
+  ],
+  "license": "MIT",
+  "homepage": "https://facebook.github.io/relay/",
+  "bugs": "https://github.com/facebook/relay/issues",
+  "repository": "facebook/relay",
+  "dependencies": {
+    "babel-runtime": "^6.23.0",
+    "fbjs": "0.8.17",
+    "relay-runtime": "1.7.0-rc.1"
+  },
+  "directories": {
+    "": "./"
+  },
+  "main": "index.js",
+  "haste_commonjs": true
+}


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.