### PR TITLE
Enable matching dotfiles when using fast-glob

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -83,6 +83,7 @@ function getFilepathsFromGlob(
   return glob.sync(patterns, {
     cwd: baseDir,
     ignore: exclude,
+    dot: true,
   });
 }
 


### PR DESCRIPTION
Currently when running on a system with watchman, you can use hidden (e.g. `.sharedFragments.js`) files with the benefit of not having name-matching enforcement. That is to say, if I put all my commonly used fragments for an app in a common folder, you don't have to start their name with the filename they're defined in, which makes it very handy for "model" definitions for common types.

When running on a system without watchman, the fastglob matcher excludes files starting with a `.` by default. So in order to make the behavior consistent regardless of what system it's running on, we should pass the `dot: true` options to fast-glob.