### PR TITLE
IDE friendly errors

### DIFF
--- a/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
+++ b/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
@@ -1471,7 +1471,7 @@ THROWN EXCEPTION:
 
 ReaderCodeGenerator: Complex argument values (Lists or InputObjects with nested variables) are not supported.
 
-Source: GraphQL request (3:17)
+Source: GraphQL request:3:17
 2: query TestQuery($date: String) {
 3:   items(filter: {date: $date}) {
                    ^
@@ -3287,13 +3287,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @connection_resolver, could not generate a default label that is unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (20:25)
+  Source: GraphQL request:20:25
   19:   ... {
   20:     comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") { #error: same default label
                               ^
   21:       count
   
-  Source: GraphQL request (9:23)
+  Source: GraphQL request:9:23
    8: fragment FeedbackComments_feedback on Feedback {
    9:   comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") {
                             ^
@@ -3334,13 +3334,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @connection_resolver, the provided label is not unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (20:89)
+  Source: GraphQL request:20:89
   19:   ... {
   20:     comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver", label: "comments") { #error: same label
                                                                                               ^
   21:       count
   
-  Source: GraphQL request (9:87)
+  Source: GraphQL request:9:87
    8: fragment FeedbackComments_feedback on Feedback {
    9:   comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver", label: "comments") {
                                                                                             ^
@@ -3376,7 +3376,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @connection_resolver fields must return a single value, not a list, found '[CommentsEdge]'
   
-  Source: GraphQL request (10:5)
+  Source: GraphQL request:10:5
    9:   comments(first: 10) {
   10:     edges @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") { # error: plural
           ^
@@ -3403,7 +3403,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - The @connection_resolver direction is not supported on scalar fields, only fields returning an object/interface/union
   
-  Source: GraphQL request (9:6)
+  Source: GraphQL request:9:6
    8: fragment FeedbackComments_feedback on Feedback {
    9:   id @connection_resolver(resolver: "FeedbackIDResolver")  # error: scalar
            ^
@@ -4657,7 +4657,7 @@ Error: Encountered 2 error(s):
 - Operation 'FeedbackQuery' references undefined variable(s):
   - $commentsKey: String.
   
-  Source (derived): GraphQL request (25:26)
+  Source (derived): GraphQL request:25:26
   24:     key: "FeedbackFragment_comments"
   25:     dynamicKey_UNSTABLE: $commentsKey
                                ^
@@ -4666,7 +4666,7 @@ Error: Encountered 2 error(s):
 - Operation 'PaginationQuery' references undefined variable(s):
   - $commentsKey: String.
   
-  Source (derived): GraphQL request (25:26)
+  Source (derived): GraphQL request:25:26
   24:     key: "FeedbackFragment_comments"
   25:     dynamicKey_UNSTABLE: $commentsKey
                                ^
@@ -5899,31 +5899,31 @@ THROWN EXCEPTION:
 
 Error: Found a circular reference from fragment 'Profile'.
 
-Source (derived): GraphQL request (2:1)
+Source (derived): GraphQL request:2:1
 1: # expected-to-throw
 2: fragment RefetchableFragment on Query @refetchable(queryName: "RefetchableFragmentQuery") @argumentDefinitions(id: {type: "ID!"}) {
    ^
 3:   node(id: $id) {
 
-Source (derived): GraphQL request (2:1)
+Source (derived): GraphQL request:2:1
 1: # expected-to-throw
 2: fragment RefetchableFragment on Query @refetchable(queryName: "RefetchableFragmentQuery") @argumentDefinitions(id: {type: "ID!"}) {
    ^
 3:   node(id: $id) {
 
-Source: GraphQL request (7:7)
+Source: GraphQL request:7:7
 6:       name
 7:       ...Profile @arguments(includeProfile: true)
          ^
 8:     }
 
-Source: GraphQL request (21:9)
+Source: GraphQL request:21:9
 20:       node {
 21:         ...Profile
             ^
 22:       }
 
-Source: GraphQL request (21:9)
+Source: GraphQL request:21:9
 20:       node {
 21:         ...Profile
             ^
@@ -6675,13 +6675,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @defer. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (12:23)
+  Source (derived): GraphQL request:12:23
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
                             ^
   13: }
   
-  Source (derived): GraphQL request (12:3)
+  Source (derived): GraphQL request:12:3
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
         ^
@@ -7082,13 +7082,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Cannot use @relay(mask: false) on fragment spreads for fragments with directives.
   
-  Source: GraphQL request (5:5)
+  Source: GraphQL request:5:5
   4:   me {
   5:     ...Profile @relay(mask: false)
          ^
   6:   }
   
-  Source: GraphQL request (9:26)
+  Source: GraphQL request:9:26
    8: 
    9: fragment Profile on User @inline {
                                ^
@@ -7482,7 +7482,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Variables are not yet supported inside @inline fragments.
   
-  Source: GraphQL request (10:24)
+  Source: GraphQL request:10:24
    9: fragment Profile on User @inline {
   10:   profilePicture(size: $pictureSize) {
                              ^
@@ -7520,7 +7520,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Variables are not yet supported inside @inline fragments.
   
-  Source: GraphQL request (17:24)
+  Source: GraphQL request:17:24
   16:   @inline
   17:   @argumentDefinitions(sizeArg: { type: "[Int]", defaultValue: [50] }) {
                              ^
@@ -8329,13 +8329,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Found conflicting @module selections: use a unique alias on the parent fields.
   
-  Source: GraphQL request (22:7)
+  Source: GraphQL request:22:7
   21:     ...MarkdownUserNameRenderer_name
   22:       @module(name: "BarMarkdownUserNameRenderer.react")
             ^
   23:   }
   
-  Source: GraphQL request (13:7)
+  Source: GraphQL request:13:7
   12:     ...MarkdownUserNameRenderer_name
   13:       @module(name: "FooMarkdownUserNameRenderer.react")
             ^
@@ -8531,13 +8531,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'capitalize: Boolean!' is missing on 'nameWithArgs' in 'TestQuery'.
   
-  Source: GraphQL request (5:7)
+  Source: GraphQL request:5:7
   4:     hometown{
   5:       nameWithArgs
            ^
   6:     }
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: query TestQuery {
      ^
@@ -9220,13 +9220,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Found conflicting @module selections: use a unique alias on the parent fields.
   
-  Source: GraphQL request (25:7)
+  Source: GraphQL request:25:7
   24:     ...MarkdownUserNameRenderer_name
   25:       @module(name: "BarMarkdownUserNameRenderer.react")
             ^
   26:   }
   
-  Source: GraphQL request (13:7)
+  Source: GraphQL request:13:7
   12:     ...MarkdownUserNameRenderer_name
   13:       @module(name: "FooMarkdownUserNameRenderer.react")
             ^
@@ -15408,13 +15408,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - RelayMaskTransform: Cannot use @relay(mask: false) on fragment spread because the fragment definition uses @argumentDefinitions.
   
-  Source: GraphQL request (5:5)
+  Source: GraphQL request:5:5
   4:   me {
   5:     ...User_user @relay(mask: false)
          ^
   6:   }
   
-  Source: GraphQL request (10:24)
+  Source: GraphQL request:10:24
    9: fragment User_user on User
   10:   @argumentDefinitions(isRelative: {type: "Boolean!", defaultValue: false}) {
                              ^
@@ -15834,13 +15834,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Variable @arguments values are only supported when the argument is defined with @argumentDefinitions. Check the definition of fragment 'ProfilePhoto'.
   
-  GraphQL request (16:36)
+  GraphQL request:16:36
   15:   __typename
   16:   ...ProfilePhoto @arguments(size: $size)
                                          ^
   17: }
   
-  GraphQL request (19:1)
+  GraphQL request:19:1
   18: 
   19: fragment ProfilePhoto on User {
       ^

--- a/packages/relay-compiler/core/RelayCompilerError.js
+++ b/packages/relay-compiler/core/RelayCompilerError.js
@@ -240,7 +240,7 @@ function highlightSourceAtLocation(
 
   const lines = body.split(/\r\n|[\n\r]/g);
   return (
-    `${source.name} (${lineNum}:${columnNum})\n` +
+    `${source.name}:${lineNum}:${columnNum}\n` +
     printPrefixedLines([
       // Lines specified like this: ["prefix", "string"],
       [`${lineNum - 1}: `, lines[lineIndex - 1]],

--- a/packages/relay-compiler/core/RelayFindGraphQLTags.js
+++ b/packages/relay-compiler/core/RelayFindGraphQLTags.js
@@ -23,14 +23,14 @@ import type {
   GraphQLTagFinder,
 } from '../language/RelayLanguagePluginInterface';
 
-const cache = new RelayCompilerCache('RelayFindGraphQLTags', 'v1');
+const cache = new RelayCompilerCache('RelayFindGraphQLTags', 'v2');
 
 function memoizedFind(
   tagFinder: GraphQLTagFinder,
   text: string,
   baseDir: string,
   file: File,
-): $ReadOnlyArray<string> {
+): $ReadOnlyArray<GraphQLTag> {
   invariant(
     file.exists,
     'RelayFindGraphQLTags: Called with non-existent file `%s`',
@@ -46,11 +46,11 @@ function find(
   tagFinder: GraphQLTagFinder,
   text: string,
   absPath: string,
-): $ReadOnlyArray<string> {
+): $ReadOnlyArray<GraphQLTag> {
   const tags = tagFinder(text, absPath);
   const moduleName = getModuleName(absPath);
   tags.forEach(tag => validateTemplate(tag, moduleName, absPath));
-  return tags.map(tag => tag.template);
+  return tags;
 }
 
 function validateTemplate(

--- a/packages/relay-compiler/core/RelaySourceModuleParser.js
+++ b/packages/relay-compiler/core/RelaySourceModuleParser.js
@@ -76,7 +76,7 @@ module.exports = (
     memoizedTagFinder(text, baseDir, file).forEach(tag => {
       const source = new GraphQL.Source(
         tag.template,
-        file.relPath,
+        path.join(path.relative(process.cwd(), baseDir), file.relPath),
         tag.sourceLocationOffset,
       );
       const ast = parseGraphQL(source);

--- a/packages/relay-compiler/core/RelaySourceModuleParser.js
+++ b/packages/relay-compiler/core/RelaySourceModuleParser.js
@@ -73,14 +73,18 @@ module.exports = (
 
     const astDefinitions = [];
     const sources = [];
-    memoizedTagFinder(text, baseDir, file).forEach(template => {
-      const source = new GraphQL.Source(template, file.relPath);
+    memoizedTagFinder(text, baseDir, file).forEach(tag => {
+      const source = new GraphQL.Source(
+        tag.template,
+        file.relPath,
+        tag.sourceLocationOffset,
+      );
       const ast = parseGraphQL(source);
       invariant(
         ast.definitions.length,
         'RelaySourceModuleParser: Expected GraphQL text to contain at least one ' +
           'definition (fragment, mutation, query, subscription), got `%s`.',
-        template,
+        tag.template,
       );
       sources.push(source.body);
       astDefinitions.push(...ast.definitions);

--- a/packages/relay-compiler/core/__tests__/RelayFindGraphQLTags-test.js
+++ b/packages/relay-compiler/core/__tests__/RelayFindGraphQLTags-test.js
@@ -15,7 +15,9 @@ const RelayFindGraphQLTags = require('../RelayFindGraphQLTags');
 
 describe('RelayFindGraphQLTags', () => {
   function find(text, absPath: string = '/path/to/FindGraphQLTags.js') {
-    return RelayFindGraphQLTags.find(FindGraphQLTags.find, text, absPath);
+    return RelayFindGraphQLTags.find(FindGraphQLTags.find, text, absPath).map(
+      tag => tag.template,
+    );
   }
 
   describe('query parsing', () => {

--- a/packages/relay-compiler/core/__tests__/__snapshots__/RelayParser-test.js.snap
+++ b/packages/relay-compiler/core/__tests__/__snapshots__/RelayParser-test.js.snap
@@ -16,7 +16,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected definition for variable '$size' to be an object with the shape: '{type: string, defaultValue?: mixed}.
   
-  GraphQL request (4:9)
+  GraphQL request:4:9
   3:   id: {type: "ID"}
   4:   size: {type: "[Int]", defaultValu: [100]} # uh-oh, typo
              ^
@@ -932,7 +932,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Invalid directives @match found on FRAGMENT_DEFINITION.
   
-  GraphQL request (2:26)
+  GraphQL request:2:26
   1: # expected-to-throw
   2: fragment Example on User @match(key: "Example"){
                               ^
@@ -955,13 +955,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Invalid directives @module, @match found on QUERY.
   
-  GraphQL request (2:27)
+  GraphQL request:2:27
   1: # expected-to-throw
   2: query TestQuery($id: ID!) @module @match{
                                ^
   3:   foo: node(id: $id) {
   
-  GraphQL request (2:35)
+  GraphQL request:2:35
   1: # expected-to-throw
   2: query TestQuery($id: ID!) @module @match{
                                        ^
@@ -990,7 +990,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Invalid directives @module found on FIELD.
   
-  GraphQL request (6:24)
+  GraphQL request:6:24
   5:       node {
   6:         profilePicture @module(preset: $preset) {
                             ^
@@ -1178,7 +1178,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 3 error(s):
 - Expected a value matching type 'PhotoSize'.
   
-  GraphQL request (4:28)
+  GraphQL request:4:28
   3:   me {
   4:     profilePicture(preset: "LARGE") { # error: string not enum
                                 ^
@@ -1186,7 +1186,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'PhotoSize'.
   
-  GraphQL request (12:28)
+  GraphQL request:12:28
   11:   me {
   12:     profilePicture(preset: 128) { # error: int not enum
                                  ^
@@ -1194,7 +1194,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'PhotoSize'.
   
-  GraphQL request (20:28)
+  GraphQL request:20:28
   19:   me {
   20:     profilePicture(preset: [LARGE]) { # error: list of enum, not enum
                                  ^
@@ -2786,13 +2786,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Variable '$environment' was defined as type 'Environment!' but used in a location expecting the type '[Environment!]!'
   
-  GraphQL request (9:53)
+  GraphQL request:9:53
    8: 
    9: fragment ChildFragment on User @argumentDefinitions(environment: {type: "Environment!"}){
                                                           ^
   10:   # variables of a non-list type cannot flow into list types,
   
-  GraphQL request (12:26)
+  GraphQL request:12:26
   11:   # the singular -> list promotion only works for literal values
   12:   checkins(environments: $environment) { # expected error
                                ^
@@ -3848,13 +3848,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Literal @arguments values are only supported when the argument is defined with @argumentDefinitions. Check the definition of fragment 'ChildFragment'.
   
-  GraphQL request (3:44)
+  GraphQL request:3:44
   2: fragment ParentFragment on User {
   3:   ...ChildFragment @arguments(pictureSize: 42) # error: $pictureSize not defined
                                                 ^
   4: }
   
-  GraphQL request (6:1)
+  GraphQL request:6:1
   5: 
   6: fragment ChildFragment on User {
      ^
@@ -3881,13 +3881,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Variable @arguments values are only supported when the argument is defined with @argumentDefinitions. Check the definition of fragment 'ChildFragment'.
   
-  GraphQL request (3:44)
+  GraphQL request:3:44
   2: fragment ParentFragment on User {
   3:   ...ChildFragment @arguments(pictureSize: $querySize) # error: $pictureSize not defined
                                                 ^
   4: }
   
-  GraphQL request (6:1)
+  GraphQL request:6:1
   5: 
   6: fragment ChildFragment on User {
      ^
@@ -3921,7 +3921,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Invalid use of @uncheckedArguments_DEPRECATED: all arguments are defined, use @arguments instead.
   
-  GraphQL request (12:10)
+  GraphQL request:12:10
   11:   }
   12:   ...Foo @uncheckedArguments_DEPRECATED(localId: $id)
                ^
@@ -5054,7 +5054,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 3 error(s):
 - Expected a value matching type 'String'.
   
-  GraphQL request (4:10)
+  GraphQL request:4:10
   3:   route(waypoints: [{
   4:     lat: 0.0 # error: float not string
               ^
@@ -5062,7 +5062,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'WayPoint!'.
   
-  GraphQL request (14:21)
+  GraphQL request:14:21
   13: query LiteralListArgumentQuery2 {
   14:   route(waypoints: ["waypoint"]) { # error: string not input object
                           ^
@@ -5070,7 +5070,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'WayPoint!'.
   
-  GraphQL request (22:20)
+  GraphQL request:22:20
   21: query LiteralListArgumentQuery3 {
   22:   route(waypoints: "waypoint") { # error: string not list
                          ^
@@ -5234,7 +5234,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 3 error(s):
 - Uknown field 'unknownField' on type 'CheckinSearchInput'.
   
-  GraphQL request (4:5)
+  GraphQL request:4:5
   3:   checkinSearchQuery(query: {
   4:     unknownField: "Facebook" # error: unknown field
          ^
@@ -5242,7 +5242,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'String'.
   
-  GraphQL request (12:12)
+  GraphQL request:12:12
   11:   checkinSearchQuery(query: {
   12:     query: FACEBOOK # error: enum not string
                  ^
@@ -5250,7 +5250,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'CheckinSearchInput'.
   
-  GraphQL request (19:29)
+  GraphQL request:19:29
   18: query LiteralObjectArgument3 {
   19:   checkinSearchQuery(query: FACEBOOK) { # error: enum not object
                                   ^
@@ -5396,7 +5396,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'ID!'.
   
-  GraphQL request (3:24)
+  GraphQL request:3:24
   2: query NullValuesQuery {
   3:   node_id_required(id: null) {
                             ^
@@ -5870,7 +5870,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Unknown type: 'UnknownType'.
   
-  GraphQL request (2:22)
+  GraphQL request:2:22
   1: # expected-to-throw
   2: query TestQuery($id: UnknownType) {
                           ^
@@ -5882,7 +5882,7 @@ exports[`RelayParser should error on fragment spread arguments with literal out 
 "RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'Int'.
   
-  GraphQL request (4:38)
+  GraphQL request:4:38
   3:         # Number.MAX_SAFE_INTEGER is 9007199254740991
   4:         ...TestChild @arguments(foo: 10000000000000000)
                                           ^
@@ -5894,13 +5894,13 @@ exports[`RelayParser should error when parsing fragment that references undeclar
 "RelayParser: Encountered 1 error(s):
 - Variable '$id' was used in locations expecting the conflicting types 'ID' and 'Int'.
   
-  GraphQL request (2:14)
+  GraphQL request:2:14
   1: fragment TestFragment on Query {
   2:     node(id: $id) {
                   ^
   3:       id
   
-  GraphQL request (5:18)
+  GraphQL request:5:18
   4:     }
   5:     task(number: $id) {
                       ^

--- a/packages/relay-compiler/core/__tests__/__snapshots__/RelayPrinter-test.js.snap
+++ b/packages/relay-compiler/core/__tests__/__snapshots__/RelayPrinter-test.js.snap
@@ -161,7 +161,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'Environment!'.
   
-  GraphQL request (3:26)
+  GraphQL request:3:26
   2: fragment UserFragment on User {
   3:   checkins(environments: "WEB") {
                               ^
@@ -205,7 +205,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'Environment!'.
   
-  GraphQL request (3:26)
+  GraphQL request:3:26
   2: fragment UserFragment on User {
   3:   checkins(environments: UNKNOWN_ENUM_VALUE) {
                               ^

--- a/packages/relay-compiler/handlers/connection/__tests__/__snapshots__/RelayConnectionTransform-test.js.snap
+++ b/packages/relay-compiler/handlers/connection/__tests__/__snapshots__/RelayConnectionTransform-test.js.snap
@@ -546,7 +546,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected field 'comments' to have a 'first' or 'last' argument.
   
-  Source: GraphQL request (8:7)
+  Source: GraphQL request:8:7
   7:     ... on Story {
   8:       comments @connection(key: "NodeQuery_comments") {
            ^
@@ -872,7 +872,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected the key argument to @connection to be of form <SomeName>_comments, got 'invalid'. For a detailed explanation, check out https://relay.dev/docs/en/pagination-container#connection
   
-  Source: GraphQL request (8:44)
+  Source: GraphQL request:8:44
   7:     ... on Story {
   8:       comments(first: 10) @connection(key: "invalid") {
                                                 ^
@@ -906,7 +906,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'String!'.
   
-  GraphQL request (8:44)
+  GraphQL request:8:44
   7:     ... on Story {
   8:       comments(first: 10) @connection(key: 10) {
                                                 ^
@@ -949,7 +949,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'String'.
   
-  GraphQL request (8:75)
+  GraphQL request:8:75
   7:     ... on Story {
   8:       comments(first: 10) @connection(key: "NodeQuery_comments", handler: 10) {
                                                                                ^
@@ -979,7 +979,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @connection used on invalid field 'actors'. Expected the return type to be a non-plural interface or object, got '[Actor]'.
   
-  Source: GraphQL request (8:7)
+  Source: GraphQL request:8:7
   7:     ... on Story {
   8:       actors @connection {
            ^
@@ -1186,7 +1186,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @stream_connection does not support aliasing the 'edges' field.
   
-  Source: GraphQL request (14:9)
+  Source: GraphQL request:14:9
   13:       ) {
   14:         commentEdges: edges {
               ^
@@ -1230,7 +1230,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @stream_connection does not support aliasing the 'pageInfo' field.
   
-  Source: GraphQL request (21:9)
+  Source: GraphQL request:21:9
   20:         }
   21:         commentPageInfo: pageInfo {
               ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/FlattenTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/FlattenTransform-test.js.snap
@@ -33,13 +33,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected all fields on the same parent with the name or alias 'friendsAlias' to have the same name and arguments.
   
-  Source: GraphQL request (14:9)
+  Source: GraphQL request:14:9
   13:       ... on User {
   14:         friendsAlias: friends(first: 10) {
               ^
   15:           edges {
   
-  Source: GraphQL request (9:9)
+  Source: GraphQL request:9:9
    8:       ... on User {
    9:         friendsAlias: friends(first: 5) {
               ^
@@ -80,13 +80,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected all fields on the same parent with the name or alias 'friends' to have the same name and arguments.
   
-  Source: GraphQL request (14:9)
+  Source: GraphQL request:14:9
   13:       ... on User {
   14:         friends(first: 10) {
               ^
   15:           edges {
   
-  Source: GraphQL request (9:9)
+  Source: GraphQL request:9:9
    8:       ... on User {
    9:         friends(first: 5) {
               ^
@@ -455,13 +455,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected all fields on the same parent with the name or alias 'nameRenderer' to have the same name and arguments.
   
-  Source: GraphQL request (11:5)
+  Source: GraphQL request:11:5
   10:     # conflicts with above: same alias but different types are matched
   11:     nameRenderer @match {
           ^
   12:       ...MarkdownUserNameRenderer_name
   
-  Source: GraphQL request (4:3)
+  Source: GraphQL request:4:3
   3:   id
   4:   nameRenderer @match {
        ^
@@ -509,13 +509,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Found conflicting @module selections: use a unique alias on the parent fields.
   
-  Source: GraphQL request (12:37)
+  Source: GraphQL request:12:37
   11:     nameRenderer @match {
   12:       ...PlainUserNameRenderer_name @module(name: "OtherPlainUserNameRenderer.react")
                                           ^
   13:       ...MarkdownUserNameRenderer_name
   
-  Source: GraphQL request (5:35)
+  Source: GraphQL request:5:35
   4:   nameRenderer @match {
   5:     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
                                        ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
@@ -303,19 +303,19 @@ THROWN EXCEPTION:
 
 Error: Found a circular reference from fragment 'Profile'.
 
-Source: GraphQL request (2:1)
+Source: GraphQL request:2:1
 1: # expected-to-throw
 2: query TestQuery(
    ^
 3:   $id: ID!
 
-Source: GraphQL request (8:5)
+Source: GraphQL request:8:5
 7:     id
 8:     ...Profile
        ^
 9:   }
 
-Source: GraphQL request (21:9)
+Source: GraphQL request:21:9
 20:       node {
 21:         ...Profile
             ^
@@ -361,7 +361,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Query 'TestQuery' references undefined variables.
   
-  GraphQL request (9:70)
+  GraphQL request:9:70
    8:     id
    9:     ...Profile @arguments(pictureSize: $pictureSize, includeFriends: $includeFriends2)
                                                                            ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayDeferStreamTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayDeferStreamTransform-test.js.snap
@@ -165,13 +165,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @defer, the provided label is not unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (13:35)
+  Source: GraphQL request:13:35
   12:   ...DeferredFragment @defer(label: "deferred")
   13:   ...OtherDeferredFragment @defer(label: "deferred")
                                         ^
   14: }
   
-  Source: GraphQL request (12:30)
+  Source: GraphQL request:12:30
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "deferred")
                                    ^
@@ -360,13 +360,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @stream, the provided label is not unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (15:29)
+  Source: GraphQL request:15:29
   14:   otherActors: actors
   15:   @stream(initial_count: 1, label: "actors") { # invalid: duplicate label
                                   ^
   16:     name
   
-  Source: GraphQL request (11:36)
+  Source: GraphQL request:11:36
   10:   id
   11:   actors @stream(initial_count: 1, label: "actors") {
                                          ^
@@ -469,7 +469,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @stream, the 'initial_count' argument is required.
   
-  Source: GraphQL request (11:10)
+  Source: GraphQL request:11:10
   10:   id
   11:   actors @stream(label: "StreamedActorsLabel") { # invalid: missing initial_count
                ^
@@ -535,7 +535,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected the 'label' value to @stream to be a string literal if provided.
   
-  Source: GraphQL request (11:43)
+  Source: GraphQL request:11:43
   10:   id
   11:   actors @stream(initial_count: 1, label: $label) {
                                                 ^
@@ -570,7 +570,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected the 'label' value to @defer to be a string literal if provided.
   
-  Source: GraphQL request (12:37)
+  Source: GraphQL request:12:37
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: $label)
                                           ^
@@ -680,13 +680,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @defer, could not generate a default label that is unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (16:15)
+  Source: GraphQL request:16:15
   15:   }
   16:   ... on User @defer { # invalid: duplicate label
                     ^
   17:     name
   
-  Source: GraphQL request (12:15)
+  Source: GraphQL request:12:15
   11:   emailAddresses
   12:   ... on User @defer {
                     ^
@@ -756,7 +756,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected the 'label' value to @defer to be a string literal if provided.
   
-  Source: GraphQL request (12:29)
+  Source: GraphQL request:12:29
   11:   emailAddresses
   12:   ... on User @defer(label: $label) {
                                   ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
@@ -92,13 +92,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Cannot combine variables with incompatible types Int and ID when applying @relay(unmask: true).
   
-  Source: GraphQL request (14:16)
+  Source: GraphQL request:14:16
   13: fragment StringFragment on Query {
   14:   task(number: $id) {
                      ^
   15:     title
   
-  Source: GraphQL request (8:12)
+  Source: GraphQL request:8:12
   7: fragment NullableIDFragment on Query {
   8:   node(id: $id) {
                 ^
@@ -132,13 +132,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Cannot combine variables with incompatible types [ID!] and ID when applying @relay(unmask: true).
   
-  Source: GraphQL request (14:14)
+  Source: GraphQL request:14:14
   13: fragment NullableIDListFragment on Query {
   14:   nodes(ids: $id) {
                    ^
   15:     id
   
-  Source: GraphQL request (8:12)
+  Source: GraphQL request:8:12
   7: fragment NullableIDFragment on Query {
   8:   node(id: $id) {
                 ^
@@ -167,13 +167,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Cannot combine global and local variables when applying @relay(unmask: true).
   
-  Source: GraphQL request (3:3)
+  Source: GraphQL request:3:3
   2: fragment ParentQuery on Query @argumentDefinitions(
   3:   id: {type: "ID!"}
        ^
   4: ) {
   
-  Source: GraphQL request (9:24)
+  Source: GraphQL request:9:24
    8: fragment NonNullIDFragment on Query {
    9:   node_id_required(id: $id) {
                              ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMatchTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMatchTransform-test.js.snap
@@ -18,7 +18,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Direct use of the 'js' field is not allowed, use @match/@module instead.
   
-  Source: GraphQL request (6:7)
+  Source: GraphQL request:6:7
   5:     ... on PlainUserNameRenderer {
   6:       js(module: "PlainUserNameRenderer.react")
            ^
@@ -54,13 +54,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid @match selection: selections must match against concrete variants/implementors of type 'UserNameRenderer'. Got 'User', expected one of 'PlainUserNameRenderer', 'MarkdownUserNameRenderer', 'CustomNameRenderer', etc.
   
-  Source: GraphQL request (6:18)
+  Source: GraphQL request:6:18
   5:     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
   6:     ...User_user @module(name: "User.react")
                       ^
   7:   }
   
-  Source: GraphQL request (17:1)
+  Source: GraphQL request:17:1
   16: 
   17: fragment User_user on User {
       ^
@@ -82,7 +82,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected at least one selection for non-scalar field 'nameRenderer' on type 'UserNameRenderer'.
   
-  GraphQL request (4:3)
+  GraphQL request:4:3
   3:   id
   4:   nameRenderer @match
        ^
@@ -123,7 +123,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid @match selection: all selections should be fragment spreads with @module.
   
-  Source: GraphQL request (5:5)
+  Source: GraphQL request:5:5
   4:   nameRenderer @match {
   5:     __typename
          ^
@@ -228,7 +228,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @module does not support @arguments.
   
-  Source: GraphQL request (7:66)
+  Source: GraphQL request:7:66
   6:     ...MarkdownUserNameRenderer_name
   7:       @module(name: "MarkdownUserNameRenderer.react") @arguments(cond: true)
                                                                       ^
@@ -269,7 +269,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid @match selection: the 'supported' argument is automatically added and cannot be supplied explicitly.
   
-  Source: GraphQL request (4:16)
+  Source: GraphQL request:4:16
   3:   id
   4:   nameRenderer(supported: ["PlainUserNameRenderer",  "MarkdownUserNameRenderer"])
                     ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayRefetchableFragmentTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayRefetchableFragmentTransform-test.js.snap
@@ -55,7 +55,7 @@ THROWN EXCEPTION:
 Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable on fragment 'UserName', only fragments on the Query type, Viewer type, Node type, or types implementing Node are supported.
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: fragment UserName on UserNameRenderable @refetchable(queryName: "RefetchableFragmentQuery") {
      ^
@@ -703,13 +703,13 @@ THROWN EXCEPTION:
 Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable with @connection in fragment 'PaginationFragment', refetchable connections must use variables for the after and first arguments.
   
-  Source: GraphQL request (10:5)
+  Source: GraphQL request:10:5
    9:     name
   10:     friends(after: $cursor, first: 10)
           ^
   11:       @connection(key: "PaginationFragment_friends") {
   
-  Source: GraphQL request (10:36)
+  Source: GraphQL request:10:36
    9:     name
   10:     friends(after: $cursor, first: 10)
                                          ^
@@ -745,13 +745,13 @@ THROWN EXCEPTION:
 Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable with @connection in fragment 'PaginationFragment', refetchable connections must use variables for the after and first arguments.
   
-  Source: GraphQL request (10:5)
+  Source: GraphQL request:10:5
    9:     name
   10:     friends(after: "<cursor>", first: $count)
           ^
   11:       @connection(key: "PaginationFragment_friends") {
   
-  Source: GraphQL request (10:20)
+  Source: GraphQL request:10:20
    9:     name
   10:     friends(after: "<cursor>", first: $count)
                          ^
@@ -794,13 +794,13 @@ THROWN EXCEPTION:
 Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable with @connection in fragment 'PaginationFragment', refetchable connections cannot appear inside plural fields.
   
-  Source: GraphQL request (14:11)
+  Source: GraphQL request:14:11
   13:         node {
   14:           friends(after: $cursor, first: $count)
                 ^
   15:             @connection(key: "PaginationFragment_friends") {
   
-  Source: GraphQL request (12:7)
+  Source: GraphQL request:12:7
   11:     friends(first: 1) {
   12:       edges {
             ^

--- a/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayRequiredArguments-test.js.snap
+++ b/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayRequiredArguments-test.js.snap
@@ -107,13 +107,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'level: Int!' is missing on 'customDirective' in 'ViewerQuery'.
   
-  Source: GraphQL request (5:10)
+  Source: GraphQL request:5:10
   4:   node {
   5:     body @customDirective {
               ^
   6:       text
   
-  Source: GraphQL request (3:1)
+  Source: GraphQL request:3:1
   2: 
   3: query ViewerQuery {
      ^
@@ -138,13 +138,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'capitalize: Boolean!' is missing on 'nameWithArgs' in 'TestQuery'.
   
-  Source: GraphQL request (5:7)
+  Source: GraphQL request:5:7
   4:     hometown{
   5:       nameWithArgs
            ^
   6:     }
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: query TestQuery {
      ^
@@ -177,13 +177,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'supported: [String!]!' is missing on 'commentBody' in 'SomeComment'.
   
-  Source: GraphQL request (3:3)
+  Source: GraphQL request:3:3
   2: fragment SomeComment on Comment {
   3:   commentBody {
        ^
   4:     ... on PlainCommentBody {
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: fragment SomeComment on Comment {
      ^
@@ -214,13 +214,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'supported: [String!]!' is missing on 'commentBody' in 'ViewerQuery'.
   
-  Source: GraphQL request (5:7)
+  Source: GraphQL request:5:7
   4:     ... on Comment {
   5:       commentBody {
            ^
   6:         ... on PlainCommentBody {
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: query ViewerQuery {
      ^
@@ -285,7 +285,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Unknown field 'commentBody' on type 'Node'.
   
-  GraphQL request (4:5)
+  GraphQL request:4:5
   3:   node {
   4:     commentBody {
          ^

--- a/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayServerOnlyDirectives-test.js.snap
+++ b/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayServerOnlyDirectives-test.js.snap
@@ -59,13 +59,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @defer. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (12:23)
+  Source (derived): GraphQL request:12:23
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
                             ^
   13: }
   
-  Source (derived): GraphQL request (12:3)
+  Source (derived): GraphQL request:12:3
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
         ^
@@ -97,13 +97,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @defer. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (5:21)
+  Source (derived): GraphQL request:5:21
   4:     id
   5:     ...UserFragment @defer(label: "DeferredFragmentLabel")
                          ^
   6:   }
   
-  Source: GraphQL request (10:3)
+  Source: GraphQL request:10:3
    9: fragment UserFragment on User {
   10:   clientField
         ^
@@ -153,13 +153,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @stream. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (13:13)
+  Source (derived): GraphQL request:13:13
   12:     bar {
   13:       users @stream(initial_count: 1, label: "StreamedActorsLabel") {
                   ^
   14:         id
   
-  Source: GraphQL request (11:3)
+  Source: GraphQL request:11:3
   10:   id
   11:   foo {
         ^
@@ -199,13 +199,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @stream. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (11:8)
+  Source (derived): GraphQL request:11:8
   10:   id
   11:   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
              ^
   12:     bar
   
-  Source: GraphQL request (11:3)
+  Source: GraphQL request:11:3
   10:   id
   11:   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
         ^
@@ -411,13 +411,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @stream. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (9:7)
+  Source (derived): GraphQL request:9:7
    8:       clientComments(first: 10)
    9:       @stream_connection(
             ^
   10:         key: "NodeQuery_clientComments"
   
-  Source: GraphQL request (8:7)
+  Source: GraphQL request:8:7
   7:     ... on Story {
   8:       clientComments(first: 10)
            ^


### PR DESCRIPTION
These changes make it so file/line locations in errors can be made linkable by IDEs. This is the format used by jest, flow, typescript, and many others.

### Before

![relay-ide-friendly-errors-before](https://user-images.githubusercontent.com/2320/58881598-c5246500-86da-11e9-8acb-3039762e734b.gif)

### After

![relay-ide-friendly-errors-after](https://user-images.githubusercontent.com/2320/58881607-cb1a4600-86da-11e9-99fc-296473ec77b0.gif)
