### PR TITLE
Hack to forward old urls to relay.dev

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -9,6 +9,15 @@
 
 'use strict';
 
+// Terrible hack until we figure out how to have a working 302 redirect.
+if (document.location.hostname === 'facebook.github.io') {
+  const current = document.location.href;
+  const next = current.replace('facebook.github.io/relay', 'relay.dev');
+  if (current !== next) {
+    document.location.replace(next);
+  }
+}
+
 const React = require('react');
 
 class Footer extends React.Component {


### PR DESCRIPTION
I tried adding a forward using GitHubs domain setting, but that clashed
with some other config and triggered an infinite redirect.

This is just a terrible hack in a terrible place to add a forward to
most pages (all that use the footer, this excludes the GraphQL spec
extension pages).