### PR TITLE
Fix deprecated yarn usage in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 script:
 - |
     if [ $TEST ]; then
-      yarn install && yarn run jest -- --runInBand --no-watchman
+      yarn install && yarn run jest --runInBand --no-watchman
     fi
 - |
     if [ $TYPECHECK ]; then


### PR DESCRIPTION
Fixes:

> warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.