### PR TITLE
Fix flow on GitHub

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,6 +12,7 @@ module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
 module.system.haste.paths.blacklist=.*/__tests__/.*
 module.system.haste.paths.blacklist=.*/__mocks__/.*
 module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/fbjs/lib/.*
+module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/fbjs/lib/emptyFunction\\.js\\.flow
 
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable

--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -109,15 +109,11 @@ function getLanguagePlugin(language: string): PluginInterface {
       // eslint-disable-next-line no-eval
       let languagePlugin: LanguagePlugin = eval('require')(requirePath);
       if (languagePlugin.default) {
-        /* $     /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
-         * error found when Flow v0.99 was deployed. To see the error, delete
-         * this comment and run Flow. */
+        // $FlowFixMe - Flow no longer considers statics of functions as any
         languagePlugin = languagePlugin.default;
       }
       if (typeof languagePlugin === 'function') {
-        /* $     /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
-         * error found when Flow v0.99 was deployed. To see the error, delete
-         * this comment and run Flow. */
+        // $FlowFixMe
         return languagePlugin();
       } else {
         throw new Error('Expected plugin to export a function.');

--- a/packages/relay-compiler/core/GraphQLCompilerProfiler.js
+++ b/packages/relay-compiler/core/GraphQLCompilerProfiler.js
@@ -170,14 +170,13 @@ function instrumentAsyncContext<F: (...any) => Promise<any>>(
   if (!enabled) {
     return fn;
   }
-  /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an error
-   * found when Flow v0.99 was deployed. To see the error, delete this comment
-   * and run Flow. */
-  const profileName = name || fn.displayName || fn.name;
+
+  const profileName: string =
+    name ||
+    // $FlowFixMe - Flow no longer considers statics of functions as any
+    fn.displayName ||
+    fn.name;
   const instrumented = async function() {
-    /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
-     * error found when Flow v0.99 was deployed. To see the error, delete this
-     * comment and run Flow. */
     const traceId = start(profileName);
     try {
       return await fn.apply(this, arguments);
@@ -200,14 +199,12 @@ function instrumentWait<F: (...any) => Promise<any>>(fn: F, name?: string): F {
   if (!enabled) {
     return fn;
   }
-  /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an error
-   * found when Flow v0.99 was deployed. To see the error, delete this comment
-   * and run Flow. */
-  const profileName = name || fn.displayName || fn.name;
+  const profileName: string =
+    name ||
+    // $FlowFixMe - Flow no longer considers statics of functions as any
+    fn.displayName ||
+    fn.name;
   const instrumented = async function() {
-    /* $FlowFixMe(>=0.99.0 site=react_native_fb) This comment suppresses an
-     * error found when Flow v0.99 was deployed. To see the error, delete this
-     * comment and run Flow. */
     const traceId = startWait(profileName);
     try {
       return await fn.apply(this, arguments);


### PR DESCRIPTION
These fixmes also apply to OSS. The `emptyFunction` type isn't
compatible with flow 0.99, so this ignores this simple function that we
probably just shouldn't use in the first place.