### PR TITLE
Expose ReactRelayContext in ReactRelayPublic

### DIFF
--- a/packages/react-relay/modern/ReactRelayPublic.js
+++ b/packages/react-relay/modern/ReactRelayPublic.js
@@ -14,6 +14,7 @@ const ReactRelayFragmentContainer = require('./ReactRelayFragmentContainer');
 const ReactRelayPaginationContainer = require('./ReactRelayPaginationContainer');
 const ReactRelayQueryRenderer = require('./ReactRelayQueryRenderer');
 const ReactRelayRefetchContainer = require('./ReactRelayRefetchContainer');
+const ReactRelayContext = require('./ReactRelayContext');
 const RelayRuntime = require('relay-runtime');
 
 export type {
@@ -46,6 +47,8 @@ module.exports = {
 
   MutationTypes: RelayRuntime.MutationTypes,
   RangeOperations: RelayRuntime.RangeOperations,
+
+  Context: ReactRelayContext,
 
   applyOptimisticMutation: RelayRuntime.applyOptimisticMutation,
   commitLocalUpdate: RelayRuntime.commitLocalUpdate,


### PR DESCRIPTION
I'd like to start a discussion on whether the React Relay internal context should be exposed publicly. I currently have two use cases that require access to it.

1. **Server Side Rendering:**

Our pattern for rendering Relay on the server looks something like this:

```js
const data = await fetchQuery(environment, query, variables);

ReactDOMServer.renderToString(
    <RelayContextProvider environment={environment} variables={variables}>
        <MyApp data={data} />
    </RelayContextProvider>
);
```

[RelayContextProvider](https://github.com/relay-tools/relay-context-provider) is a package that I maintain which creates a React context in the shape Relay containers expect, allowing them the render prefetched data from the environment. This package uses the old context API but will no longer work with the new Relay Context API. `<ReactRelayContext.Provider>` would be a drop in replacement.

I think this use case may be solved in the future with React Suspense and the experimental `createQueryRenderer` but we will be blocked from updating Relay until both of those are stable.


2. **Manually unmasking data for use in shared functions:** 

We have a lot of functions that use data that is fetched from GraphQL. These are usually for analytics tracking and are called from multiple components when certain events happen. Since these require a specific amount of data to be passed, we define a standalone fragment for this function, and include it in the component's fragments. We usually use `@relay(mask: false)` on these fragments for simplicity, [but there are issues with this when the fragments contain variables](https://github.com/facebook/relay/pull/2359). 

Ideally we could unmask the data from these fragments using the methods in `relay-runtime`, but this requires access to the variables that are stored in React context. We could do this before by setting `contextTypes` on the component but it will now require access to `<RelayContext.Consumer>`.

@jstejada @josephsavona @kassens @taion 