### PR TITLE
Set Docusaurus cname config

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -92,6 +92,7 @@ const siteConfig = {
   title: 'Relay',
   tagline: 'A JavaScript framework for building data-driven React applications',
   url: 'https://relay.dev',
+  cname: 'relay.dev',
   baseUrl: '/',
   projectName: 'relay',
   users,


### PR DESCRIPTION
https://relay.dev/ is now live and working, but old urls like `https://facebook.github.io/relay/` don't redirect there the same way Jest urls redirect from `https://facebook.github.io/jest/`. The only thing I noticed that might be related is this cname config that Jest has set.

Test Plan:
Pretty much just push and pray, not show of a better way to test this as github pages are pushed by CI from master.