### PR TITLE
fix(QueryRenderer cache)

### DIFF
--- a/packages/react-relay/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/ReactRelayQueryRenderer.js
@@ -145,9 +145,9 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
       !areEqual(prevState.prevPropsVariables, nextProps.variables)
     ) {
       const {query} = nextProps;
-      const prevSelectionReferences = prevState.queryFetcher.getSelectionReferences();
       prevState.queryFetcher.disposeRequest();
-
+      const prevSelectionReferences = prevState.queryFetcher.getSelectionReferences();
+      
       let queryFetcher;
       if (query) {
         const {getRequest} = nextProps.environment.unstable_internal;

--- a/packages/react-relay/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/ReactRelayQueryRenderer.js
@@ -145,6 +145,13 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
       !areEqual(prevState.prevPropsVariables, nextProps.variables)
     ) {
       const {query} = nextProps;
+      /*
+          The prevState.queryFetcher.disposeRequest() invokes the dispose of the pending request which 
+          adds new functions to the variable selectionReferences (request.unsubscribe()).
+          That's why it's necessary to call the disposeRequest before retrieving the selectionReferences 
+          (prevState.queryFetcher.getSelectionReferences()) in order to create a new instance of 
+          ReactRelayQueryFetcher with all previous selectionReferences.
+      */
       prevState.queryFetcher.disposeRequest();
       const prevSelectionReferences = prevState.queryFetcher.getSelectionReferences();
       


### PR DESCRIPTION
dispose the pending request before retrieving the selectionReferences in order to creating a new instance of ReactRelayQueryFetcher.