### PR TITLE
Remove nested backticks from pagination container example

### DIFF
--- a/docs/Modern-PaginationContainer.md
+++ b/docs/Modern-PaginationContainer.md
@@ -273,7 +273,7 @@ module.exports = createPaginationContainer(
       };
     },
     query: graphql`
-      # Pagination query to be fetched upon calling `loadMore`.
+      # Pagination query to be fetched upon calling 'loadMore'.
       # Notice that we re-use our fragment, and the shape of this query matches our fragment spec.
       query FeedPaginationQuery(
         $count: Int!


### PR DESCRIPTION
Pagination Container example is invalid javascript because it has backticks in the graphql string which are not escaped