### PR TITLE
Remove unused dependency run-sequence

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,6 @@ const chmod = require('gulp-chmod');
 const gulpUtil = require('gulp-util');
 const header = require('gulp-header');
 const path = require('path');
-const runSequence = require('run-sequence');
 const webpack = require('webpack');
 const webpackStream = require('webpack-stream');
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "prop-types": "^15.5.8",
     "react": "16.6.3",
     "react-test-renderer": "16.6.3",
-    "run-sequence": "2.2.1",
     "signedsource": "^1.0.0",
     "webpack": "^4.20.2",
     "webpack-stream": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6616,15 +6616,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-run-sequence@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/run-sequence/-/run-sequence-2.2.1.tgz#1ce643da36fd8c7ea7e1a9329da33fc2b8898495"
-  integrity sha512-qkzZnQWMZjcKbh3CNly2srtrkaO/2H/SI5f2eliMCapdRD3UhMrwjfOAZJAnZ2H8Ju4aBzFZkBGXUqFs9V0yxw==
-  dependencies:
-    chalk "^1.1.3"
-    fancy-log "^1.3.2"
-    plugin-error "^0.1.2"
-
 rxjs@^5.5.2:
   version "5.5.11"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"


### PR DESCRIPTION
This was used before the gulp upgrade but is no longer needed.

Test Plan:
rg run-sequence