### PR TITLE
remove references to classic generateClientID from modern tests

### DIFF
--- a/packages/relay-runtime/store/__tests__/DataChecker-test.js
+++ b/packages/relay-runtime/store/__tests__/DataChecker-test.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-jest.mock('generateClientID');
+const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
+const RelayModernRecord = require('../RelayModernRecord');
+
+const getRelayHandleKey = require('../../util/getRelayHandleKey');
 
 const {check} = require('../DataChecker');
-const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
 const {ROOT_ID} = require('../RelayStoreUtils');
-const RelayModernRecord = require('../RelayModernRecord');
 const {generateAndCompile} = require('RelayModernTestUtils');
-const getRelayHandleKey = require('../../util/getRelayHandleKey');
 
 beforeEach(() => {
   jest.resetModules();

--- a/packages/relay-runtime/store/__tests__/RelayReader-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-test.js
@@ -10,14 +10,12 @@
 
 'use strict';
 
-jest.mock('generateClientID');
-
 const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
 const RelayModernTestUtils = require('RelayModernTestUtils');
 
+const {getRequest, createOperationDescriptor} = require('../RelayCore');
 const {read} = require('../RelayReader');
 const {ROOT_ID} = require('../RelayStoreUtils');
-const {getRequest, createOperationDescriptor} = require('../RelayCore');
 
 describe('RelayReader', () => {
   const {generateAndCompile, generateWithTransforms} = RelayModernTestUtils;

--- a/packages/relay-runtime/store/__tests__/RelayReferenceMarker-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReferenceMarker-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.mock('generateClientID');
-
 const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
 const RelayModernTestUtils = require('RelayModernTestUtils');
 

--- a/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
@@ -10,13 +10,12 @@
 
 'use strict';
 
-jest.mock('generateClientID');
-
 const RelayInMemoryRecordSource = require('../RelayInMemoryRecordSource');
 const RelayModernRecord = require('../RelayModernRecord');
+const RelayModernTestUtils = require('RelayModernTestUtils');
+
 const {normalize} = require('../RelayResponseNormalizer');
 const {ROOT_ID, ROOT_TYPE} = require('../RelayStoreUtils');
-const RelayModernTestUtils = require('RelayModernTestUtils');
 
 describe('RelayResponseNormalizer', () => {
   const {


### PR DESCRIPTION
Summary: `generateClientID` (not to be confused with `generateRelayClientID`) is only used in classic, no need to mock it here.

Differential Revision: D13923193
