### PR TITLE
Include script to redirect facebook.github.io/relay to relay.dev

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -127,6 +127,7 @@ const siteConfig = {
   enableUpdateTime: true,
   enableUpdateBy: true,
   docsSideNavCollapsible: true,
+  scripts: ['/js/redirect.js'],
 };
 
 module.exports = siteConfig;

--- a/website/static/js/redirect.js
+++ b/website/static/js/redirect.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// File to help with client-side redirect. No-op on relay.dev


### PR DESCRIPTION
I've added `js/redirect.js` to `facebook/facebook.github.io` repo and modified Relay website to load a `/js/redirect.js` file. Loading this JS file on:

- When someone goes to `facebook.github.io/relay` they will be redirected to `relay.dev`
- When someone goes to `relay.dev` will see a `js/redirect.js` 404 loading error because there's no real `/js/redirect.js` there. I could add a stub file in relay/website if you don't want to see the 404 in the console. Lemme know if you want that.