### PR TITLE
Remove react-dom dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,8 +69,6 @@ const babelOptions = require('./scripts/getBabelOptions')({
     React: 'react',
     'react-lifecycles-compat': 'react-lifecycles-compat',
     'relay-compiler': 'relay-compiler',
-    ReactDOM: 'react-dom',
-    ReactNative: 'react-native',
     RelayRuntime: 'relay-runtime',
     'relay-runtime': 'relay-runtime',
     signedsource: 'signedsource',

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "prettier": "1.14.3",
     "prop-types": "^15.5.8",
     "react": "16.6.3",
-    "react-dom": "16.6.3",
     "react-test-renderer": "16.6.3",
     "run-sequence": "2.2.1",
     "signedsource": "^1.0.0",
@@ -120,7 +119,6 @@
       "<rootDir>/node_modules/fbjs/node_modules/promise/",
       "<rootDir>/node_modules/object-assign/",
       "<rootDir>/node_modules/prop-types/",
-      "<rootDir>/node_modules/react-dom/",
       "<rootDir>/node_modules/react/"
     ],
     "testEnvironment": "node"

--- a/packages/react-relay/__tests__/ReactRelayFragmentMockRenderer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayFragmentMockRenderer-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-jest.mock('ReactDOM', () => ({}));
-
 const React = require('React');
 const ReactTestRenderer = require('ReactTestRenderer');
 const ReactRelayRefetchContainer = require('../ReactRelayRefetchContainer');

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -27,10 +27,7 @@ const babelOptions = getBabelOptions({
     '@babel/parser': '@babel/parser',
     immutable: 'immutable',
     React: 'react',
-    ReactDOM: 'react-dom',
-    ReactDOMServer: 'react-dom/server',
     ReactTestRenderer: 'react-test-renderer',
-    ReactTestUtils: 'react-dom/test-utils',
   },
   plugins: [
     [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6323,16 +6323,6 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.6.3:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
-  integrity sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.11.2"
-
 react-is@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"


### PR DESCRIPTION
We no longer have code specific to `react-dom` (we equally support react-native for example).

Test Plan:
grep for react-dom and ReactDOM