### PR TITLE
Add relay-config package for centralised configuration

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -260,6 +260,7 @@ const modules = gulp.parallel(
               '!**/__tests__/**',
               '!**/__flowtests__/**',
               '!**/__mocks__/**',
+              '!**/node_modules/**',
             ],
             {
               cwd: path.join(PACKAGES, build.package),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,6 +54,7 @@ const babelOptions = require('./scripts/getBabelOptions')({
     'babel-plugin-macros': 'babel-plugin-macros',
     chalk: 'chalk',
     child_process: 'child_process',
+    cosmiconfig: 'cosmiconfig',
     crypto: 'crypto',
     'fast-glob': 'fast-glob',
     'fb-watchman': 'fb-watchman',
@@ -238,6 +239,21 @@ const builds = [
         entry: 'index.js',
         output: 'relay-test-utils',
         libraryName: 'RelayTestUtils',
+        target: 'node',
+        noMinify: true, // Note: uglify can't yet handle modern JS
+      },
+    ],
+  },
+  {
+    package: 'relay-config',
+    exports: {
+      index: 'index.js',
+    },
+    bundles: [
+      {
+        entry: 'index.js',
+        output: 'relay-config',
+        libraryName: 'RelayConfig',
         target: 'node',
         noMinify: true, // Note: uglify can't yet handle modern JS
       },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-plugin-tester": "^6.0.1",
     "babel-preset-fbjs": "^3.1.2",
     "chalk": "^2.4.1",
+    "cosmiconfig": "^5.2.1",
     "del": "3.0.0",
     "eslint": "5.4.0",
     "eslint-config-fbjs": "2.0.1",

--- a/packages/babel-plugin-relay/BabelPluginRelay.js
+++ b/packages/babel-plugin-relay/BabelPluginRelay.js
@@ -17,6 +17,12 @@ const getValidGraphQLTag = require('./getValidGraphQLTag');
 const getValidRelayQLTag = require('./getValidRelayQLTag');
 const invariant = require('./invariant');
 
+let RelayConfig;
+try {
+  // eslint-disable-next-line no-eval
+  RelayConfig = eval('require')('relay-config');
+} catch (_) {}
+
 import type {Validator} from './RelayQLTransformer';
 
 export type RelayPluginOptions = {
@@ -38,7 +44,7 @@ export type RelayPluginOptions = {
   snakeCase?: boolean,
   substituteVariables?: boolean,
   validator?: Validator<any>,
-  // Directory as specified by outputDir when running relay-compiler
+  // Directory as specified by artifactDirectory when running relay-compiler
   artifactDirectory?: string,
 };
 
@@ -115,7 +121,8 @@ module.exports = function BabelPluginRelay(context: {types: $FlowFixMe}): any {
   return {
     visitor: {
       Program(path, state) {
-        path.traverse(visitor, state);
+        const config = RelayConfig && RelayConfig.loadConfig();
+        path.traverse(visitor, {...state, opts: {...config, ...state.opts}});
       },
     },
   };

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -100,6 +100,14 @@ const argv = yargs
       type: 'string',
       default: null,
     },
+    customScalars: {
+      describe:
+        'Mappings from custom scalars in your schema to built-in GraphQL ' +
+        'types, for type emission purposes. (Uses yargs dot-notation, e.g. ' +
+        '--customScalars.URL=String)',
+      type: 'object',
+      default: {},
+    },
   })
   .help().argv;
 

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -15,101 +15,156 @@ require('@babel/polyfill');
 const {main} = require('./RelayCompilerMain');
 const yargs = require('yargs');
 
+import type {Config} from './RelayCompilerMain';
+
+type OptionBase<T> = {|
+  describe: string,
+  default?: T,
+|};
+
+/**
+ * Maps from a value type to a corresponding yargs option object type.
+ *
+ * For instance, a required array string type maps to:
+ *
+ *     { describe: string, default?: Array<string>, type: 'string', array: true, demandOption: true }
+ *
+ * Whereas an optional single string type maps to:
+ *
+ *     { describe: string, default?: string, type: 'string', array: false, demandOption: false }
+ */
+type OptionTypeMap<T> = $Call<
+  | ((
+      Array<string>,
+    ) => {|...OptionBase<Array<string>>, array: true, type: 'string'|})
+  | ((
+      ?string,
+    ) => {|
+      ...OptionBase<string>,
+      array: false,
+      demandOption: false,
+      type: 'string',
+    |})
+  | (string => {|
+      ...OptionBase<string>,
+      array: false,
+      demandOption: true,
+      type: 'string',
+    |})
+  | ((?boolean) => {|...OptionBase<boolean>, type: 'boolean'|})
+  | (({}) => {|...OptionBase<{}>, type: 'object'|}),
+  T,
+>;
+
+/**
+ * Generates an object type with all keys from Config and values mapped to yargs option object types.
+ */
+type Options = $ObjMap<Config, <T>(T) => OptionTypeMap<T>>;
+
+const options: Options = {
+  schema: {
+    describe: 'Path to schema.graphql or schema.json',
+    demandOption: true,
+    type: 'string',
+    array: false,
+  },
+  src: {
+    describe: 'Root directory of application code',
+    demandOption: true,
+    type: 'string',
+    array: false,
+  },
+  include: {
+    describe: 'Directories to include under src',
+    type: 'string',
+    array: true,
+    default: ['**'],
+  },
+  exclude: {
+    describe: 'Directories to ignore under src',
+    type: 'string',
+    array: true,
+    default: ['**/node_modules/**', '**/__mocks__/**', '**/__generated__/**'],
+  },
+  extensions: {
+    array: true,
+    describe:
+      'File extensions to compile (defaults to extensions provided by the ' +
+      'language plugin)',
+    type: 'string',
+  },
+  verbose: {
+    describe: 'More verbose logging',
+    type: 'boolean',
+  },
+  quiet: {
+    describe: 'No output to stdout',
+    type: 'boolean',
+  },
+  watchman: {
+    describe: 'Use watchman when not in watch mode',
+    type: 'boolean',
+    default: true,
+  },
+  watch: {
+    describe: 'If specified, watches files and regenerates on changes',
+    type: 'boolean',
+  },
+  validate: {
+    describe:
+      'Looks for pending changes and exits with non-zero code instead of ' +
+      'writing to disk',
+    type: 'boolean',
+    default: false,
+  },
+  persistOutput: {
+    describe:
+      'A path to a .json file where persisted query metadata should be saved',
+    demandOption: false,
+    type: 'string',
+    array: false,
+  },
+  noFutureProofEnums: {
+    describe:
+      'This option controls whether or not a catch-all entry is added to enum type definitions ' +
+      'for values that may be added in the future. Enabling this means you will have to update ' +
+      'your application whenever the GraphQL server schema adds new enum values to prevent it ' +
+      'from breaking.',
+    type: 'boolean',
+    default: false,
+  },
+  language: {
+    describe:
+      'The name of the language plugin used for input files and artifacts',
+    demandOption: false,
+    type: 'string',
+    array: false,
+    default: 'javascript',
+  },
+  artifactDirectory: {
+    describe:
+      'A specific directory to output all artifacts to. When enabling this ' +
+      'the babel plugin needs `artifactDirectory` set as well.',
+    demandOption: false,
+    type: 'string',
+    array: false,
+  },
+  customScalars: {
+    describe:
+      'Mappings from custom scalars in your schema to built-in GraphQL ' +
+      'types, for type emission purposes. (Uses yargs dot-notation, e.g. ' +
+      '--customScalars.URL=String)',
+    type: 'object',
+  },
+};
+
 // Collect args
 const argv = yargs
   .usage(
     'Create Relay generated files\n\n' +
       '$0 --schema <path> --src <path> [--watch]',
   )
-  .options({
-    schema: {
-      describe: 'Path to schema.graphql or schema.json',
-      demandOption: true,
-      type: 'string',
-    },
-    src: {
-      describe: 'Root directory of application code',
-      demandOption: true,
-      type: 'string',
-    },
-    include: {
-      array: true,
-      default: ['**'],
-      describe: 'Directories to include under src',
-      type: 'string',
-    },
-    exclude: {
-      array: true,
-      default: ['**/node_modules/**', '**/__mocks__/**', '**/__generated__/**'],
-      describe: 'Directories to ignore under src',
-      type: 'string',
-    },
-    extensions: {
-      array: true,
-      describe:
-        'File extensions to compile (defaults to extensions provided by the ' +
-        'language plugin)',
-      type: 'string',
-    },
-    verbose: {
-      describe: 'More verbose logging',
-      type: 'boolean',
-    },
-    quiet: {
-      describe: 'No output to stdout',
-      type: 'boolean',
-    },
-    watchman: {
-      describe: 'Use watchman when not in watch mode',
-      type: 'boolean',
-      default: true,
-    },
-    watch: {
-      describe: 'If specified, watches files and regenerates on changes',
-      type: 'boolean',
-    },
-    validate: {
-      describe:
-        'Looks for pending changes and exits with non-zero code instead of ' +
-        'writing to disk',
-      type: 'boolean',
-      default: false,
-    },
-    'persist-output': {
-      describe:
-        'A path to a .json file where persisted query metadata should be saved',
-    },
-    noFutureProofEnums: {
-      describe:
-        'This option controls whether or not a catch-all entry is added to enum type definitions ' +
-        'for values that may be added in the future. Enabling this means you will have to update ' +
-        'your application whenever the GraphQL server schema adds new enum values to prevent it ' +
-        'from breaking.',
-      default: false,
-    },
-    language: {
-      describe:
-        'The name of the language plugin used for input files and artifacts',
-      type: 'string',
-      default: 'javascript',
-    },
-    artifactDirectory: {
-      describe:
-        'A specific directory to output all artifacts to. When enabling this ' +
-        'the babel plugin needs `artifactDirectory` set as well.',
-      type: 'string',
-      default: null,
-    },
-    customScalars: {
-      describe:
-        'Mappings from custom scalars in your schema to built-in GraphQL ' +
-        'types, for type emission purposes. (Uses yargs dot-notation, e.g. ' +
-        '--customScalars.URL=String)',
-      type: 'object',
-      default: {},
-    },
-  })
-  .help().argv;
+  .options(options).argv;
 
 // Run script with args
 // $FlowFixMe: Invalid types for yargs. Please fix this when touching this code.

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -106,10 +106,12 @@ const options: Options = {
   verbose: {
     describe: 'More verbose logging',
     type: 'boolean',
+    default: false,
   },
   quiet: {
     describe: 'No output to stdout',
     type: 'boolean',
+    default: false,
   },
   watchman: {
     describe: 'Use watchman when not in watch mode',
@@ -119,6 +121,7 @@ const options: Options = {
   watch: {
     describe: 'If specified, watches files and regenerates on changes',
     type: 'boolean',
+    default: false,
   },
   validate: {
     describe:

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -65,7 +65,11 @@ type OptionTypeMap<T> = $Call<
 /**
  * Generates an object type with all keys from Config and values mapped to yargs option object types.
  */
-type Options = $ObjMap<Config, <T>(T) => OptionTypeMap<T>>;
+type Options = $ObjMap<
+  // TODO: Unsure how to remove function types from T with Flow, so instead just narrowing it here by hand.
+  Config & {language: string},
+  <T>(T) => OptionTypeMap<T>,
+>;
 
 const options: Options = {
   schema: {

--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -162,7 +162,7 @@ async function main(config: Config) {
     persistOutput = path.resolve(process.cwd(), persistOutput);
     const persistOutputDir = path.dirname(persistOutput);
     if (!fs.existsSync(persistOutputDir)) {
-      throw new Error(`--persist-output path does not exist: ${persistOutput}`);
+      throw new Error(`--persistOutput path does not exist: ${persistOutput}`);
     }
   }
   if (config.watch && !config.watchman) {

--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -406,4 +406,4 @@ function hasWatchmanRootFile(testPath) {
   return false;
 }
 
-module.exports = {getCodegenRunner, main};
+module.exports = {getCodegenRunner, getLanguagePlugin, main};

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -10,44 +10,94 @@
 
 'use strict';
 
-jest.mock('fs', () => ({
-  existsSync(path) {
-    return path.startsWith('/existing/');
-  },
-}));
+// jest.mock('fs', () => ({
+//   existsSync(path) {
+//     return path.startsWith('/existent/');
+//   },
+// }));
 
-const {main} = require('../RelayCompilerMain');
+jest.mock('../../codegen/RelayFileWriter');
+const RelayFileWriter = require('../../codegen/RelayFileWriter');
+
+const {getCodegenRunner, main} = require('../RelayCompilerMain');
+const {testSchemaPath} = require('relay-test-utils');
+const path = require('path');
 
 describe('RelayCompilerMain', () => {
-  it('should throw error when schema path does not exist', async () => {
+  it('throws when schema path does not exist', async () => {
     await expect(
       main({
-        schema: '/nonexisting/schema.graphql',
-        src: '/existing/',
+        schema: './non-existent/schema.graphql',
+        src: '.',
       }),
     ).rejects.toEqual(
-      new Error('--schema path does not exist: /nonexisting/schema.graphql'),
+      new Error(
+        `--schema path does not exist: ${path.resolve(
+          'non-existent/schema.graphql',
+        )}`,
+      ),
     );
   });
 
-  it('should throw error when src path does not exist', async () => {
+  it('throws when src path does not exist', async () => {
     await expect(
       main({
-        schema: '/existing/schema.graphql',
-        src: '/nonexisting/src',
-      }),
-    ).rejects.toEqual(new Error('--src path does not exist: /nonexisting/src'));
-  });
-
-  it('should throw error when persist-output parent directory does not exist', async () => {
-    await expect(
-      main({
-        schema: '/existing/schema.graphql',
-        src: '/existing/src/',
-        persistOutput: '/nonexisting/output/',
+        schema: testSchemaPath,
+        src: './non-existent/src',
       }),
     ).rejects.toEqual(
-      new Error('--persist-output path does not exist: /nonexisting/output'),
+      new Error(
+        `--src path does not exist: ${path.resolve('non-existent/src')}`,
+      ),
     );
+  });
+
+  it('throws when persist-output parent directory does not exist', async () => {
+    await expect(
+      main({
+        schema: testSchemaPath,
+        src: '.',
+        persistOutput: './non-existent/output/',
+      }),
+    ).rejects.toEqual(
+      new Error(
+        `--persist-output path does not exist: ${path.resolve(
+          'non-existent/output',
+        )}`,
+      ),
+    );
+  });
+
+  describe('concerning the codegen runner', () => {
+    const options = {
+      schema: testSchemaPath,
+      language: 'javascript',
+      include: [],
+      exclude: [],
+      src: '.',
+    };
+
+    describe('and its writer configurations', () => {
+      it('configures the language', () => {
+        const codegenRunner = getCodegenRunner({
+          language: 'javascript',
+          ...options,
+        });
+        const config = codegenRunner.writerConfigs.js;
+        expect(codegenRunner.parserConfigs[config.parser]).not.toBeUndefined();
+      });
+
+      it('configures the file writer with custom scalars', () => {
+        const codegenRunner = getCodegenRunner({...options});
+        const config = codegenRunner.writerConfigs.js;
+        const writeFiles = config.writeFiles;
+        writeFiles({onlyValidate: true});
+        expect(RelayFileWriter.writeAll).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: expect.objectContaining({customScalars: {}}),
+          }),
+        );
+      });
+    });
   });
 });

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -112,6 +112,22 @@ describe('RelayCompilerMain', () => {
       );
     });
 
+    it('accepts a plugin initializer function', () => {
+      const plugin = jest.fn(() => RelayLanguagePluginJavaScript());
+      expect(getLanguagePlugin(plugin)).toEqual(
+        RelayLanguagePluginJavaScript(),
+      );
+      expect(plugin).toHaveBeenCalled();
+    });
+
+    it('accepts a plugin initializer function from a ES6 module', () => {
+      const plugin = {default: jest.fn(() => RelayLanguagePluginJavaScript())};
+      expect(getLanguagePlugin(plugin)).toEqual(
+        RelayLanguagePluginJavaScript(),
+      );
+      expect(plugin.default).toHaveBeenCalled();
+    });
+
     it('loads a plugin from a local module', () => {
       const pluginModuleMockPath = path.join(
         __dirname,

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -10,63 +10,205 @@
 
 'use strict';
 
+const path = require('path');
+
+const RelayFileWriter = require('../../codegen/RelayFileWriter');
+const {
+  isAvailable: isWatchmanAvailable,
+} = require('../../core/GraphQLWatchmanClient');
+const RelayLanguagePluginJavaScript = require('../../language/javascript/RelayLanguagePluginJavaScript');
+const {testSchemaPath} = require('relay-test-utils');
+
+const RelayCompilerMain = require('../RelayCompilerMain');
 const {
   getCodegenRunner,
   getLanguagePlugin,
+  getWatchConfig,
   main,
-} = require('../RelayCompilerMain');
-const RelayFileWriter = require('../../codegen/RelayFileWriter');
-const RelayLanguagePluginJavaScript = require('../../language/javascript/RelayLanguagePluginJavaScript');
-const {testSchemaPath} = require('relay-test-utils');
-const path = require('path');
-
-jest.mock('../../codegen/RelayFileWriter');
+} = RelayCompilerMain;
 
 import type {PluginInitializer} from '../../language/RelayLanguagePluginInterface';
 
+jest.mock('../../codegen/RelayFileWriter');
+jest.mock('../../core/GraphQLWatchmanClient');
+
+isWatchmanAvailable.mockImplementation(() => Promise.resolve(true));
+
 describe('RelayCompilerMain', () => {
-  it('throws when schema path does not exist', async () => {
-    await expect(
-      main({
-        schema: './non-existent/schema.graphql',
-        src: '.',
-      }),
-    ).rejects.toEqual(
-      new Error(
-        `--schema path does not exist: ${path.resolve(
-          'non-existent/schema.graphql',
-        )}`,
-      ),
-    );
+  let config;
+
+  beforeEach(() => {
+    config = {
+      exclude: [],
+      include: [],
+      language: 'javascript',
+      schema: testSchemaPath,
+      src: path.resolve('.'),
+      validate: false,
+      watch: true,
+      watchman: true,
+    };
   });
 
-  it('throws when src path does not exist', async () => {
-    await expect(
-      main({
-        schema: testSchemaPath,
-        src: './non-existent/src',
-      }),
-    ).rejects.toEqual(
-      new Error(
-        `--src path does not exist: ${path.resolve('non-existent/src')}`,
-      ),
-    );
+  describe('main', () => {
+    let getCodegenRunnerSpy;
+    let codegenRunnerMock;
+
+    beforeEach(() => {
+      codegenRunnerMock = {
+        watchAll: jest.fn(),
+        compileAll: jest.fn(),
+      };
+      getCodegenRunnerSpy = jest
+        .spyOn(RelayCompilerMain, 'getCodegenRunner')
+        .mockImplementation(() => codegenRunnerMock);
+    });
+
+    afterEach(() => {
+      getCodegenRunnerSpy.mockRestore();
+    });
+
+    it('throws when schema path does not exist', async () => {
+      await expect(
+        main({
+          ...config,
+          schema: './non-existent/schema.graphql',
+        }),
+      ).rejects.toEqual(
+        new Error(
+          `--schema path does not exist: ${path.resolve(
+            'non-existent/schema.graphql',
+          )}`,
+        ),
+      );
+    });
+
+    it('throws when src path does not exist', async () => {
+      await expect(
+        main({
+          ...config,
+          src: './non-existent/src',
+        }),
+      ).rejects.toEqual(
+        new Error(
+          `--src path does not exist: ${path.resolve('non-existent/src')}`,
+        ),
+      );
+    });
+
+    it('throws when persist-output parent directory does not exist', async () => {
+      await expect(
+        main({
+          ...config,
+          persistOutput: './non-existent/output/',
+        }),
+      ).rejects.toEqual(
+        new Error(
+          `--persistOutput path does not exist: ${path.resolve(
+            'non-existent/output',
+          )}`,
+        ),
+      );
+    });
+
+    it('throws when enabling both verbose and quiet mode', async () => {
+      await expect(
+        main({...config, verbose: true, quiet: true}),
+      ).rejects.toThrow();
+    });
+
+    it('invokes getCodegenRunner with the correct watchman config', async () => {
+      isWatchmanAvailable.mockImplementationOnce(() => Promise.resolve(false));
+      await main(config);
+      expect(getCodegenRunnerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({watchman: false}),
+      );
+    });
+
+    it('tells the CodegenRunner instance to watch', async () => {
+      await main({...config, watch: true});
+      expect(codegenRunnerMock.watchAll).toHaveBeenCalled();
+    });
+
+    it('tells the CodegenRunner instance to do a single compilation pass', async () => {
+      await main({...config, watch: false});
+      expect(codegenRunnerMock.compileAll).toHaveBeenCalled();
+    });
   });
 
-  it('throws when persist-output parent directory does not exist', async () => {
-    await expect(
-      main({
-        schema: testSchemaPath,
-        src: '.',
-        persistOutput: './non-existent/output/',
-      }),
-    ).rejects.toEqual(
-      new Error(
-        `--persistOutput path does not exist: ${path.resolve(
-          'non-existent/output',
-        )}`,
-      ),
-    );
+  describe('getWatchConfig', () => {
+    let logSpy;
+
+    beforeEach(() => {
+      logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    it('works', async () => {
+      expect(await getWatchConfig(config)).toEqual(config);
+    });
+
+    it('throws when enabling watch mode but disabling watchman', async () => {
+      await expect(
+        getWatchConfig({...config, watchman: false}),
+      ).rejects.toThrowError(/watchman is required/i);
+    });
+
+    it('throws when enabling watch mode but not having a watchman root file', async () => {
+      const spy = jest
+        .spyOn(RelayCompilerMain, 'hasWatchmanRootFile')
+        .mockImplementation(() => false);
+      await expect(getWatchConfig(config)).rejects.toThrowError(
+        /have a valid watchman "root" file/i,
+      );
+      spy.mockRestore();
+    });
+
+    it('disables the watchman setting if watchman is not available', async () => {
+      isWatchmanAvailable.mockImplementationOnce(() => Promise.resolve(false));
+      expect(await getWatchConfig(config)).toEqual({
+        ...config,
+        watchman: false,
+      });
+    });
+
+    it('does not enable watchman if disabled by user, regardless of watchman being available', async () => {
+      const result = await getWatchConfig({
+        ...config,
+        watch: false,
+        watchman: false,
+      });
+      expect(result.watchman).toEqual(false);
+    });
+
+    describe('concerning its hint to enable watch mode', () => {
+      beforeEach(() => {
+        config = {...config, watch: false, validate: false};
+      });
+
+      it('logs when not watching, not validating artifacts, and watchman being available', async () => {
+        await getWatchConfig(config);
+        expect(logSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/pass --watch/i),
+        );
+      });
+
+      it('does not log when only validating artifacts', async () => {
+        await getWatchConfig({...config, validate: true});
+        expect(logSpy).not.toHaveBeenCalled();
+      });
+
+      it('does not log when watchman is not available', async () => {
+        isWatchmanAvailable.mockImplementationOnce(() =>
+          Promise.resolve(false),
+        );
+        await getWatchConfig(config);
+        expect(logSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('getCodegenRunner', () => {

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -69,7 +69,7 @@ describe('RelayCompilerMain', () => {
     );
   });
 
-  describe('concerning the codegen runner', () => {
+  describe('getCodegenRunner', () => {
     const options = {
       schema: testSchemaPath,
       language: 'javascript',
@@ -78,34 +78,32 @@ describe('RelayCompilerMain', () => {
       src: '.',
     };
 
-    describe('and its writer configurations', () => {
-      it('configures the language', () => {
-        const codegenRunner = getCodegenRunner({
-          ...options,
-          language: 'javascript',
-        });
-        const config = codegenRunner.writerConfigs.js;
-        expect(codegenRunner.parserConfigs[config.parser]).not.toBeUndefined();
+    it('configures the language', () => {
+      const codegenRunner = getCodegenRunner({
+        ...options,
+        language: 'javascript',
       });
+      const config = codegenRunner.writerConfigs.js;
+      expect(codegenRunner.parserConfigs[config.parser]).not.toBeUndefined();
+    });
 
-      it('configures the file writer with custom scalars', () => {
-        const codegenRunner = getCodegenRunner({
-          ...options,
-          customScalars: {URL: 'String'},
-        });
-        const config = codegenRunner.writerConfigs.js;
-        const writeFiles = config.writeFiles;
-        writeFiles({onlyValidate: true});
-        expect(RelayFileWriter.writeAll).toHaveBeenCalledWith(
-          expect.objectContaining({
-            config: expect.objectContaining({customScalars: {URL: 'String'}}),
-          }),
-        );
+    it('configures the file writer with custom scalars', () => {
+      const codegenRunner = getCodegenRunner({
+        ...options,
+        customScalars: {URL: 'String'},
       });
+      const config = codegenRunner.writerConfigs.js;
+      const writeFiles = config.writeFiles;
+      writeFiles({onlyValidate: true});
+      expect(RelayFileWriter.writeAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({customScalars: {URL: 'String'}}),
+        }),
+      );
     });
   });
 
-  describe('concerning language plugins', () => {
+  describe('getLanguagePlugin', () => {
     it('uses the builtin Flow generator for javascript', () => {
       expect(getLanguagePlugin('javascript')).toEqual(
         RelayLanguagePluginJavaScript(),

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -45,7 +45,7 @@ describe('RelayCompilerMain', () => {
       schema: testSchemaPath,
       src: path.resolve('.'),
       validate: false,
-      watch: true,
+      watch: false,
       watchman: true,
     };
   });
@@ -148,7 +148,10 @@ describe('RelayCompilerMain', () => {
     });
 
     it('returns an unaltered config if enalbing watch mode and watchman is available', async () => {
-      expect(await getWatchConfig(config)).toEqual(config);
+      expect(await getWatchConfig({...config, watch: true})).toEqual({
+        ...config,
+        watch: true,
+      });
     });
 
     it('disables the watchman setting if watchman is not available', async () => {
@@ -171,7 +174,7 @@ describe('RelayCompilerMain', () => {
 
     it('throws when enabling watch mode but disabling watchman', async () => {
       await expect(
-        getWatchConfig({...config, watchman: false}),
+        getWatchConfig({...config, watch: true, watchman: false}),
       ).rejects.toThrowError(/watchman is required/i);
     });
 
@@ -179,16 +182,16 @@ describe('RelayCompilerMain', () => {
       const spy = jest
         .spyOn(RelayCompilerMain, 'hasWatchmanRootFile')
         .mockImplementation(() => false);
-      await expect(getWatchConfig(config)).rejects.toThrowError(
-        /have a valid watchman "root" file/i,
-      );
+      await expect(
+        getWatchConfig({...config, watch: true}),
+      ).rejects.toThrowError(/have a valid watchman "root" file/i);
       spy.mockRestore();
     });
 
     it('throws when enabling watch mode but watchman not being available', async () => {
       isWatchmanAvailable.mockImplementationOnce(() => Promise.resolve(false));
       await expect(
-        getWatchConfig({...config, watchman: true}),
+        getWatchConfig({...config, watch: true, watchman: true}),
       ).rejects.toThrowError(/watchman is required/i);
     });
 

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -10,12 +10,6 @@
 
 'use strict';
 
-// jest.mock('fs', () => ({
-//   existsSync(path) {
-//     return path.startsWith('/existent/');
-//   },
-// }));
-
 jest.mock('../../codegen/RelayFileWriter');
 const RelayFileWriter = require('../../codegen/RelayFileWriter');
 
@@ -80,21 +74,24 @@ describe('RelayCompilerMain', () => {
     describe('and its writer configurations', () => {
       it('configures the language', () => {
         const codegenRunner = getCodegenRunner({
-          language: 'javascript',
           ...options,
+          language: 'javascript',
         });
         const config = codegenRunner.writerConfigs.js;
         expect(codegenRunner.parserConfigs[config.parser]).not.toBeUndefined();
       });
 
       it('configures the file writer with custom scalars', () => {
-        const codegenRunner = getCodegenRunner({...options});
+        const codegenRunner = getCodegenRunner({
+          ...options,
+          customScalars: {URL: 'String'},
+        });
         const config = codegenRunner.writerConfigs.js;
         const writeFiles = config.writeFiles;
         writeFiles({onlyValidate: true});
         expect(RelayFileWriter.writeAll).toHaveBeenCalledWith(
           expect.objectContaining({
-            config: expect.objectContaining({customScalars: {}}),
+            config: expect.objectContaining({customScalars: {URL: 'String'}}),
           }),
         );
       });

--- a/packages/relay-compiler/bin/__tests__/fixtures/plugin-module.js
+++ b/packages/relay-compiler/bin/__tests__/fixtures/plugin-module.js
@@ -1,0 +1,3 @@
+const RelayLanguagePluginJavaScript = require('../../../language/javascript/RelayLanguagePluginJavaScript');
+
+module.exports = RelayLanguagePluginJavaScript;

--- a/packages/relay-config/index.js
+++ b/packages/relay-config/index.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+const cosmiconfig = require('cosmiconfig');
+
+import type {Config} from '../relay-compiler/bin/RelayCompilerMain';
+
+const explorer = cosmiconfig('relay', {
+  searchPlaces: ['relay.config.js', 'relay.config.json', 'package.json'],
+
+  loaders: {
+    '.json': cosmiconfig.loadJson,
+    '.yaml': cosmiconfig.loadYaml,
+    '.yml': cosmiconfig.loadYaml,
+    '.js': cosmiconfig.loadJs,
+    '.es6': cosmiconfig.loadJs,
+    noExt: cosmiconfig.loadYaml,
+  },
+});
+
+function loadConfig(): ?Config {
+  const result = explorer.searchSync();
+  if (result) {
+    return result.config;
+  }
+}
+
+module.exports = {loadConfig};

--- a/packages/relay-config/package.json
+++ b/packages/relay-config/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "relay-config",
+  "description": "Config parser for Relay applications.",
+  "version": "4.0.0",
+  "keywords": [
+    "graphql",
+    "relay"
+  ],
+  "license": "MIT",
+  "homepage": "https://facebook.github.io/relay/",
+  "bugs": "https://github.com/facebook/relay/issues",
+  "repository": "facebook/relay",
+  "main": "index.js",
+  "dependencies": {
+    "cosmiconfig": "^5.2.1"
+  },
+  "peerDependencies": {
+    "relay-compiler": "4.0.0"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,6 +1835,13 @@ call-me-maybe@^1.0.1:
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
   integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
 
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1842,10 +1849,22 @@ caller-path@^0.1.0:
   dependencies:
     callsites "^0.2.0"
 
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
+
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
   integrity sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
+
+callsites@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
 callsites@^3.0.0:
   version "3.0.0"
@@ -2228,6 +2247,16 @@ cosmiconfig@^5.0.5:
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
+cosmiconfig@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
+  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
 create-ecdh@^4.0.0:
@@ -3802,6 +3831,14 @@ immutable@~3.7.6:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
   integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
 
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
+
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
@@ -4615,6 +4652,14 @@ js-yaml@^3.12.0:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
   integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Closes #2518 

_Note: Includes #2745, so that should probably be merged first and then this can be rebased._

I tried multiple times to come up with a doc describing the integration a few times, but then yesterday I had a whole day and figured I’d just write _a_ implementation to show what it could look like. Please feel free to poke holes as much as you need.

----

What this change does:

* Add a new `relay-config` package

* Usage of the package is optional. If installed it will be picked-up, otherwise relay will function as it does today.

* RelayConfig relies on [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to do its bidding. It’s configured to load from:

  - a `relay` key in `package.json`

    ```json
    {
      "relay": {
        "src": "./src"
      }
    }
    ```


  - a `relay.config.json` file

    ```json
    {
      "src": "./src"
    }
    ```

  - or a `relay.config.js` file

    ```js
    module.exports = {
      src: "./src",
    }
    ```

* It accepts all the same configuration as the CLI does. (As a bonus, I typed the configuration object and the Yargs options object.)

* Additionally, when using the `relay.config.js` file, a configuration entry like the language plugin also accepts an actual function:

  ```js
  const typescript = require("relay-compiler-language-typescript")

  module.exports = {
    language: typescript,
  }
  ```

  In the future, other entries such as `persistedQueries` and `customScalars` could also be configured as such and allow for project specific setup.

* It is used by all pieces of Relay that take configuration–i.e. `relay-compiler` and `babel-plugin-relay`. For instance, previously one would have needed to specify `artifactDirectory` on the CLI to `relay-compiler` and the same setting in `.babelrc` for `babel-plugin-relay`. This can now be reduced to a single centralised setting.

  Additional external tooling can also start relying on this. For instance, the `vscode-apollo` extension, with [this change](https://github.com/apollographql/apollo-tooling/pull/1288), will allow for custom GraphQL validation rules to surface in the UI. Leveraging the centralised config allows one to surface `relay-compiler` specific validations without needing to take in the same configuration in a different place yet again.

* Finally, this also adds some previously missing test coverage around language plugin loading.