### PR TITLE
Export flow types to npm

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,6 +33,7 @@ const gulpUtil = require('gulp-util');
 const header = require('gulp-header');
 const once = require('gulp-once');
 const path = require('path');
+const rename = require('gulp-rename');
 const webpack = require('webpack');
 const webpackStream = require('webpack-stream');
 
@@ -252,6 +253,20 @@ const modules = gulp.parallel(
   ),
 );
 
+const flowDefs = gulp.parallel(
+  ...builds.map(
+    build =>
+      function modulesTask() {
+        return gulp
+          .src(['**/*.js', '!**/__tests__/**/*.js', '!**/__mocks__/**/*.js'], {
+            cwd: PACKAGES + '/' + build.package,
+          })
+          .pipe(rename({extname: '.js.flow'}))
+          .pipe(gulp.dest(path.join(DIST, build.package)));
+      },
+  ),
+);
+
 const copyFilesTasks = [];
 builds.forEach(build => {
   copyFilesTasks.push(
@@ -282,6 +297,7 @@ const copyFiles = gulp.parallel(copyFilesTasks);
 
 const exportsFiles = gulp.series(
   copyFiles,
+  flowDefs,
   modules,
   gulp.parallel(
     ...builds.map(

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gulp-chmod": "2.0.0",
     "gulp-header": "2.0.7",
     "gulp-once": "2.0.3",
+    "gulp-rename": "^2.0.0",
     "gulp-util": "3.0.8",
     "immutable": "~3.7.6",
     "jest": "^24.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,6 +3385,11 @@ gulp-once@2.0.3:
   dependencies:
     plugin-error "^1.0.1"
 
+gulp-rename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-2.0.0.tgz#9bbc3962b0c0f52fc67cd5eaff6c223ec5b9cf6c"
+  integrity sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==
+
 gulp-util@3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"


### PR DESCRIPTION
I still need to figure out how to test this, but I think this might work to allow npm consumers to use the generated flow types.