### PR TITLE
Fix a typo in an error thrown by RelayParser

### DIFF
--- a/packages/relay-compiler/core/RelayParser.js
+++ b/packages/relay-compiler/core/RelayParser.js
@@ -213,7 +213,7 @@ class RelayParser {
     });
     if (duplicated.size) {
       throw new Error(
-        'RelayParser: Encountered duplicate defintitions for one or more ' +
+        'RelayParser: Encountered duplicate definitions for one or more ' +
           'documents: each document must have a unique name. Duplicated documents:\n' +
           Array.from(duplicated, name => `- ${name}`).join('\n'),
       );


### PR DESCRIPTION
Hi there :open_hands: 

This is a super minor PR, but I found a typo while using gatsby, which relies on the RelayParser for its graphql queries... So I thought it could be nice to fix it!

Cheers