### PR TITLE
Support external publish queues

### DIFF
--- a/packages/relay-runtime/store/DataChecker.js
+++ b/packages/relay-runtime/store/DataChecker.js
@@ -286,6 +286,7 @@ class DataChecker {
           this._traverseSelections(selection.selections, dataID);
           break;
         case SCALAR_HANDLE:
+          break;
         case FRAGMENT_SPREAD:
           invariant(
             false,

--- a/packages/relay-runtime/store/RelayModernQueryExecutor.js
+++ b/packages/relay-runtime/store/RelayModernQueryExecutor.js
@@ -328,10 +328,6 @@ class Executor {
   }
 
   _processResponse(response: GraphQLResponseWithData): void {
-    if (this._optimisticUpdate !== null) {
-      this._publishQueue.revertUpdate(this._optimisticUpdate);
-      this._optimisticUpdate = null;
-    }
     const payload = normalizeResponse(
       response,
       this._operation.root,
@@ -342,7 +338,8 @@ class Executor {
     this._incrementalResults.clear();
     this._source.clear();
     this._processPayloadFollowups(payload);
-    this._publishQueue.commitPayload(this._operation, payload, this._updater);
+    this._publishQueue.commitPayload(this._operation, payload, this._updater, this._optimisticUpdate);
+    this._optimisticUpdate = null;
     const updatedOwners = this._publishQueue.run();
     this._updateOperationTracker(updatedOwners);
 

--- a/packages/relay-runtime/store/RelayModernRecord.js
+++ b/packages/relay-runtime/store/RelayModernRecord.js
@@ -85,17 +85,20 @@ function clone(record: Record): Record {
 /**
  * @public
  *
- * Copies all fields from `source` to `sink`, excluding `__id` and `__typename`.
+ * Copies all fields from `source` to `sink`, excluding `__id`.
  *
  * NOTE: This function does not treat `id` specially. To preserve the id,
  * manually reset it after calling this function. Also note that values are
  * copied by reference and not value; callers should ensure that values are
  * copied on write.
+ *
+ * `__typename` is not excluded because two normalized payloads could
+ * have the same `storageKey`, but different `__typename` values
  */
 function copyFields(source: Record, sink: Record): void {
   for (const key in source) {
     if (source.hasOwnProperty(key)) {
-      if (key !== ID_KEY && key !== TYPENAME_KEY) {
+      if (key !== ID_KEY) {
         sink[key] = source[key];
       }
     }

--- a/packages/relay-runtime/store/RelayPublishQueue.js
+++ b/packages/relay-runtime/store/RelayPublishQueue.js
@@ -149,7 +149,11 @@ class RelayPublishQueue implements PublishQueue {
     operation: OperationDescriptor,
     {fieldPayloads, source}: RelayResponsePayload,
     updater?: ?SelectorStoreUpdater,
+    optimisticUpdate?: OptimisticUpdate | null
   ): void {
+    if (optimisticUpdate) {
+      this.revertUpdate(optimisticUpdate)
+    }
     this._pendingBackupRebase = true;
     this._pendingData.add({
       kind: 'payload',

--- a/packages/relay-runtime/store/__tests__/RelayModernRecord-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernRecord-test.js
@@ -60,7 +60,7 @@ describe('RelayModernRecord', () => {
       RelayModernRecord.copyFields(source, sink);
       expect(sink).toEqual({
         [ID_KEY]: '4',
-        [TYPENAME_KEY]: 'User',
+        [TYPENAME_KEY]: '__User',
         name: 'Zuck',
         pet: {[REF_KEY]: 'beast'},
         pets: {[REFS_KEY]: ['beast']},


### PR DESCRIPTION
The following changes make it possible to support a 3rd party PublishQueue, such as https://yarnpkg.com/en/package/relay-linear-publish-queue

Quick description of the problem & solution here: https://dev.to/mattkrick/distributed-state-101-why-i-forked-facebook-s-relay-1p7d

Please let me know what else is needed to move this along!
