### PR TITLE
[RelayCompilerError] Use graphql-js exported utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fbjs": "^1.0.0",
     "fbjs-scripts": "^1.1.0",
     "flow-bin": "^0.102.0",
-    "graphql": "^14.2.0",
+    "graphql": "^14.4.0",
     "gulp": "4.0.0",
     "gulp-babel": "8.0.0",
     "gulp-chmod": "2.0.0",

--- a/packages/babel-plugin-relay/__tests__/__snapshots__/BabelPluginRelay-classic-test.js.snap
+++ b/packages/babel-plugin-relay/__tests__/__snapshots__/BabelPluginRelay-classic-test.js.snap
@@ -43,7 +43,7 @@ GraphQL Validation Error: Expected type Boolean, found "true".
 >
 >           isViewerFriend: "true"
 >                           ^^^
-GraphQL Validation Error: Expected type Gender, found "MALE"; Did you mean the enum value MALE or FEMALE?
+GraphQL Validation Error: Expected type Gender, found "MALE". Did you mean the enum value MALE or FEMALE?
 >
 >           gender: "MALE"
 >                   ^^^

--- a/packages/babel-plugin-relay/package.json
+++ b/packages/babel-plugin-relay/package.json
@@ -16,6 +16,6 @@
     "babel-plugin-macros": "^2.0.0"
   },
   "peerDependencies": {
-    "graphql": "^14.2.0"
+    "graphql": "^14.4.0"
   }
 }

--- a/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
+++ b/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
@@ -1471,7 +1471,7 @@ THROWN EXCEPTION:
 
 ReaderCodeGenerator: Complex argument values (Lists or InputObjects with nested variables) are not supported.
 
