### PR TITLE
Update readme relay example default package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The [relay-examples](https://github.com/relayjs/relay-examples) repository conta
 ```
 git clone https://github.com/relayjs/relay-examples.git
 cd relay-examples/todo
-npm install
-npm run build
-npm start
+yarn
+yarn build
+yarn start
 ```
 
 Then, just point your browser at `http://localhost:3000`.


### PR DESCRIPTION
Since there's a `yarn.lock` in relay examples todo application yarn considered as the default package manager so that the readme should also point to use yarn by default