### PR TITLE
Remove jest automock config

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,16 +113,6 @@
     "transformIgnorePatterns": [
       "<rootDir>/node_modules/"
     ],
-    "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/fbjs-scripts/",
-      "<rootDir>/node_modules/fbjs/lib/(?!(ErrorUtils.js$|fetch.js$|fetchWithRetries.js$))",
-      "<rootDir>/node_modules/fbjs/node_modules/core-js/",
-      "<rootDir>/node_modules/fbjs/node_modules/promise/",
-      "<rootDir>/node_modules/object-assign/",
-      "<rootDir>/node_modules/prop-types/",
-      "<rootDir>/node_modules/react-dom/",
-      "<rootDir>/node_modules/react/"
-    ],
     "testEnvironment": "node"
   },
   "devDependencies": {}


### PR DESCRIPTION
We no longer use auto-mocking anywhere in Relay, so this is no longer needed.