### PR TITLE
export RelayCompilerMain

### DIFF
--- a/packages/relay-compiler/index.js
+++ b/packages/relay-compiler/index.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+const {main} = require('./bin/RelayCompilerMain');
+
 const ASTCache = require('./core/ASTCache');
 const ASTConvert = require('./core/ASTConvert');
 const CodeMarker = require('./util/CodeMarker');
@@ -112,6 +114,8 @@ const RelayJSModuleParser: $FlowFixMe = RelaySourceModuleParser(
 );
 
 module.exports = {
+  relayCompiler: main,
+
   ASTConvert,
   CodegenDirectory,
   CodegenRunner,


### PR DESCRIPTION
This exports the function exposed by `RelayCompilerMain` to allow consumers to run relay compiler through a node api.

Our use case for this is a custom toolkit package (similar to react-scripts) the encapsulates our logic for running relay-compiler (and other scripts) with the correct settings for our environment. Since our toolkit knows all the correct options to be passed to relay compiler, we'd like to bypass the `relay.config.js` file and instead pass in the options directly as a javascript object.

```js
const { relayCompiler } = require('relay-compiler');

relayCompiler({
    schema,
    src,
    extensions: ['js', 'jsx'],
    // ... etc
}).catch(e => {
    console.error(e);
});
```

