### PR TITLE
Fix require statements with single artifact directory on windows+metro

### DIFF
--- a/packages/babel-plugin-relay/createModernNode.js
+++ b/packages/babel-plugin-relay/createModernNode.js
@@ -125,12 +125,12 @@ function getRelativeImportPath(
   const relative = path.relative(
     path.dirname(filename),
     path.resolve(artifactDirectory),
-  );
+  ).replace(/\\/g, '/');
 
   const relativeReference =
     relative.length === 0 || !relative.startsWith('.') ? './' : '';
 
-  return relativeReference + path.join(relative, fileToRequire);
+  return relativeReference + path.posix.join(relative, fileToRequire);
 }
 
 module.exports = createModernNode;


### PR DESCRIPTION
File paths on windows have backslashes, but this code expects forward
slashes (see relativeReference variable).
Backslashes are ok in node, but metro bundler does not support them and
consequently the paths generated do not resolve when used with it
Lets use forward slashes on windows and unix as they work everywhere