### PR TITLE
Fix an anchor link in the docs

### DIFF
--- a/docs/Introduction-InstallationAndSetup.md
+++ b/docs/Introduction-InstallationAndSetup.md
@@ -56,7 +56,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay.html#relay-compiler.html), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay.html#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 yarn add --dev relay-compiler


### PR DESCRIPTION
The page with the wrong link: https://facebook.github.io/relay/docs/en/installation-and-setup.html
