### PR TITLE
Add persistFunction option to relay compiler

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -81,9 +81,16 @@ const options = {
     type: 'boolean',
     default: false,
   },
+  persistFunction: {
+    describe:
+      'An async function (or path to a module exporting this function) which will persist the query text and return the id.',
+    demandOption: false,
+    type: 'string',
+    array: false,
+  },
   persistOutput: {
     describe:
-      'A path to a .json file where persisted query metadata should be saved',
+      'A path to a .json file where persisted query metadata should be saved. Will use the default implementation (md5 hash) if `persistQueryFunction` is not passed.',
     demandOption: false,
     type: 'string',
     array: false,

--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -166,9 +166,13 @@ function getPersistQueryFunction(
   } else if (typeof config.persistFunction === 'string') {
     try {
       // eslint-disable-next-line no-eval
-      return eval('require')(
+      const persistFunction = eval('require')(
         path.resolve(process.cwd(), String(config.persistFunction)),
       );
+      if (persistFunction.default) {
+        return persistFunction.default;
+      }
+      return persistFunction;
     } catch (err) {
       const e = new Error(
         `Unable to load persistFunction ${config.persistFunction}: ${


### PR DESCRIPTION
Adds a new option to relay compiler `persistFunction`. This allows customizing how the `id` is generated for persisted queries