### PR TITLE
Fix interface implementation

### DIFF
--- a/docs/GraphQL-ServerSpecification.md
+++ b/docs/GraphQL-ServerSpecification.md
@@ -39,13 +39,13 @@ interface Node {
   id: ID!
 }
 
-type Faction : Node {
+type Faction implements Node {
   id: ID!
   name: String
   ships: ShipConnection
 }
 
-type Ship : Node {
+type Ship implements Node {
   id: ID!
   name: String
 }


### PR DESCRIPTION
The type syntax for Faction and Ship type are wrong. According with (official graphql documentation for interface implementation)[https://graphql.org/learn/schema/#interfaces], the correct syntax is `type TypeName implements InterfaceName` instead of `type TypeName : InterfaceName`.