### PR TITLE
[Docs] Clarify behavior of query param when null

### DIFF
--- a/docs/Modern-QueryRenderer.md
+++ b/docs/Modern-QueryRenderer.md
@@ -12,7 +12,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 ## Props
 
 * `environment`: The [Relay Environment](./relay-environment.html)
-* `query?`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat.html), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
+* `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat.html), `relay-compiler` enforces the query to be named as `<FileName>Query`. If null, no query is sent and an empty `props` object is passed to the `render` callback.
 * `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 * `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables is passed, the `QueryRenderer` will re-fetch the query.
 * `render`: Function of type `({error, props, retry}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.

--- a/docs/Modern-QueryRenderer.md
+++ b/docs/Modern-QueryRenderer.md
@@ -12,7 +12,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 ## Props
 
 * `environment`: The [Relay Environment](./relay-environment.html)
-* `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat.html), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
+* `query?`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat.html), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 * `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 * `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables is passed, the `QueryRenderer` will re-fetch the query.
 * `render`: Function of type `({error, props, retry}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.


### PR DESCRIPTION
cacheConfig is displayed with a ? to make it obvious it is optional (it then follows with the word Optional, which helps.)  I missed that query was optional without the same signaling.