### PR TITLE
[relay-compiler][easy] update many Array types to $ReadOnlyArray

### DIFF
--- a/packages/relay-compiler/codegen/CodegenWatcher.js
+++ b/packages/relay-compiler/codegen/CodegenWatcher.js
@@ -21,7 +21,7 @@ import type {File} from './CodegenTypes';
 const SUBSCRIPTION_NAME = 'graphql-codegen';
 const QUERY_RETRIES = 3;
 
-export type WatchmanExpression = Array<string | WatchmanExpression>;
+export type WatchmanExpression = $ReadOnlyArray<string | WatchmanExpression>;
 
 export type FileFilter = (file: File) => boolean;
 
@@ -31,7 +31,7 @@ type WatchmanChange = {
   'content.sha1hex': ?string,
 };
 type WatchmanChanges = {
-  files?: Array<WatchmanChange>,
+  files?: $ReadOnlyArray<WatchmanChange>,
 };
 
 async function queryFiles(
@@ -58,7 +58,7 @@ async function queryFiles(
 async function queryDirectories(
   baseDir: string,
   expression: WatchmanExpression,
-): Promise<Array<string>> {
+): Promise<$ReadOnlyArray<string>> {
   return await Profiler.waitFor('Watchman:query', async () => {
     const client = new GraphQLWatchmanClient();
     const watchResp = await client.watchProject(baseDir);
@@ -74,7 +74,7 @@ async function queryDirectories(
 
 async function getFields(
   client: GraphQLWatchmanClient,
-): Promise<Array<string>> {
+): Promise<$ReadOnlyArray<string>> {
   const fields = ['name', 'exists'];
   if (await client.hasCapability('field-content.sha1hex')) {
     fields.push('content.sha1hex');
@@ -85,7 +85,7 @@ async function getFields(
 // For use when not using Watchman.
 async function queryFilepaths(
   baseDir: string,
-  filepaths: Array<string>,
+  filepaths: $ReadOnlyArray<string>,
   filter: FileFilter,
 ): Promise<Set<File>> {
   // Construct WatchmanChange objects as an intermediate step before
@@ -202,7 +202,7 @@ function updateFiles(
   files: Set<File>,
   baseDir: string,
   filter: FileFilter,
-  fileChanges: Array<WatchmanChange>,
+  fileChanges: $ReadOnlyArray<WatchmanChange>,
 ): Set<File> {
   const fileMap = new Map();
   files.forEach(file => {

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -57,12 +57,12 @@ export type WriterConfig = {
   customScalars: ScalarTypeMapping,
   formatModule: FormatModule,
   generateExtraFiles?: GenerateExtraFiles,
-  optionalInputFieldsForFlow: Array<string>,
+  optionalInputFieldsForFlow: $ReadOnlyArray<string>,
   outputDir?: ?string,
-  generatedDirectories?: Array<string>,
+  generatedDirectories?: $ReadOnlyArray<string>,
   persistQuery?: ?(text: string) => Promise<string>,
   platform?: string,
-  schemaExtensions: Array<string>,
+  schemaExtensions: $ReadOnlyArray<string>,
   noFutureProofEnums: boolean,
   useHaste: boolean,
   extension: string,
@@ -71,8 +71,8 @@ export type WriterConfig = {
   // TODO(T22422153) support non-haste environments
   enumsHasteModule?: string,
   validationRules?: {
-    GLOBAL_RULES?: Array<ValidationRule>,
-    LOCAL_RULES?: Array<ValidationRule>,
+    GLOBAL_RULES?: $ReadOnlyArray<ValidationRule>,
+    LOCAL_RULES?: $ReadOnlyArray<ValidationRule>,
   },
   printModuleDependency?: string => string,
   // EXPERIMENTAL: skips deleting extra files in the generated directories
@@ -102,11 +102,11 @@ function compileAll({
   compilerTransforms: RelayCompilerTransforms,
   documents: $ReadOnlyArray<DocumentNode>,
   extraValidationRules?: {
-    GLOBAL_RULES?: Array<ValidationRule>,
-    LOCAL_RULES?: Array<ValidationRule>,
+    GLOBAL_RULES?: $ReadOnlyArray<ValidationRule>,
+    LOCAL_RULES?: $ReadOnlyArray<ValidationRule>,
   },
   reporter: Reporter,
-  schemaExtensions: Array<string>,
+  schemaExtensions: $ReadOnlyArray<string>,
   typeGenerator: TypeGenerator,
 |}) {
   // Can't convert to IR unless the schema already has Relay-local extensions

--- a/packages/relay-compiler/codegen/compileRelayArtifacts.js
+++ b/packages/relay-compiler/codegen/compileRelayArtifacts.js
@@ -24,11 +24,11 @@ import type {GraphQLReporter as Reporter} from '../reporters/GraphQLReporter';
 import type {GeneratedNode} from 'relay-runtime';
 
 export type RelayCompilerTransforms = {
-  commonTransforms: Array<IRTransform>,
-  codegenTransforms: Array<IRTransform>,
-  fragmentTransforms: Array<IRTransform>,
-  printTransforms: Array<IRTransform>,
-  queryTransforms: Array<IRTransform>,
+  commonTransforms: $ReadOnlyArray<IRTransform>,
+  codegenTransforms: $ReadOnlyArray<IRTransform>,
+  fragmentTransforms: $ReadOnlyArray<IRTransform>,
+  printTransforms: $ReadOnlyArray<IRTransform>,
+  queryTransforms: $ReadOnlyArray<IRTransform>,
 };
 
 export type RelayCompilerValidations = {

--- a/packages/relay-compiler/core/ASTConvert.js
+++ b/packages/relay-compiler/core/ASTConvert.js
@@ -171,7 +171,7 @@ function definitionsFromDocuments(
  */
 function transformASTSchema(
   schema: GraphQLSchema,
-  schemaExtensions: Array<string>,
+  schemaExtensions: $ReadOnlyArray<string>,
 ): GraphQLSchema {
   return Profiler.run('ASTConvert.transformASTSchema', () => {
     if (schemaExtensions.length === 0) {

--- a/packages/relay-compiler/core/GraphQLCompilerContext.js
+++ b/packages/relay-compiler/core/GraphQLCompilerContext.js
@@ -97,7 +97,7 @@ class GraphQLCompilerContext {
    * Apply a list of compiler transforms and return a new compiler context.
    */
   applyTransforms(
-    transforms: Array<IRTransform>,
+    transforms: $ReadOnlyArray<IRTransform>,
     reporter?: GraphQLReporter,
   ): GraphQLCompilerContext {
     return Profiler.run('applyTransforms', () =>

--- a/packages/relay-compiler/core/RelayGraphQLEnumsGenerator.js
+++ b/packages/relay-compiler/core/RelayGraphQLEnumsGenerator.js
@@ -19,7 +19,7 @@ import type {GraphQLSchema} from 'graphql';
 
 function writeForSchema(
   schema: GraphQLSchema,
-  licenseHeader: Array<string>,
+  licenseHeader: $ReadOnlyArray<string>,
   codegenDir: CodegenDirectory,
   moduleName: string,
 ): void {

--- a/packages/relay-compiler/core/RelayIRTransforms.js
+++ b/packages/relay-compiler/core/RelayIRTransforms.js
@@ -38,7 +38,7 @@ const SkipUnreachableNodeTransform = require('../transforms/SkipUnreachableNodeT
 import type {IRTransform} from './GraphQLCompilerContext';
 
 // Transforms applied to the code used to process a query response.
-const relaySchemaExtensions: Array<string> = [
+const relaySchemaExtensions: $ReadOnlyArray<string> = [
   RelayConnectionTransform.SCHEMA_EXTENSION,
   RelayMatchTransform.SCHEMA_EXTENSION,
   ConnectionFieldTransform.SCHEMA_EXTENSION,
@@ -51,7 +51,7 @@ const relaySchemaExtensions: Array<string> = [
 
 // Transforms applied to both operations and fragments for both reading and
 // writing from the store.
-const relayCommonTransforms: Array<IRTransform> = [
+const relayCommonTransforms: $ReadOnlyArray<IRTransform> = [
   RelayConnectionTransform.transform,
   RelayRelayDirectiveTransform.transform,
   RelayMaskTransform.transform,
@@ -61,7 +61,7 @@ const relayCommonTransforms: Array<IRTransform> = [
 ];
 
 // Transforms applied to fragments used for reading data from a store
-const relayFragmentTransforms: Array<IRTransform> = [
+const relayFragmentTransforms: $ReadOnlyArray<IRTransform> = [
   ClientExtensionsTransform.transform,
   RelayFieldHandleTransform.transform,
   InlineDataFragmentTransform.transform,
@@ -71,7 +71,7 @@ const relayFragmentTransforms: Array<IRTransform> = [
 
 // Transforms applied to queries/mutations/subscriptions that are used for
 // fetching data from the server and parsing those responses.
-const relayQueryTransforms: Array<IRTransform> = [
+const relayQueryTransforms: $ReadOnlyArray<IRTransform> = [
   RelayApplyFragmentArgumentTransform.transform,
   RelayGenerateIDFieldTransform.transform,
   RelayDeferStreamTransform.transform,
@@ -79,7 +79,7 @@ const relayQueryTransforms: Array<IRTransform> = [
 ];
 
 // Transforms applied to the code used to process a query response.
-const relayCodegenTransforms: Array<IRTransform> = [
+const relayCodegenTransforms: $ReadOnlyArray<IRTransform> = [
   SkipUnreachableNodeTransform.transform,
   RelaySplitModuleImportTransform.transform,
   InlineFragmentsTransform.transform,
@@ -97,7 +97,7 @@ const relayCodegenTransforms: Array<IRTransform> = [
 ];
 
 // Transforms applied before printing the query sent to the server.
-const relayPrintTransforms: Array<IRTransform> = [
+const relayPrintTransforms: $ReadOnlyArray<IRTransform> = [
   // NOTE: Skipping client extensions might leave empty selections, which we
   // skip by running SkipUnreachableNodeTransform immediately after.
   ClientExtensionsTransform.transform,

--- a/packages/relay-compiler/core/RelayParser.js
+++ b/packages/relay-compiler/core/RelayParser.js
@@ -148,7 +148,7 @@ function parse(
   schema: GraphQLSchema,
   text: string,
   filename?: string,
-): Array<Root | Fragment> {
+): $ReadOnlyArray<Root | Fragment> {
   const ast = parseGraphQL(new Source(text, filename));
   // TODO T24511737 figure out if this is dangerous
   schema = extendSchema(schema, ast, {assumeValid: true});
@@ -220,7 +220,7 @@ class RelayParser {
     }
   }
 
-  transform(): Array<Root | Fragment> {
+  transform(): $ReadOnlyArray<Root | Fragment> {
     let errors;
     const nodes = [];
     const entries = new Map();
@@ -759,7 +759,7 @@ class GraphQLDefinitionParser {
   _transformSelections(
     selectionSet: SelectionSetNode,
     parentType: GraphQLOutputType,
-  ): Array<Selection> {
+  ): $ReadOnlyArray<Selection> {
     return selectionSet.selections.map(selection => {
       let node;
       if (selection.kind === 'Field') {
@@ -1098,7 +1098,7 @@ class GraphQLDefinitionParser {
   _transformDirectives(
     directives: $ReadOnlyArray<DirectiveNode>,
     location: DirectiveLocationEnum,
-  ): Array<Directive> {
+  ): $ReadOnlyArray<Directive> {
     this._validateDirectivesLocation(directives, location);
     return directives.map(directive => {
       const name = getName(directive);
@@ -1126,8 +1126,8 @@ class GraphQLDefinitionParser {
 
   _transformArguments(
     args: $ReadOnlyArray<ArgumentNode>,
-    argumentDefinitions: Array<GraphQLArgument>,
-  ): Array<Argument> {
+    argumentDefinitions: $ReadOnlyArray<GraphQLArgument>,
+  ): $ReadOnlyArray<Argument> {
     return args.map(arg => {
       const argName = getName(arg);
       const argDef = argumentDefinitions.find(def => def.name === argName);
@@ -1515,7 +1515,7 @@ function transformLiteralValue(ast: ValueNode, context: ASTNode): mixed {
  */
 function buildArgumentDefinitions(
   variables: VariableDefinitions,
-): Array<LocalArgumentDefinition> {
+): $ReadOnlyArray<LocalArgumentDefinition> {
   return Array.from(variables.values(), ({ast, name, type, defaultValue}) => {
     return {
       kind: 'LocalArgumentDefinition',

--- a/packages/relay-compiler/handlers/connection/RelayConnectionTransform.js
+++ b/packages/relay-compiler/handlers/connection/RelayConnectionTransform.js
@@ -392,7 +392,7 @@ function transformConnectionSelections(
   direction: 'forward' | 'backward' | 'bidirectional',
   connectionArguments: ConnectionArguments,
   directiveLocation: Location,
-): Array<Selection> {
+): $ReadOnlyArray<Selection> {
   const derivedFieldLocation = {kind: 'Derived', source: field.loc};
   const derivedDirectiveLocation = {
     kind: 'Derived',

--- a/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+++ b/packages/relay-compiler/language/RelayLanguagePluginInterface.js
@@ -255,7 +255,7 @@ export type TypeGenerator = {
    * Transforms that should be applied to the intermediate representation of the
    * GraphQL document before passing to the `generate` function.
    */
-  transforms: Array<IRTransform>,
+  transforms: $ReadOnlyArray<IRTransform>,
 
   /**
    * Given GraphQL document IR, this function should generate type information

--- a/packages/relay-compiler/language/javascript/FindGraphQLTags.js
+++ b/packages/relay-compiler/language/javascript/FindGraphQLTags.js
@@ -43,7 +43,7 @@ const BABYLON_OPTIONS = {
   strictMode: false,
 };
 
-function find(text: string): Array<GraphQLTag> {
+function find(text: string): $ReadOnlyArray<GraphQLTag> {
   const result: Array<GraphQLTag> = [];
   const ast = babylon.parse(text, BABYLON_OPTIONS);
 
@@ -227,5 +227,5 @@ function traverse(node, visitors) {
 module.exports = {
   find: (Profiler.instrument(find, 'FindGraphQLTags.find'): (
     text: string,
-  ) => Array<GraphQLTag>),
+  ) => $ReadOnlyArray<GraphQLTag>),
 };

--- a/packages/relay-compiler/language/javascript/RelayFlowBabelFactories.js
+++ b/packages/relay-compiler/language/javascript/RelayFlowBabelFactories.js
@@ -27,7 +27,9 @@ function anyTypeAlias(name: string): BabelAST {
  *   PROPS
  * |}
  */
-function exactObjectTypeAnnotation(props: Array<BabelAST>): $FlowFixMe {
+function exactObjectTypeAnnotation(
+  props: $ReadOnlyArray<BabelAST>,
+): $FlowFixMe {
   const typeAnnotation = t.objectTypeAnnotation(props);
   typeAnnotation.exact = true;
   return typeAnnotation;
@@ -47,7 +49,10 @@ function exportType(name: string, type: BabelAST): $FlowFixMe {
 /**
  * import type {NAMES[0], NAMES[1], ...} from 'MODULE';
  */
-function importTypes(names: Array<string>, module: string): $FlowFixMe {
+function importTypes(
+  names: $ReadOnlyArray<string>,
+  module: string,
+): $FlowFixMe {
   const importDeclaration = t.importDeclaration(
     names.map(name =>
       t.importSpecifier(t.identifier(name), t.identifier(name)),
@@ -63,7 +68,7 @@ function importTypes(names: Array<string>, module: string): $FlowFixMe {
  *
  * TYPES[0] & TYPES[1] & ...
  */
-function intersectionTypeAnnotation(types: Array<BabelAST>): BabelAST {
+function intersectionTypeAnnotation(types: $ReadOnlyArray<BabelAST>): BabelAST {
   invariant(
     types.length > 0,
     'RelayFlowBabelFactories: cannot create an intersection of 0 types',
@@ -71,7 +76,9 @@ function intersectionTypeAnnotation(types: Array<BabelAST>): BabelAST {
   return types.length === 1 ? types[0] : t.intersectionTypeAnnotation(types);
 }
 
-function lineComments(...lines: Array<string>): Array<$FlowFixMe> {
+function lineComments(
+  ...lines: $ReadOnlyArray<string>
+): $ReadOnlyArray<$FlowFixMe> {
   return lines.map(line => ({type: 'CommentLine', value: ' ' + line}));
 }
 
@@ -103,7 +110,7 @@ function stringLiteralTypeAnnotation(value: string): $FlowFixMe {
  *
  * TYPES[0] | TYPES[1] | ...
  */
-function unionTypeAnnotation(types: Array<BabelAST>): BabelAST {
+function unionTypeAnnotation(types: $ReadOnlyArray<BabelAST>): BabelAST {
   invariant(
     types.length > 0,
     'RelayFlowBabelFactories: cannot create a union of 0 types',

--- a/packages/relay-compiler/language/javascript/RelayFlowGenerator.js
+++ b/packages/relay-compiler/language/javascript/RelayFlowGenerator.js
@@ -749,7 +749,7 @@ function generateInputVariablesType(node: Root, state: State) {
   );
 }
 
-function groupRefs(props): Array<Selection> {
+function groupRefs(props): $ReadOnlyArray<Selection> {
   const result = [];
   const refs = [];
   props.forEach(prop => {
@@ -866,7 +866,7 @@ function getDataTypeName(name: string): string {
   return `${name}$data`;
 }
 
-const FLOW_TRANSFORMS: Array<IRTransform> = [
+const FLOW_TRANSFORMS: $ReadOnlyArray<IRTransform> = [
   RelayRelayDirectiveTransform.transform,
   RelayMaskTransform.transform,
   ConnectionFieldTransform.transform,

--- a/packages/relay-compiler/reporters/GraphQLMultiReporter.js
+++ b/packages/relay-compiler/reporters/GraphQLMultiReporter.js
@@ -13,9 +13,9 @@
 import type {GraphQLReporter} from './GraphQLReporter';
 
 class GraphQLMultiReporter implements GraphQLReporter {
-  _reporters: Array<GraphQLReporter>;
+  _reporters: $ReadOnlyArray<GraphQLReporter>;
 
-  constructor(...reporters: Array<GraphQLReporter>) {
+  constructor(...reporters: $ReadOnlyArray<GraphQLReporter>) {
     this._reporters = reporters;
   }
 

--- a/packages/relay-compiler/transforms/FlattenTransform.js
+++ b/packages/relay-compiler/transforms/FlattenTransform.js
@@ -325,7 +325,7 @@ function mergeSelections(
   nodeB: Node,
   state: State,
   type: GraphQLType,
-): Array<Selection> {
+): $ReadOnlyArray<Selection> {
   const flattenedSelections = new Map();
   flattenSelectionsInto(flattenedSelections, nodeA, state, type);
   flattenSelectionsInto(flattenedSelections, nodeB, state, type);

--- a/packages/relay-compiler/transforms/RelayApplyFragmentArgumentTransform.js
+++ b/packages/relay-compiler/transforms/RelayApplyFragmentArgumentTransform.js
@@ -74,7 +74,7 @@ function relayApplyFragmentArgumentTransform(
     Fragment: () => null,
   });
 
-  return (Array.from(fragments.values()): Array<?Fragment>).reduce(
+  return (Array.from(fragments.values()): $ReadOnlyArray<?Fragment>).reduce(
     (ctx: CompilerContext, fragment) => (fragment ? ctx.add(fragment) : ctx),
     nextContext,
   );

--- a/packages/relay-compiler/transforms/RelayRefetchableFragmentTransform.js
+++ b/packages/relay-compiler/transforms/RelayRefetchableFragmentTransform.js
@@ -348,7 +348,7 @@ function extractConnectionMetadata(
 
 function buildOperationArgumentDefinitions(
   argumentDefinitions: $ReadOnlyArray<ArgumentDefinition>,
-): Array<LocalArgumentDefinition> {
+): $ReadOnlyArray<LocalArgumentDefinition> {
   return argumentDefinitions.map(argDef => {
     if (argDef.kind === 'LocalArgumentDefinition') {
       return argDef;

--- a/packages/relay-compiler/util/joinArgumentDefinitions.js
+++ b/packages/relay-compiler/util/joinArgumentDefinitions.js
@@ -29,7 +29,7 @@ function joinArgumentDefinitions(
   fragment: Fragment,
   reachableArguments: $ReadOnlyArray<ArgumentDefinition>,
   directiveName: string,
-): Array<ArgumentDefinition> {
+): $ReadOnlyArray<ArgumentDefinition> {
   const joinedArgumentDefinitions = new Map();
   fragment.argumentDefinitions.forEach(prevArgDef => {
     joinedArgumentDefinitions.set(prevArgDef.name, prevArgDef);

--- a/packages/relay-compiler/util/partitionArray.js
+++ b/packages/relay-compiler/util/partitionArray.js
@@ -18,7 +18,7 @@
 function partitionArray<Tv>(
   array: $ReadOnlyArray<Tv>,
   predicate: (value: Tv) => boolean,
-): [Array<Tv>, Array<Tv>] {
+): [$ReadOnlyArray<Tv>, $ReadOnlyArray<Tv>] {
   const first = [];
   const second = [];
   for (let i = 0; i < array.length; i++) {

--- a/packages/relay-compiler/validations/validateRelayRequiredArugments.js
+++ b/packages/relay-compiler/validations/validateRelayRequiredArugments.js
@@ -73,7 +73,7 @@ function visitField(
 
 function validateRequiredArguments(
   node: Directive | LinkedField | ScalarField,
-  definitionArgs: ?Array<GraphQLArgument>,
+  definitionArgs: ?$ReadOnlyArray<GraphQLArgument>,
   rootNode,
 ): void {
   if (!definitionArgs) {


### PR DESCRIPTION
Many places don't need writable `Array`s, so update them to the stricter `$ReadOnlyArray` flow type.