### PR TITLE
Remove babel-core bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@babel/runtime": "^7.0.0",
     "@babel/traverse": "^7.0.0",
     "@babel/types": "^7.0.0",
-    "babel-core": "^7.0.0-bridge",
     "babel-eslint": "9.0.0",
     "babel-plugin-macros": "^2.0.0",
     "babel-plugin-tester": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,11 +1389,6 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-core@^7.0.0-bridge:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-eslint@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-9.0.0.tgz#7d9445f81ed9f60aff38115f838970df9f2b6220"


### PR DESCRIPTION
I don't see any require for this. This was just used during migration to babel 7.