### PR TITLE
test: replace require.requireActual with jest.requireActual

### DIFF
--- a/packages/react-relay/classic/container/__mocks__/getRelayQueries.js
+++ b/packages/react-relay/classic/container/__mocks__/getRelayQueries.js
@@ -9,6 +9,6 @@
 
 'use strict';
 
-const getRelayQueries = require.requireActual('../getRelayQueries');
+const getRelayQueries = jest.requireActual('../getRelayQueries');
 
 module.exports = jest.fn(getRelayQueries);

--- a/packages/react-relay/classic/mutation/__tests__/RelayMutation-test.js
+++ b/packages/react-relay/classic/mutation/__tests__/RelayMutation-test.js
@@ -31,7 +31,7 @@ describe('RelayMutation', function() {
 
   function applyUpdate(mutation) {
     /* eslint-disable no-shadow */
-    const RelayEnvironment = require.requireActual(
+    const RelayEnvironment = jest.requireActual(
       '../../store/RelayEnvironment',
     );
     const environment = new RelayEnvironment();

--- a/packages/react-relay/classic/network/__mocks__/RelayNetworkLayer.js
+++ b/packages/react-relay/classic/network/__mocks__/RelayNetworkLayer.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const RelayNetworkLayer = require.requireActual('../RelayNetworkLayer');
+const RelayNetworkLayer = jest.requireActual('../RelayNetworkLayer');
 
 function RelayNetworkLayerMock() {
   const networkLayer = new RelayNetworkLayer();

--- a/packages/react-relay/classic/query-config/__mocks__/RelayQueryConfig.js
+++ b/packages/react-relay/classic/query-config/__mocks__/RelayQueryConfig.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const RelayQueryConfig = require.requireActual('../RelayQueryConfig');
+const RelayQueryConfig = jest.requireActual('../RelayQueryConfig');
 
 RelayQueryConfig.genMock = jest.fn(staticProperties => {
   class MockQueryConfig extends RelayQueryConfig {}

--- a/packages/react-relay/classic/query/__mocks__/RelayFragmentPointer.js
+++ b/packages/react-relay/classic/query/__mocks__/RelayFragmentPointer.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const RelayFragmentPointer = require.requireActual('../RelayFragmentPointer');
+const RelayFragmentPointer = jest.requireActual('../RelayFragmentPointer');
 
 RelayFragmentPointer.createForRoot = jest.fn(
   RelayFragmentPointer.createForRoot,

--- a/packages/react-relay/classic/query/__mocks__/RelayQueryPath.js
+++ b/packages/react-relay/classic/query/__mocks__/RelayQueryPath.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const RelayQueryPath = require.requireActual('../RelayQueryPath');
+const RelayQueryPath = jest.requireActual('../RelayQueryPath');
 
 RelayQueryPath.fromJSON = jest.fn(RelayQueryPath.fromJSON);
 

--- a/packages/react-relay/classic/query/__mocks__/generateRQLFieldAlias.js
+++ b/packages/react-relay/classic/query/__mocks__/generateRQLFieldAlias.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = jest.fn(require.requireActual('../generateRQLFieldAlias'));
+module.exports = jest.fn(jest.requireActual('../generateRQLFieldAlias'));

--- a/packages/react-relay/classic/route/__mocks__/RelayRoute.js
+++ b/packages/react-relay/classic/route/__mocks__/RelayRoute.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const RelayRoute = require.requireActual('../RelayRoute');
+const RelayRoute = jest.requireActual('../RelayRoute');
 
 RelayRoute.genMock = jest.fn(() => {
   class MockRoute extends RelayRoute {}

--- a/packages/react-relay/classic/store/__mocks__/RelayEnvironment.js
+++ b/packages/react-relay/classic/store/__mocks__/RelayEnvironment.js
@@ -9,8 +9,8 @@
 
 'use strict';
 
-const RelayEnvironment = require.requireActual('../RelayEnvironment');
-const RelayStoreData = require.requireActual('../RelayStoreData');
+const RelayEnvironment = jest.requireActual('../RelayEnvironment');
+const RelayStoreData = jest.requireActual('../RelayStoreData');
 const RelayRecordStore = require('../RelayRecordStore');
 
 const resolveImmediate = require('resolveImmediate');

--- a/packages/react-relay/classic/store/__mocks__/RelayRecord.js
+++ b/packages/react-relay/classic/store/__mocks__/RelayRecord.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const RelayRecord = require.requireActual('../RelayRecord');
+const RelayRecord = jest.requireActual('../RelayRecord');
 
 Object.keys(RelayRecord).forEach(name => {
   const method = RelayRecord[name];

--- a/packages/react-relay/classic/store/__mocks__/readRelayQueryData.js
+++ b/packages/react-relay/classic/store/__mocks__/readRelayQueryData.js
@@ -9,5 +9,5 @@
 
 'use strict';
 
-const readRelayQueryData = require.requireActual('../readRelayQueryData');
+const readRelayQueryData = jest.requireActual('../readRelayQueryData');
 module.exports = jest.fn(readRelayQueryData);

--- a/packages/react-relay/classic/store/__mocks__/validateRelayReadQuery.js
+++ b/packages/react-relay/classic/store/__mocks__/validateRelayReadQuery.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const validateRelayReadQuery = require.requireActual(
+const validateRelayReadQuery = jest.requireActual(
   '../validateRelayReadQuery',
 );
 module.exports = validateRelayReadQuery;

--- a/packages/react-relay/classic/traversal/__mocks__/checkRelayQueryData.js
+++ b/packages/react-relay/classic/traversal/__mocks__/checkRelayQueryData.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = jest.fn(require.requireActual('../checkRelayQueryData'));
+module.exports = jest.fn(jest.requireActual('../checkRelayQueryData'));

--- a/packages/react-relay/classic/traversal/__mocks__/diffRelayQuery.js
+++ b/packages/react-relay/classic/traversal/__mocks__/diffRelayQuery.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = jest.fn(require.requireActual('../diffRelayQuery'));
+module.exports = jest.fn(jest.requireActual('../diffRelayQuery'));

--- a/packages/react-relay/classic/traversal/__mocks__/findRelayQueryLeaves.js
+++ b/packages/react-relay/classic/traversal/__mocks__/findRelayQueryLeaves.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = jest.fn(require.requireActual('../findRelayQueryLeaves'));
+module.exports = jest.fn(jest.requireActual('../findRelayQueryLeaves'));

--- a/packages/react-relay/classic/traversal/__mocks__/intersectRelayQuery.js
+++ b/packages/react-relay/classic/traversal/__mocks__/intersectRelayQuery.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = jest.fn(require.requireActual('../intersectRelayQuery'));
+module.exports = jest.fn(jest.requireActual('../intersectRelayQuery'));

--- a/packages/react-relay/classic/traversal/__mocks__/splitDeferredRelayQueries.js
+++ b/packages/react-relay/classic/traversal/__mocks__/splitDeferredRelayQueries.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = jest.fn(require.requireActual('../splitDeferredRelayQueries'));
+module.exports = jest.fn(jest.requireActual('../splitDeferredRelayQueries'));

--- a/packages/react-relay/classic/traversal/__mocks__/transformRelayQueryPayload.js
+++ b/packages/react-relay/classic/traversal/__mocks__/transformRelayQueryPayload.js
@@ -10,5 +10,5 @@
 'use strict';
 
 module.exports = jest.fn(
-  require.requireActual('../transformRelayQueryPayload'),
+  jest.requireActual('../transformRelayQueryPayload'),
 );

--- a/packages/react-relay/classic/traversal/__mocks__/writeRelayQueryPayload.js
+++ b/packages/react-relay/classic/traversal/__mocks__/writeRelayQueryPayload.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = jest.fn(require.requireActual('../writeRelayQueryPayload'));
+module.exports = jest.fn(jest.requireActual('../writeRelayQueryPayload'));

--- a/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
+++ b/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
@@ -147,7 +147,7 @@ describe('Configs: NODE_DELETE', () => {
     expect(callback.mock.calls.length).toBe(0);
   });
   it('throws error with classic environment', () => {
-    const RelayEnvironment = require.requireActual(
+    const RelayEnvironment = jest.requireActual(
       'react-relay/classic/store/__mocks__/RelayEnvironment',
     );
     const environment = new RelayEnvironment();

--- a/scripts/rewrite-modules.js
+++ b/scripts/rewrite-modules.js
@@ -50,7 +50,7 @@ module.exports = function(babel) {
   var t = babel.types;
 
   /**
-   * Transforms `require('Foo')` and `require.requireActual('Foo')`.
+   * Transforms `require('Foo')` and `jest.requireActual('Foo')`.
    */
   function transformRequireCall(path, state) {
     var calleePath = path.get('callee');


### PR DESCRIPTION
A while back Jest introduced `jest.requireActual` and `jest.requireMock` which are aliases to `require.requireActual` and `require.requireMock`. We believe that users should use official Jest API and are planning to deprecate the latter.

Followup PR from RN: https://github.com/facebook/react-native/pull/21849