### PR TITLE
Fix section header in Pagination Container docs

### DIFF
--- a/docs/Modern-PaginationContainer.md
+++ b/docs/Modern-PaginationContainer.md
@@ -144,7 +144,7 @@ type Props = {
   * `loadMore`: See `loadMore` [docs](#loadmore)
   * `refetchConnection `: See `refetchConnection` [docs](#refetchconnection)
 
-## `hasMore()`
+## `hasMore`
 
 `hasMore` is a function available on the `relay` [prop](#available-props). This function indicates whether there are more pages to fetch from the server or not.
 


### PR DESCRIPTION
The `hasMore` header had an extra `()` appended at the end, unlike other functions in the same section.