### PR TITLE
Update startCursor and endCursor in Connections.md spec

### DIFF
--- a/website/spec/Connections.md
+++ b/website/spec/Connections.md
@@ -328,7 +328,8 @@ The server must provide a type called `PageInfo`.
 
 `PageInfo` must contain fields `hasPreviousPage` and `hasNextPage`, both
 of which return non-null booleans.  It must also contain fields `startCursor`
-and `endCursor`, both of which return non-null opaque strings.
+and `endCursor`, both of which return opaque strings.  The fields
+`startCursor` and `endCursor` can be null if there are no results.
 
 `hasPreviousPage` is used to indicate whether more edges exist prior to the set
 defined by the clients arguments. If the client is paginating with 

--- a/website/spec/Connections.md
+++ b/website/spec/Connections.md
@@ -429,23 +429,17 @@ returns
         {
           "name": "startCursor",
           "type": {
-            "name": null,
-            "kind": "NON_NULL",
-            "ofType": {
-              "name": "String",
-              "kind": "SCALAR"
-            }
+            "name": "String",
+            "kind": "SCALAR",
+            "ofType": null
           }
         },
         {
           "name": "endCursor",
           "type": {
-            "name": null,
-            "kind": "NON_NULL",
-            "ofType": {
-              "name": "String",
-              "kind": "SCALAR"
-            }
+            "name": "String",
+            "kind": "SCALAR",
+            "ofType": null
           }
         }
       ]


### PR DESCRIPTION
Actual usage requires that `startCursor` and `endCursor` are nullable for empty results.

This is reflected in #2122 and implemented in https://github.com/facebook/relay/commit/a17b462b3ff7355df4858a42ddda75f58c161302.