### PR TITLE
Remove RelayClassic environment reference from RelayModern test

### DIFF
--- a/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
+++ b/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
@@ -156,10 +156,7 @@ describe('Configs: NODE_DELETE', () => {
     expect(callback.mock.calls.length).toBe(0);
   });
   it('throws error with classic environment', () => {
-    const RelayEnvironment = jest.requireActual(
-      'react-relay/classic/store/__mocks__/RelayEnvironment',
-    );
-    const environment = new RelayEnvironment();
+    const notARelayModernEnvironment = {};
     const mutation = generateAndCompile(`
       mutation CommentDeleteMutation(
         $input: CommentDeleteInput
@@ -178,7 +175,7 @@ describe('Configs: NODE_DELETE', () => {
     };
 
     expect(() =>
-      commitRelayModernMutation(environment, {
+      commitRelayModernMutation(notARelayModernEnvironment, {
         mutation,
         variables,
       }),

--- a/packages/relay-runtime/store/__tests__/isRelayModernEnvironment-test.js
+++ b/packages/relay-runtime/store/__tests__/isRelayModernEnvironment-test.js
@@ -27,8 +27,8 @@ describe('isRelayModernEnvironment()', () => {
   });
 
   it('returns false for classic RelayEnvironment instances', () => {
-    const environment = new RelayEnvironment();
-    expect(isRelayModernEnvironment(environment)).toBe(false);
+    const notARelayModernEnvironment = {};
+    expect(isRelayModernEnvironment(notARelayModernEnvironment)).toBe(false);
   });
 
   it('returns false for plain objects that conform to the interface', () => {


### PR DESCRIPTION
Removes one of the last requires from modern into classic. Makes the test a bit weaker, but this is probably what we have to do when we want to remove classic fully.