### PR TITLE
Update CI to node 12 and remove node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,15 @@ cache: yarn
 
 matrix:
   include:
-  - node_js: '11.10.1'
+  - node_js: '12'
     env: TEST=1
   - node_js: '10'
     env: TEST=1
   - node_js: '8'
     env: TEST=1
-  - node_js: '6'
-    env: TEST=1
-  - node_js: '10'
+  - node_js: '12'
     env: TYPECHECK=1
-  - node_js: '10'
+  - node_js: '12'
     env: LINT=1
 
 script:


### PR DESCRIPTION
Node 11 and 6 are no longer supported and node 12 is now a supported version.

See https://nodejs.org/en/about/releases/

Test Plan:
CI passes except for the broken flow test fixed by https://github.com/facebook/relay/pull/2750