### PR TITLE
Properly handle null cursor in PaginationContainer

### DIFF
--- a/packages/react-relay/modern/ReactRelayPaginationContainer.js
+++ b/packages/react-relay/modern/ReactRelayPaginationContainer.js
@@ -708,8 +708,8 @@ function createContainerWithFragments<
         componentName,
       );
       fetchVariables = {
-        ...fetchVariables,
         ...this._refetchVariables,
+        ...fetchVariables,
       };
 
       const cacheConfig: ?CacheConfig = options


### PR DESCRIPTION
I made this change to fix a bug I encountered. If I called `refetchConnection` with `cursor: null`, subsequent `loadMore()` calls would always load the same page of results from the server. 

This spreading of `this._refetchVariables` is apparently intended to make sure that `fetchVariables` has the expected shape, in case `connectionConfig.getVariables` doesn't return all the needed keys.

However, this breaks pagination if `refetchConnection` is called with `{cursor: null}`. This sets `this._refetchVariables` to contain `{cursor: null}`, and then if you call `loadMore()`, the cursor is always overridden by `null`, causing the same page of results to be loaded again and again. It's easily fixed by simply reversing the order of the spreading.