### PR TITLE
Docs: Remove docs for alternative container fragment format

### DIFF
--- a/docs/Modern-FragmentContainer.md
+++ b/docs/Modern-FragmentContainer.md
@@ -18,18 +18,15 @@ Table of Contents:
 ```javascript
 createFragmentContainer(
   component: ReactComponentClass,
-  fragmentSpec: GraphQLTaggedNode | {[string]: GraphQLTaggedNode},
+  fragmentSpec: {[string]: GraphQLTaggedNode},
 ): ReactComponentClass;
 ```
 
 ### Arguments
 
 * `component`: The React Component *class* of the component requiring the fragment data.
-* `fragmentSpec`: Specifies the data requirements for the Component via a GraphQL fragment. The required data will be available on the component as props that match the shape of the provided fragment. `fragmentSpec` can be one of 2 things:
-  * A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
-  If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
-  * An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop in the resulting Component.
-  * **Note:** `relay-compiler` enforces fragments to be named as `<FileName>_<propName>` to help keeping names unique.
+* `fragmentSpec`: Specifies the data requirements for the Component via a GraphQL fragment. The required data will be available on the component as props that match the shape of the provided fragment. `fragmentSpec` should be an object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
+  * **Note:** `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 
 ### Available Props
 
@@ -115,41 +112,6 @@ export default createFragmentContainer(TodoItem, {
 });
 ```
 
-Relay will infer the prop name from the fragment name according to the fragment naming convention `<FileName><...>_<propName>`. The example below is equivalent to the one above:
-
-```javascript
-export default createFragmentContainer(
-  TodoItem,
-  graphql`
-    fragment TodoItem_item on Todo {
-      text
-      isComplete
-    }
-  `,
-);
-```
-
-If there is no `_<propName>` suffix, the `data` prop name will be used:
-
-```javascript
-class TodoItem extends React.Component {
-  render() {
-    const item = this.props.data;
-    // ...
-  }
-}
-
-export default createFragmentContainer(
-  TodoItem,
-  graphql`
-    fragment TodoItem on Todo {
-      text
-      isComplete
-    }
-  `,
-);
-```
-
 ## Container Composition
 
 React and Relay support creating arbitrarily complex applications through *composition*. Larger components can be created by composing smaller components, helping us to create modular, robust applications.
@@ -184,11 +146,10 @@ Fragment composition works similarly &mdash; a parent container's fragment compo
 ```javascript
 class TodoList extends React.Component {/* as above */}
 
-export default createFragmentContainer(
-  TodoList,
-  // This `_list` fragment name suffix corresponds to the prop named `list` that
-  // is expected to be populated with server data by the `<TodoList>` component.
-  graphql`
+export default createFragmentContainer(TodoList, {
+  // This `list` fragment corresponds to the prop named `list` that is
+  // expected to be populated with server data by the `<TodoList>` component.
+  list: graphql`
     fragment TodoList_list on TodoList {
       # Specify any fields required by '<TodoList>' itself.
       title
@@ -198,7 +159,7 @@ export default createFragmentContainer(
       }
     }
   `,
-);
+});
 ```
 
 Note that when composing fragments, the type of the composed fragment must match the field on the parent in which it is embedded. For example, it wouldn't make sense to embed a fragment of type `Story` into a parent's field of type `User`. Relay and GraphQL will provide helpful error messages if you get this wrong (and if they aren't helpful, let us know!).

--- a/docs/Modern-PaginationContainer.md
+++ b/docs/Modern-PaginationContainer.md
@@ -80,7 +80,7 @@ fragment Feed_user on User {
 ```javascript
 createPaginationContainer(
   component: ReactComponentClass,
-  fragmentSpec: GraphQLTaggedNode | {[string]: GraphQLTaggedNode},
+  fragmentSpec: {[string]: GraphQLTaggedNode},
   connectionConfig: ConnectionConfig,
 ): ReactComponentClass;
 
@@ -110,10 +110,7 @@ type ConnectionData = {
 ### Arguments
 
 * `component`: The React Component *class* of the component requiring the fragment data.
-* `fragmentSpec`: Specifies the data requirements for the Component via a GraphQL fragment. It is expected that one of the fragments specified here will contain a [`@connection`](#connection) for pagination. The required data will be available on the component as props that match the shape of the provided fragment. `fragmentSpec` can be one of 2 things:
-  * A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
-  If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
-  * An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
+* `fragmentSpec`: Specifies the data requirements for the Component via a GraphQL fragment. It is expected that one of the fragments specified here will contain a [`@connection`](#connection) for pagination. The required data will be available on the component as props that match the shape of the provided fragment. `fragmentSpec` should be an object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
   * **Note:** `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 * `connectionConfig`:
   * `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.

--- a/docs/Modern-RefetchContainer.md
+++ b/docs/Modern-RefetchContainer.md
@@ -17,7 +17,7 @@ Table of Contents:
 ```javascript
 createRefetchContainer(
   component: ReactComponentClass,
-  fragmentSpec: GraphQLTaggedNode | {[string]: GraphQLTaggedNode},
+  fragmentSpec: {[string]: GraphQLTaggedNode},
   refetchQuery: GraphQLTaggedNode,
 ): ReactComponentClass;
 ```
@@ -25,10 +25,7 @@ createRefetchContainer(
 ### Arguments
 
 * `component`: The React Component *class* of the component requiring the fragment data.
-* `fragmentSpec`: Specifies the data requirements for the Component via a GraphQL fragment. The required data will be available on the component as props that match the shape of the provided fragment. `fragmentSpec` can be one of 2 things:
-  * A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
-  If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
-  * An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
+* `fragmentSpec`: Specifies the data requirements for the Component via a GraphQL fragment. The required data will be available on the component as props that match the shape of the provided fragment. `fragmentSpec` should be an object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
   * **Note:** `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 * `refetchQuery`: A `graphql` tagged query to be fetched upon calling [`props.relay.refetch`](#refetch). As with any query, upon fetching this query, its result will be normalized into the store, any relevant subscriptions associated with the changed records will be fired, and subscribed components will re-render.
 


### PR DESCRIPTION
This format is about to no longer be supported, so we should remove the docs for it.