### PR TITLE
Cleanup: remove single iterall dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,6 @@ const babelOptions = require('./scripts/getBabelOptions')({
     fs: 'fs',
     graphql: 'graphql',
     immutable: 'immutable',
-    iterall: 'iterall',
     net: 'net',
     os: 'os',
     path: 'path',

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "gulp-header": "2.0.7",
     "gulp-util": "3.0.8",
     "immutable": "~3.7.6",
-    "iterall": "^1.2.1",
     "jest": "^24.1.0",
     "nullthrows": "^1.1.0",
     "object-assign": "4.1.1",

--- a/packages/relay-test-utils/RelayModernTestUtils.js
+++ b/packages/relay-test-utils/RelayModernTestUtils.js
@@ -41,11 +41,10 @@ expect.addSnapshotSerializer({
 
 const matchers = {
   toBeDeeplyFrozen(actual) {
-    const {isCollection, forEach} = require('iterall');
     function check(value) {
       expect(Object.isFrozen(value)).toBe(true);
-      if (isCollection(value)) {
-        forEach(value, check);
+      if (Array.isArray(value)) {
+        value.forEach(item => check(item));
       } else if (typeof value === 'object' && value !== null) {
         for (const key in value) {
           check(value[key]);

--- a/packages/relay-test-utils/package.json
+++ b/packages/relay-test-utils/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "fbjs": "^1.0.0",
-    "iterall": "^1.2.1",
     "prop-types": "^15.5.8",
     "relay-compiler": "3.0.0",
     "relay-runtime": "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4205,7 +4205,7 @@ istanbul-reports@^2.1.1:
   dependencies:
     handlebars "^4.1.0"
 
-iterall@^1.2.1, iterall@^1.2.2:
+iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==


### PR DESCRIPTION
We only test on arrays here, so we don't really need an external dep for this.

Test Plan: CI