### PR TITLE
remove __typename as exclusion criterion in copyFields

### DIFF
--- a/packages/relay-runtime/store/RelayModernRecord.js
+++ b/packages/relay-runtime/store/RelayModernRecord.js
@@ -84,17 +84,20 @@ function clone(record: Record): Record {
 /**
  * @public
  *
- * Copies all fields from `source` to `sink`, excluding `__id` and `__typename`.
+ * Copies all fields from `source` to `sink`, excluding `__id`.
  *
  * NOTE: This function does not treat `id` specially. To preserve the id,
  * manually reset it after calling this function. Also note that values are
  * copied by reference and not value; callers should ensure that values are
  * copied on write.
+ *
+ * `__typename` is not excluded because two normalized payloads could
+ * have the same `storageKey`, but different `__typename` values
  */
 function copyFields(source: Record, sink: Record): void {
   for (const key in source) {
     if (source.hasOwnProperty(key)) {
-      if (key !== ID_KEY && key !== TYPENAME_KEY) {
+      if (key !== ID_KEY) {
         sink[key] = source[key];
       }
     }

--- a/packages/relay-runtime/store/__tests__/RelayModernRecord-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernRecord-test.js
@@ -60,7 +60,7 @@ describe('RelayModernRecord', () => {
       RelayModernRecord.copyFields(source, sink);
       expect(sink).toEqual({
         [ID_KEY]: '4',
-        [TYPENAME_KEY]: 'User',
+        [TYPENAME_KEY]: '__User',
         name: 'Zuck',
         pet: {[REF_KEY]: 'beast'},
         pets: {[REFS_KEY]: ['beast']},


### PR DESCRIPTION
normalizing 2 payloads of the same union type could result in the same `storageKey`. I don't think this is a real-world issue today (aside from the 1 changed test), but it is a blocker for custom publish queues #2482 

NOTE:

v2.0.0 RelayModernRecord::update gives a warning that is a false positive for conflicting types.
"RelayModernRecord: Invalid record update, expected both versions of record...."
Using the example above, 2 subscription payloads of a union type could have the same `storageKey` but different types. Maybe we should timestamp subscription payloads as they come in?
