### PR TITLE
Remove promise polyfill

### DIFF
--- a/packages/relay-runtime/store/RelayModernStore.js
+++ b/packages/relay-runtime/store/RelayModernStore.js
@@ -20,7 +20,7 @@ const deepFreeze = require('../util/deepFreeze');
 const defaultGetDataID = require('./defaultGetDataID');
 const hasOverlappingIDs = require('./hasOverlappingIDs');
 const recycleNodesInto = require('../util/recycleNodesInto');
-const resolveImmediate = require('resolveImmediate');
+const resolveImmediate = require('../util/resolveImmediate');
 
 const {UNPUBLISH_RECORD_SENTINEL} = require('./RelayStoreUtils');
 

--- a/packages/relay-runtime/util/resolveImmediate.js
+++ b/packages/relay-runtime/util/resolveImmediate.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+var resolvedPromise = Promise.resolve();
+
+/**
+ * An alternative to setImmediate based on Promise.
+ */
+function resolveImmediate(callback: () => void) {
+  resolvedPromise.then(callback).catch(throwNext);
+}
+
+function throwNext(error) {
+  setTimeout(() => {
+    throw error;
+  }, 0);
+}
+
+module.exports = resolveImmediate;


### PR DESCRIPTION
relay-runtime depends on fbjs/lib/resolveImmediate which depends on
promise package.

In modern apps promises are not always necessary to polyfill. On the
other side users may already have globally defined polyfill.

`promise` package with its `asap` dependency adds 10kb (minified) to our
bundle.

I suggest to reimplement resolveImmediate with globally defined promise.