### PR TITLE
Remove RelayCompat from error messages

### DIFF
--- a/packages/react-relay/buildReactRelayContainer.js
+++ b/packages/react-relay/buildReactRelayContainer.js
@@ -97,23 +97,8 @@ function buildReactRelayContainer<TBase: React$ComponentType<*>>(
   const ForwardContainer = React.forwardRef(forwardRef);
 
   if (__DEV__) {
-    /* $FlowFixMe(>=0.89.0 site=www,mobile,react_native_fb,oss) Suppressing
-     * errors found while preparing to upgrade to 0.89.0 */
-    ForwardContainer.__ComponentClass = ComponentClass;
-    // Classic container static methods.
-    /* $FlowFixMe(>=0.89.0 site=www,mobile,react_native_fb,oss) Suppressing
-     * errors found while preparing to upgrade to 0.89.0 */
-    ForwardContainer.getFragment = function getFragmentOnModernContainer() {
-      throw new Error(
-        `RelayModernContainer: ${containerName}.getFragment() was called on ` +
-          'a Relay Modern component by a Relay Classic or Relay Compat ' +
-          'component.\n' +
-          'When using Relay Modern and Relay Classic in the same ' +
-          'application, ensure components use Relay Compat to work in ' +
-          'both environments.\n' +
-          'See: http://facebook.github.io/relay/docs/relay-compat.html',
-      );
-    };
+    // Used by RelayModernTestUtils
+    (ForwardContainer: any).__ComponentClass = ComponentClass;
   }
 
   /* $FlowFixMe(>=0.89.0 site=www,mobile,react_native_fb,oss) Suppressing errors

--- a/packages/react-relay/buildReactRelayContainer.js
+++ b/packages/react-relay/buildReactRelayContainer.js
@@ -57,11 +57,7 @@ function buildReactRelayContainer<TBase: React$ComponentType<*>>(
         if (!isRelayModernEnvironment(environment)) {
           throw new Error(
             'RelayModernContainer: Can only use Relay Modern component ' +
-              `${containerName} in a Relay Modern environment!\n` +
-              'When using Relay Modern and Relay Classic in the same ' +
-              'application, ensure components use Relay Compat to work in ' +
-              'both environments.\n' +
-              'See: http://facebook.github.io/relay/docs/relay-compat.html',
+              `${containerName} in a Relay Modern environment!`,
           );
         }
       }

--- a/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
+++ b/packages/relay-runtime/mutations/__tests__/commitRelayModernMutation-test.js
@@ -180,11 +180,7 @@ describe('Configs: NODE_DELETE', () => {
       }),
     ).toThrowError(
       'commitRelayModernMutation: expected `environment` to be an instance of ' +
-        '`RelayModernEnvironment`.\n' +
-        'When using Relay Modern and Relay Classic in the same ' +
-        'application, ensure mutations use Relay Compat to work in ' +
-        'both environments.\n' +
-        'See: http://facebook.github.io/relay/docs/relay-compat.html',
+        '`RelayModernEnvironment`.',
     );
   });
 });

--- a/packages/relay-runtime/mutations/applyRelayModernOptimisticMutation.js
+++ b/packages/relay-runtime/mutations/applyRelayModernOptimisticMutation.js
@@ -39,11 +39,7 @@ function applyRelayModernOptimisticMutation(
   invariant(
     isRelayModernEnvironment(environment),
     'commitRelayModernMutation: expected `environment` to be an instance of ' +
-      '`RelayModernEnvironment`.\n' +
-      'When using Relay Modern and Relay Classic in the same ' +
-      'application, ensure mutations use Relay Compat to work in ' +
-      'both environments.\n' +
-      'See: http://facebook.github.io/relay/docs/relay-compat.html',
+      '`RelayModernEnvironment`.',
   );
   const {createOperationDescriptor, getRequest} = environment.unstable_internal;
   const mutation = getRequest(config.mutation);

--- a/packages/relay-runtime/mutations/commitRelayModernMutation.js
+++ b/packages/relay-runtime/mutations/commitRelayModernMutation.js
@@ -46,11 +46,7 @@ function commitRelayModernMutation<T>(
   invariant(
     isRelayModernEnvironment(environment),
     'commitRelayModernMutation: expected `environment` to be an instance of ' +
-      '`RelayModernEnvironment`.\n' +
-      'When using Relay Modern and Relay Classic in the same ' +
-      'application, ensure mutations use Relay Compat to work in ' +
-      'both environments.\n' +
-      'See: http://facebook.github.io/relay/docs/relay-compat.html',
+      '`RelayModernEnvironment`.',
   );
   const {createOperationDescriptor, getRequest} = environment.unstable_internal;
   const mutation = getRequest(config.mutation);


### PR DESCRIPTION
This was only useful to improve the error message in case someone calls `getFragment()` on a RelayModern container which doesn't have this static method.

No runtime behavior actually changes by this as the method was throwing an error before and after.