### PR TITLE
fix: Check for single-value-as-array earlier

### DIFF
--- a/packages/relay-compiler/core/GraphQLIRPrinter.js
+++ b/packages/relay-compiler/core/GraphQLIRPrinter.js
@@ -427,6 +427,10 @@ function printLiteral(value: mixed, type: ?GraphQLInputType): string {
     return (
       '[' + value.map(item => printLiteral(item, itemType)).join(', ') + ']'
     );
+  } else if (type instanceof GraphQLList && value != null) {
+    // Not an array, but still a list. Treat as list-of-one as per spec 3.1.7:
+    // http://facebook.github.io/graphql/October2016/#sec-Lists
+    return printLiteral(value, type.ofType);
   } else if (typeof value === 'object' && value != null) {
     const fields = [];
     invariant(
@@ -442,10 +446,6 @@ function printLiteral(value: mixed, type: ?GraphQLInputType): string {
       }
     }
     return '{' + fields.join(', ') + '}';
-  } else if (type instanceof GraphQLList && value != null) {
-    // Not an array, but still a list. Treat as list-of-one as per spec 3.1.7:
-    // http://facebook.github.io/graphql/October2016/#sec-Lists
-    return printLiteral(value, type.ofType);
   } else {
     // $FlowFixMe(>=0.95.0) JSON.stringify can return undefined
     return JSON.stringify(value);

--- a/packages/relay-compiler/core/__tests__/__snapshots__/RelayPrinter-test.js.snap
+++ b/packages/relay-compiler/core/__tests__/__snapshots__/RelayPrinter-test.js.snap
@@ -146,6 +146,28 @@ fragment UserFragment on User @argumentDefinitions(
 
 `;
 
+exports[`GraphQLIRPrinter matches expected output: single-value-array-of-objects.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query SingleValueArrayQuery {
+  route(waypoints: { lat: "123", lon: "456" }) {
+    steps {
+      lat
+      lon
+    }
+  }
+}
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+query SingleValueArrayQuery {
+  route(waypoints: {lat: "123", lon: "456"}) {
+    steps {
+      lat
+      lon
+    }
+  }
+}
+
+`;
+
 exports[`GraphQLIRPrinter matches expected output: string-enum-arg.invalid.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 # expected-to-throw

--- a/packages/relay-compiler/core/__tests__/fixtures/printer/single-value-array-of-objects.graphql
+++ b/packages/relay-compiler/core/__tests__/fixtures/printer/single-value-array-of-objects.graphql
@@ -1,0 +1,8 @@
+query SingleValueArrayQuery {
+  route(waypoints: { lat: "123", lon: "456" }) {
+    steps {
+      lat
+      lon
+    }
+  }
+}


### PR DESCRIPTION
`GraphQLIRPrinter`'s `printLiteral` does currently check for single values on List input fields, but does not handle a single object on a List field, because this will be caught by the `if` block before. Solved by moving the block up.

Not sure about your test setup. Please advise if this should be done differently/somewhere else.