### PR TITLE
Add config support for babel-plugin-relay/macro

### DIFF
--- a/docs/Introduction-InstallationAndSetup.md
+++ b/docs/Introduction-InstallationAndSetup.md
@@ -41,6 +41,21 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+
+For example:
+
+```
+// babel-plugin-macros.config.js
+module.exports = {
+  // ...
+  // Other macros config
+  relay: {
+    compat: true,
+  },
+}
+```
+
 ## Set up relay-compiler
 
 Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay.html#relay-compiler.html), which you can install via `yarn` or `npm`:

--- a/packages/babel-plugin-relay/BabelPluginRelay.macro.js
+++ b/packages/babel-plugin-relay/BabelPluginRelay.macro.js
@@ -14,18 +14,24 @@ const compileGraphQLTag = require('./compileGraphQLTag');
 const getValidGraphQLTag = require('./getValidGraphQLTag');
 
 const {createMacro} = require('babel-plugin-macros');
+const configName = 'relay';
 
-function BabelPluginRelayMacro({references, state, babel}) {
+function BabelPluginRelayMacro({references, state, babel, config}) {
   const {types: t} = babel;
   Object.keys(references).forEach(referenceKey => {
     references[referenceKey].forEach(reference => {
       const path = reference.parentPath;
       const ast = getValidGraphQLTag(path);
       if (ast) {
-        compileGraphQLTag(t, path, state, ast);
+        compileGraphQLTag(
+          t,
+          path,
+          Object.assign(state, config ? {opts: config} : {}),
+          ast,
+        );
       }
     });
   });
 }
 
-module.exports = createMacro(BabelPluginRelayMacro);
+module.exports = createMacro(BabelPluginRelayMacro, {configName});


### PR DESCRIPTION
Allows configuration options (e.g. `artifactDirectory`, `schema`) to be passed to usages of `babel-plugin-relay/macro` using experimental support in babel-macros. The options can be specified in any of the possible ways listed in the following URL: https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/author.md#config-experimental

Notably allows more complex configurations in projects created with create-react-app. In my case, I'd like to use an un-ejected CRA project with [relay-compiler-language-typescript](
https://github.com/relay-tools/relay-compiler-language-typescript).