### PR TITLE
Expose custom scalars configuration from CLI.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -260,6 +260,7 @@ const modules = gulp.parallel(
               '!**/__tests__/**',
               '!**/__flowtests__/**',
               '!**/__mocks__/**',
+              '!**/node_modules/**',
             ],
             {
               cwd: path.join(PACKAGES, build.package),

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -100,6 +100,14 @@ const argv = yargs
       type: 'string',
       default: null,
     },
+    customScalars: {
+      describe:
+        'Mappings from custom scalars in your schema to built-in GraphQL ' +
+        'types, for type emission purposes. (Uses yargs dot-notation, e.g. ' +
+        '--customScalars.URL=String)',
+      type: 'object',
+      default: {},
+    },
   })
   .help().argv;
 

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -10,44 +10,94 @@
 
 'use strict';
 
-jest.mock('fs', () => ({
-  existsSync(path) {
-    return path.startsWith('/existing/');
-  },
-}));
+// jest.mock('fs', () => ({
+//   existsSync(path) {
+//     return path.startsWith('/existent/');
+//   },
+// }));
 
-const {main} = require('../RelayCompilerMain');
+jest.mock('../../codegen/RelayFileWriter');
+const RelayFileWriter = require('../../codegen/RelayFileWriter');
+
+const {getCodegenRunner, main} = require('../RelayCompilerMain');
+const {testSchemaPath} = require('relay-test-utils');
+const path = require('path');
 
 describe('RelayCompilerMain', () => {
-  it('should throw error when schema path does not exist', async () => {
+  it('throws when schema path does not exist', async () => {
     await expect(
       main({
-        schema: '/nonexisting/schema.graphql',
-        src: '/existing/',
+        schema: './non-existent/schema.graphql',
+        src: '.',
       }),
     ).rejects.toEqual(
-      new Error('--schema path does not exist: /nonexisting/schema.graphql'),
+      new Error(
+        `--schema path does not exist: ${path.resolve(
+          'non-existent/schema.graphql',
+        )}`,
+      ),
     );
   });
 
-  it('should throw error when src path does not exist', async () => {
+  it('throws when src path does not exist', async () => {
     await expect(
       main({
-        schema: '/existing/schema.graphql',
-        src: '/nonexisting/src',
-      }),
-    ).rejects.toEqual(new Error('--src path does not exist: /nonexisting/src'));
-  });
-
-  it('should throw error when persist-output parent directory does not exist', async () => {
-    await expect(
-      main({
-        schema: '/existing/schema.graphql',
-        src: '/existing/src/',
-        persistOutput: '/nonexisting/output/',
+        schema: testSchemaPath,
+        src: './non-existent/src',
       }),
     ).rejects.toEqual(
-      new Error('--persist-output path does not exist: /nonexisting/output'),
+      new Error(
+        `--src path does not exist: ${path.resolve('non-existent/src')}`,
+      ),
     );
+  });
+
+  it('throws when persist-output parent directory does not exist', async () => {
+    await expect(
+      main({
+        schema: testSchemaPath,
+        src: '.',
+        persistOutput: './non-existent/output/',
+      }),
+    ).rejects.toEqual(
+      new Error(
+        `--persist-output path does not exist: ${path.resolve(
+          'non-existent/output',
+        )}`,
+      ),
+    );
+  });
+
+  describe('concerning the codegen runner', () => {
+    const options = {
+      schema: testSchemaPath,
+      language: 'javascript',
+      include: [],
+      exclude: [],
+      src: '.',
+    };
+
+    describe('and its writer configurations', () => {
+      it('configures the language', () => {
+        const codegenRunner = getCodegenRunner({
+          language: 'javascript',
+          ...options,
+        });
+        const config = codegenRunner.writerConfigs.js;
+        expect(codegenRunner.parserConfigs[config.parser]).not.toBeUndefined();
+      });
+
+      it('configures the file writer with custom scalars', () => {
+        const codegenRunner = getCodegenRunner({...options});
+        const config = codegenRunner.writerConfigs.js;
+        const writeFiles = config.writeFiles;
+        writeFiles({onlyValidate: true});
+        expect(RelayFileWriter.writeAll).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: expect.objectContaining({customScalars: {}}),
+          }),
+        );
+      });
+    });
   });
 });

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -10,12 +10,6 @@
 
 'use strict';
 
-// jest.mock('fs', () => ({
-//   existsSync(path) {
-//     return path.startsWith('/existent/');
-//   },
-// }));
-
 jest.mock('../../codegen/RelayFileWriter');
 const RelayFileWriter = require('../../codegen/RelayFileWriter');
 
@@ -80,21 +74,24 @@ describe('RelayCompilerMain', () => {
     describe('and its writer configurations', () => {
       it('configures the language', () => {
         const codegenRunner = getCodegenRunner({
-          language: 'javascript',
           ...options,
+          language: 'javascript',
         });
         const config = codegenRunner.writerConfigs.js;
         expect(codegenRunner.parserConfigs[config.parser]).not.toBeUndefined();
       });
 
       it('configures the file writer with custom scalars', () => {
-        const codegenRunner = getCodegenRunner({...options});
+        const codegenRunner = getCodegenRunner({
+          ...options,
+          customScalars: {URL: 'String'},
+        });
         const config = codegenRunner.writerConfigs.js;
         const writeFiles = config.writeFiles;
         writeFiles({onlyValidate: true});
         expect(RelayFileWriter.writeAll).toHaveBeenCalledWith(
           expect.objectContaining({
-            config: expect.objectContaining({customScalars: {}}),
+            config: expect.objectContaining({customScalars: {URL: 'String'}}),
           }),
         );
       });


### PR DESCRIPTION
Closes #2162.

In preparation of #2518, as requested by @josephsavona we should have CLI versions of each possible argument, hereby CLI support for custom scalars.

I ended up going with the dot-notation syntax of yargs, which seems a little foreign (to me), but it comes builtin with yargs. Let me know what you think.

E.g.

```
$ relay-compiler --customScalars.URL=String --customScalars.Date=String
```