### PR TITLE
Allow Declarative Mutation Configs to support root field aliases

### DIFF
--- a/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
+++ b/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
@@ -387,7 +387,10 @@ function getRootField(request: ConcreteRequest): ?string {
     request.fragment.selections.length > 0 &&
     request.fragment.selections[0].kind === 'LinkedField'
   ) {
-    return request.fragment.selections[0].name;
+    return (
+      request.fragment.selections[0].alias ||
+      request.fragment.selections[0].name
+    );
   }
   return null;
 }


### PR DESCRIPTION
Currently declarative mutation configs silently fail when using aliased root fields, this is a simple PR to add support for field aliases. 

I haven't had a chance to write a test case for this yet, I'd love some help there if anybody has any interest in this.