### PR TITLE
validateMutation should not recurse into strings

### DIFF
--- a/packages/relay-runtime/mutations/validateMutation.js
+++ b/packages/relay-runtime/mutations/validateMutation.js
@@ -162,7 +162,11 @@ if (__DEV__) {
     context: ValidationContext,
   ) => {
     if (Array.isArray(optimisticResponse)) {
-      optimisticResponse.forEach(r => validateOptimisticResponse(r, context));
+      optimisticResponse.forEach(r => {
+        if (r instanceof Object) {
+          validateOptimisticResponse(r, context);
+        });
+      }
       return;
     }
     Object.keys(optimisticResponse).forEach((key: string) => {

--- a/packages/relay-runtime/mutations/validateMutation.js
+++ b/packages/relay-runtime/mutations/validateMutation.js
@@ -165,8 +165,8 @@ if (__DEV__) {
       optimisticResponse.forEach(r => {
         if (r instanceof Object) {
           validateOptimisticResponse(r, context);
-        });
-      }
+        }
+      });
       return;
     }
     Object.keys(optimisticResponse).forEach((key: string) => {


### PR DESCRIPTION
Given the `changeTags` Mutation Payload is:
```graphql
type ChangeTagsPayload {
  tags: [String!]!
}
```

And I execute the mutation:
```js
const mutation = graphql`
  mutation ChangeTagsMutation(
    $input: ChangeTagsInput!
  ) {
    changeTags(data: $input) {
      tags
    }
  }
`;

const optimisticResponse = {
  changeTags: {
    tags: ["Tag1", "Tag2"],
  },
};

commitMutation(
  environment,
  {
    mutation,
    optimisticResponse,
    variables,
  },
);
```

I'm getting the following errors:
```
Warning: validateMutation: `optimisticResponse` for mutation `ChangeTagsMutation`, contains an unused field ROOT.changeTags.tags.0
Warning: validateMutation: `optimisticResponse` for mutation `ChangeTagsMutation`, contains an unused field ROOT.changeTags.tags.1
Warning: validateMutation: `optimisticResponse` for mutation `ChangeTagsMutation`, contains an unused field ROOT.changeTags.tags.2
Warning: validateMutation: `optimisticResponse` for mutation `ChangeTagsMutation`, contains an unused field ROOT.changeTags.tags.3
Warning: validateMutation: `optimisticResponse` for mutation `ChangeTagsMutation`, contains an unused field ROOT.changeTags.tags.0
Warning: validateMutation: `optimisticResponse` for mutation `ChangeTagsMutation`, contains an unused field ROOT.changeTags.tags.1
Warning: validateMutation: `optimisticResponse` for mutation `ChangeTagsMutation`, contains an unused field ROOT.changeTags.tags.2
Warning: validateMutation: `optimisticResponse` for mutation `ChangeTagsMutation`, contains an unused field ROOT.changeTags.tags.3
```

My debugging session resulted in the function `validateOptimisticResponse` of the file `packages/relay-runtime/mutations/validateMutation.js`. When it meets an array, it doesn't check if its values are objects before recursing into them. This PR adds this check.

Tested on: Relay `v4.0.0` and `v.3.0.0`.