### PR TITLE
Change Sigma to Merit in USERS.md

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -49,6 +49,7 @@ Using Relay in your production app? If you'd like to add your team to the list, 
 
 - [M1 Finance](https://www.m1finance.com/)
 - [MeasureChina](http://www.measurechina.cn/)
+- [Merit](https://merits.com)
 - [Mixcloud](https://www.mixcloud.com/)
 
 ## N
@@ -76,7 +77,6 @@ Using Relay in your production app? If you'd like to add your team to the list, 
 ## S
 
 - [Sainsburys](https://sainsburys.co.uk/)
-- [Sigma](https://sig.ma)
 - [Skupos](https://www.skupos.com)
 
 ## T


### PR DESCRIPTION
Sigma is now known as Merit (and is still using Relay!)
https://www.merits.com/blog/sigma-rebrands-as-merit