### PR TITLE
[split-modern] cleanup Flow imports from classic

### DIFF
--- a/packages/react-relay/classic/query/RelayQuery.js
+++ b/packages/react-relay/classic/query/RelayQuery.js
@@ -499,7 +499,7 @@ class RelayQueryRoot extends RelayQueryNode {
     return batchCall;
   }
 
-  getCallsWithValues(): Array<Call> {
+  getCallsWithValues(): $ReadOnlyArray<Call> {
     let calls = this.__calls__;
     if (!calls) {
       const concreteCalls = (this.__concreteNode__: ConcreteQuery).calls;
@@ -1131,7 +1131,7 @@ class RelayQueryField extends RelayQueryNode {
   }: {
     alias?: ?string,
     directives?: ?Array<Directive>,
-    calls?: ?Array<Call>,
+    calls?: ?$ReadOnlyArray<Call>,
     children?: ?NextChildren,
     fieldName: string,
     metadata?: ?ConcreteFieldMetadata,
@@ -1342,7 +1342,7 @@ class RelayQueryField extends RelayQueryNode {
     return (this.__concreteNode__: ConcreteField).metadata.inferredPrimaryKey;
   }
 
-  getCallsWithValues(): Array<Call> {
+  getCallsWithValues(): $ReadOnlyArray<Call> {
     let calls = this.__calls__;
     if (!calls) {
       const concreteCalls = (this.__concreteNode__: ConcreteField).calls;
@@ -1395,7 +1395,7 @@ class RelayQueryField extends RelayQueryNode {
 
   cloneFieldWithCalls(
     children: NextChildren,
-    calls: Array<Call>,
+    calls: $ReadOnlyArray<Call>,
   ): ?RelayQueryField {
     if (!this.canHaveSubselections()) {
       // Compact new children *after* this check, for consistency.
@@ -1612,7 +1612,7 @@ function cloneChildren(
 /**
  * Creates an opaque serialization of calls.
  */
-function serializeCalls(calls: Array<Call>): string {
+function serializeCalls(calls: $ReadOnlyArray<Call>): string {
   if (calls.length) {
     const callMap = {};
     calls.forEach(call => {
@@ -1630,8 +1630,8 @@ function serializeCalls(calls: Array<Call>): string {
  * the Babel plugin.
  */
 function areCallValuesEqual(
-  thisCalls: Array<Call>,
-  thatCalls: Array<Call>,
+  thisCalls: $ReadOnlyArray<Call>,
+  thatCalls: $ReadOnlyArray<Call>,
 ): boolean {
   if (thisCalls.length !== thatCalls.length) {
     return false;

--- a/packages/react-relay/classic/query/callsToGraphQL.js
+++ b/packages/react-relay/classic/query/callsToGraphQL.js
@@ -20,7 +20,7 @@ import type {ConcreteCall} from './ConcreteQuery';
  *
  * Convert from plain object `{name, value}` calls to GraphQL call nodes.
  */
-function callsToGraphQL(calls: Array<Call>): Array<ConcreteCall> {
+function callsToGraphQL(calls: $ReadOnlyArray<Call>): Array<ConcreteCall> {
   return calls.map(({name, type, value}) => {
     let concreteValue = null;
     if (Array.isArray(value)) {

--- a/packages/react-relay/classic/store/RelayRecord.js
+++ b/packages/react-relay/classic/store/RelayRecord.js
@@ -17,7 +17,7 @@ import type {DataID, Variables} from 'relay-runtime';
 export type Record = {
   // Records may contain many other fields as [fieldName: string]: mixed
   __dataID__: string,
-  __filterCalls__?: Array<Call>,
+  __filterCalls__?: $ReadOnlyArray<Call>,
   __forceIndex__?: number,
   __mutationIDs__?: Array<ClientMutationID>,
   __mutationStatus__?: string,
@@ -89,6 +89,7 @@ const RelayRecord = {
     }
   },
 
+  // $FlowFixMe
   getDataID(record: Record): string {
     return record.__dataID__;
   },

--- a/packages/react-relay/classic/store/RelayRecordStore.js
+++ b/packages/react-relay/classic/store/RelayRecordStore.js
@@ -49,8 +49,8 @@ type RootCallMapCollection = {
 };
 
 export type RangeInfo = {
-  diffCalls: Array<Call>,
-  filterCalls: Array<Call>,
+  diffCalls: $ReadOnlyArray<Call>,
+  filterCalls: $ReadOnlyArray<Call>,
   pageInfo: ?PageInfo,
   requestedEdgeIDs: Array<string>,
   filteredEdges: Array<RangeEdge>,
@@ -325,7 +325,10 @@ class RelayRecordStore {
    * - `filterCalls`: the subset of `calls` that are condition calls
    *   (`orderby`).
    */
-  getRangeMetadata(connectionID: ?DataID, calls: Array<Call>): ?RangeInfo {
+  getRangeMetadata(
+    connectionID: ?DataID,
+    calls: $ReadOnlyArray<Call>,
+  ): ?RangeInfo {
     if (connectionID == null) {
       return connectionID;
     }
@@ -442,7 +445,7 @@ class RelayRecordStore {
  * Filter calls to only those that specify conditions on the returned results
  * (ex: `orderby(TOP_STORIES)`), removing generic calls (ex: `first`, `find`).
  */
-function getFilterCalls(calls: Array<Call>): Array<Call> {
+function getFilterCalls(calls: $ReadOnlyArray<Call>): $ReadOnlyArray<Call> {
   return calls.filter(call => !ConnectionInterface.isConnectionCall(call));
 }
 

--- a/packages/react-relay/classic/store/RelayRecordWriter.js
+++ b/packages/react-relay/classic/store/RelayRecordWriter.js
@@ -425,7 +425,7 @@ class RelayRecordWriter {
    */
   putRange(
     connectionID: DataID,
-    calls: Array<Call>,
+    calls: $ReadOnlyArray<Call>,
     forceIndex?: ?number,
   ): void {
     invariant(
@@ -466,7 +466,7 @@ class RelayRecordWriter {
    */
   putRangeEdges(
     connectionID: DataID,
-    calls: Array<Call>,
+    calls: $ReadOnlyArray<Call>,
     pageInfo: PageInfo,
     edges: Array<DataID>,
   ): void {
@@ -520,6 +520,8 @@ class RelayRecordWriter {
     );
     return RelayRecord.createWithFields(edgeID, {
       cursor: this.getField(edgeID, CURSOR),
+
+      // $FlowFixMe
       node: RelayRecord.create(nodeID),
     });
   }
@@ -661,7 +663,7 @@ class RelayRecordWriter {
  * Filter calls to only those that specify conditions on the returned results
  * (ex: `orderby(TOP_STORIES)`), removing generic calls (ex: `first`, `find`).
  */
-function getFilterCalls(calls: Array<Call>): Array<Call> {
+function getFilterCalls(calls: $ReadOnlyArray<Call>): $ReadOnlyArray<Call> {
   return calls.filter(call => !ConnectionInterface.isConnectionCall(call));
 }
 

--- a/packages/react-relay/classic/traversal/findRelayQueryLeaves.js
+++ b/packages/react-relay/classic/traversal/findRelayQueryLeaves.js
@@ -30,7 +30,7 @@ type FinderState = {
   dataID: DataID,
   missingData: boolean,
   path: QueryPath,
-  rangeCalls: ?Array<Call>,
+  rangeCalls: ?$ReadOnlyArray<Call>,
   rangeInfo: ?RangeInfo,
 };
 
@@ -42,7 +42,7 @@ export type NodeState = {
   dataID: ?DataID,
   node: RelayQuery.Node,
   path: QueryPath,
-  rangeCalls: ?Array<Call>,
+  rangeCalls: ?$ReadOnlyArray<Call>,
 };
 
 /**
@@ -62,7 +62,7 @@ function findRelayQueryLeaves(
   queryNode: RelayQuery.Node,
   dataID: DataID,
   path: QueryPath,
-  rangeCalls: ?Array<Call>,
+  rangeCalls: ?$ReadOnlyArray<Call>,
 ): FinderResult {
   const finder = new RelayQueryLeavesFinder(store, cachedRecords);
 

--- a/packages/relay-runtime/handlers/connection/RelayConnectionInterface.js
+++ b/packages/relay-runtime/handlers/connection/RelayConnectionInterface.js
@@ -10,8 +10,11 @@
 
 'use strict';
 
-import type {Record} from 'react-relay/classic/store/RelayRecord';
-import type {Call} from 'react-relay/classic/tools/RelayInternalTypes';
+import type {Record} from '../../util/RelayCombinedEnvironmentTypes';
+
+type Call = {
+  name: string,
+};
 
 export type EdgeRecord = Record & {
   cursor: mixed,
@@ -83,7 +86,7 @@ const RelayConnectionInterface = {
    * Checks whether a set of calls on a connection supply enough information to
    * fetch the range fields (i.e. `edges` and `page_info`).
    */
-  hasRangeCalls(calls: Array<Call>): boolean {
+  hasRangeCalls(calls: $ReadOnlyArray<Call>): boolean {
     return calls.some(call => REQUIRED_RANGE_CALLS.hasOwnProperty(call.name));
   },
 


### PR DESCRIPTION
`RelayConnectionInterface` is part of RelayModern, so it shouldn't
import anything from classic in preparation of removing classic.