### PR TITLE
Fix variable name in RelaySplitModuleImportTransform

### DIFF
--- a/packages/relay-compiler/transforms/RelaySplitModuleImportTransform.js
+++ b/packages/relay-compiler/transforms/RelaySplitModuleImportTransform.js
@@ -66,14 +66,14 @@ function visitModuleImport(node: ModuleImport, state: State): ModuleImport {
   // It's possible for the same fragment to be selected in multiple usages
   // of @module: skip processing a node if its SplitOperation has already
   // been generated
-  const normalizatioName = getNormalizationOperationName(node.name);
-  if (state.splitOperations.has(normalizatioName)) {
+  const normalizationName = getNormalizationOperationName(node.name);
+  if (state.splitOperations.has(normalizationName)) {
     return node;
   }
   const transformedNode = this.traverse(node, state);
   const splitOperation: SplitOperation = {
     kind: 'SplitOperation',
-    name: normalizatioName,
+    name: normalizationName,
     selections: transformedNode.selections,
     loc: {kind: 'Derived', source: node.loc},
     metadata: {
@@ -81,7 +81,7 @@ function visitModuleImport(node: ModuleImport, state: State): ModuleImport {
     },
     type: state.parentType,
   };
-  state.splitOperations.set(normalizatioName, splitOperation);
+  state.splitOperations.set(normalizationName, splitOperation);
   return transformedNode;
 }
 


### PR DESCRIPTION
normalizatioName -> normalizationName

A harmless typo because all instances were misspelled in exactly the same way.