### PR TITLE
Move persisted id generation to RelayCompilerMain

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -22,6 +22,7 @@ const RelayFileWriter = require('../codegen/RelayFileWriter');
 const RelayIRTransforms = require('../core/RelayIRTransforms');
 const RelayLanguagePluginJavaScript = require('../language/javascript/RelayLanguagePluginJavaScript');
 
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 
@@ -304,7 +305,10 @@ function getRelayFileWriter(
     let queryMap;
     if (persistedQueryPath != null) {
       queryMap = new Map();
-      persistQuery = (text: string, id: string) => {
+      persistQuery = (text: string) => {
+        const hasher = crypto.createHash('md5');
+        hasher.update(text);
+        const id = hasher.digest('hex');
         queryMap.set(id, text);
         return Promise.resolve(id);
       };

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -60,7 +60,7 @@ export type WriterConfig = {
   optionalInputFieldsForFlow: Array<string>,
   outputDir?: ?string,
   generatedDirectories?: Array<string>,
-  persistQuery?: ?(text: string, id: string) => Promise<string>,
+  persistQuery?: ?(text: string) => Promise<string>,
   platform?: string,
   schemaExtensions: Array<string>,
   noFutureProofEnums: boolean,

--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -49,7 +49,7 @@ async function writeRelayGeneratedFile(
   _generatedNode: GeneratedNode,
   formatModule: FormatModule,
   typeText: string,
-  _persistQuery: ?(text: string, id: string) => Promise<string>,
+  _persistQuery: ?(text: string) => Promise<string>,
   platform: ?string,
   sourceHash: string,
   extension: string,
@@ -118,7 +118,7 @@ async function writeRelayGeneratedFile(
             params: {
               operationKind: generatedNode.params.operationKind,
               name: generatedNode.params.name,
-              id: await persistQuery(text, sourceHash),
+              id: await persistQuery(text),
               text: null,
               metadata: generatedNode.params.metadata,
             },


### PR DESCRIPTION
### Summary

The current hash that we use for persisted queries (`sourceHash`) does not include the full query text and only the query node.

For example the following query and fragments:

App A:
```graphql
query CardsScreenQuery {
  viewer {
    ...CardsScreen_viewer
  }
}

fragment CardsScreen_viewer on Viewer {
  name
}
```

App B:
```graphql
query CardsScreenQuery {
  viewer {
    ...CardsScreen_viewer
  }
}

fragment CardsScreen_viewer on Viewer {
  logo
}
```

Would generate the same id because the current hash includes only the query part and not the fragment. This means it only hashes:

```graphql
query CardsScreenQuery {
  viewer {
    ...CardsScreen_viewer
  }
}
```

### Fix

To fix this I added a hash for the whole query text and pass that as the id to `persistQuery`. This makes sure the previous two queries in the example generate a different id.

Note that the ids used to work prior to upgrading to version 2.0 and using `--persisted-output`. Before I used a custom relay-compiler-bin that generated the queries map in `persistQuery`. 

### Test plan

Tested that this fix works in my apps where I discovered the issue. Basically I have 2 apps with some modules with the same name / query but different fragments. When generating the persisted queries for each app and merging them together I added a check to make sure there where not 2 different queries with the same id. The check fails before this change and passes after.