### PR TITLE
New function will be created with each render

### DIFF
--- a/docs/Modern-QueryRenderer.md
+++ b/docs/Modern-QueryRenderer.md
@@ -27,16 +27,16 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay';
 
-const Example = (props) => {
-  const renderQuery = ({error, props}) => {
-    if (error) {
-      return <div>{error.message}</div>;
-    } else if (props) {
-      return <div>{props.page.name} is great!</div>;
-    }
-    return <div>Loading</div>;
+const renderQuery = ({error, props}) => {
+  if (error) {
+    return <div>{error.message}</div>;
+  } else if (props) {
+    return <div>{props.page.name} is great!</div>;
   }
-
+  return <div>Loading</div>;
+}
+  
+const Example = (props) => {
   return (
     <QueryRenderer
       environment={environment}

--- a/docs/Modern-QueryRenderer.md
+++ b/docs/Modern-QueryRenderer.md
@@ -28,6 +28,15 @@ import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay';
 
 class Example extends React.Component {
+  renderQuery = ({error, props}) => {
+    if (error) {
+      return <div>{error.message}</div>;
+    } else if (props) {
+      return <div>{props.page.name} is great!</div>;
+    }
+    return <div>Loading</div>;
+  }
+
   render() {
     return (
       <QueryRenderer
@@ -42,14 +51,7 @@ class Example extends React.Component {
         variables={{
           pageID: '110798995619330',
         }}
-        render={({error, props}) => {
-          if (error) {
-            return <div>{error.message}</div>;
-          } else if (props) {
-            return <div>{props.page.name} is great!</div>;
-          }
-          return <div>Loading</div>;
-        }}
+        render={this.renderQuery}
       />
     );
   }

--- a/docs/Modern-QueryRenderer.md
+++ b/docs/Modern-QueryRenderer.md
@@ -27,8 +27,8 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 import React from 'react';
 import { QueryRenderer, graphql } from 'react-relay';
 
-class Example extends React.Component {
-  renderQuery = ({error, props}) => {
+const Example = (props) => {
+  const renderQuery = ({error, props}) => {
     if (error) {
       return <div>{error.message}</div>;
     } else if (props) {
@@ -37,23 +37,21 @@ class Example extends React.Component {
     return <div>Loading</div>;
   }
 
-  render() {
-    return (
-      <QueryRenderer
-        environment={environment}
-        query={graphql`
-          query ExampleQuery($pageID: ID!) {
-            page(id: $pageID) {
-              name
-            }
+  return (
+    <QueryRenderer
+      environment={environment}
+      query={graphql`
+        query ExampleQuery($pageID: ID!) {
+          page(id: $pageID) {
+            name
           }
-        `}
-        variables={{
-          pageID: '110798995619330',
-        }}
-        render={this.renderQuery}
-      />
-    );
-  }
+        }
+      `}
+      variables={{
+        pageID: '110798995619330',
+      }}
+      render={renderQuery}
+    />
+  );
 }
 ```


### PR DESCRIPTION
[docs] New function will be created with each render of the module, so render function passed inside render of QueryRenderer needs to be inside the class itself, so that it is created once and used any time after that.

Somebody will say, why not doing the same for query function ?
the answer is this depends on object pooling, and relay shares created queries objects.