### PR TITLE
Adds a missing @babel/core dependency

### DIFF
--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -15,6 +15,7 @@
     "relay-compiler": "bin/relay-compiler"
   },
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/generator": "^7.0.0",
     "@babel/parser": "^7.0.0",
     "@babel/polyfill": "^7.0.0",


### PR DESCRIPTION
The `relay-compiler` package doesn't properly list `@babel/core` in its dependencies.