-Source: GraphQL request (3:17)
+Source: GraphQL request:3:17
 2: query TestQuery($date: String) {
 3:   items(filter: {date: $date}) {
                    ^
@@ -3287,13 +3287,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @connection_resolver, could not generate a default label that is unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (20:25)
+  Source: GraphQL request:20:25
   19:   ... {
   20:     comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") { #error: same default label
                               ^
   21:       count
   
-  Source: GraphQL request (9:23)
+  Source: GraphQL request:9:23
    8: fragment FeedbackComments_feedback on Feedback {
    9:   comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") {
                             ^
@@ -3334,13 +3334,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @connection_resolver, the provided label is not unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (20:89)
+  Source: GraphQL request:20:89
   19:   ... {
   20:     comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver", label: "comments") { #error: same label
                                                                                               ^
   21:       count
   
-  Source: GraphQL request (9:87)
+  Source: GraphQL request:9:87
    8: fragment FeedbackComments_feedback on Feedback {
    9:   comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver", label: "comments") {
                                                                                             ^
@@ -3376,7 +3376,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @connection_resolver fields must return a single value, not a list, found '[CommentsEdge]'
   
-  Source: GraphQL request (10:5)
+  Source: GraphQL request:10:5
    9:   comments(first: 10) {
   10:     edges @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") { # error: plural
           ^
@@ -3403,7 +3403,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - The @connection_resolver direction is not supported on scalar fields, only fields returning an object/interface/union
   
-  Source: GraphQL request (9:6)
+  Source: GraphQL request:9:6
    8: fragment FeedbackComments_feedback on Feedback {
    9:   id @connection_resolver(resolver: "FeedbackIDResolver")  # error: scalar
            ^
@@ -4657,7 +4657,7 @@ Error: Encountered 2 error(s):
 - Operation 'FeedbackQuery' references undefined variable(s):
   - $commentsKey: String.
   
-  Source (derived): GraphQL request (25:26)
+  Source (derived): GraphQL request:25:26
   24:     key: "FeedbackFragment_comments"
   25:     dynamicKey_UNSTABLE: $commentsKey
                                ^
@@ -4666,7 +4666,7 @@ Error: Encountered 2 error(s):
 - Operation 'PaginationQuery' references undefined variable(s):
   - $commentsKey: String.
   
-  Source (derived): GraphQL request (25:26)
+  Source (derived): GraphQL request:25:26
   24:     key: "FeedbackFragment_comments"
   25:     dynamicKey_UNSTABLE: $commentsKey
                                ^
@@ -5899,31 +5899,31 @@ THROWN EXCEPTION:
 
 Error: Found a circular reference from fragment 'Profile'.
 
-Source (derived): GraphQL request (2:1)
+Source (derived): GraphQL request:2:1
 1: # expected-to-throw
 2: fragment RefetchableFragment on Query @refetchable(queryName: "RefetchableFragmentQuery") @argumentDefinitions(id: {type: "ID!"}) {
    ^
 3:   node(id: $id) {
 
-Source (derived): GraphQL request (2:1)
+Source (derived): GraphQL request:2:1
 1: # expected-to-throw
 2: fragment RefetchableFragment on Query @refetchable(queryName: "RefetchableFragmentQuery") @argumentDefinitions(id: {type: "ID!"}) {
    ^
 3:   node(id: $id) {
 
-Source: GraphQL request (7:7)
+Source: GraphQL request:7:7
 6:       name
 7:       ...Profile @arguments(includeProfile: true)
          ^
 8:     }
 
-Source: GraphQL request (21:9)
+Source: GraphQL request:21:9
 20:       node {
 21:         ...Profile
             ^
 22:       }
 
-Source: GraphQL request (21:9)
+Source: GraphQL request:21:9
 20:       node {
 21:         ...Profile
             ^
@@ -6675,13 +6675,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @defer. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (12:23)
+  Source (derived): GraphQL request:12:23
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
                             ^
   13: }
   
-  Source (derived): GraphQL request (12:3)
+  Source (derived): GraphQL request:12:3
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
         ^
@@ -7082,13 +7082,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Cannot use @relay(mask: false) on fragment spreads for fragments with directives.
   
-  Source: GraphQL request (5:5)
+  Source: GraphQL request:5:5
   4:   me {
   5:     ...Profile @relay(mask: false)
          ^
   6:   }
   
-  Source: GraphQL request (9:26)
+  Source: GraphQL request:9:26
    8: 
    9: fragment Profile on User @inline {
                                ^
@@ -7482,7 +7482,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Variables are not yet supported inside @inline fragments.
   
-  Source: GraphQL request (10:24)
+  Source: GraphQL request:10:24
    9: fragment Profile on User @inline {
   10:   profilePicture(size: $pictureSize) {
                              ^
@@ -7520,7 +7520,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Variables are not yet supported inside @inline fragments.
   
-  Source: GraphQL request (17:24)
+  Source: GraphQL request:17:24
   16:   @inline
   17:   @argumentDefinitions(sizeArg: { type: "[Int]", defaultValue: [50] }) {
                              ^
@@ -8329,13 +8329,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Found conflicting @module selections: use a unique alias on the parent fields.
   
-  Source: GraphQL request (22:7)
+  Source: GraphQL request:22:7
   21:     ...MarkdownUserNameRenderer_name
   22:       @module(name: "BarMarkdownUserNameRenderer.react")
             ^
   23:   }
   
-  Source: GraphQL request (13:7)
+  Source: GraphQL request:13:7
   12:     ...MarkdownUserNameRenderer_name
   13:       @module(name: "FooMarkdownUserNameRenderer.react")
             ^
@@ -8531,13 +8531,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'capitalize: Boolean!' is missing on 'nameWithArgs' in 'TestQuery'.
   
-  Source: GraphQL request (5:7)
+  Source: GraphQL request:5:7
   4:     hometown{
   5:       nameWithArgs
            ^
   6:     }
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: query TestQuery {
      ^
@@ -9220,13 +9220,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Found conflicting @module selections: use a unique alias on the parent fields.
   
-  Source: GraphQL request (25:7)
+  Source: GraphQL request:25:7
   24:     ...MarkdownUserNameRenderer_name
   25:       @module(name: "BarMarkdownUserNameRenderer.react")
             ^
   26:   }
   
-  Source: GraphQL request (13:7)
+  Source: GraphQL request:13:7
   12:     ...MarkdownUserNameRenderer_name
   13:       @module(name: "FooMarkdownUserNameRenderer.react")
             ^
@@ -15408,13 +15408,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - RelayMaskTransform: Cannot use @relay(mask: false) on fragment spread because the fragment definition uses @argumentDefinitions.
   
-  Source: GraphQL request (5:5)
+  Source: GraphQL request:5:5
   4:   me {
   5:     ...User_user @relay(mask: false)
          ^
   6:   }
   
-  Source: GraphQL request (10:24)
+  Source: GraphQL request:10:24
    9: fragment User_user on User
   10:   @argumentDefinitions(isRelative: {type: "Boolean!", defaultValue: false}) {
                              ^
@@ -15834,13 +15834,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Variable @arguments values are only supported when the argument is defined with @argumentDefinitions. Check the definition of fragment 'ProfilePhoto'.
   
-  GraphQL request (16:36)
+  GraphQL request:16:36
   15:   __typename
   16:   ...ProfilePhoto @arguments(size: $size)
                                          ^
   17: }
   
-  GraphQL request (19:1)
+  GraphQL request:19:1
   18: 
   19: fragment ProfilePhoto on User {
       ^

--- a/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
+++ b/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
@@ -1472,10 +1472,10 @@ THROWN EXCEPTION:
 ReaderCodeGenerator: Complex argument values (Lists or InputObjects with nested variables) are not supported.
 
 Source: GraphQL request:3:17
-2: query TestQuery($date: String) {
-3:   items(filter: {date: $date}) {
-                   ^
-4:     date
+2 | query TestQuery($date: String) {
+3 |   items(filter: {date: $date}) {
+  |                 ^
+4 |     date
 
 `;
 
@@ -3288,16 +3288,16 @@ Error: Encountered 1 error(s):
 - Invalid use of @connection_resolver, could not generate a default label that is unique. Specify a unique 'label' as a literal string.
   
   Source: GraphQL request:20:25
-  19:   ... {
-  20:     comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") { #error: same default label
-                              ^
-  21:       count
+  19 |   ... {
+  20 |     comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") { #error: same default label
+     |                         ^
+  21 |       count
   
   Source: GraphQL request:9:23
-   8: fragment FeedbackComments_feedback on Feedback {
-   9:   comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") {
-                            ^
-  10:     edges {
+   8 | fragment FeedbackComments_feedback on Feedback {
+   9 |   comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") {
+     |                       ^
+  10 |     edges {
   
 `;
 
@@ -3335,16 +3335,15 @@ Error: Encountered 1 error(s):
 - Invalid use of @connection_resolver, the provided label is not unique. Specify a unique 'label' as a literal string.
   
   Source: GraphQL request:20:89
-  19:   ... {
-  20:     comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver", label: "comments") { #error: same label
-                                                                                              ^
-  21:       count
+  20 |     comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesRes
+     | olver", label: "comments") { #error: same label
+     |         ^
   
   Source: GraphQL request:9:87
-   8: fragment FeedbackComments_feedback on Feedback {
-   9:   comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver", label: "comments") {
-                                                                                            ^
-  10:     edges { # error: plural
+   8 | fragment FeedbackComments_feedback on Feedback {
+   9 |   comments(first: 10) @connection_resolver(resolver: "FeedbackCommentsEdgesResolver", label: "comments") {
+     |                                                                                       ^
+  10 |     edges { # error: plural
   
 `;
 
@@ -3377,10 +3376,10 @@ Error: Encountered 1 error(s):
 - @connection_resolver fields must return a single value, not a list, found '[CommentsEdge]'
   
   Source: GraphQL request:10:5
-   9:   comments(first: 10) {
-  10:     edges @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") { # error: plural
-          ^
-  11:       node {
+   9 |   comments(first: 10) {
+  10 |     edges @connection_resolver(resolver: "FeedbackCommentsEdgesResolver") { # error: plural
+     |     ^
+  11 |       node {
   
 `;
 
@@ -3404,10 +3403,10 @@ Error: Encountered 1 error(s):
 - The @connection_resolver direction is not supported on scalar fields, only fields returning an object/interface/union
   
   Source: GraphQL request:9:6
-   8: fragment FeedbackComments_feedback on Feedback {
-   9:   id @connection_resolver(resolver: "FeedbackIDResolver")  # error: scalar
-           ^
-  10: }
+   8 | fragment FeedbackComments_feedback on Feedback {
+   9 |   id @connection_resolver(resolver: "FeedbackIDResolver")  # error: scalar
+     |      ^
+  10 | }
   
 `;
 
@@ -4658,19 +4657,19 @@ Error: Encountered 2 error(s):
   - $commentsKey: String.
   
   Source (derived): GraphQL request:25:26
-  24:     key: "FeedbackFragment_comments"
-  25:     dynamicKey_UNSTABLE: $commentsKey
-                               ^
-  26:     filters: ["orderby"]
+  24 |     key: "FeedbackFragment_comments"
+  25 |     dynamicKey_UNSTABLE: $commentsKey
+     |                          ^
+  26 |     filters: ["orderby"]
   
 - Operation 'PaginationQuery' references undefined variable(s):
   - $commentsKey: String.
   
   Source (derived): GraphQL request:25:26
-  24:     key: "FeedbackFragment_comments"
-  25:     dynamicKey_UNSTABLE: $commentsKey
-                               ^
-  26:     filters: ["orderby"]
+  24 |     key: "FeedbackFragment_comments"
+  25 |     dynamicKey_UNSTABLE: $commentsKey
+     |                          ^
+  26 |     filters: ["orderby"]
   
 `;
 
@@ -5900,34 +5899,32 @@ THROWN EXCEPTION:
 Error: Found a circular reference from fragment 'Profile'.
 
 Source (derived): GraphQL request:2:1
-1: # expected-to-throw
-2: fragment RefetchableFragment on Query @refetchable(queryName: "RefetchableFragmentQuery") @argumentDefinitions(id: {type: "ID!"}) {
-   ^
-3:   node(id: $id) {
+2 | fragment RefetchableFragment on Query @refetchable(queryName: "RefetchableFragme
+  | ^
+  | ntQuery") @argumentDefinitions(id: {type: "ID!"}) {
 
 Source (derived): GraphQL request:2:1
-1: # expected-to-throw
-2: fragment RefetchableFragment on Query @refetchable(queryName: "RefetchableFragmentQuery") @argumentDefinitions(id: {type: "ID!"}) {
-   ^
-3:   node(id: $id) {
+2 | fragment RefetchableFragment on Query @refetchable(queryName: "RefetchableFragme
+  | ^
+  | ntQuery") @argumentDefinitions(id: {type: "ID!"}) {
 
 Source: GraphQL request:7:7
-6:       name
-7:       ...Profile @arguments(includeProfile: true)
-         ^
-8:     }
+6 |       name
+7 |       ...Profile @arguments(includeProfile: true)
+  |       ^
+8 |     }
 
 Source: GraphQL request:21:9
-20:       node {
-21:         ...Profile
-            ^
-22:       }
+20 |       node {
+21 |         ...Profile
+   |         ^
+22 |       }
 
 Source: GraphQL request:21:9
-20:       node {
-21:         ...Profile
-            ^
-22:       }
+20 |       node {
+21 |         ...Profile
+   |         ^
+22 |       }
 
 `;
 
@@ -6676,16 +6673,16 @@ Error: Encountered 1 error(s):
 - Unexpected directive: @defer. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
   Source (derived): GraphQL request:12:23
-  11:   emailAddresses
-  12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
-                            ^
-  13: }
+  11 |   emailAddresses
+  12 |   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
+     |                       ^
+  13 | }
   
   Source (derived): GraphQL request:12:3
-  11:   emailAddresses
-  12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
-        ^
-  13: }
+  11 |   emailAddresses
+  12 |   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
+     |   ^
+  13 | }
   
 `;
 
@@ -7083,16 +7080,16 @@ Error: Encountered 1 error(s):
 - Cannot use @relay(mask: false) on fragment spreads for fragments with directives.
   
   Source: GraphQL request:5:5
-  4:   me {
-  5:     ...Profile @relay(mask: false)
-         ^
-  6:   }
+  4 |   me {
+  5 |     ...Profile @relay(mask: false)
+    |     ^
+  6 |   }
   
   Source: GraphQL request:9:26
-   8: 
-   9: fragment Profile on User @inline {
-                               ^
-  10:   id
+   8 | 
+   9 | fragment Profile on User @inline {
+     |                          ^
+  10 |   id
   
 `;
 
@@ -7483,10 +7480,10 @@ Error: Encountered 1 error(s):
 - Variables are not yet supported inside @inline fragments.
   
   Source: GraphQL request:10:24
-   9: fragment Profile on User @inline {
-  10:   profilePicture(size: $pictureSize) {
-                             ^
-  11:     uri
+   9 | fragment Profile on User @inline {
+  10 |   profilePicture(size: $pictureSize) {
+     |                        ^
+  11 |     uri
   
 `;
 
@@ -7521,10 +7518,10 @@ Error: Encountered 1 error(s):
 - Variables are not yet supported inside @inline fragments.
   
   Source: GraphQL request:17:24
-  16:   @inline
-  17:   @argumentDefinitions(sizeArg: { type: "[Int]", defaultValue: [50] }) {
-                             ^
-  18:   profilePicture(size: $sizeArg) {
+  16 |   @inline
+  17 |   @argumentDefinitions(sizeArg: { type: "[Int]", defaultValue: [50] }) {
+     |                        ^
+  18 |   profilePicture(size: $sizeArg) {
   
 `;
 
@@ -8330,16 +8327,16 @@ Error: Encountered 1 error(s):
 - Found conflicting @module selections: use a unique alias on the parent fields.
   
   Source: GraphQL request:22:7
-  21:     ...MarkdownUserNameRenderer_name
-  22:       @module(name: "BarMarkdownUserNameRenderer.react")
-            ^
-  23:   }
+  21 |     ...MarkdownUserNameRenderer_name
+  22 |       @module(name: "BarMarkdownUserNameRenderer.react")
+     |       ^
+  23 |   }
   
   Source: GraphQL request:13:7
-  12:     ...MarkdownUserNameRenderer_name
-  13:       @module(name: "FooMarkdownUserNameRenderer.react")
-            ^
-  14:   }
+  12 |     ...MarkdownUserNameRenderer_name
+  13 |       @module(name: "FooMarkdownUserNameRenderer.react")
+     |       ^
+  14 |   }
   
 `;
 
@@ -8532,16 +8529,16 @@ Error: Encountered 1 error(s):
 - Required argument 'capitalize: Boolean!' is missing on 'nameWithArgs' in 'TestQuery'.
   
   Source: GraphQL request:5:7
-  4:     hometown{
-  5:       nameWithArgs
-           ^
-  6:     }
+  4 |     hometown{
+  5 |       nameWithArgs
+    |       ^
+  6 |     }
   
   Source: GraphQL request:2:1
-  1: # expected-to-throw
-  2: query TestQuery {
-     ^
-  3:   node {
+  1 | # expected-to-throw
+  2 | query TestQuery {
+    | ^
+  3 |   node {
   
 `;
 
@@ -9221,16 +9218,16 @@ Error: Encountered 1 error(s):
 - Found conflicting @module selections: use a unique alias on the parent fields.
   
   Source: GraphQL request:25:7
-  24:     ...MarkdownUserNameRenderer_name
-  25:       @module(name: "BarMarkdownUserNameRenderer.react")
-            ^
-  26:   }
+  24 |     ...MarkdownUserNameRenderer_name
+  25 |       @module(name: "BarMarkdownUserNameRenderer.react")
+     |       ^
+  26 |   }
   
   Source: GraphQL request:13:7
-  12:     ...MarkdownUserNameRenderer_name
-  13:       @module(name: "FooMarkdownUserNameRenderer.react")
-            ^
-  14:     ...PlainUserNameRenderer_name
+  12 |     ...MarkdownUserNameRenderer_name
+  13 |       @module(name: "FooMarkdownUserNameRenderer.react")
+     |       ^
+  14 |     ...PlainUserNameRenderer_name
   
 `;
 
@@ -15409,16 +15406,16 @@ Error: Encountered 1 error(s):
 - RelayMaskTransform: Cannot use @relay(mask: false) on fragment spread because the fragment definition uses @argumentDefinitions.
   
   Source: GraphQL request:5:5
-  4:   me {
-  5:     ...User_user @relay(mask: false)
-         ^
-  6:   }
+  4 |   me {
+  5 |     ...User_user @relay(mask: false)
+    |     ^
+  6 |   }
   
   Source: GraphQL request:10:24
-   9: fragment User_user on User
-  10:   @argumentDefinitions(isRelative: {type: "Boolean!", defaultValue: false}) {
-                             ^
-  11: 
+   9 | fragment User_user on User
+  10 |   @argumentDefinitions(isRelative: {type: "Boolean!", defaultValue: false}) {
+     |                        ^
+  11 | 
   
 `;
 
@@ -15835,17 +15832,16 @@ Error: RelayParser: Encountered 1 error(s):
 - Variable @arguments values are only supported when the argument is defined with @argumentDefinitions. Check the definition of fragment 'ProfilePhoto'.
   
   GraphQL request:16:36
-  15:   __typename
-  16:   ...ProfilePhoto @arguments(size: $size)
-                                         ^
-  17: }
+  15 |   __typename
+  16 |   ...ProfilePhoto @arguments(size: $size)
+     |                                    ^
+  17 | }
   
   GraphQL request:19:1
-  18: 
-  19: fragment ProfilePhoto on User {
-      ^
-  20:   profilePicture(size: [100]) {
-  
+  18 | 
+  19 | fragment ProfilePhoto on User {
+     | ^
+  20 |   profilePicture(size: [100]) {
 `;
 
 exports[`compileRelayArtifacts matches expected output: unused-fragment-argdef-unchecked.graphql 1`] = `

--- a/packages/relay-compiler/core/RelayCompilerError.js
+++ b/packages/relay-compiler/core/RelayCompilerError.js
@@ -240,7 +240,7 @@ function highlightSourceAtLocation(
 
   const lines = body.split(/\r\n|[\n\r]/g);
   return (
-    `${source.name} (${lineNum}:${columnNum})\n` +
+    `${source.name}:${lineNum}:${columnNum}\n` +
     printPrefixedLines([
       // Lines specified like this: ["prefix", "string"],
       [`${lineNum - 1}: `, lines[lineIndex - 1]],

--- a/packages/relay-compiler/core/RelayFindGraphQLTags.js
+++ b/packages/relay-compiler/core/RelayFindGraphQLTags.js
@@ -23,14 +23,14 @@ import type {
   GraphQLTagFinder,
 } from '../language/RelayLanguagePluginInterface';
 
-const cache = new RelayCompilerCache('RelayFindGraphQLTags', 'v1');
+const cache = new RelayCompilerCache('RelayFindGraphQLTags', 'v2');
 
 function memoizedFind(
   tagFinder: GraphQLTagFinder,
   text: string,
   baseDir: string,
   file: File,
-): $ReadOnlyArray<string> {
+): $ReadOnlyArray<GraphQLTag> {
   invariant(
     file.exists,
     'RelayFindGraphQLTags: Called with non-existent file `%s`',
@@ -46,11 +46,11 @@ function find(
   tagFinder: GraphQLTagFinder,
   text: string,
   absPath: string,
-): $ReadOnlyArray<string> {
+): $ReadOnlyArray<GraphQLTag> {
   const tags = tagFinder(text, absPath);
   const moduleName = getModuleName(absPath);
   tags.forEach(tag => validateTemplate(tag, moduleName, absPath));
-  return tags.map(tag => tag.template);
+  return tags;
 }
 
 function validateTemplate(

--- a/packages/relay-compiler/core/RelaySourceModuleParser.js
+++ b/packages/relay-compiler/core/RelaySourceModuleParser.js
@@ -76,7 +76,7 @@ module.exports = (
     memoizedTagFinder(text, baseDir, file).forEach(tag => {
       const source = new GraphQL.Source(
         tag.template,
-        file.relPath,
+        path.join(path.relative(process.cwd(), baseDir), file.relPath),
         tag.sourceLocationOffset,
       );
       const ast = parseGraphQL(source);

--- a/packages/relay-compiler/core/RelaySourceModuleParser.js
+++ b/packages/relay-compiler/core/RelaySourceModuleParser.js
@@ -73,14 +73,18 @@ module.exports = (
 
     const astDefinitions = [];
     const sources = [];
-    memoizedTagFinder(text, baseDir, file).forEach(template => {
-      const source = new GraphQL.Source(template, file.relPath);
+    memoizedTagFinder(text, baseDir, file).forEach(tag => {
+      const source = new GraphQL.Source(
+        tag.template,
+        file.relPath,
+        tag.sourceLocationOffset,
+      );
       const ast = parseGraphQL(source);
       invariant(
         ast.definitions.length,
         'RelaySourceModuleParser: Expected GraphQL text to contain at least one ' +
           'definition (fragment, mutation, query, subscription), got `%s`.',
-        template,
+        tag.template,
       );
       sources.push(source.body);
       astDefinitions.push(...ast.definitions);

--- a/packages/relay-compiler/core/__tests__/RelayFindGraphQLTags-test.js
+++ b/packages/relay-compiler/core/__tests__/RelayFindGraphQLTags-test.js
@@ -15,7 +15,9 @@ const RelayFindGraphQLTags = require('../RelayFindGraphQLTags');
 
 describe('RelayFindGraphQLTags', () => {
   function find(text, absPath: string = '/path/to/FindGraphQLTags.js') {
-    return RelayFindGraphQLTags.find(FindGraphQLTags.find, text, absPath);
+    return RelayFindGraphQLTags.find(FindGraphQLTags.find, text, absPath).map(
+      tag => tag.template,
+    );
   }
 
   describe('query parsing', () => {

--- a/packages/relay-compiler/core/__tests__/__snapshots__/RelayParser-test.js.snap
+++ b/packages/relay-compiler/core/__tests__/__snapshots__/RelayParser-test.js.snap
@@ -16,7 +16,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected definition for variable '$size' to be an object with the shape: '{type: string, defaultValue?: mixed}.
   
-  GraphQL request (4:9)
+  GraphQL request:4:9
   3:   id: {type: "ID"}
   4:   size: {type: "[Int]", defaultValu: [100]} # uh-oh, typo
              ^
@@ -932,7 +932,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Invalid directives @match found on FRAGMENT_DEFINITION.
   
-  GraphQL request (2:26)
+  GraphQL request:2:26
   1: # expected-to-throw
   2: fragment Example on User @match(key: "Example"){
                               ^
@@ -955,13 +955,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Invalid directives @module, @match found on QUERY.
   
-  GraphQL request (2:27)
+  GraphQL request:2:27
   1: # expected-to-throw
   2: query TestQuery($id: ID!) @module @match{
                                ^
   3:   foo: node(id: $id) {
   
-  GraphQL request (2:35)
+  GraphQL request:2:35
   1: # expected-to-throw
   2: query TestQuery($id: ID!) @module @match{
                                        ^
@@ -990,7 +990,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Invalid directives @module found on FIELD.
   
-  GraphQL request (6:24)
+  GraphQL request:6:24
   5:       node {
   6:         profilePicture @module(preset: $preset) {
                             ^
@@ -1178,7 +1178,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 3 error(s):
 - Expected a value matching type 'PhotoSize'.
   
-  GraphQL request (4:28)
+  GraphQL request:4:28
   3:   me {
   4:     profilePicture(preset: "LARGE") { # error: string not enum
                                 ^
@@ -1186,7 +1186,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'PhotoSize'.
   
-  GraphQL request (12:28)
+  GraphQL request:12:28
   11:   me {
   12:     profilePicture(preset: 128) { # error: int not enum
                                  ^
@@ -1194,7 +1194,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'PhotoSize'.
   
-  GraphQL request (20:28)
+  GraphQL request:20:28
   19:   me {
   20:     profilePicture(preset: [LARGE]) { # error: list of enum, not enum
                                  ^
@@ -2786,13 +2786,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Variable '$environment' was defined as type 'Environment!' but used in a location expecting the type '[Environment!]!'
   
-  GraphQL request (9:53)
+  GraphQL request:9:53
    8: 
    9: fragment ChildFragment on User @argumentDefinitions(environment: {type: "Environment!"}){
                                                           ^
   10:   # variables of a non-list type cannot flow into list types,
   
-  GraphQL request (12:26)
+  GraphQL request:12:26
   11:   # the singular -> list promotion only works for literal values
   12:   checkins(environments: $environment) { # expected error
                                ^
@@ -3848,13 +3848,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Literal @arguments values are only supported when the argument is defined with @argumentDefinitions. Check the definition of fragment 'ChildFragment'.
   
-  GraphQL request (3:44)
+  GraphQL request:3:44
   2: fragment ParentFragment on User {
   3:   ...ChildFragment @arguments(pictureSize: 42) # error: $pictureSize not defined
                                                 ^
   4: }
   
-  GraphQL request (6:1)
+  GraphQL request:6:1
   5: 
   6: fragment ChildFragment on User {
      ^
@@ -3881,13 +3881,13 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Variable @arguments values are only supported when the argument is defined with @argumentDefinitions. Check the definition of fragment 'ChildFragment'.
   
-  GraphQL request (3:44)
+  GraphQL request:3:44
   2: fragment ParentFragment on User {
   3:   ...ChildFragment @arguments(pictureSize: $querySize) # error: $pictureSize not defined
                                                 ^
   4: }
   
-  GraphQL request (6:1)
+  GraphQL request:6:1
   5: 
   6: fragment ChildFragment on User {
      ^
@@ -3921,7 +3921,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Invalid use of @uncheckedArguments_DEPRECATED: all arguments are defined, use @arguments instead.
   
-  GraphQL request (12:10)
+  GraphQL request:12:10
   11:   }
   12:   ...Foo @uncheckedArguments_DEPRECATED(localId: $id)
                ^
@@ -5054,7 +5054,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 3 error(s):
 - Expected a value matching type 'String'.
   
-  GraphQL request (4:10)
+  GraphQL request:4:10
   3:   route(waypoints: [{
   4:     lat: 0.0 # error: float not string
               ^
@@ -5062,7 +5062,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'WayPoint!'.
   
-  GraphQL request (14:21)
+  GraphQL request:14:21
   13: query LiteralListArgumentQuery2 {
   14:   route(waypoints: ["waypoint"]) { # error: string not input object
                           ^
@@ -5070,7 +5070,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'WayPoint!'.
   
-  GraphQL request (22:20)
+  GraphQL request:22:20
   21: query LiteralListArgumentQuery3 {
   22:   route(waypoints: "waypoint") { # error: string not list
                          ^
@@ -5234,7 +5234,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 3 error(s):
 - Uknown field 'unknownField' on type 'CheckinSearchInput'.
   
-  GraphQL request (4:5)
+  GraphQL request:4:5
   3:   checkinSearchQuery(query: {
   4:     unknownField: "Facebook" # error: unknown field
          ^
@@ -5242,7 +5242,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'String'.
   
-  GraphQL request (12:12)
+  GraphQL request:12:12
   11:   checkinSearchQuery(query: {
   12:     query: FACEBOOK # error: enum not string
                  ^
@@ -5250,7 +5250,7 @@ Error: RelayParser: Encountered 3 error(s):
   
 - Expected a value matching type 'CheckinSearchInput'.
   
-  GraphQL request (19:29)
+  GraphQL request:19:29
   18: query LiteralObjectArgument3 {
   19:   checkinSearchQuery(query: FACEBOOK) { # error: enum not object
                                   ^
@@ -5396,7 +5396,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'ID!'.
   
-  GraphQL request (3:24)
+  GraphQL request:3:24
   2: query NullValuesQuery {
   3:   node_id_required(id: null) {
                             ^
@@ -5870,7 +5870,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Unknown type: 'UnknownType'.
   
-  GraphQL request (2:22)
+  GraphQL request:2:22
   1: # expected-to-throw
   2: query TestQuery($id: UnknownType) {
                           ^
@@ -5882,7 +5882,7 @@ exports[`RelayParser should error on fragment spread arguments with literal out 
 "RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'Int'.
   
-  GraphQL request (4:38)
+  GraphQL request:4:38
   3:         # Number.MAX_SAFE_INTEGER is 9007199254740991
   4:         ...TestChild @arguments(foo: 10000000000000000)
                                           ^
@@ -5894,13 +5894,13 @@ exports[`RelayParser should error when parsing fragment that references undeclar
 "RelayParser: Encountered 1 error(s):
 - Variable '$id' was used in locations expecting the conflicting types 'ID' and 'Int'.
   
-  GraphQL request (2:14)
+  GraphQL request:2:14
   1: fragment TestFragment on Query {
   2:     node(id: $id) {
                   ^
   3:       id
   
-  GraphQL request (5:18)
+  GraphQL request:5:18
   4:     }
   5:     task(number: $id) {
                       ^

--- a/packages/relay-compiler/core/__tests__/__snapshots__/RelayParser-test.js.snap
+++ b/packages/relay-compiler/core/__tests__/__snapshots__/RelayParser-test.js.snap
@@ -17,11 +17,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Expected definition for variable '$size' to be an object with the shape: '{type: string, defaultValue?: mixed}.
   
   GraphQL request:4:9
-  3:   id: {type: "ID"}
-  4:   size: {type: "[Int]", defaultValu: [100]} # uh-oh, typo
-             ^
-  5: ) {
-  
+  3 |   id: {type: "ID"}
+  4 |   size: {type: "[Int]", defaultValu: [100]} # uh-oh, typo
+    |         ^
+  5 | ) {
 `;
 
 exports[`RelayParser matches expected output: client-fields.graphql 1`] = `
@@ -933,11 +932,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Invalid directives @match found on FRAGMENT_DEFINITION.
   
   GraphQL request:2:26
-  1: # expected-to-throw
-  2: fragment Example on User @match(key: "Example"){
-                              ^
-  3:   friends {
-  
+  1 | # expected-to-throw
+  2 | fragment Example on User @match(key: "Example"){
+    |                          ^
+  3 |   friends {
 `;
 
 exports[`RelayParser matches expected output: directive-module-match-on-query.invalid.graphql 1`] = `
@@ -956,17 +954,16 @@ Error: RelayParser: Encountered 1 error(s):
 - Invalid directives @module, @match found on QUERY.
   
   GraphQL request:2:27
-  1: # expected-to-throw
-  2: query TestQuery($id: ID!) @module @match{
-                               ^
-  3:   foo: node(id: $id) {
+  1 | # expected-to-throw
+  2 | query TestQuery($id: ID!) @module @match{
+    |                           ^
+  3 |   foo: node(id: $id) {
   
   GraphQL request:2:35
-  1: # expected-to-throw
-  2: query TestQuery($id: ID!) @module @match{
-                                       ^
-  3:   foo: node(id: $id) {
-  
+  1 | # expected-to-throw
+  2 | query TestQuery($id: ID!) @module @match{
+    |                                   ^
+  3 |   foo: node(id: $id) {
 `;
 
 exports[`RelayParser matches expected output: directive-module-on-field.invalid.graphql 1`] = `
@@ -991,11 +988,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Invalid directives @module found on FIELD.
   
   GraphQL request:6:24
-  5:       node {
-  6:         profilePicture @module(preset: $preset) {
-                            ^
-  7:           uri
-  
+  5 |       node {
+  6 |         profilePicture @module(preset: $preset) {
+    |                        ^
+  7 |           uri
 `;
 
 exports[`RelayParser matches expected output: enum-values.graphql 1`] = `
@@ -1179,27 +1175,24 @@ Error: RelayParser: Encountered 3 error(s):
 - Expected a value matching type 'PhotoSize'.
   
   GraphQL request:4:28
-  3:   me {
-  4:     profilePicture(preset: "LARGE") { # error: string not enum
-                                ^
-  5:       uri
-  
+  3 |   me {
+  4 |     profilePicture(preset: "LARGE") { # error: string not enum
+    |                            ^
+  5 |       uri
 - Expected a value matching type 'PhotoSize'.
   
   GraphQL request:12:28
-  11:   me {
-  12:     profilePicture(preset: 128) { # error: int not enum
-                                 ^
-  13:       uri
-  
+  11 |   me {
+  12 |     profilePicture(preset: 128) { # error: int not enum
+     |                            ^
+  13 |       uri
 - Expected a value matching type 'PhotoSize'.
   
   GraphQL request:20:28
-  19:   me {
-  20:     profilePicture(preset: [LARGE]) { # error: list of enum, not enum
-                                 ^
-  21:       uri
-  
+  19 |   me {
+  20 |     profilePicture(preset: [LARGE]) { # error: list of enum, not enum
+     |                            ^
+  21 |       uri
 `;
 
 exports[`RelayParser matches expected output: field-arguments.graphql 1`] = `
@@ -2787,17 +2780,16 @@ Error: RelayParser: Encountered 1 error(s):
 - Variable '$environment' was defined as type 'Environment!' but used in a location expecting the type '[Environment!]!'
   
   GraphQL request:9:53
-   8: 
-   9: fragment ChildFragment on User @argumentDefinitions(environment: {type: "Environment!"}){
-                                                          ^
-  10:   # variables of a non-list type cannot flow into list types,
+   8 | 
+   9 | fragment ChildFragment on User @argumentDefinitions(environment: {type: "Environment!"}){
+     |                                                     ^
+  10 |   # variables of a non-list type cannot flow into list types,
   
   GraphQL request:12:26
-  11:   # the singular -> list promotion only works for literal values
-  12:   checkins(environments: $environment) { # expected error
-                               ^
-  13:     query
-  
+  11 |   # the singular -> list promotion only works for literal values
+  12 |   checkins(environments: $environment) { # expected error
+     |                          ^
+  13 |     query
 `;
 
 exports[`RelayParser matches expected output: fragment-with-literal-enum-list-arguments.graphql 1`] = `
@@ -3849,17 +3841,16 @@ Error: RelayParser: Encountered 1 error(s):
 - Literal @arguments values are only supported when the argument is defined with @argumentDefinitions. Check the definition of fragment 'ChildFragment'.
   
   GraphQL request:3:44
-  2: fragment ParentFragment on User {
-  3:   ...ChildFragment @arguments(pictureSize: 42) # error: $pictureSize not defined
-                                                ^
-  4: }
+  2 | fragment ParentFragment on User {
+  3 |   ...ChildFragment @arguments(pictureSize: 42) # error: $pictureSize not defined
+    |                                            ^
+  4 | }
   
   GraphQL request:6:1
-  5: 
-  6: fragment ChildFragment on User {
-     ^
-  7:   profilePicture(size: $pictureSize) {
-  
+  5 | 
+  6 | fragment ChildFragment on User {
+    | ^
+  7 |   profilePicture(size: $pictureSize) {
 `;
 
 exports[`RelayParser matches expected output: fragment-with-undefined-variable-arguments.invalid.graphql 1`] = `
@@ -3882,17 +3873,16 @@ Error: RelayParser: Encountered 1 error(s):
 - Variable @arguments values are only supported when the argument is defined with @argumentDefinitions. Check the definition of fragment 'ChildFragment'.
   
   GraphQL request:3:44
-  2: fragment ParentFragment on User {
-  3:   ...ChildFragment @arguments(pictureSize: $querySize) # error: $pictureSize not defined
-                                                ^
-  4: }
+  2 | fragment ParentFragment on User {
+  3 |   ...ChildFragment @arguments(pictureSize: $querySize) # error: $pictureSize not defined
+    |                                            ^
+  4 | }
   
   GraphQL request:6:1
-  5: 
-  6: fragment ChildFragment on User {
-     ^
-  7:   profilePicture(size: $pictureSize) {
-  
+  5 | 
+  6 | fragment ChildFragment on User {
+    | ^
+  7 |   profilePicture(size: $pictureSize) {
 `;
 
 exports[`RelayParser matches expected output: fragment-with-unnecessary-unchecked-arguments.invalid.graphql 1`] = `
@@ -3922,11 +3912,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Invalid use of @uncheckedArguments_DEPRECATED: all arguments are defined, use @arguments instead.
   
   GraphQL request:12:10
-  11:   }
-  12:   ...Foo @uncheckedArguments_DEPRECATED(localId: $id)
-               ^
-  13: }
-  
+  11 |   }
+  12 |   ...Foo @uncheckedArguments_DEPRECATED(localId: $id)
+     |          ^
+  13 | }
 `;
 
 exports[`RelayParser matches expected output: inline-untyped-fragment.graphql 1`] = `
@@ -5055,27 +5044,24 @@ Error: RelayParser: Encountered 3 error(s):
 - Expected a value matching type 'String'.
   
   GraphQL request:4:10
-  3:   route(waypoints: [{
-  4:     lat: 0.0 # error: float not string
-              ^
-  5:     lon: "0.0"
-  
+  3 |   route(waypoints: [{
+  4 |     lat: 0.0 # error: float not string
+    |          ^
+  5 |     lon: "0.0"
 - Expected a value matching type 'WayPoint!'.
   
   GraphQL request:14:21
-  13: query LiteralListArgumentQuery2 {
-  14:   route(waypoints: ["waypoint"]) { # error: string not input object
-                          ^
-  15:     steps {
-  
+  13 | query LiteralListArgumentQuery2 {
+  14 |   route(waypoints: ["waypoint"]) { # error: string not input object
+     |                     ^
+  15 |     steps {
 - Expected a value matching type 'WayPoint!'.
   
   GraphQL request:22:20
-  21: query LiteralListArgumentQuery3 {
-  22:   route(waypoints: "waypoint") { # error: string not list
-                         ^
-  23:     steps {
-  
+  21 | query LiteralListArgumentQuery3 {
+  22 |   route(waypoints: "waypoint") { # error: string not list
+     |                    ^
+  23 |     steps {
 `;
 
 exports[`RelayParser matches expected output: literal-object-argument.graphql 1`] = `
@@ -5235,27 +5221,24 @@ Error: RelayParser: Encountered 3 error(s):
 - Uknown field 'unknownField' on type 'CheckinSearchInput'.
   
   GraphQL request:4:5
-  3:   checkinSearchQuery(query: {
-  4:     unknownField: "Facebook" # error: unknown field
-         ^
-  5:   }) {
-  
+  3 |   checkinSearchQuery(query: {
+  4 |     unknownField: "Facebook" # error: unknown field
+    |     ^
+  5 |   }) {
 - Expected a value matching type 'String'.
   
   GraphQL request:12:12
-  11:   checkinSearchQuery(query: {
-  12:     query: FACEBOOK # error: enum not string
-                 ^
-  13:   }) {
-  
+  11 |   checkinSearchQuery(query: {
+  12 |     query: FACEBOOK # error: enum not string
+     |            ^
+  13 |   }) {
 - Expected a value matching type 'CheckinSearchInput'.
   
   GraphQL request:19:29
-  18: query LiteralObjectArgument3 {
-  19:   checkinSearchQuery(query: FACEBOOK) { # error: enum not object
-                                  ^
-  20:     query
-  
+  18 | query LiteralObjectArgument3 {
+  19 |   checkinSearchQuery(query: FACEBOOK) { # error: enum not object
+     |                             ^
+  20 |     query
 `;
 
 exports[`RelayParser matches expected output: null-values.graphql 1`] = `
@@ -5397,11 +5380,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'ID!'.
   
   GraphQL request:3:24
-  2: query NullValuesQuery {
-  3:   node_id_required(id: null) {
-                            ^
-  4:     id
-  
+  2 | query NullValuesQuery {
+  3 |   node_id_required(id: null) {
+    |                        ^
+  4 |     id
 `;
 
 exports[`RelayParser matches expected output: object-argument.graphql 1`] = `
@@ -5871,11 +5853,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Unknown type: 'UnknownType'.
   
   GraphQL request:2:22
-  1: # expected-to-throw
-  2: query TestQuery($id: UnknownType) {
-                          ^
-  3:   node(id: "someid") {
-  
+  1 | # expected-to-throw
+  2 | query TestQuery($id: UnknownType) {
+    |                      ^
+  3 |   node(id: "someid") {
 `;
 
 exports[`RelayParser should error on fragment spread arguments with literal out of bounds values 1`] = `
@@ -5883,11 +5864,10 @@ exports[`RelayParser should error on fragment spread arguments with literal out 
 - Expected a value matching type 'Int'.
   
   GraphQL request:4:38
-  3:         # Number.MAX_SAFE_INTEGER is 9007199254740991
-  4:         ...TestChild @arguments(foo: 10000000000000000)
-                                          ^
-  5:       }
-  "
+  3 |         # Number.MAX_SAFE_INTEGER is 9007199254740991
+  4 |         ...TestChild @arguments(foo: 10000000000000000)
+    |                                      ^
+  5 |       }"
 `;
 
 exports[`RelayParser should error when parsing fragment that references undeclared variables are used with differing types 1`] = `
@@ -5895,15 +5875,14 @@ exports[`RelayParser should error when parsing fragment that references undeclar
 - Variable '$id' was used in locations expecting the conflicting types 'ID' and 'Int'.
   
   GraphQL request:2:14
-  1: fragment TestFragment on Query {
-  2:     node(id: $id) {
-                  ^
-  3:       id
+  1 | fragment TestFragment on Query {
+  2 |     node(id: $id) {
+    |              ^
+  3 |       id
   
   GraphQL request:5:18
-  4:     }
-  5:     task(number: $id) {
-                      ^
-  6:       title
-  "
+  4 |     }
+  5 |     task(number: $id) {
+    |                  ^
+  6 |       title"
 `;

--- a/packages/relay-compiler/core/__tests__/__snapshots__/RelayPrinter-test.js.snap
+++ b/packages/relay-compiler/core/__tests__/__snapshots__/RelayPrinter-test.js.snap
@@ -161,7 +161,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'Environment!'.
   
-  GraphQL request (3:26)
+  GraphQL request:3:26
   2: fragment UserFragment on User {
   3:   checkins(environments: "WEB") {
                               ^
@@ -205,7 +205,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'Environment!'.
   
-  GraphQL request (3:26)
+  GraphQL request:3:26
   2: fragment UserFragment on User {
   3:   checkins(environments: UNKNOWN_ENUM_VALUE) {
                               ^

--- a/packages/relay-compiler/core/__tests__/__snapshots__/RelayPrinter-test.js.snap
+++ b/packages/relay-compiler/core/__tests__/__snapshots__/RelayPrinter-test.js.snap
@@ -162,11 +162,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'Environment!'.
   
   GraphQL request:3:26
-  2: fragment UserFragment on User {
-  3:   checkins(environments: "WEB") {
-                              ^
-  4:     __typename
-  
+  2 | fragment UserFragment on User {
+  3 |   checkins(environments: "WEB") {
+    |                          ^
+  4 |     __typename
 `;
 
 exports[`GraphQLIRPrinter matches expected output: string-enum-fragment-arg.graphql 1`] = `
@@ -206,9 +205,8 @@ Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'Environment!'.
   
   GraphQL request:3:26
-  2: fragment UserFragment on User {
-  3:   checkins(environments: UNKNOWN_ENUM_VALUE) {
-                              ^
-  4:     __typename
-  
+  2 | fragment UserFragment on User {
+  3 |   checkins(environments: UNKNOWN_ENUM_VALUE) {
+    |                          ^
+  4 |     __typename
 `;

--- a/packages/relay-compiler/handlers/connection/__tests__/__snapshots__/RelayConnectionTransform-test.js.snap
+++ b/packages/relay-compiler/handlers/connection/__tests__/__snapshots__/RelayConnectionTransform-test.js.snap
@@ -546,7 +546,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected field 'comments' to have a 'first' or 'last' argument.
   
-  Source: GraphQL request (8:7)
+  Source: GraphQL request:8:7
   7:     ... on Story {
   8:       comments @connection(key: "NodeQuery_comments") {
            ^
@@ -872,7 +872,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected the key argument to @connection to be of form <SomeName>_comments, got 'invalid'. For a detailed explanation, check out https://relay.dev/docs/en/pagination-container#connection
   
-  Source: GraphQL request (8:44)
+  Source: GraphQL request:8:44
   7:     ... on Story {
   8:       comments(first: 10) @connection(key: "invalid") {
                                                 ^
@@ -906,7 +906,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'String!'.
   
-  GraphQL request (8:44)
+  GraphQL request:8:44
   7:     ... on Story {
   8:       comments(first: 10) @connection(key: 10) {
                                                 ^
@@ -949,7 +949,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'String'.
   
-  GraphQL request (8:75)
+  GraphQL request:8:75
   7:     ... on Story {
   8:       comments(first: 10) @connection(key: "NodeQuery_comments", handler: 10) {
                                                                                ^
@@ -979,7 +979,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @connection used on invalid field 'actors'. Expected the return type to be a non-plural interface or object, got '[Actor]'.
   
-  Source: GraphQL request (8:7)
+  Source: GraphQL request:8:7
   7:     ... on Story {
   8:       actors @connection {
            ^
@@ -1186,7 +1186,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @stream_connection does not support aliasing the 'edges' field.
   
-  Source: GraphQL request (14:9)
+  Source: GraphQL request:14:9
   13:       ) {
   14:         commentEdges: edges {
               ^
@@ -1230,7 +1230,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @stream_connection does not support aliasing the 'pageInfo' field.
   
-  Source: GraphQL request (21:9)
+  Source: GraphQL request:21:9
   20:         }
   21:         commentPageInfo: pageInfo {
               ^

--- a/packages/relay-compiler/handlers/connection/__tests__/__snapshots__/RelayConnectionTransform-test.js.snap
+++ b/packages/relay-compiler/handlers/connection/__tests__/__snapshots__/RelayConnectionTransform-test.js.snap
@@ -547,10 +547,10 @@ Error: Encountered 1 error(s):
 - Expected field 'comments' to have a 'first' or 'last' argument.
   
   Source: GraphQL request:8:7
-  7:     ... on Story {
-  8:       comments @connection(key: "NodeQuery_comments") {
-           ^
-  9:         edges {
+  7 |     ... on Story {
+  8 |       comments @connection(key: "NodeQuery_comments") {
+    |       ^
+  9 |         edges {
   
 `;
 
@@ -873,10 +873,10 @@ Error: Encountered 1 error(s):
 - Expected the key argument to @connection to be of form <SomeName>_comments, got 'invalid'. For a detailed explanation, check out https://relay.dev/docs/en/pagination-container#connection
   
   Source: GraphQL request:8:44
-  7:     ... on Story {
-  8:       comments(first: 10) @connection(key: "invalid") {
-                                                ^
-  9:         edges {
+  7 |     ... on Story {
+  8 |       comments(first: 10) @connection(key: "invalid") {
+    |                                            ^
+  9 |         edges {
   
 `;
 
@@ -907,11 +907,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'String!'.
   
   GraphQL request:8:44
-  7:     ... on Story {
-  8:       comments(first: 10) @connection(key: 10) {
-                                                ^
-  9:         edges {
-  
+  7 |     ... on Story {
+  8 |       comments(first: 10) @connection(key: 10) {
+    |                                            ^
+  9 |         edges {
 `;
 
 exports[`RelayConnectionTransform matches expected output: invalid-connection-with-custom-handler.graphql 1`] = `
@@ -950,11 +949,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Expected a value matching type 'String'.
   
   GraphQL request:8:75
-  7:     ... on Story {
-  8:       comments(first: 10) @connection(key: "NodeQuery_comments", handler: 10) {
-                                                                               ^
-  9:         edges {
-  
+  7 |     ... on Story {
+  8 |       comments(first: 10) @connection(key: "NodeQuery_comments", handler: 10) {
+    |                                                                           ^
+  9 |         edges {
 `;
 
 exports[`RelayConnectionTransform matches expected output: invalid-type.graphql 1`] = `
@@ -980,10 +978,10 @@ Error: Encountered 1 error(s):
 - @connection used on invalid field 'actors'. Expected the return type to be a non-plural interface or object, got '[Actor]'.
   
   Source: GraphQL request:8:7
-  7:     ... on Story {
-  8:       actors @connection {
-           ^
-  9:         name
+  7 |     ... on Story {
+  8 |       actors @connection {
+    |       ^
+  9 |         name
   
 `;
 
@@ -1187,10 +1185,10 @@ Error: Encountered 1 error(s):
 - @stream_connection does not support aliasing the 'edges' field.
   
   Source: GraphQL request:14:9
-  13:       ) {
-  14:         commentEdges: edges {
-              ^
-  15:           node {
+  13 |       ) {
+  14 |         commentEdges: edges {
+     |         ^
+  15 |           node {
   
 `;
 
@@ -1231,9 +1229,9 @@ Error: Encountered 1 error(s):
 - @stream_connection does not support aliasing the 'pageInfo' field.
   
   Source: GraphQL request:21:9
-  20:         }
-  21:         commentPageInfo: pageInfo {
-              ^
-  22:           hasNextPage
+  20 |         }
+  21 |         commentPageInfo: pageInfo {
+     |         ^
+  22 |           hasNextPage
   
 `;

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -34,6 +34,6 @@
     "yargs": "^9.0.0"
   },
   "peerDependencies": {
-    "graphql": "^14.2.0"
+    "graphql": "^14.4.0"
   }
 }

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/FlattenTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/FlattenTransform-test.js.snap
@@ -34,16 +34,16 @@ Error: Encountered 1 error(s):
 - Expected all fields on the same parent with the name or alias 'friendsAlias' to have the same name and arguments.
   
   Source: GraphQL request:14:9
-  13:       ... on User {
-  14:         friendsAlias: friends(first: 10) {
-              ^
-  15:           edges {
+  13 |       ... on User {
+  14 |         friendsAlias: friends(first: 10) {
+     |         ^
+  15 |           edges {
   
   Source: GraphQL request:9:9
-   8:       ... on User {
-   9:         friendsAlias: friends(first: 5) {
-              ^
-  10:           count
+   8 |       ... on User {
+   9 |         friendsAlias: friends(first: 5) {
+     |         ^
+  10 |           count
   
 `;
 
@@ -81,16 +81,16 @@ Error: Encountered 1 error(s):
 - Expected all fields on the same parent with the name or alias 'friends' to have the same name and arguments.
   
   Source: GraphQL request:14:9
-  13:       ... on User {
-  14:         friends(first: 10) {
-              ^
-  15:           edges {
+  13 |       ... on User {
+  14 |         friends(first: 10) {
+     |         ^
+  15 |           edges {
   
   Source: GraphQL request:9:9
-   8:       ... on User {
-   9:         friends(first: 5) {
-              ^
-  10:           count
+   8 |       ... on User {
+   9 |         friends(first: 5) {
+     |         ^
+  10 |           count
   
 `;
 
@@ -456,16 +456,16 @@ Error: Encountered 1 error(s):
 - Expected all fields on the same parent with the name or alias 'nameRenderer' to have the same name and arguments.
   
   Source: GraphQL request:11:5
-  10:     # conflicts with above: same alias but different types are matched
-  11:     nameRenderer @match {
-          ^
-  12:       ...MarkdownUserNameRenderer_name
+  10 |     # conflicts with above: same alias but different types are matched
+  11 |     nameRenderer @match {
+     |     ^
+  12 |       ...MarkdownUserNameRenderer_name
   
   Source: GraphQL request:4:3
-  3:   id
-  4:   nameRenderer @match {
-       ^
-  5:     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
+  3 |   id
+  4 |   nameRenderer @match {
+    |   ^
+  5 |     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
   
 `;
 
@@ -510,16 +510,16 @@ Error: Encountered 1 error(s):
 - Found conflicting @module selections: use a unique alias on the parent fields.
   
   Source: GraphQL request:12:37
-  11:     nameRenderer @match {
-  12:       ...PlainUserNameRenderer_name @module(name: "OtherPlainUserNameRenderer.react")
-                                          ^
-  13:       ...MarkdownUserNameRenderer_name
+  11 |     nameRenderer @match {
+  12 |       ...PlainUserNameRenderer_name @module(name: "OtherPlainUserNameRenderer.react")
+     |                                     ^
+  13 |       ...MarkdownUserNameRenderer_name
   
   Source: GraphQL request:5:35
-  4:   nameRenderer @match {
-  5:     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
-                                       ^
-  6:     ...MarkdownUserNameRenderer_name
+  4 |   nameRenderer @match {
+  5 |     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
+    |                                   ^
+  6 |     ...MarkdownUserNameRenderer_name
   
 `;
 

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/FlattenTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/FlattenTransform-test.js.snap
@@ -33,13 +33,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected all fields on the same parent with the name or alias 'friendsAlias' to have the same name and arguments.
   
-  Source: GraphQL request (14:9)
+  Source: GraphQL request:14:9
   13:       ... on User {
   14:         friendsAlias: friends(first: 10) {
               ^
   15:           edges {
   
-  Source: GraphQL request (9:9)
+  Source: GraphQL request:9:9
    8:       ... on User {
    9:         friendsAlias: friends(first: 5) {
               ^
@@ -80,13 +80,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected all fields on the same parent with the name or alias 'friends' to have the same name and arguments.
   
-  Source: GraphQL request (14:9)
+  Source: GraphQL request:14:9
   13:       ... on User {
   14:         friends(first: 10) {
               ^
   15:           edges {
   
-  Source: GraphQL request (9:9)
+  Source: GraphQL request:9:9
    8:       ... on User {
    9:         friends(first: 5) {
               ^
@@ -455,13 +455,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected all fields on the same parent with the name or alias 'nameRenderer' to have the same name and arguments.
   
-  Source: GraphQL request (11:5)
+  Source: GraphQL request:11:5
   10:     # conflicts with above: same alias but different types are matched
   11:     nameRenderer @match {
           ^
   12:       ...MarkdownUserNameRenderer_name
   
-  Source: GraphQL request (4:3)
+  Source: GraphQL request:4:3
   3:   id
   4:   nameRenderer @match {
        ^
@@ -509,13 +509,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Found conflicting @module selections: use a unique alias on the parent fields.
   
-  Source: GraphQL request (12:37)
+  Source: GraphQL request:12:37
   11:     nameRenderer @match {
   12:       ...PlainUserNameRenderer_name @module(name: "OtherPlainUserNameRenderer.react")
                                           ^
   13:       ...MarkdownUserNameRenderer_name
   
-  Source: GraphQL request (5:35)
+  Source: GraphQL request:5:35
   4:   nameRenderer @match {
   5:     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
                                        ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
@@ -304,22 +304,22 @@ THROWN EXCEPTION:
 Error: Found a circular reference from fragment 'Profile'.
 
 Source: GraphQL request:2:1
-1: # expected-to-throw
-2: query TestQuery(
-   ^
-3:   $id: ID!
+1 | # expected-to-throw
+2 | query TestQuery(
+  | ^
+3 |   $id: ID!
 
 Source: GraphQL request:8:5
-7:     id
-8:     ...Profile
-       ^
-9:   }
+7 |     id
+8 |     ...Profile
+  |     ^
+9 |   }
 
 Source: GraphQL request:21:9
-20:       node {
-21:         ...Profile
-            ^
-22:       }
+20 |       node {
+21 |         ...Profile
+   |         ^
+22 |       }
 
 `;
 
@@ -362,11 +362,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Query 'TestQuery' references undefined variables.
   
   GraphQL request:9:70
-   8:     id
-   9:     ...Profile @arguments(pictureSize: $pictureSize, includeFriends: $includeFriends2)
-                                                                           ^
-  10:   }
-  
+   8 |     id
+   9 |     ...Profile @arguments(pictureSize: $pictureSize, includeFriends: $includeFriends2)
+     |                                                                      ^
+  10 |   }
 `;
 
 exports[`RelayApplyFragmentArgumentTransform matches expected output: uses-defaults-for-literal-null-arguments.graphql 1`] = `

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayApplyFragmentArgumentTransform-test.js.snap
@@ -303,19 +303,19 @@ THROWN EXCEPTION:
 
 Error: Found a circular reference from fragment 'Profile'.
 
-Source: GraphQL request (2:1)
+Source: GraphQL request:2:1
 1: # expected-to-throw
 2: query TestQuery(
    ^
 3:   $id: ID!
 
-Source: GraphQL request (8:5)
+Source: GraphQL request:8:5
 7:     id
 8:     ...Profile
        ^
 9:   }
 
-Source: GraphQL request (21:9)
+Source: GraphQL request:21:9
 20:       node {
 21:         ...Profile
             ^
@@ -361,7 +361,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Query 'TestQuery' references undefined variables.
   
-  GraphQL request (9:70)
+  GraphQL request:9:70
    8:     id
    9:     ...Profile @arguments(pictureSize: $pictureSize, includeFriends: $includeFriends2)
                                                                            ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayDeferStreamTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayDeferStreamTransform-test.js.snap
@@ -165,13 +165,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @defer, the provided label is not unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (13:35)
+  Source: GraphQL request:13:35
   12:   ...DeferredFragment @defer(label: "deferred")
   13:   ...OtherDeferredFragment @defer(label: "deferred")
                                         ^
   14: }
   
-  Source: GraphQL request (12:30)
+  Source: GraphQL request:12:30
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "deferred")
                                    ^
@@ -360,13 +360,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @stream, the provided label is not unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (15:29)
+  Source: GraphQL request:15:29
   14:   otherActors: actors
   15:   @stream(initial_count: 1, label: "actors") { # invalid: duplicate label
                                   ^
   16:     name
   
-  Source: GraphQL request (11:36)
+  Source: GraphQL request:11:36
   10:   id
   11:   actors @stream(initial_count: 1, label: "actors") {
                                          ^
@@ -469,7 +469,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @stream, the 'initial_count' argument is required.
   
-  Source: GraphQL request (11:10)
+  Source: GraphQL request:11:10
   10:   id
   11:   actors @stream(label: "StreamedActorsLabel") { # invalid: missing initial_count
                ^
@@ -535,7 +535,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected the 'label' value to @stream to be a string literal if provided.
   
-  Source: GraphQL request (11:43)
+  Source: GraphQL request:11:43
   10:   id
   11:   actors @stream(initial_count: 1, label: $label) {
                                                 ^
@@ -570,7 +570,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected the 'label' value to @defer to be a string literal if provided.
   
-  Source: GraphQL request (12:37)
+  Source: GraphQL request:12:37
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: $label)
                                           ^
@@ -680,13 +680,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid use of @defer, could not generate a default label that is unique. Specify a unique 'label' as a literal string.
   
-  Source: GraphQL request (16:15)
+  Source: GraphQL request:16:15
   15:   }
   16:   ... on User @defer { # invalid: duplicate label
                     ^
   17:     name
   
-  Source: GraphQL request (12:15)
+  Source: GraphQL request:12:15
   11:   emailAddresses
   12:   ... on User @defer {
                     ^
@@ -756,7 +756,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Expected the 'label' value to @defer to be a string literal if provided.
   
-  Source: GraphQL request (12:29)
+  Source: GraphQL request:12:29
   11:   emailAddresses
   12:   ... on User @defer(label: $label) {
                                   ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayDeferStreamTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayDeferStreamTransform-test.js.snap
@@ -166,16 +166,16 @@ Error: Encountered 1 error(s):
 - Invalid use of @defer, the provided label is not unique. Specify a unique 'label' as a literal string.
   
   Source: GraphQL request:13:35
-  12:   ...DeferredFragment @defer(label: "deferred")
-  13:   ...OtherDeferredFragment @defer(label: "deferred")
-                                        ^
-  14: }
+  12 |   ...DeferredFragment @defer(label: "deferred")
+  13 |   ...OtherDeferredFragment @defer(label: "deferred")
+     |                                   ^
+  14 | }
   
   Source: GraphQL request:12:30
-  11:   emailAddresses
-  12:   ...DeferredFragment @defer(label: "deferred")
-                                   ^
-  13:   ...OtherDeferredFragment @defer(label: "deferred")
+  11 |   emailAddresses
+  12 |   ...DeferredFragment @defer(label: "deferred")
+     |                              ^
+  13 |   ...OtherDeferredFragment @defer(label: "deferred")
   
 `;
 
@@ -361,16 +361,16 @@ Error: Encountered 1 error(s):
 - Invalid use of @stream, the provided label is not unique. Specify a unique 'label' as a literal string.
   
   Source: GraphQL request:15:29
-  14:   otherActors: actors
-  15:   @stream(initial_count: 1, label: "actors") { # invalid: duplicate label
-                                  ^
-  16:     name
+  14 |   otherActors: actors
+  15 |   @stream(initial_count: 1, label: "actors") { # invalid: duplicate label
+     |                             ^
+  16 |     name
   
   Source: GraphQL request:11:36
-  10:   id
-  11:   actors @stream(initial_count: 1, label: "actors") {
-                                         ^
-  12:     name
+  10 |   id
+  11 |   actors @stream(initial_count: 1, label: "actors") {
+     |                                    ^
+  12 |     name
   
 `;
 
@@ -470,10 +470,10 @@ Error: Encountered 1 error(s):
 - Invalid use of @stream, the 'initial_count' argument is required.
   
   Source: GraphQL request:11:10
-  10:   id
-  11:   actors @stream(label: "StreamedActorsLabel") { # invalid: missing initial_count
-               ^
-  12:     name
+  10 |   id
+  11 |   actors @stream(label: "StreamedActorsLabel") { # invalid: missing initial_count
+     |          ^
+  12 |     name
   
 `;
 
@@ -536,10 +536,10 @@ Error: Encountered 1 error(s):
 - Expected the 'label' value to @stream to be a string literal if provided.
   
   Source: GraphQL request:11:43
-  10:   id
-  11:   actors @stream(initial_count: 1, label: $label) {
-                                                ^
-  12:     name
+  10 |   id
+  11 |   actors @stream(initial_count: 1, label: $label) {
+     |                                           ^
+  12 |     name
   
 `;
 
@@ -571,10 +571,10 @@ Error: Encountered 1 error(s):
 - Expected the 'label' value to @defer to be a string literal if provided.
   
   Source: GraphQL request:12:37
-  11:   emailAddresses
-  12:   ...DeferredFragment @defer(label: $label)
-                                          ^
-  13: }
+  11 |   emailAddresses
+  12 |   ...DeferredFragment @defer(label: $label)
+     |                                     ^
+  13 | }
   
 `;
 
@@ -681,16 +681,16 @@ Error: Encountered 1 error(s):
 - Invalid use of @defer, could not generate a default label that is unique. Specify a unique 'label' as a literal string.
   
   Source: GraphQL request:16:15
-  15:   }
-  16:   ... on User @defer { # invalid: duplicate label
-                    ^
-  17:     name
+  15 |   }
+  16 |   ... on User @defer { # invalid: duplicate label
+     |               ^
+  17 |     name
   
   Source: GraphQL request:12:15
-  11:   emailAddresses
-  12:   ... on User @defer {
-                    ^
-  13:     id
+  11 |   emailAddresses
+  12 |   ... on User @defer {
+     |               ^
+  13 |     id
   
 `;
 
@@ -757,10 +757,10 @@ Error: Encountered 1 error(s):
 - Expected the 'label' value to @defer to be a string literal if provided.
   
   Source: GraphQL request:12:29
-  11:   emailAddresses
-  12:   ... on User @defer(label: $label) {
-                                  ^
-  13:     id
+  11 |   emailAddresses
+  12 |   ... on User @defer(label: $label) {
+     |                             ^
+  13 |     id
   
 `;
 

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
@@ -92,13 +92,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Cannot combine variables with incompatible types Int and ID when applying @relay(unmask: true).
   
-  Source: GraphQL request (14:16)
+  Source: GraphQL request:14:16
   13: fragment StringFragment on Query {
   14:   task(number: $id) {
                      ^
   15:     title
   
-  Source: GraphQL request (8:12)
+  Source: GraphQL request:8:12
   7: fragment NullableIDFragment on Query {
   8:   node(id: $id) {
                 ^
@@ -132,13 +132,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Cannot combine variables with incompatible types [ID!] and ID when applying @relay(unmask: true).
   
-  Source: GraphQL request (14:14)
+  Source: GraphQL request:14:14
   13: fragment NullableIDListFragment on Query {
   14:   nodes(ids: $id) {
                    ^
   15:     id
   
-  Source: GraphQL request (8:12)
+  Source: GraphQL request:8:12
   7: fragment NullableIDFragment on Query {
   8:   node(id: $id) {
                 ^
@@ -167,13 +167,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Cannot combine global and local variables when applying @relay(unmask: true).
   
-  Source: GraphQL request (3:3)
+  Source: GraphQL request:3:3
   2: fragment ParentQuery on Query @argumentDefinitions(
   3:   id: {type: "ID!"}
        ^
   4: ) {
   
-  Source: GraphQL request (9:24)
+  Source: GraphQL request:9:24
    8: fragment NonNullIDFragment on Query {
    9:   node_id_required(id: $id) {
                              ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMaskTransform-test.js.snap
@@ -93,16 +93,16 @@ Error: Encountered 1 error(s):
 - Cannot combine variables with incompatible types Int and ID when applying @relay(unmask: true).
   
   Source: GraphQL request:14:16
-  13: fragment StringFragment on Query {
-  14:   task(number: $id) {
-                     ^
-  15:     title
+  13 | fragment StringFragment on Query {
+  14 |   task(number: $id) {
+     |                ^
+  15 |     title
   
   Source: GraphQL request:8:12
-  7: fragment NullableIDFragment on Query {
-  8:   node(id: $id) {
-                ^
-  9:     id
+  7 | fragment NullableIDFragment on Query {
+  8 |   node(id: $id) {
+    |            ^
+  9 |     id
   
 `;
 
@@ -133,16 +133,16 @@ Error: Encountered 1 error(s):
 - Cannot combine variables with incompatible types [ID!] and ID when applying @relay(unmask: true).
   
   Source: GraphQL request:14:14
-  13: fragment NullableIDListFragment on Query {
-  14:   nodes(ids: $id) {
-                   ^
-  15:     id
+  13 | fragment NullableIDListFragment on Query {
+  14 |   nodes(ids: $id) {
+     |              ^
+  15 |     id
   
   Source: GraphQL request:8:12
-  7: fragment NullableIDFragment on Query {
-  8:   node(id: $id) {
-                ^
-  9:     id
+  7 | fragment NullableIDFragment on Query {
+  8 |   node(id: $id) {
+    |            ^
+  9 |     id
   
 `;
 
@@ -168,16 +168,16 @@ Error: Encountered 1 error(s):
 - Cannot combine global and local variables when applying @relay(unmask: true).
   
   Source: GraphQL request:3:3
-  2: fragment ParentQuery on Query @argumentDefinitions(
-  3:   id: {type: "ID!"}
-       ^
-  4: ) {
+  2 | fragment ParentQuery on Query @argumentDefinitions(
+  3 |   id: {type: "ID!"}
+    |   ^
+  4 | ) {
   
   Source: GraphQL request:9:24
-   8: fragment NonNullIDFragment on Query {
-   9:   node_id_required(id: $id) {
-                             ^
-  10:     id
+   8 | fragment NonNullIDFragment on Query {
+   9 |   node_id_required(id: $id) {
+     |                        ^
+  10 |     id
   
 `;
 

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMatchTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMatchTransform-test.js.snap
@@ -18,7 +18,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Direct use of the 'js' field is not allowed, use @match/@module instead.
   
-  Source: GraphQL request (6:7)
+  Source: GraphQL request:6:7
   5:     ... on PlainUserNameRenderer {
   6:       js(module: "PlainUserNameRenderer.react")
            ^
@@ -54,13 +54,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid @match selection: selections must match against concrete variants/implementors of type 'UserNameRenderer'. Got 'User', expected one of 'PlainUserNameRenderer', 'MarkdownUserNameRenderer', 'CustomNameRenderer', etc.
   
-  Source: GraphQL request (6:18)
+  Source: GraphQL request:6:18
   5:     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
   6:     ...User_user @module(name: "User.react")
                       ^
   7:   }
   
-  Source: GraphQL request (17:1)
+  Source: GraphQL request:17:1
   16: 
   17: fragment User_user on User {
       ^
@@ -82,7 +82,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Expected at least one selection for non-scalar field 'nameRenderer' on type 'UserNameRenderer'.
   
-  GraphQL request (4:3)
+  GraphQL request:4:3
   3:   id
   4:   nameRenderer @match
        ^
@@ -123,7 +123,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid @match selection: all selections should be fragment spreads with @module.
   
-  Source: GraphQL request (5:5)
+  Source: GraphQL request:5:5
   4:   nameRenderer @match {
   5:     __typename
          ^
@@ -228,7 +228,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - @module does not support @arguments.
   
-  Source: GraphQL request (7:66)
+  Source: GraphQL request:7:66
   6:     ...MarkdownUserNameRenderer_name
   7:       @module(name: "MarkdownUserNameRenderer.react") @arguments(cond: true)
                                                                       ^
@@ -269,7 +269,7 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Invalid @match selection: the 'supported' argument is automatically added and cannot be supplied explicitly.
   
-  Source: GraphQL request (4:16)
+  Source: GraphQL request:4:16
   3:   id
   4:   nameRenderer(supported: ["PlainUserNameRenderer",  "MarkdownUserNameRenderer"])
                     ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMatchTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayMatchTransform-test.js.snap
@@ -19,10 +19,10 @@ Error: Encountered 1 error(s):
 - Direct use of the 'js' field is not allowed, use @match/@module instead.
   
   Source: GraphQL request:6:7
-  5:     ... on PlainUserNameRenderer {
-  6:       js(module: "PlainUserNameRenderer.react")
-           ^
-  7:     }
+  5 |     ... on PlainUserNameRenderer {
+  6 |       js(module: "PlainUserNameRenderer.react")
+    |       ^
+  7 |     }
   
 `;
 
@@ -55,16 +55,16 @@ Error: Encountered 1 error(s):
 - Invalid @match selection: selections must match against concrete variants/implementors of type 'UserNameRenderer'. Got 'User', expected one of 'PlainUserNameRenderer', 'MarkdownUserNameRenderer', 'CustomNameRenderer', etc.
   
   Source: GraphQL request:6:18
-  5:     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
-  6:     ...User_user @module(name: "User.react")
-                      ^
-  7:   }
+  5 |     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
+  6 |     ...User_user @module(name: "User.react")
+    |                  ^
+  7 |   }
   
   Source: GraphQL request:17:1
-  16: 
-  17: fragment User_user on User {
-      ^
-  18:   __typename
+  16 | 
+  17 | fragment User_user on User {
+     | ^
+  18 |   __typename
   
 `;
 
@@ -83,11 +83,10 @@ Error: RelayParser: Encountered 1 error(s):
 - Expected at least one selection for non-scalar field 'nameRenderer' on type 'UserNameRenderer'.
   
   GraphQL request:4:3
-  3:   id
-  4:   nameRenderer @match
-       ^
-  5: }
-  
+  3 |   id
+  4 |   nameRenderer @match
+    |   ^
+  5 | }
 `;
 
 exports[`RelayMatchTransform matches expected output: invalid-non-empty-selections.graphql 1`] = `
@@ -124,10 +123,10 @@ Error: Encountered 1 error(s):
 - Invalid @match selection: all selections should be fragment spreads with @module.
   
   Source: GraphQL request:5:5
-  4:   nameRenderer @match {
-  5:     __typename
-         ^
-  6:     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
+  4 |   nameRenderer @match {
+  5 |     __typename
+    |     ^
+  6 |     ...PlainUserNameRenderer_name @module(name: "PlainUserNameRenderer.react")
   
 `;
 
@@ -229,10 +228,10 @@ Error: Encountered 1 error(s):
 - @module does not support @arguments.
   
   Source: GraphQL request:7:66
-  6:     ...MarkdownUserNameRenderer_name
-  7:       @module(name: "MarkdownUserNameRenderer.react") @arguments(cond: true)
-                                                                      ^
-  8:   }
+  6 |     ...MarkdownUserNameRenderer_name
+  7 |       @module(name: "MarkdownUserNameRenderer.react") @arguments(cond: true)
+    |                                                                  ^
+  8 |   }
   
 `;
 
@@ -270,10 +269,10 @@ Error: Encountered 1 error(s):
 - Invalid @match selection: the 'supported' argument is automatically added and cannot be supplied explicitly.
   
   Source: GraphQL request:4:16
-  3:   id
-  4:   nameRenderer(supported: ["PlainUserNameRenderer",  "MarkdownUserNameRenderer"])
-                    ^
-  5:     @match {
+  3 |   id
+  4 |   nameRenderer(supported: ["PlainUserNameRenderer",  "MarkdownUserNameRenderer"])
+    |                ^
+  5 |     @match {
   
 `;
 

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayRefetchableFragmentTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayRefetchableFragmentTransform-test.js.snap
@@ -55,7 +55,7 @@ THROWN EXCEPTION:
 Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable on fragment 'UserName', only fragments on the Query type, Viewer type, Node type, or types implementing Node are supported.
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: fragment UserName on UserNameRenderable @refetchable(queryName: "RefetchableFragmentQuery") {
      ^
@@ -703,13 +703,13 @@ THROWN EXCEPTION:
 Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable with @connection in fragment 'PaginationFragment', refetchable connections must use variables for the after and first arguments.
   
-  Source: GraphQL request (10:5)
+  Source: GraphQL request:10:5
    9:     name
   10:     friends(after: $cursor, first: 10)
           ^
   11:       @connection(key: "PaginationFragment_friends") {
   
-  Source: GraphQL request (10:36)
+  Source: GraphQL request:10:36
    9:     name
   10:     friends(after: $cursor, first: 10)
                                          ^
@@ -745,13 +745,13 @@ THROWN EXCEPTION:
 Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable with @connection in fragment 'PaginationFragment', refetchable connections must use variables for the after and first arguments.
   
-  Source: GraphQL request (10:5)
+  Source: GraphQL request:10:5
    9:     name
   10:     friends(after: "<cursor>", first: $count)
           ^
   11:       @connection(key: "PaginationFragment_friends") {
   
-  Source: GraphQL request (10:20)
+  Source: GraphQL request:10:20
    9:     name
   10:     friends(after: "<cursor>", first: $count)
                          ^
@@ -794,13 +794,13 @@ THROWN EXCEPTION:
 Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable with @connection in fragment 'PaginationFragment', refetchable connections cannot appear inside plural fields.
   
-  Source: GraphQL request (14:11)
+  Source: GraphQL request:14:11
   13:         node {
   14:           friends(after: $cursor, first: $count)
                 ^
   15:             @connection(key: "PaginationFragment_friends") {
   
-  Source: GraphQL request (12:7)
+  Source: GraphQL request:12:7
   11:     friends(first: 1) {
   12:       edges {
             ^

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayRefetchableFragmentTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/RelayRefetchableFragmentTransform-test.js.snap
@@ -56,10 +56,10 @@ Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable on fragment 'UserName', only fragments on the Query type, Viewer type, Node type, or types implementing Node are supported.
   
   Source: GraphQL request:2:1
-  1: # expected-to-throw
-  2: fragment UserName on UserNameRenderable @refetchable(queryName: "RefetchableFragmentQuery") {
-     ^
-  3:   name
+  1 | # expected-to-throw
+  2 | fragment UserName on UserNameRenderable @refetchable(queryName: "RefetchableFragmentQuery") {
+    | ^
+  3 |   name
   
 `;
 
@@ -704,16 +704,16 @@ Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable with @connection in fragment 'PaginationFragment', refetchable connections must use variables for the after and first arguments.
   
   Source: GraphQL request:10:5
-   9:     name
-  10:     friends(after: $cursor, first: 10)
-          ^
-  11:       @connection(key: "PaginationFragment_friends") {
+   9 |     name
+  10 |     friends(after: $cursor, first: 10)
+     |     ^
+  11 |       @connection(key: "PaginationFragment_friends") {
   
   Source: GraphQL request:10:36
-   9:     name
-  10:     friends(after: $cursor, first: 10)
-                                         ^
-  11:       @connection(key: "PaginationFragment_friends") {
+   9 |     name
+  10 |     friends(after: $cursor, first: 10)
+     |                                    ^
+  11 |       @connection(key: "PaginationFragment_friends") {
   
 `;
 
@@ -746,16 +746,16 @@ Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable with @connection in fragment 'PaginationFragment', refetchable connections must use variables for the after and first arguments.
   
   Source: GraphQL request:10:5
-   9:     name
-  10:     friends(after: "<cursor>", first: $count)
-          ^
-  11:       @connection(key: "PaginationFragment_friends") {
+   9 |     name
+  10 |     friends(after: "<cursor>", first: $count)
+     |     ^
+  11 |       @connection(key: "PaginationFragment_friends") {
   
   Source: GraphQL request:10:20
-   9:     name
-  10:     friends(after: "<cursor>", first: $count)
-                         ^
-  11:       @connection(key: "PaginationFragment_friends") {
+   9 |     name
+  10 |     friends(after: "<cursor>", first: $count)
+     |                    ^
+  11 |       @connection(key: "PaginationFragment_friends") {
   
 `;
 
@@ -795,16 +795,16 @@ Error: RelayRefetchableFragmentTransform: Encountered 1 error(s):
 - Invalid use of @refetchable with @connection in fragment 'PaginationFragment', refetchable connections cannot appear inside plural fields.
   
   Source: GraphQL request:14:11
-  13:         node {
-  14:           friends(after: $cursor, first: $count)
-                ^
-  15:             @connection(key: "PaginationFragment_friends") {
+  13 |         node {
+  14 |           friends(after: $cursor, first: $count)
+     |           ^
+  15 |             @connection(key: "PaginationFragment_friends") {
   
   Source: GraphQL request:12:7
-  11:     friends(first: 1) {
-  12:       edges {
-            ^
-  13:         node {
+  11 |     friends(first: 1) {
+  12 |       edges {
+     |       ^
+  13 |         node {
   
 `;
 

--- a/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayRequiredArguments-test.js.snap
+++ b/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayRequiredArguments-test.js.snap
@@ -108,16 +108,16 @@ Error: Encountered 1 error(s):
 - Required argument 'level: Int!' is missing on 'customDirective' in 'ViewerQuery'.
   
   Source: GraphQL request:5:10
-  4:   node {
-  5:     body @customDirective {
-              ^
-  6:       text
+  4 |   node {
+  5 |     body @customDirective {
+    |          ^
+  6 |       text
   
   Source: GraphQL request:3:1
-  2: 
-  3: query ViewerQuery {
-     ^
-  4:   node {
+  2 | 
+  3 | query ViewerQuery {
+    | ^
+  4 |   node {
   
 `;
 
@@ -139,16 +139,16 @@ Error: Encountered 1 error(s):
 - Required argument 'capitalize: Boolean!' is missing on 'nameWithArgs' in 'TestQuery'.
   
   Source: GraphQL request:5:7
-  4:     hometown{
-  5:       nameWithArgs
-           ^
-  6:     }
+  4 |     hometown{
+  5 |       nameWithArgs
+    |       ^
+  6 |     }
   
   Source: GraphQL request:2:1
-  1: # expected-to-throw
-  2: query TestQuery {
-     ^
-  3:   node {
+  1 | # expected-to-throw
+  2 | query TestQuery {
+    | ^
+  3 |   node {
   
 `;
 
@@ -178,16 +178,16 @@ Error: Encountered 1 error(s):
 - Required argument 'supported: [String!]!' is missing on 'commentBody' in 'SomeComment'.
   
   Source: GraphQL request:3:3
-  2: fragment SomeComment on Comment {
-  3:   commentBody {
-       ^
-  4:     ... on PlainCommentBody {
+  2 | fragment SomeComment on Comment {
+  3 |   commentBody {
+    |   ^
+  4 |     ... on PlainCommentBody {
   
   Source: GraphQL request:2:1
-  1: # expected-to-throw
-  2: fragment SomeComment on Comment {
-     ^
-  3:   commentBody {
+  1 | # expected-to-throw
+  2 | fragment SomeComment on Comment {
+    | ^
+  3 |   commentBody {
   
 `;
 
@@ -215,16 +215,16 @@ Error: Encountered 1 error(s):
 - Required argument 'supported: [String!]!' is missing on 'commentBody' in 'ViewerQuery'.
   
   Source: GraphQL request:5:7
-  4:     ... on Comment {
-  5:       commentBody {
-           ^
-  6:         ... on PlainCommentBody {
+  4 |     ... on Comment {
+  5 |       commentBody {
+    |       ^
+  6 |         ... on PlainCommentBody {
   
   Source: GraphQL request:2:1
-  1: # expected-to-throw
-  2: query ViewerQuery {
-     ^
-  3:   node {
+  1 | # expected-to-throw
+  2 | query ViewerQuery {
+    | ^
+  3 |   node {
   
 `;
 
@@ -286,9 +286,8 @@ Error: RelayParser: Encountered 1 error(s):
 - Unknown field 'commentBody' on type 'Node'.
   
   GraphQL request:4:5
-  3:   node {
-  4:     commentBody {
-         ^
-  5:       ... on PlainCommentBody {
-  
+  3 |   node {
+  4 |     commentBody {
+    |     ^
+  5 |       ... on PlainCommentBody {
 `;

--- a/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayRequiredArguments-test.js.snap
+++ b/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayRequiredArguments-test.js.snap
@@ -107,13 +107,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'level: Int!' is missing on 'customDirective' in 'ViewerQuery'.
   
-  Source: GraphQL request (5:10)
+  Source: GraphQL request:5:10
   4:   node {
   5:     body @customDirective {
               ^
   6:       text
   
-  Source: GraphQL request (3:1)
+  Source: GraphQL request:3:1
   2: 
   3: query ViewerQuery {
      ^
@@ -138,13 +138,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'capitalize: Boolean!' is missing on 'nameWithArgs' in 'TestQuery'.
   
-  Source: GraphQL request (5:7)
+  Source: GraphQL request:5:7
   4:     hometown{
   5:       nameWithArgs
            ^
   6:     }
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: query TestQuery {
      ^
@@ -177,13 +177,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'supported: [String!]!' is missing on 'commentBody' in 'SomeComment'.
   
-  Source: GraphQL request (3:3)
+  Source: GraphQL request:3:3
   2: fragment SomeComment on Comment {
   3:   commentBody {
        ^
   4:     ... on PlainCommentBody {
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: fragment SomeComment on Comment {
      ^
@@ -214,13 +214,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Required argument 'supported: [String!]!' is missing on 'commentBody' in 'ViewerQuery'.
   
-  Source: GraphQL request (5:7)
+  Source: GraphQL request:5:7
   4:     ... on Comment {
   5:       commentBody {
            ^
   6:         ... on PlainCommentBody {
   
-  Source: GraphQL request (2:1)
+  Source: GraphQL request:2:1
   1: # expected-to-throw
   2: query ViewerQuery {
      ^
@@ -285,7 +285,7 @@ THROWN EXCEPTION:
 Error: RelayParser: Encountered 1 error(s):
 - Unknown field 'commentBody' on type 'Node'.
   
-  GraphQL request (4:5)
+  GraphQL request:4:5
   3:   node {
   4:     commentBody {
          ^

--- a/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayServerOnlyDirectives-test.js.snap
+++ b/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayServerOnlyDirectives-test.js.snap
@@ -59,13 +59,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @defer. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (12:23)
+  Source (derived): GraphQL request:12:23
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
                             ^
   13: }
   
-  Source (derived): GraphQL request (12:3)
+  Source (derived): GraphQL request:12:3
   11:   emailAddresses
   12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
         ^
@@ -97,13 +97,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @defer. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (5:21)
+  Source (derived): GraphQL request:5:21
   4:     id
   5:     ...UserFragment @defer(label: "DeferredFragmentLabel")
                          ^
   6:   }
   
-  Source: GraphQL request (10:3)
+  Source: GraphQL request:10:3
    9: fragment UserFragment on User {
   10:   clientField
         ^
@@ -153,13 +153,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @stream. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (13:13)
+  Source (derived): GraphQL request:13:13
   12:     bar {
   13:       users @stream(initial_count: 1, label: "StreamedActorsLabel") {
                   ^
   14:         id
   
-  Source: GraphQL request (11:3)
+  Source: GraphQL request:11:3
   10:   id
   11:   foo {
         ^
@@ -199,13 +199,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @stream. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (11:8)
+  Source (derived): GraphQL request:11:8
   10:   id
   11:   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
              ^
   12:     bar
   
-  Source: GraphQL request (11:3)
+  Source: GraphQL request:11:3
   10:   id
   11:   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
         ^
@@ -411,13 +411,13 @@ THROWN EXCEPTION:
 Error: Encountered 1 error(s):
 - Unexpected directive: @stream. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
-  Source (derived): GraphQL request (9:7)
+  Source (derived): GraphQL request:9:7
    8:       clientComments(first: 10)
    9:       @stream_connection(
             ^
   10:         key: "NodeQuery_clientComments"
   
-  Source: GraphQL request (8:7)
+  Source: GraphQL request:8:7
   7:     ... on Story {
   8:       clientComments(first: 10)
            ^

--- a/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayServerOnlyDirectives-test.js.snap
+++ b/packages/relay-compiler/validations/__tests__/__snapshots__/validateRelayServerOnlyDirectives-test.js.snap
@@ -60,16 +60,16 @@ Error: Encountered 1 error(s):
 - Unexpected directive: @defer. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
   Source (derived): GraphQL request:12:23
-  11:   emailAddresses
-  12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
-                            ^
-  13: }
+  11 |   emailAddresses
+  12 |   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
+     |                       ^
+  13 | }
   
   Source (derived): GraphQL request:12:3
-  11:   emailAddresses
-  12:   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
-        ^
-  13: }
+  11 |   emailAddresses
+  12 |   ...DeferredFragment @defer(label: "DeferredFragmentLabel")
+     |   ^
+  13 | }
   
 `;
 
@@ -98,16 +98,16 @@ Error: Encountered 1 error(s):
 - Unexpected directive: @defer. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
   Source (derived): GraphQL request:5:21
-  4:     id
-  5:     ...UserFragment @defer(label: "DeferredFragmentLabel")
-                         ^
-  6:   }
+  4 |     id
+  5 |     ...UserFragment @defer(label: "DeferredFragmentLabel")
+    |                     ^
+  6 |   }
   
   Source: GraphQL request:10:3
-   9: fragment UserFragment on User {
-  10:   clientField
-        ^
-  11: }
+   9 | fragment UserFragment on User {
+  10 |   clientField
+     |   ^
+  11 | }
   
 `;
 
@@ -154,16 +154,16 @@ Error: Encountered 1 error(s):
 - Unexpected directive: @stream. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
   Source (derived): GraphQL request:13:13
-  12:     bar {
-  13:       users @stream(initial_count: 1, label: "StreamedActorsLabel") {
-                  ^
-  14:         id
+  12 |     bar {
+  13 |       users @stream(initial_count: 1, label: "StreamedActorsLabel") {
+     |             ^
+  14 |         id
   
   Source: GraphQL request:11:3
-  10:   id
-  11:   foo {
-        ^
-  12:     bar {
+  10 |   id
+  11 |   foo {
+     |   ^
+  12 |     bar {
   
 `;
 
@@ -200,16 +200,16 @@ Error: Encountered 1 error(s):
 - Unexpected directive: @stream. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
   Source (derived): GraphQL request:11:8
-  10:   id
-  11:   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
-             ^
-  12:     bar
+  10 |   id
+  11 |   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+     |        ^
+  12 |     bar
   
   Source: GraphQL request:11:3
-  10:   id
-  11:   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
-        ^
-  12:     bar
+  10 |   id
+  11 |   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+     |   ^
+  12 |     bar
   
 `;
 
@@ -412,15 +412,15 @@ Error: Encountered 1 error(s):
 - Unexpected directive: @stream. This directive can only be used on fields/fragments that are fetched from the server schema, but it is used inside a client-only selection.
   
   Source (derived): GraphQL request:9:7
-   8:       clientComments(first: 10)
-   9:       @stream_connection(
-            ^
-  10:         key: "NodeQuery_clientComments"
+   8 |       clientComments(first: 10)
+   9 |       @stream_connection(
+     |       ^
+  10 |         key: "NodeQuery_clientComments"
   
   Source: GraphQL request:8:7
-  7:     ... on Story {
-  8:       clientComments(first: 10)
-           ^
-  9:       @stream_connection(
+  7 |     ... on Story {
+  8 |       clientComments(first: 10)
+    |       ^
+  9 |       @stream_connection(
   
 `;

--- a/packages/relay-test-utils-internal/package.json
+++ b/packages/relay-test-utils-internal/package.json
@@ -17,7 +17,7 @@
     "relay-compiler": "5.0.0"
   },
   "peerDependencies": {
-    "graphql": "^14.2.0"
+    "graphql": "^14.4.0"
   },
   "directories": {
     "": "./"

--- a/packages/relay-test-utils/package.json
+++ b/packages/relay-test-utils/package.json
@@ -16,7 +16,7 @@
     "relay-runtime": "5.0.0"
   },
   "peerDependencies": {
-    "graphql": "^14.2.0"
+    "graphql": "^14.4.0"
   },
   "directories": {
     "": "./"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,10 +3259,10 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
-graphql@^14.0.0, graphql@^14.2.0:
-  version "14.3.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.3.1.tgz#b3aa50e61a841ada3c1f9ccda101c483f8e8c807"
-  integrity sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==
+graphql@^14.0.0, graphql@^14.4.0:
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.4.0.tgz#e97086acfc0338e4fdc8f7dba519c6b8a6badfd9"
+  integrity sha512-E55z1oK6e4cGxCqlSsRWytYDPcIUxky3XkbuQUf6TIjCmn6C7CuBJpmkMF1066q95yPAGOZVPTVT7jABKbRFSA==
   dependencies:
     iterall "^1.2.2"
 


### PR DESCRIPTION
⚠️ 
* This includes #2752, so that one should ideally be merged first. The real change for this PR is in 73671f7.
* ~~The graphql-js changes are in master but not yet in a release, so this PR needs to be updated to point to a release once that’s out.~~

Follow-up from https://github.com/facebook/relay/pull/2752#issuecomment-502046563, https://github.com/graphql/graphql-js/pull/1985#issuecomment-502401686, and as [discussed in Slack](https://graphql.slack.com/archives/C044QJ51J/p1559654699006600) with @josephsavona and @IvanGoncharov.

This change removes graphql-js code that was vendored and uses the newly exported graphql-js utilities instead.