### PR TITLE
RFC: Custom Opaque Types for ID fields

### DIFF
--- a/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+++ b/packages/relay-compiler/language/RelayLanguagePluginInterface.js
@@ -188,6 +188,10 @@ export type TypeGeneratorOptions = {|
    */
   +existingFragmentNames: Set<string>,
 
+  /*
+   * if set all ID fields are set to be of the provided opaque type */
+  +opaqueRelayIDImport: ?{typeName: string, fileWithDefinition: string},
+
   /**
    * Whether or not relay-compiler will store artifacts next to the module that
    * they originate from or all together in a single directory.

--- a/packages/relay-compiler/language/javascript/RelayFlowGenerator.js
+++ b/packages/relay-compiler/language/javascript/RelayFlowGenerator.js
@@ -55,6 +55,7 @@ export type State = {|
   },
   +usedEnums: {[name: string]: GraphQLEnumType},
   +usedFragments: Set<string>,
+  usedID: boolean,
 |};
 
 function generate(
@@ -260,6 +261,7 @@ function createVisitor(options: TypeGeneratorOptions) {
     useHaste: options.useHaste,
     useSingleArtifactDirectory: options.useSingleArtifactDirectory,
     noFutureProofEnums: options.noFutureProofEnums,
+    usedID: false,
   };
 
   return {
@@ -285,6 +287,7 @@ function createVisitor(options: TypeGeneratorOptions) {
           ]),
         );
         return t.program([
+          ...getIDImports(state),
           ...getFragmentImports(state),
           ...getEnumDefinitions(state),
           ...inputObjectTypes,
@@ -474,6 +477,15 @@ function groupRefs(props): Array<Selection> {
     });
   }
   return result;
+}
+
+function getIDImports(state: State) {
+  if (!state.usedID) {
+    return [];
+  }
+  const imports = [];
+  imports.push(importTypes([state.typeName]), state.modulePath);
+  return imports;
 }
 
 function getFragmentImports(state: State) {

--- a/packages/relay-compiler/language/javascript/RelayFlowTypeTransformers.js
+++ b/packages/relay-compiler/language/javascript/RelayFlowTypeTransformers.js
@@ -81,6 +81,13 @@ function transformGraphQLScalarType(type: GraphQLScalarType, state: State) {
   const customType = state.customScalars[type.name];
   switch (customType || type.name) {
     case 'ID':
+      state.idFieldUsed = true;
+      if (!state.opaqueRelayIDImport) {
+        return t.stringTypeAnnotation();
+      }
+      return t.genericTypeAnnotation(
+        t.identifier(state.opaqueRelayIDImport.typeName),
+      );
     case 'String':
       return t.stringTypeAnnotation();
     case 'Float':


### PR DESCRIPTION
Before I go too deep into a bad path. I would like to get feedback on the approach for generating Opaque types for ID fields. 

In this PR if the user provides config for using a custom opaque types, all ID fields will be replaced with the provided type. 

I think it is better developer experience if relay-came with a global ID field as the fallback instead of a string if the user does not provide this opaque type. 

Tests pending.