### PR TITLE
Only whitelist some folder for haste in Jest

### DIFF
--- a/scripts/jest/hasteImpl.js
+++ b/scripts/jest/hasteImpl.js
@@ -19,7 +19,9 @@ const BLACKLISTED_PATTERNS/*: Array<RegExp>*/ = [
 ];
 
 const WHITELISTED_PREFIXES/*: Array<string>*/ = [
-  'packages'
+  'packages/graphql-compiler',
+  'packages/relay-compiler',
+  'packages/relay-test-utils',
 ];
 
 const NAME_REDUCERS/*: Array<[RegExp, string]>*/ = [

--- a/scripts/jest/hasteImpl.js
+++ b/scripts/jest/hasteImpl.js
@@ -15,7 +15,6 @@ const ROOT = path.join(__dirname, '..', '..');
 
 const BLACKLISTED_PATTERNS/*: Array<RegExp>*/ = [
   /.*\/__(mocks|tests)__\/.*/,
-  /^packages\/babel-plugin-relay\/invariant\.js/,
 ];
 
 const WHITELISTED_PREFIXES/*: Array<string>*/ = [


### PR DESCRIPTION
We've moved away from Haste for the most part in Relay, this changes the
Jest config, so only the compiler and test-utils directories are still
searched for Haste files when running the tests.