### PR TITLE
[Added]: crossenv for jest script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "repository": "facebook/relay",
   "scripts": {
     "build": "gulp",
-    "jest": "NODE_ENV=test jest \"$@\"",
-    "jest:win32": "SET NODE_ENV=test && jest \"$@\"",
+    "jest": "cross-env NODE_ENV=test jest \"$@\"",
     "lint": "eslint --max-warnings 0 .",
     "prepublish": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && npm run build",
     "prettier": "find . -name node_modules -prune -or -name dist -prune -or -name '*.js' -print | xargs prettier --write",
@@ -38,6 +37,7 @@
     "babel-plugin-tester": "^6.0.1",
     "babel-preset-fbjs": "^3.1.2",
     "chalk": "^2.4.1",
+    "cross-env":"^5.2.0",
     "del": "3.0.0",
     "eslint": "5.4.0",
     "eslint-config-fbjs": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "gulp",
     "jest": "NODE_ENV=test jest \"$@\"",
+    "jest:win32": "SET NODE_ENV=test && jest \"$@\"",
     "lint": "eslint --max-warnings 0 .",
     "prepublish": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && npm run build",
     "prettier": "find . -name node_modules -prune -or -name dist -prune -or -name '*.js' -print | xargs prettier --write",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,6 +2261,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -4143,7 +4151,7 @@ is-valid-glob@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz#29bf3eff701be2d4d315dbacc39bc39fe8f601aa"
   integrity sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=
 
-is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==


### PR DESCRIPTION
**The present script**

```bash

"jest": "NODE_ENV=test jest \"$@\"",

```

**Present Error**

Will throw a system error in windows displaying
```
'NODE_ENV' is not recognized as an internal or external command,
operable program or batch file.


```


**fix**
To fix this we can have seperate jest script based on platform

**The new script**

```bash
 "jest:win32": "SET NODE_ENV=test && jest \"$@\"",

```

The above script will work fine with windows and OSX. And the `jest` for
linux