### PR TITLE
Fix async RelayCompilerMain test

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -143,11 +143,11 @@ async function main(options: {
 }) {
   const schemaPath = path.resolve(process.cwd(), options.schema);
   if (!fs.existsSync(schemaPath)) {
-    throw new Error(`--schema path does not exist: ${schemaPath}.`);
+    throw new Error(`--schema path does not exist: ${schemaPath}`);
   }
   const srcDir = path.resolve(process.cwd(), options.src);
   if (!fs.existsSync(srcDir)) {
-    throw new Error(`--src path does not exist: ${srcDir}.`);
+    throw new Error(`--src path does not exist: ${srcDir}`);
   }
 
   let persistedQueryPath = options.persistOutput;
@@ -156,7 +156,7 @@ async function main(options: {
     const persistOutputDir = path.dirname(persistedQueryPath);
     if (!fs.existsSync(persistOutputDir)) {
       throw new Error(
-        `--persist-output path does not exist: ${persistedQueryPath}.`,
+        `--persist-output path does not exist: ${persistedQueryPath}`,
       );
     }
   }

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -10,46 +10,45 @@
 
 'use strict';
 
-jest.mock('fs');
+jest.mock('fs', () => ({
+  existsSync(path) {
+    return path.startsWith('/existing/');
+    return false;
+  },
+}));
 
 const {main} = require('../RelayCompilerMain');
 
 describe('RelayCompilerMain', () => {
   it('should throw error when schema path does not exist', async () => {
-    expect(
+    await expect(
       main({
-        schema: './some/path/schema.graphql',
-        src: './',
+        schema: '/nonexisting/schema.graphql',
+        src: '/existing/',
       }),
     ).rejects.toEqual(
-      new Error(
-        "--schema './some/path/schema.graphql' invalid: path does not exist",
-      ),
+      new Error('--schema path does not exist: /nonexisting/schema.graphql'),
     );
   });
 
   it('should throw error when src path does not exist', async () => {
-    expect(
+    await expect(
       main({
-        schema: './',
-        src: './some/path/src',
+        schema: '/existing/schema.graphql',
+        src: '/nonexisting/src',
       }),
-    ).rejects.toEqual(
-      new Error("--src './some/path/src' invalid: path does not exist"),
-    );
+    ).rejects.toEqual(new Error('--src path does not exist: /nonexisting/src'));
   });
 
   it('should throw error when persist-output parent directory does not exist', async () => {
-    expect(
+    await expect(
       main({
-        schema: './',
-        src: './',
-        persistOutput: './some/path/queries.json',
+        schema: '/existing/schema.graphql',
+        src: '/existing/src/',
+        persistOutput: '/nonexisting/output/',
       }),
     ).rejects.toEqual(
-      new Error(
-        "--persist-output './some/path/queries.json' invalid: parent directory does not exist",
-      ),
+      new Error('--persist-output path does not exist: /nonexisting/output'),
     );
   });
 });


### PR DESCRIPTION
This test was actually *not* passing, but the error was just printed to
the console. Async tests have to `await` the `.rejects.` promise to
correctly attribute the failure.