### PR TITLE
Fix Developer Tools link for 1.7.1 docs

### DIFF
--- a/website/versioned_docs/version-v1.7.1/Modern-Debugging.md
+++ b/website/versioned_docs/version-v1.7.1/Modern-Debugging.md
@@ -13,5 +13,5 @@ Relay DevTools is tool designed to help developers inspect their Relay state and
 ![Store Explorer](/relay/img/docs/store-explorer-updated.png)
 ![Mutations View](/relay/img/docs/mutations-view-updated.png)
 
-[extension]:https://chrome.google.com/webstore/detail/relay-developer-tools/ncedobpgnmkhcmnnkcimnobpfepidad
+[extension]:https://chrome.google.com/webstore/detail/relay-developer-tools/ncedobpgnmkhcmnnkcimnobpfepidadl
 [app]: https://www.npmjs.com/package/relay-devtools


### PR DESCRIPTION
Thanks @ro-savage for noticing, the link in the docs was broken. This
was previously fixed in #2585, but only for the next version. This fixes
the docs for the current 1.7.1 release.