### PR TITLE
[split-modern] Remove Classic flow types from RelayModern

### DIFF
--- a/packages/react-relay/classic/mutation/validateMutationConfig.js
+++ b/packages/react-relay/classic/mutation/validateMutationConfig.js
@@ -135,6 +135,7 @@ function validateMutationConfig(
       });
       break;
 
+    // $FlowFixMe no longer part of the flow type from RelayModern
     case 'REQUIRED_CHILDREN':
       assertValid({
         children: REQUIRED,

--- a/packages/react-relay/modern/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/modern/ReactRelayQueryRenderer.js
@@ -18,7 +18,6 @@ const areEqual = require('areEqual');
 
 const {deepFreeze} = require('relay-runtime');
 
-import type {RelayEnvironmentInterface as ClassicEnvironment} from '../classic/store/RelayEnvironment';
 import type {
   CacheConfig,
   GraphQLTaggedNode,
@@ -59,11 +58,10 @@ const DataFromEnum = {
   STORE_THEN_NETWORK,
 };
 type DataFrom = $Keys<typeof DataFromEnum>;
-type CompatEnvironment = IEnvironment | ClassicEnvironment;
 export type Props = {
   cacheConfig?: ?CacheConfig,
   dataFrom?: DataFrom,
-  environment: CompatEnvironment,
+  environment: IEnvironment,
   query: ?GraphQLTaggedNode,
   render: (renderProps: RenderProps) => React.Node,
   variables: Variables,
@@ -71,7 +69,7 @@ export type Props = {
 
 type State = {
   error: Error | null,
-  prevPropsEnvironment: CompatEnvironment,
+  prevPropsEnvironment: IEnvironment,
   prevPropsVariables: Variables,
   prevQuery: ?GraphQLTaggedNode,
   queryFetcher: ReactRelayQueryFetcher,
@@ -112,10 +110,7 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
     if (props.query) {
       const {query} = props;
 
-      // $FlowFixMe TODO t16225453 QueryRenderer works with old+new environment.
-      const genericEnvironment = (props.environment: IEnvironment);
-
-      const {getRequest} = genericEnvironment.unstable_internal;
+      const {getRequest} = props.environment.unstable_internal;
       const request = getRequest(query);
       requestCacheKey = getRequestCacheKey(request.params, props.variables);
       queryFetcher = requestCache[requestCacheKey]
@@ -155,9 +150,7 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
 
       let queryFetcher;
       if (query) {
-        // $FlowFixMe TODO t16225453 QueryRenderer works with old+new environment.
-        const genericEnvironment = (nextProps.environment: IEnvironment);
-        const {getRequest} = genericEnvironment.unstable_internal;
+        const {getRequest} = nextProps.environment.unstable_internal;
         const request = getRequest(query);
         const requestCacheKey = getRequestCacheKey(
           request.params,

--- a/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
+++ b/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
@@ -21,7 +21,6 @@ import type {
 import type {SelectorData} from '../util/RelayCombinedEnvironmentTypes';
 import type {ConcreteRequest} from '../util/RelayConcreteNode';
 import type {DataID, Variables} from '../util/RelayRuntimeTypes';
-import type {RelayConcreteNode} from 'react-relay/classic/query/RelayQL';
 
 const MutationTypes = Object.freeze({
   RANGE_ADD: 'RANGE_ADD',
@@ -90,18 +89,11 @@ type LegacyFieldsChangeConfig = {|
   fieldIDs: {[fieldName: string]: DataID | Array<DataID>},
 |};
 
-// Unused in Relay Modern
-type LegacyRequiredChildrenConfig = {|
-  type: 'REQUIRED_CHILDREN',
-  children: Array<RelayConcreteNode>,
-|};
-
 export type DeclarativeMutationConfig =
   | RangeAddConfig
   | RangeDeleteConfig
   | NodeDeleteConfig
-  | LegacyFieldsChangeConfig
-  | LegacyRequiredChildrenConfig;
+  | LegacyFieldsChangeConfig;
 
 function convert(
   configs: Array<DeclarativeMutationConfig>,


### PR DESCRIPTION
Removes references to classic from the code in the `/modern/` directory. Preparing us for the deleting of those directories.

Fingers crossed this doesn't blow up to bad when imported..