### PR TITLE
improve the relay store doc by using the consistent imported name

### DIFF
--- a/docs/Modern-RelayStore.md
+++ b/docs/Modern-RelayStore.md
@@ -459,7 +459,7 @@ import {ConnectionHandler} from 'relay-runtime';
 
 // The `friends` connection record can be accessed with:
 const user = store.get(userID);
-const friends = RelayConnectionHandler.getConnection(
+const friends = ConnectionHandler.getConnection(
  user,                        // parent record
  'FriendsFragment_friends'    // connection key
  {orderby: 'firstname'}       // 'filters' that is used to identify the connection
@@ -486,14 +486,14 @@ Given a connection, inserts the edge at the end of the connection, or after the 
 
 ```
 const user = store.get(userID);
-const friends = RelayConnectionHandler.getConnection(user, 'friends');
-const edge = RelayConnectionHandler.createEdge(store, friends, user, 'UserEdge');
+const friends = ConnectionHandler.getConnection(user, 'friends');
+const edge = ConnectionHandler.createEdge(store, friends, user, 'UserEdge');
 
 // No cursor provided, append the edge at the end.
-RelayConnectionHandler.insertEdgeAfter(friends, edge);
+ConnectionHandler.insertEdgeAfter(friends, edge);
 
 // No cursor provided, Insert the edge at the front:
-RelayConnectionHandler.insertEdgeBefore(friends, edge);
+ConnectionHandler.insertEdgeBefore(friends, edge);
 ```
 
 ### `deleteNode(connection: RecordProxy, nodeID: string): void`
@@ -504,6 +504,6 @@ Given a connection, deletes any edges whose id matches the given id.
 
 ```
 const user = store.get(userID);
-const friends = RelayConnectionHandler.getConnection(user, 'friends');
-RelayConnectionHandler.deleteNode(friends, idToDelete);
+const friends = ConnectionHandler.getConnection(user, 'friends');
+ConnectionHandler.deleteNode(friends, idToDelete);
 ```


### PR DESCRIPTION
This part of the doc is very confusing, as you can see we import the pubic api in [L458](https://github.com/facebook/relay/pull/2665/files#diff-af6b98bdc4cbe6dedaed354e06c40bf4R458): `import {ConnectionHandler} from 'relay-runtime'` , but using `RelayConnectionHandler` in the rest of this page.

This patch change all of them to the imported one `ConnectionHandler`.