### PR TITLE
fix: use correct file in "main" of relay-compiler

### DIFF
--- a/packages/graphql-compiler/package.json
+++ b/packages/graphql-compiler/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-rc.1",
   "license": "MIT",
   "description": "A Code-generation toolkit for GraphQL",
-  "main": "GraphQLCompilerPublic.js",
+  "main": "lib/GraphQLCompilerPublic.js",
   "dependencies": {
     "chalk": "^1.1.1",
     "fb-watchman": "^2.0.0",

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://facebook.github.io/relay/",
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
-  "main": "lib/RelayCompilerPublic",
+  "main": "lib/RelayCompilerPublic.js",
   "bin": {
     "relay-compiler": "bin/relay-compiler"
   },

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://facebook.github.io/relay/",
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
-  "main": "RelayCompilerPublic",
+  "main": "lib/RelayCompilerPublic",
   "bin": {
     "relay-compiler": "bin/relay-compiler"
   },


### PR DESCRIPTION
I noticed this when trying out yarn PnP, which is more strict about the module resolution algorithm than node is (which is technically a bug in Yarn, cc @arcanis), but anyway: let's fix the file here!

Node will fall back to `index.js`, while Yarn tried to use the non-existing `RelayCompilerPublic`