### PR TITLE
Don't include @babel packages in generated bundles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,7 +118,10 @@ const PRODUCTION_HEADER =
 
 const buildDist = function(filename, opts, isProduction) {
   const webpackOpts = {
-    externals: [/^[-/a-zA-Z0-9]+$/],
+    externals: [
+      /^[-/a-zA-Z0-9]+$/,
+      /^@babel\/.+$/,
+    ],
     target: opts.target,
     node: {
       fs: 'empty',
@@ -250,6 +253,7 @@ const builds = [
         entry: 'index.js',
         output: 'relay-test-utils',
         libraryName: 'RelayTestUtils',
+        libraryTarget: 'commonjs2',
         target: 'node',
         noMinify: true, // Note: uglify can't yet handle modern JS
       },


### PR DESCRIPTION
See background in #2759.

Before this change, the `relay-compiler` binary pulls in `lodash`:

```
dist/relay-compiler/bin/relay-compiler
23734:module.exports = require("lodash/clone");
26487:module.exports = require("lodash/uniq");
27035:module.exports = require("lodash/isPlainObject");
27041:module.exports = require("lodash/isRegExp");
28413:module.exports = require("lodash/isInteger");
28419:module.exports = require("lodash/repeat");
```

And, only these files in `dist/` reference `lodash`:

```
$ rg lodash dist/ -l
dist/relay-compiler/relay-compiler.js
dist/relay-compiler/relay-compiler.min.js
dist/relay-compiler/bin/relay-compiler
```

After this change, no files in `dist/` contain references to `lodash`. This seems consistent with what's contained in Relay packages before they were upgraded to Babel 7 (where the `@` was added) in #2536.