### PR TITLE
Upgrade Docusaurus to 1.9.0

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -86,310 +86,310 @@
       "videos": {
         "title": "Videos"
       },
-      "version-1.5.0-installation-and-setup": {
+      "version-1.5.0/version-1.5.0-installation-and-setup": {
         "title": "Installation and Setup"
       },
-      "version-1.5.0-quick-start-guide": {
+      "version-1.5.0/version-1.5.0-quick-start-guide": {
         "title": "Quick Start Guide"
       },
-      "version-1.5.0-converting-mutations": {
+      "version-1.5.0/version-1.5.0-converting-mutations": {
         "title": "Converting Mutations"
       },
-      "version-1.5.0-mutations": {
+      "version-1.5.0/version-1.5.0-mutations": {
         "title": "Mutations"
       },
-      "version-1.5.0-network-layer": {
+      "version-1.5.0/version-1.5.0-network-layer": {
         "title": "Network Layer"
       },
-      "version-1.5.0-pagination-container": {
+      "version-1.5.0/version-1.5.0-pagination-container": {
         "title": "Pagination Container"
       },
-      "version-1.5.0-query-renderer": {
+      "version-1.5.0/version-1.5.0-query-renderer": {
         "title": "<QueryRenderer />"
       },
-      "version-1.5.0-refetch-container": {
+      "version-1.5.0/version-1.5.0-refetch-container": {
         "title": "Refetch Container"
       },
-      "version-1.5.0-relay-store": {
+      "version-1.5.0/version-1.5.0-relay-store": {
         "title": "Relay Store"
       },
-      "version-1.5.0-subscriptions": {
+      "version-1.5.0/version-1.5.0-subscriptions": {
         "title": "Subscriptions"
       },
-      "version-1.5.0-thinking-in-graphql": {
+      "version-1.5.0/version-1.5.0-thinking-in-graphql": {
         "title": "Thinking in GraphQL"
       },
-      "version-1.6.0-installation-and-setup": {
+      "version-1.6.0/version-1.6.0-installation-and-setup": {
         "title": "Installation and Setup"
       },
-      "version-1.6.0-quick-start-guide": {
+      "version-1.6.0/version-1.6.0-quick-start-guide": {
         "title": "Quick Start Guide"
       },
-      "version-1.6.0-fetch-query": {
+      "version-1.6.0/version-1.6.0-fetch-query": {
         "title": "fetchQuery"
       },
-      "version-1.6.0-graphql-in-relay": {
+      "version-1.6.0/version-1.6.0-graphql-in-relay": {
         "title": "GraphQL in Relay"
       },
-      "version-1.6.0-mutations": {
+      "version-1.6.0/version-1.6.0-mutations": {
         "title": "Mutations"
       },
-      "version-1.6.0-pagination-container": {
+      "version-1.6.0/version-1.6.0-pagination-container": {
         "title": "Pagination Container"
       },
-      "version-1.6.0-query-renderer": {
+      "version-1.6.0/version-1.6.0-query-renderer": {
         "title": "<QueryRenderer />"
       },
-      "version-1.6.0-thinking-in-relay": {
+      "version-1.6.0/version-1.6.0-thinking-in-relay": {
         "title": "Thinking In Relay"
       },
-      "version-1.6.1-installation-and-setup": {
+      "version-1.6.1/version-1.6.1-installation-and-setup": {
         "title": "Installation and Setup"
       },
-      "version-1.6.1-graphql-in-relay": {
+      "version-1.6.1/version-1.6.1-graphql-in-relay": {
         "title": "GraphQL in Relay"
       },
-      "version-1.6.1-network-layer": {
+      "version-1.6.1/version-1.6.1-network-layer": {
         "title": "Network Layer"
       },
-      "version-1.6.1-pagination-container": {
+      "version-1.6.1/version-1.6.1-pagination-container": {
         "title": "Pagination Container"
       },
-      "version-1.6.1-query-renderer": {
+      "version-1.6.1/version-1.6.1-query-renderer": {
         "title": "<QueryRenderer />"
       },
-      "version-1.6.1-relay-store": {
+      "version-1.6.1/version-1.6.1-relay-store": {
         "title": "Relay Store"
       },
-      "version-1.6.2-mutations": {
+      "version-1.6.2/version-1.6.2-mutations": {
         "title": "Mutations"
       },
-      "version-classic-classic-api-reference-relay-container": {
+      "version-classic/version-classic-classic-api-reference-relay-container": {
         "title": "RelayContainer"
       },
-      "version-classic-classic-api-reference-relay-graphql-mutation": {
+      "version-classic/version-classic-classic-api-reference-relay-graphql-mutation": {
         "title": "Relay.GraphQLMutation"
       },
-      "version-classic-classic-api-reference-relay-mutation": {
+      "version-classic/version-classic-classic-api-reference-relay-mutation": {
         "title": "Relay.Mutation"
       },
-      "version-classic-classic-api-reference-relay-proptypes": {
+      "version-classic/version-classic-classic-api-reference-relay-proptypes": {
         "title": "Relay.PropTypes"
       },
-      "version-classic-classic-api-reference-relay-ql": {
+      "version-classic/version-classic-classic-api-reference-relay-ql": {
         "title": "Relay.QL"
       },
-      "version-classic-classic-api-reference-relay": {
+      "version-classic/version-classic-classic-api-reference-relay": {
         "title": "Relay"
       },
-      "version-classic-classic-api-reference-relay-renderer": {
+      "version-classic/version-classic-classic-api-reference-relay-renderer": {
         "title": "Relay.Renderer"
       },
-      "version-classic-classic-api-reference-relay-root-container": {
+      "version-classic/version-classic-classic-api-reference-relay-root-container": {
         "title": "Relay.RootContainer"
       },
-      "version-classic-classic-api-reference-relay-route": {
+      "version-classic/version-classic-classic-api-reference-relay-route": {
         "title": "Relay.Route"
       },
-      "version-classic-classic-api-reference-relay-store": {
+      "version-classic/version-classic-classic-api-reference-relay-store": {
         "title": "Relay.Store"
       },
-      "version-classic-classic-guides-containers": {
+      "version-classic/version-classic-classic-guides-containers": {
         "title": "Containers"
       },
-      "version-classic-classic-guides-mutations": {
+      "version-classic/version-classic-classic-guides-mutations": {
         "title": "Mutations"
       },
-      "version-classic-classic-guides-network-layer": {
+      "version-classic/version-classic-classic-guides-network-layer": {
         "title": "Network Layer"
       },
-      "version-classic-classic-guides-ready-state": {
+      "version-classic/version-classic-classic-guides-ready-state": {
         "title": "Ready State"
       },
-      "version-classic-classic-guides-root-container": {
+      "version-classic/version-classic-classic-guides-root-container": {
         "title": "Root Container"
       },
-      "version-classic-classic-guides-routes": {
+      "version-classic/version-classic-classic-guides-routes": {
         "title": "Routes"
       },
-      "version-classic-classic-interfaces-relay-mutation-request": {
+      "version-classic/version-classic-classic-interfaces-relay-mutation-request": {
         "title": "RelayMutationRequest"
       },
-      "version-classic-classic-interfaces-relay-network-layer": {
+      "version-classic/version-classic-classic-interfaces-relay-network-layer": {
         "title": "RelayNetworkLayer"
       },
-      "version-classic-classic-interfaces-relay-query-request": {
+      "version-classic/version-classic-classic-interfaces-relay-query-request": {
         "title": "RelayQueryRequest"
       },
-      "version-classic-graphql-server-specification": {
+      "version-classic/version-classic-graphql-server-specification": {
         "title": "GraphQL Server Specification"
       },
-      "version-classic-installation-and-setup": {
+      "version-classic/version-classic-installation-and-setup": {
         "title": "Installation and Setup"
       },
-      "version-classic-introduction-to-relay": {
+      "version-classic/version-classic-introduction-to-relay": {
         "title": "Introduction to Relay"
       },
-      "version-classic-prerequisites": {
+      "version-classic/version-classic-prerequisites": {
         "title": "Prerequisites"
       },
-      "version-classic-quick-start-guide": {
+      "version-classic/version-classic-quick-start-guide": {
         "title": "Quick Start Guide"
       },
-      "version-classic-api-cheatsheet": {
+      "version-classic/version-classic-api-cheatsheet": {
         "title": "API Cheatsheet"
       },
-      "version-classic-compatibility-cheatsheet": {
+      "version-classic/version-classic-compatibility-cheatsheet": {
         "title": "Compatibility Cheatsheet"
       },
-      "version-classic-conversion-playbook": {
+      "version-classic/version-classic-conversion-playbook": {
         "title": "Conversion Playbook"
       },
-      "version-classic-conversion-scripts": {
+      "version-classic/version-classic-conversion-scripts": {
         "title": "Conversion Scripts"
       },
-      "version-classic-converting-mutations": {
+      "version-classic/version-classic-converting-mutations": {
         "title": "Converting Mutations"
       },
-      "version-classic-relay-debugging": {
+      "version-classic/version-classic-relay-debugging": {
         "title": "Debugging"
       },
-      "version-classic-fragment-container": {
+      "version-classic/version-classic-fragment-container": {
         "title": "Fragment Container"
       },
-      "version-classic-graphql-in-relay": {
+      "version-classic/version-classic-graphql-in-relay": {
         "title": "GraphQL in Relay"
       },
-      "version-classic-migration-setup": {
+      "version-classic/version-classic-migration-setup": {
         "title": "Migration Setup"
       },
-      "version-classic-mutations": {
+      "version-classic/version-classic-mutations": {
         "title": "Mutations"
       },
-      "version-classic-network-layer": {
+      "version-classic/version-classic-network-layer": {
         "title": "Network Layer"
       },
-      "version-classic-new-in-relay-modern": {
+      "version-classic/version-classic-new-in-relay-modern": {
         "title": "New in Relay Modern"
       },
-      "version-classic-pagination-container": {
+      "version-classic/version-classic-pagination-container": {
         "title": "Pagination Container"
       },
-      "version-classic-query-renderer": {
+      "version-classic/version-classic-query-renderer": {
         "title": "<QueryRenderer />"
       },
-      "version-classic-refetch-container": {
+      "version-classic/version-classic-refetch-container": {
         "title": "Refetch Container"
       },
-      "version-classic-relay-compat": {
+      "version-classic/version-classic-relay-compat": {
         "title": "Compatibility Mode"
       },
-      "version-classic-relay-environment": {
+      "version-classic/version-classic-relay-environment": {
         "title": "Relay Environment"
       },
-      "version-classic-relay-store": {
+      "version-classic/version-classic-relay-store": {
         "title": "Relay Store"
       },
-      "version-classic-routing": {
+      "version-classic/version-classic-routing": {
         "title": "Routing"
       },
-      "version-classic-subscriptions": {
+      "version-classic/version-classic-subscriptions": {
         "title": "Subscriptions"
       },
-      "version-classic-upgrading-setvariables": {
+      "version-classic/version-classic-upgrading-setvariables": {
         "title": "Upgrading setVariables"
       },
-      "version-classic-compiler-architecture": {
+      "version-classic/version-classic-compiler-architecture": {
         "title": "Compiler Architecture"
       },
-      "version-classic-architecture-overview": {
+      "version-classic/version-classic-architecture-overview": {
         "title": "Architecture Overview"
       },
-      "version-classic-runtime-architecture": {
+      "version-classic/version-classic-runtime-architecture": {
         "title": "Runtime Architecture"
       },
-      "version-classic-thinking-in-graphql": {
+      "version-classic/version-classic-thinking-in-graphql": {
         "title": "Thinking in GraphQL"
       },
-      "version-classic-thinking-in-relay": {
+      "version-classic/version-classic-thinking-in-relay": {
         "title": "Thinking In Relay"
       },
-      "version-classic-videos": {
+      "version-classic/version-classic-videos": {
         "title": "Videos"
       },
-      "version-v1.7.0-installation-and-setup": {
+      "version-v1.7.0/version-v1.7.0-installation-and-setup": {
         "title": "Installation and Setup"
       },
-      "version-v1.7.0-quick-start-guide": {
+      "version-v1.7.0/version-v1.7.0-quick-start-guide": {
         "title": "Quick Start Guide"
       },
-      "version-v1.7.0-converting-mutations": {
+      "version-v1.7.0/version-v1.7.0-converting-mutations": {
         "title": "Converting Mutations"
       },
-      "version-v1.7.0-fetch-query": {
+      "version-v1.7.0/version-v1.7.0-fetch-query": {
         "title": "fetchQuery"
       },
-      "version-v1.7.0-graphql-in-relay": {
+      "version-v1.7.0/version-v1.7.0-graphql-in-relay": {
         "title": "GraphQL in Relay"
       },
-      "version-v1.7.0-mutations": {
+      "version-v1.7.0/version-v1.7.0-mutations": {
         "title": "Mutations"
       },
-      "version-v1.7.0-network-layer": {
+      "version-v1.7.0/version-v1.7.0-network-layer": {
         "title": "Network Layer"
       },
-      "version-v1.7.0-pagination-container": {
+      "version-v1.7.0/version-v1.7.0-pagination-container": {
         "title": "Pagination Container"
       },
-      "version-v1.7.0-query-renderer": {
+      "version-v1.7.0/version-v1.7.0-query-renderer": {
         "title": "<QueryRenderer />"
       },
-      "version-v1.7.0-refetch-container": {
+      "version-v1.7.0/version-v1.7.0-refetch-container": {
         "title": "Refetch Container"
       },
-      "version-v1.7.0-relay-store": {
+      "version-v1.7.0/version-v1.7.0-relay-store": {
         "title": "Relay Store"
       },
-      "version-v1.7.0-subscriptions": {
+      "version-v1.7.0/version-v1.7.0-subscriptions": {
         "title": "Subscriptions"
       },
-      "version-v1.7.0-architecture-overview": {
+      "version-v1.7.0/version-v1.7.0-architecture-overview": {
         "title": "Architecture Overview"
       },
-      "version-v1.7.0-runtime-architecture": {
+      "version-v1.7.0/version-v1.7.0-runtime-architecture": {
         "title": "Runtime Architecture"
       },
-      "version-v1.7.0-thinking-in-graphql": {
+      "version-v1.7.0/version-v1.7.0-thinking-in-graphql": {
         "title": "Thinking in GraphQL"
       },
-      "version-v1.7.0-thinking-in-relay": {
+      "version-v1.7.0/version-v1.7.0-thinking-in-relay": {
         "title": "Thinking In Relay"
       },
-      "version-v1.7.0-videos": {
+      "version-v1.7.0/version-v1.7.0-videos": {
         "title": "Videos"
       },
-      "version-v2.0.0-community-learning-resources": {
+      "version-v2.0.0/version-v2.0.0-community-learning-resources": {
         "title": "Community Learning Resources"
       },
-      "version-v2.0.0-graphql-server-specification": {
+      "version-v2.0.0/version-v2.0.0-graphql-server-specification": {
         "title": "GraphQL Server Specification"
       },
-      "version-v2.0.0-installation-and-setup": {
+      "version-v2.0.0/version-v2.0.0-installation-and-setup": {
         "title": "Installation and Setup"
       },
-      "version-v2.0.0-relay-debugging": {
+      "version-v2.0.0/version-v2.0.0-relay-debugging": {
         "title": "Debugging"
       },
-      "version-v2.0.0-graphql-in-relay": {
+      "version-v2.0.0/version-v2.0.0-graphql-in-relay": {
         "title": "GraphQL in Relay"
       },
-      "version-v2.0.0-mutations": {
+      "version-v2.0.0/version-v2.0.0-mutations": {
         "title": "Mutations"
       },
-      "version-v2.0.0-persisted-queries": {
+      "version-v2.0.0/version-v2.0.0-persisted-queries": {
         "title": "Persisted Queries"
       },
-      "version-v3.0.0-type-emission": {
+      "version-v3.0.0/version-v3.0.0-type-emission": {
         "title": "Type Emission"
       }
     },

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "crowdin-download": "crowdin-cli --config ../crowdin.yaml download -b master"
   },
   "dependencies": {
-    "docusaurus": "1.7.2",
+    "docusaurus": "1.9.0",
     "spec-md": "^0.6.0"
   }
 }

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -50,8 +50,7 @@ class HomeSplash extends React.Component {
                   <div className="pluginRowBlock">
                     <Button
                       href={
-                        siteConfig.baseUrl +
-                        'docs/en/introduction-to-relay.html'
+                        siteConfig.baseUrl + 'docs/en/introduction-to-relay'
                       }>
                       Get Started
                     </Button>
@@ -137,7 +136,7 @@ class Index extends React.Component {
             <div className="more-users">
               <a
                 className="button"
-                href={siteConfig.baseUrl + this.props.language + '/users.html'}>
+                href={siteConfig.baseUrl + this.props.language + '/users'}>
                 More Relay Users
               </a>
             </div>

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -40,7 +40,7 @@ class Versions extends React.Component {
                     <a
                       href={`${
                         siteConfig.baseUrl
-                      }docs/en/next/introduction-to-relay.html`}>
+                      }docs/en/next/introduction-to-relay`}>
                       Documentation
                     </a>
                   </td>
@@ -61,7 +61,7 @@ class Versions extends React.Component {
                     <a
                       href={`${
                         siteConfig.baseUrl
-                      }docs/en/introduction-to-relay.html`}>
+                      }docs/en/introduction-to-relay`}>
                       Documentation
                     </a>
                   </td>
@@ -94,10 +94,10 @@ class Versions extends React.Component {
                               version === 'classic'
                                 ? `${
                                     siteConfig.baseUrl
-                                  }docs/en/${version}/classic-guides-containers.html`
+                                  }docs/en/${version}/classic-guides-containers`
                                 : `${
                                     siteConfig.baseUrl
-                                  }docs/en/${version}/introduction-to-relay.html`
+                                  }docs/en/${version}/introduction-to-relay`
                             }>
                             Documentation
                           </a>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -113,6 +113,14 @@ const siteConfig = {
     apiKey: '3d7d5825d50ea36bca0e6ad06c926f06',
     indexName: 'relay',
   },
+  cleanUrl: true,
+  scrollToTop: true,
+  scrollToTopOptions: {
+    zIndex: 100,
+  },
+  enableUpdateTime: true,
+  enableUpdateBy: true,
+  docsSideNavCollapsible: true,
 };
 
 module.exports = siteConfig;

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1902,10 +1902,10 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-docusaurus@1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.7.2.tgz#2de7323a8b27da3a4e54cab90fc397c786326a9a"
-  integrity sha512-bPuEvejWaDNrsivt3G9aLX+byhfEjwu3j23c0E3Cn5KRUDkEouHwDvrWXtiWqAl05le321opkhOWGidbe0eG9Q==
+docusaurus@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.9.0.tgz#cb670d70c7bdabd9d2f6e26cd697b50bb4f28bfe"
+  integrity sha512-FyZ7Bk82PB5cE3xWnO/lAH41T4UkY68ME+pHmhCXveZs+/cjaH5F7DZGlasf+JFeixYjnQvcHWc6ugw/cDB9Ig==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"


### PR DESCRIPTION
Docusaurus just released v1.9.0 and I thought I would help Relay upgrade their version and at the same time use some of the newer features:

- Clean HTML (no more `.html` in the path)
- Show last updated time and author
- Collapsed sidenav (helpful especially when Relay has such a long list of side navigation items)
- Scroll to top button

<img width="1532" alt="Screen Shot 2019-04-29 at 4 25 05 PM" src="https://user-images.githubusercontent.com/1315101/56933175-955ebd80-6a9b-11e9-9090-3a1ec67aa6dd.png">
<img width="1532" alt="Screen Shot 2019-04-29 at 4 21 18 PM" src="https://user-images.githubusercontent.com/1315101/56933176-955ebd80-6a9b-11e9-8387-8822237c743b.png">
