### PR TITLE
[relay-compiler] Use global state for persisted queries to fix --watch

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -305,8 +305,8 @@ function getRelayFileWriter(
     let queryMap;
     if (persistedQueryPath != null) {
       queryMap = new Map();
-      persistQuery = (text: string, id: string, filename: string) => {
-        queryMap.set(filename, {id, text});
+      persistQuery = (text: string, id: string) => {
+        queryMap.set(id, text);
         return Promise.resolve(id);
       };
     }
@@ -340,7 +340,7 @@ function getRelayFileWriter(
     });
     if (queryMap != null && persistedQueryPath != null) {
       const object = {};
-      for (const {id, text} of queryMap.values()) {
+      for (const [id, text] of queryMap.entries()) {
         object[id] = text;
       }
       const data = JSON.stringify(object, null, 2);

--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -305,8 +305,8 @@ function getRelayFileWriter(
     let queryMap;
     if (persistedQueryPath != null) {
       queryMap = new Map();
-      persistQuery = (text: string, id: string) => {
-        queryMap.set(id, text);
+      persistQuery = (text: string, id: string, filename: string) => {
+        queryMap.set(filename, {id, text});
         return Promise.resolve(id);
       };
     }
@@ -340,8 +340,8 @@ function getRelayFileWriter(
     });
     if (queryMap != null && persistedQueryPath != null) {
       const object = {};
-      for (const [key, value] of queryMap.entries()) {
-        object[key] = value;
+      for (const {id, text} of queryMap.values()) {
+        object[id] = text;
       }
       const data = JSON.stringify(object, null, 2);
       fs.writeFileSync(persistedQueryPath, data, 'utf8');

--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -301,13 +301,18 @@ function getRelayFileWriter(
     sourceControl,
     reporter,
   }: WriteFilesOptions) => {
+    let registerQuery;
     let persistQuery;
     let queryMap;
     if (persistedQueryPath != null) {
       queryMap = new Map();
       persistQuery = (text: string, id: string) => {
-        queryMap.set(id, text);
+        // This function used for FB internal implementation of persistence
         return Promise.resolve(id);
+      };
+      registerQuery = (text: string, id: string) => {
+        // Add query to queryMap for eventual output to disk
+        queryMap.set(id, text);
       };
     }
     const results = RelayFileWriter.writeAll({
@@ -330,6 +335,7 @@ function getRelayFileWriter(
         typeGenerator: languagePlugin.typeGenerator,
         outputDir,
         persistQuery,
+        registerQuery,
       },
       onlyValidate,
       schema,

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -60,11 +60,7 @@ export type WriterConfig = {
   optionalInputFieldsForFlow: Array<string>,
   outputDir?: ?string,
   generatedDirectories?: Array<string>,
-  persistQuery?: ?(
-    text: string,
-    id: string,
-    filename: string,
-  ) => Promise<string>,
+  persistQuery?: ?(text: string, id: string) => Promise<string>,
   platform?: string,
   schemaExtensions: Array<string>,
   noFutureProofEnums: boolean,

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -60,7 +60,11 @@ export type WriterConfig = {
   optionalInputFieldsForFlow: Array<string>,
   outputDir?: ?string,
   generatedDirectories?: Array<string>,
-  persistQuery?: ?(text: string, id: string) => Promise<string>,
+  persistQuery?: ?(
+    text: string,
+    id: string,
+    filename: string,
+  ) => Promise<string>,
   platform?: string,
   schemaExtensions: Array<string>,
   noFutureProofEnums: boolean,

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -61,6 +61,7 @@ export type WriterConfig = {
   outputDir?: ?string,
   generatedDirectories?: Array<string>,
   persistQuery?: ?(text: string, id: string) => Promise<string>,
+  registerQuery?: (text: string, id: string) => void,
   platform?: string,
   schemaExtensions: Array<string>,
   noFutureProofEnums: boolean,
@@ -343,6 +344,7 @@ function writeAll({
             sourceHash,
             writerConfig.extension,
             writerConfig.printModuleDependency,
+            writerConfig.registerQuery,
           );
         }),
       );

--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -48,11 +48,7 @@ async function writeRelayGeneratedFile(
   _generatedNode: GeneratedNode,
   formatModule: FormatModule,
   typeText: string,
-  _persistQuery: ?(
-    text: string,
-    id: string,
-    filename: string,
-  ) => Promise<string>,
+  _persistQuery: ?(text: string, id: string) => Promise<string>,
   platform: ?string,
   sourceHash: string,
   extension: string,
@@ -101,8 +97,9 @@ async function writeRelayGeneratedFile(
     });
 
     const {text} = generatedNode.params;
+    let persistedQueryId = null;
     if (persistQuery && text != null) {
-      await persistQuery(text, sourceHash, filename);
+      persistedQueryId = await persistQuery(text, sourceHash);
     }
 
     if (hash === oldHash) {
@@ -121,11 +118,15 @@ async function writeRelayGeneratedFile(
             text != null,
             'writeRelayGeneratedFile: Expected `text` in order to persist query',
           );
+          invariant(
+            persistedQueryId != null,
+            'writeRelayGeneratedFile: Expected `persistedQueryId` in order to persist query',
+          );
           devOnlyProperties.params = {text};
           generatedNode = {
             ...generatedNode,
             params: {
-              id: sourceHash,
+              id: persistedQueryId,
               text: null,
               ...restParams,
             },

--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -48,7 +48,11 @@ async function writeRelayGeneratedFile(
   _generatedNode: GeneratedNode,
   formatModule: FormatModule,
   typeText: string,
-  _persistQuery: ?(text: string, id: string) => Promise<string>,
+  _persistQuery: ?(
+    text: string,
+    id: string,
+    filename: string,
+  ) => Promise<string>,
   platform: ?string,
   sourceHash: string,
   extension: string,
@@ -95,6 +99,12 @@ async function writeRelayGeneratedFile(
       hash = hasher.digest('hex');
       return extractHash(oldContent);
     });
+
+    const {text} = generatedNode.params;
+    if (persistQuery && text != null) {
+      await persistQuery(text, sourceHash, filename);
+    }
+
     if (hash === oldHash) {
       codegenDir.markUnchanged(filename);
       return null;
@@ -115,7 +125,7 @@ async function writeRelayGeneratedFile(
           generatedNode = {
             ...generatedNode,
             params: {
-              id: await persistQuery(text, sourceHash),
+              id: sourceHash,
               text: null,
               ...restParams,
             },


### PR DESCRIPTION
This is my attempt to fix the issue raised here https://github.com/facebook/relay/issues/2625

I'm using a map keyed by filename and ensuring all queries are written even if unchanged while watching. The map is initialised in scope when writing, so old files are omitted if removed and the state is therefore hopefully correct for each write. My assumption is there is a 1 to 1 relationship of filenames to query id.

The main logic is making sure persistQuery is called even if the query is unchanged (ie. the hashes match).