### PR TITLE
Update URLs to relay.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Relay](https://facebook.github.io/relay/) [![Build Status](https://travis-ci.org/facebook/relay.svg?branch=master)](https://travis-ci.org/facebook/relay) [![npm version](https://badge.fury.io/js/react-relay.svg)](http://badge.fury.io/js/react-relay)
+# [Relay](https://relay.dev) [![Build Status](https://travis-ci.org/facebook/relay.svg?branch=master)](https://travis-ci.org/facebook/relay) [![npm version](https://badge.fury.io/js/react-relay.svg)](http://badge.fury.io/js/react-relay)
 
 Relay is a JavaScript framework for building data-driven React applications.
 
@@ -6,7 +6,7 @@ Relay is a JavaScript framework for building data-driven React applications.
 * **Colocation:** Queries live next to the views that rely on them, so you can easily reason about your app. Relay aggregates queries into efficient network requests to fetch only what you need.
 * **Mutations:** Relay lets you mutate data on the client and server using GraphQL mutations, and offers automatic data consistency, optimistic updates, and error handling.
 
-[See how to use Relay in your own project](http://facebook.github.io/relay/docs/en/introduction-to-relay.html) or check out the community-driven tutorial at [Learn Relay](https://www.learnrelay.org).
+[See how to use Relay in your own project](https://relay.dev/docs/en/introduction-to-relay) or check out the community-driven tutorial at [Learn Relay](https://www.learnrelay.org).
 
 ## Example
 

--- a/docs/Introduction-QuickStartGuide.md
+++ b/docs/Introduction-QuickStartGuide.md
@@ -583,9 +583,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations.html#configs) and an [`updater`](https://facebook.github.io/relay/docs/en/mutations.html#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations.html#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations.html) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
 
 ## Next Steps
 

--- a/docs/Modern-Debugging.md
+++ b/docs/Modern-Debugging.md
@@ -10,7 +10,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 **Given:** You've properly setup your schema on the backend and React on the frontend. You've read through the documents but can't seem to identify what's wrong with your code. You've even done a number of searches but can't find the answer you're looking for.
 
 **A few questions to ask yourself:**
-* _Is my [compilation](https://facebook.github.io/relay/docs/en/installation-and-setup.html#set-up-relay-compiler) up-to-date?_
+* _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
 * _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/docs/Modern-PaginationContainer.md
+++ b/docs/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 ---
 
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container.html), that is designed to simplify the workflow of loading more items in a list &mdash; in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container.html), that is designed to simplify the workflow of loading more items in a list &mdash; in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 - [`@connection`](#connection)
@@ -16,9 +16,9 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](https://facebook.github.io/relay/docs/en/fragment-container.html) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
-However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://facebook.github.io/relay/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
+However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
 The purpose of the `@connection` directive is to allow Relay to uniquely identify different connections under a parent type. The `@connection` directive takes 2 arguments that help identify the connection:
 

--- a/docs/Modern-RelayEnvironment.md
+++ b/docs/Modern-RelayEnvironment.md
@@ -37,7 +37,7 @@ Once you have an environment, you can pass it in to your [`QueryRenderer`](./que
 
 ## Adding a `handlerProvider`
 
-The example above did not configure a `handlerProvider`, which means that a default one will be provided. Relay Modern comes with a couple of built-in handlers that augment the core with special functionality for handling connections (which is not a standard GraphQL feature, but a set of pagination conventions used at Facebook, specified in detail in the [Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm), and well-supported by Relay itself) and the `viewer` field (again, not a standard GraphQL schema feature, but one which has been conventionally used extensively within Facebook).
+The example above did not configure a `handlerProvider`, which means that a default one will be provided. Relay Modern comes with a couple of built-in handlers that augment the core with special functionality for handling connections (which is not a standard GraphQL feature, but a set of pagination conventions used at Facebook, specified in detail in the [Relay Cursor Connections Specification](https://relay.dev/graphql/connections.htm), and well-supported by Relay itself) and the `viewer` field (again, not a standard GraphQL schema feature, but one which has been conventionally used extensively within Facebook).
 
 If you wish to provide your own `handlerProvider`, you can do so:
 

--- a/docs/Modern-Subscriptions.md
+++ b/docs/Modern-Subscriptions.md
@@ -41,7 +41,7 @@ Now let's take a closer look at the `config`:
   the server, with the raw GraphQL response payload.
 * `updater`: an optional function that can supply custom logic for updating the
   in-memory Relay store based on the server response.
-* `configs`: an array containing the updater configurations. It is the same as [`configs`](https://facebook.github.io/relay/docs/mutations.html#configs) in `commitMutation`.
+* `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
 
 ## Example
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A framework for building data-driven React applications.",
   "version": "4.0.0",
   "license": "MIT",
-  "homepage": "https://facebook.github.io/relay/",
+  "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
   "scripts": {

--- a/packages/babel-plugin-relay/BabelPluginRelay.js
+++ b/packages/babel-plugin-relay/BabelPluginRelay.js
@@ -92,7 +92,7 @@ module.exports = function BabelPluginRelay(context: {types: $FlowFixMe}): any {
           'babel-plugin-relay: Missing schema option. ' +
             'Check your .babelrc file or wherever you configure your Babel ' +
             'plugins to ensure the "relay" plugin has a "schema" option.\n' +
-            'https://facebook.github.io/relay/docs/babel-plugin-relay.html#additional-options',
+            'https://relay.dev/docs/en/installation-and-setup#set-up-babel-plugin-relay',
         );
         const documentName = getDocumentName(path, state);
         path.replaceWith(

--- a/packages/babel-plugin-relay/RelayQLPrinter.js
+++ b/packages/babel-plugin-relay/RelayQLPrinter.js
@@ -766,7 +766,7 @@ module.exports = function(t: any, options: PrinterOptions): Function {
             'You defined a `node(%s: %s)` field on type `%s`, but Relay requires ' +
               'the `node` field to be defined on the root type. See the Object ' +
               'Identification Guide: \n' +
-              'https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification',
+              'https://relay.dev/docs/en/graphql-server-specification#object-identification',
             ID,
             argNames[0] && argTypes[argNames[0]].getName({modifiers: true}),
             parentType.getName({modifiers: false}),

--- a/packages/babel-plugin-relay/__tests__/__snapshots__/BabelPluginRelay-classic-test.js.snap
+++ b/packages/babel-plugin-relay/__tests__/__snapshots__/BabelPluginRelay-classic-test.js.snap
@@ -4591,7 +4591,7 @@ var fragment = RelayClassic.QL\`
 ERROR:
 
 Error: undefined: Relay Transform Error: You defined a \`node(id: Int)\` field on type \`InvalidType\`, but Relay requires the \`node\` field to be defined on the root type. See the Object Identification Guide: 
-https://facebook.github.io/relay/docs/en/graphql-server-specification.html#object-identification
+https://relay.dev/docs/en/graphql-server-specification#object-identification
   1 | const RelayClassic = require('react-relay/classic');
 > 2 | var fragment = RelayClassic.QL\`
     |                ^

--- a/packages/babel-plugin-relay/createClassicNode.js
+++ b/packages/babel-plugin-relay/createClassicNode.js
@@ -341,7 +341,7 @@ function getSchemaOption(state) {
     'babel-plugin-relay: Missing schema option. ' +
       'Check your .babelrc file or wherever you configure your Babel ' +
       'plugins to ensure the "relay" plugin has a "schema" option.\n' +
-      'https://facebook.github.io/relay/docs/babel-plugin-relay.html#additional-options',
+      'https://relay.dev/docs/en/installation-and-setup#set-up-babel-plugin-relay',
   );
   return schema;
 }

--- a/packages/babel-plugin-relay/package.json
+++ b/packages/babel-plugin-relay/package.json
@@ -9,7 +9,7 @@
     "babel-plugin"
   ],
   "license": "MIT",
-  "homepage": "https://facebook.github.io/relay/",
+  "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
   "dependencies": {

--- a/packages/react-relay/package.json
+++ b/packages/react-relay/package.json
@@ -8,7 +8,7 @@
     "react"
   ],
   "license": "MIT",
-  "homepage": "https://facebook.github.io/relay/",
+  "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
   "dependencies": {

--- a/packages/relay-compiler/handlers/connection/RelayConnectionTransform.js
+++ b/packages/relay-compiler/handlers/connection/RelayConnectionTransform.js
@@ -234,7 +234,7 @@ function buildConnectionArguments(
       `Expected the ${KEY} argument to @${connectionDirective.name} to be of ` +
         `form <SomeName>_${postfix}, got '${key}'. ` +
         'For a detailed explanation, check out ' +
-        'https://facebook.github.io/relay/docs/en/pagination-container.html#connection',
+        'https://relay.dev/docs/en/pagination-container#connection',
       [keyArg?.value?.loc ?? connectionDirective.loc],
     );
   }

--- a/packages/relay-compiler/handlers/connection/__tests__/__snapshots__/RelayConnectionTransform-test.js.snap
+++ b/packages/relay-compiler/handlers/connection/__tests__/__snapshots__/RelayConnectionTransform-test.js.snap
@@ -870,7 +870,7 @@ query NodeQuery(
 THROWN EXCEPTION:
 
 Error: Encountered 1 error(s):
-- Expected the key argument to @connection to be of form <SomeName>_comments, got 'invalid'. For a detailed explanation, check out https://facebook.github.io/relay/docs/en/pagination-container.html#connection
+- Expected the key argument to @connection to be of form <SomeName>_comments, got 'invalid'. For a detailed explanation, check out https://relay.dev/docs/en/pagination-container#connection
   
   Source: GraphQL request (8:44)
   7:     ... on Story {

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -7,7 +7,7 @@
     "relay"
   ],
   "license": "MIT",
-  "homepage": "https://facebook.github.io/relay/",
+  "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
   "main": "index.js",

--- a/packages/relay-runtime/package.json
+++ b/packages/relay-runtime/package.json
@@ -7,7 +7,7 @@
     "relay"
   ],
   "license": "MIT",
-  "homepage": "https://facebook.github.io/relay/",
+  "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
   "dependencies": {

--- a/packages/relay-test-utils/package.json
+++ b/packages/relay-test-utils/package.json
@@ -7,7 +7,7 @@
     "relay"
   ],
   "license": "MIT",
-  "homepage": "https://facebook.github.io/relay/",
+  "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
   "dependencies": {

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -395,37 +395,37 @@
       "version-v3.0.0/version-v3.0.0-type-emission": {
         "title": "Type Emission"
       },
-      "version-v4.0.0/installation-and-setup": {
+      "version-v4.0.0/version-v4.0.0-installation-and-setup": {
         "title": "Installation and Setup"
       },
-      "version-v4.0.0/quick-start-guide": {
+      "version-v4.0.0/version-v4.0.0-quick-start-guide": {
         "title": "Quick Start Guide"
       },
-      "version-v4.0.0/fetch-query": {
+      "version-v4.0.0/version-v4.0.0-fetch-query": {
         "title": "fetchQuery"
       },
-      "version-v4.0.0/fragment-container": {
+      "version-v4.0.0/version-v4.0.0-fragment-container": {
         "title": "Fragment Container"
       },
-      "version-v4.0.0/graphql-in-relay": {
+      "version-v4.0.0/version-v4.0.0-graphql-in-relay": {
         "title": "GraphQL in Relay"
       },
-      "version-v4.0.0/mutations": {
+      "version-v4.0.0/version-v4.0.0-mutations": {
         "title": "Mutations"
       },
-      "version-v4.0.0/pagination-container": {
+      "version-v4.0.0/version-v4.0.0-pagination-container": {
         "title": "Pagination Container"
       },
-      "version-v4.0.0/query-renderer": {
+      "version-v4.0.0/version-v4.0.0-query-renderer": {
         "title": "<QueryRenderer />"
       },
-      "version-v4.0.0/refetch-container": {
+      "version-v4.0.0/version-v4.0.0-refetch-container": {
         "title": "Refetch Container"
       },
-      "version-v4.0.0/relay-store": {
+      "version-v4.0.0/version-v4.0.0-relay-store": {
         "title": "Relay Store"
       },
-      "version-v4.0.0/testing-relay-components": {
+      "version-v4.0.0/version-v4.0.0-testing-relay-components": {
         "title": "Testing Relay Components"
       }
     },


### PR DESCRIPTION
Updates the URLs pointing at the github.io address that I was able to find to point at relay.dev instead.