### PR TITLE
Clarify use of onCompleted vs onError

### DIFF
--- a/docs/Modern-Mutations.md
+++ b/docs/Modern-Mutations.md
@@ -37,7 +37,10 @@ commitMutation(
 * `config`:
   * `mutation`: The `graphql` tagged mutation query.
   * `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
-  * `onCompleted`: Callback function executed when the request is completed and the in-memory Relay store is updated with the `updater` function. Takes a `response` object, which is the "raw" server response, and `errors`, an array containing any errors from the server. .
+  * `onCompleted`: Callback function executed when the request is completed and the in-memory Relay store is updated with the `updater` function. Takes a `response` object, which is the "raw" server response, and `errors`, an array containing any errors from the server. 
+**Please note:** 
+    * This callback (and not `onError`) will be executed whenever the response contains `data`, even if `data` is `null`.
+    * Use this callback's error parameter to get errors returned from the server.
   * `onError`: Callback function executed if Relay encounters an error during the request.
   * `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, *before* `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
   * `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.


### PR DESCRIPTION
This took me a while to figure out, so I think it's a good idea to add this information to the documentation.

[This article](https://itnext.io/the-definitive-guide-to-handling-graphql-errors-e0c58b52b5e1) writes:

> As of March 2018, neither Apollo-Client (including subscriptions-transport-ws) nor Relay Modern is perfect at handling errors. 
> Relay’s mutation API comes close with its onCompleted(result, errors) callback, but this is sorely missed for queries and 
> subscriptions. 

and

>  If GraphQL gives you a result with data, even if that result contains errors, it is not an error.