### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/GraphQL-ServerSpecification.md
+++ b/docs/GraphQL-ServerSpecification.md
@@ -192,7 +192,7 @@ The `Node` interface and `node` field assume globally unique IDs for this refetc
 
 The IDs we got back were base64 strings. IDs are designed to be opaque (the only thing that should be passed to the `id` argument on `node` is the unaltered result of querying `id` on some object in the system), and base64ing a string is a useful convention in GraphQL to remind viewers that the string is an opaque identifier.
 
-Complete details on how the server should behave are available in the [GraphQL Object Identification](/relay/graphql/objectidentification.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Object Identification](/graphql/objectidentification.htm) spec.
 
 ## Connections
 
@@ -443,7 +443,7 @@ So on the first query for ships, GraphQL told us there was a next page, but on t
 
 Relay uses all of this functionality to build out abstractions around connections, to make these easy to work with efficiently without having to manually manage cursors on the client.
 
-Complete details on how the server should behave are available in the [GraphQL Cursor Connections](/relay/graphql/connections.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Cursor Connections](/graphql/connections.htm) spec.
 
 ## Mutations
 
@@ -513,10 +513,10 @@ and we'll get this result:
 }
 ```
 
-Complete details on how the server should behave are available in the [GraphQL Input Object Mutations](/relay/graphql/mutations.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Input Object Mutations](/graphql/mutations.htm) spec.
 
 ## Further Reading
 
-This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/relay/graphql/connections.htm) model, the [Relay global object identification](/relay/graphql/objectidentification.htm) model, and the [Relay input object mutation](/relay/graphql/mutations.htm) are all available.
+This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/graphql/connections.htm) model, the [Relay global object identification](/graphql/objectidentification.htm) model, and the [Relay input object mutation](/graphql/mutations.htm) are all available.
 
 To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/docs/Modern-Debugging.md
+++ b/docs/Modern-Debugging.md
@@ -26,8 +26,8 @@ Relay DevTools is tool designed to help developers inspect their Relay state and
 
 - [Chrome Extension][extension] creates a Relay tab in the developer tools interface for debugging apps in Chrome
 
-![Store Explorer](/relay/img/docs/store-explorer-updated.png)
-![Mutations View](/relay/img/docs/mutations-view-updated.png)
+![Store Explorer](/img/docs/store-explorer-updated.png)
+![Mutations View](/img/docs/mutations-view-updated.png)
 
 [extension]:https://chrome.google.com/webstore/detail/relay-developer-tools/ncedobpgnmkhcmnnkcimnobpfepidadl
 [app]: https://www.npmjs.com/package/relay-devtools

--- a/website/versioned_docs/version-classic/Classic-APIReference-GraphQLMutation.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-GraphQLMutation.md
@@ -6,7 +6,7 @@ original_id: classic-api-reference-relay-graphql-mutation
 
 `Relay.GraphQLMutation` is a low-level API for modeling a GraphQL mutation.
 
-This is the lowest level of abstraction at which product code may deal with mutations in Relay, and it corresponds to the mutation operation ("a write followed by a fetch") described in [the GraphQL Specification](/relay/graphql/mutations.htm). You specify the mutation, the inputs, and the query.
+This is the lowest level of abstraction at which product code may deal with mutations in Relay, and it corresponds to the mutation operation ("a write followed by a fetch") described in [the GraphQL Specification](/graphql/mutations.htm). You specify the mutation, the inputs, and the query.
 
 `Relay.GraphQLMutation` doesn't provide any bells and whistles such as fat queries or tracked queries (that is, automatic synthesis at runtime of the mutation query to be sent to the server), instead having the user define a static and explicit query. Restricting yourself to the low-level API is a useful preparatory step that will help you ready your codebase for migration to the new static Relay core. In the meantime, if you want those dynamic features, you can opt in to the higher-level `Relay.Mutation` API.
 

--- a/website/versioned_docs/version-classic/Classic-Guides-Containers.md
+++ b/website/versioned_docs/version-classic/Classic-Guides-Containers.md
@@ -93,7 +93,7 @@ Relay containers are higher-order components — `Relay.createContainer` is a fu
 Here's what happens when the container is rendered:
 
 <div class="diagram">
-  <img src="/relay/img/docs/Guides-Containers-HOC-Relay.png" title="Relay Containers" />
+  <img src="/img/docs/Guides-Containers-HOC-Relay.png" title="Relay Containers" />
 </div>
 
 In the diagram above:

--- a/website/versioned_docs/version-classic/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-classic/GraphQL-ServerSpecification.md
@@ -193,7 +193,7 @@ The `Node` interface and `node` field assume globally unique IDs for this refetc
 
 The IDs we got back were base64 strings. IDs are designed to be opaque (the only thing that should be passed to the `id` argument on `node` is the unaltered result of querying `id` on some object in the system), and base64ing a string is a useful convention in GraphQL to remind viewers that the string is an opaque identifier.
 
-Complete details on how the server should behave are available in the [GraphQL Object Identification](/relay/graphql/objectidentification.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Object Identification](/graphql/objectidentification.htm) spec.
 
 ## Connections
 
@@ -444,7 +444,7 @@ So on the first query for ships, GraphQL told us there was a next page, but on t
 
 Relay uses all of this functionality to build out abstractions around connections, to make these easy to work with efficiently without having to manually manage cursors on the client.
 
-Complete details on how the server should behave are available in the [GraphQL Cursor Connections](/relay/graphql/connections.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Cursor Connections](/graphql/connections.htm) spec.
 
 ## Mutations
 
@@ -514,10 +514,10 @@ and we'll get this result:
 }
 ```
 
-Complete details on how the server should behave are available in the [GraphQL Input Object Mutations](/relay/graphql/mutations.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Input Object Mutations](/graphql/mutations.htm) spec.
 
 ## Further Reading
 
-This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/relay/graphql/connections.htm) model, the [Relay global object identification](/relay/graphql/objectidentification.htm) model, and the [Relay input object mutation](/relay/graphql/mutations.htm) are all available.
+This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/graphql/connections.htm) model, the [Relay global object identification](/graphql/objectidentification.htm) model, and the [Relay input object mutation](/graphql/mutations.htm) are all available.
 
 To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-classic/Modern-Debugging.md
+++ b/website/versioned_docs/version-classic/Modern-Debugging.md
@@ -11,8 +11,8 @@ Relay DevTools is tool designed to help developers inspect their Relay state and
 - [Chrome Extension][extension] creates a Relay tab in the developer tools interface for debugging apps in Chrome
 - [Electron App][app] that connects to React Native apps running Relay
 
-![Store Explorer](/relay/img/docs/store-explorer.png)
-![Mutations View](/relay/img/docs/mutations-view.png)
+![Store Explorer](/img/docs/store-explorer.png)
+![Mutations View](/img/docs/mutations-view.png)
 
 [extension]:https://chrome.google.com/webstore/detail/relay-devtools/oppikflppfjfdpjimpdadhelffjpciba
 [app]: https://www.npmjs.com/package/relay-devtools

--- a/website/versioned_docs/version-v2.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v2.0.0/GraphQL-ServerSpecification.md
@@ -193,7 +193,7 @@ The `Node` interface and `node` field assume globally unique IDs for this refetc
 
 The IDs we got back were base64 strings. IDs are designed to be opaque (the only thing that should be passed to the `id` argument on `node` is the unaltered result of querying `id` on some object in the system), and base64ing a string is a useful convention in GraphQL to remind viewers that the string is an opaque identifier.
 
-Complete details on how the server should behave are available in the [GraphQL Object Identification](/relay/graphql/objectidentification.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Object Identification](/graphql/objectidentification.htm) spec.
 
 ## Connections
 
@@ -444,7 +444,7 @@ So on the first query for ships, GraphQL told us there was a next page, but on t
 
 Relay uses all of this functionality to build out abstractions around connections, to make these easy to work with efficiently without having to manually manage cursors on the client.
 
-Complete details on how the server should behave are available in the [GraphQL Cursor Connections](/relay/graphql/connections.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Cursor Connections](/graphql/connections.htm) spec.
 
 ## Mutations
 
@@ -514,10 +514,10 @@ and we'll get this result:
 }
 ```
 
-Complete details on how the server should behave are available in the [GraphQL Input Object Mutations](/relay/graphql/mutations.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Input Object Mutations](/graphql/mutations.htm) spec.
 
 ## Further Reading
 
-This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/relay/graphql/connections.htm) model, the [Relay global object identification](/relay/graphql/objectidentification.htm) model, and the [Relay input object mutation](/relay/graphql/mutations.htm) are all available.
+This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/graphql/connections.htm) model, the [Relay global object identification](/graphql/objectidentification.htm) model, and the [Relay input object mutation](/graphql/mutations.htm) are all available.
 
 To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v2.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-Debugging.md
@@ -27,8 +27,8 @@ Relay DevTools is tool designed to help developers inspect their Relay state and
 
 - [Chrome Extension][extension] creates a Relay tab in the developer tools interface for debugging apps in Chrome
 
-![Store Explorer](/relay/img/docs/store-explorer-updated.png)
-![Mutations View](/relay/img/docs/mutations-view-updated.png)
+![Store Explorer](/img/docs/store-explorer-updated.png)
+![Mutations View](/img/docs/mutations-view-updated.png)
 
 [extension]:https://chrome.google.com/webstore/detail/relay-developer-tools/ncedobpgnmkhcmnnkcimnobpfepidadl
 [app]: https://www.npmjs.com/package/relay-devtools

--- a/website/versioned_docs/version-v5.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v5.0.0/GraphQL-ServerSpecification.md
@@ -193,7 +193,7 @@ The `Node` interface and `node` field assume globally unique IDs for this refetc
 
 The IDs we got back were base64 strings. IDs are designed to be opaque (the only thing that should be passed to the `id` argument on `node` is the unaltered result of querying `id` on some object in the system), and base64ing a string is a useful convention in GraphQL to remind viewers that the string is an opaque identifier.
 
-Complete details on how the server should behave are available in the [GraphQL Object Identification](/relay/graphql/objectidentification.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Object Identification](/graphql/objectidentification.htm) spec.
 
 ## Connections
 
@@ -444,7 +444,7 @@ So on the first query for ships, GraphQL told us there was a next page, but on t
 
 Relay uses all of this functionality to build out abstractions around connections, to make these easy to work with efficiently without having to manually manage cursors on the client.
 
-Complete details on how the server should behave are available in the [GraphQL Cursor Connections](/relay/graphql/connections.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Cursor Connections](/graphql/connections.htm) spec.
 
 ## Mutations
 
@@ -514,10 +514,10 @@ and we'll get this result:
 }
 ```
 
-Complete details on how the server should behave are available in the [GraphQL Input Object Mutations](/relay/graphql/mutations.htm) spec.
+Complete details on how the server should behave are available in the [GraphQL Input Object Mutations](/graphql/mutations.htm) spec.
 
 ## Further Reading
 
-This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/relay/graphql/connections.htm) model, the [Relay global object identification](/relay/graphql/objectidentification.htm) model, and the [Relay input object mutation](/relay/graphql/mutations.htm) are all available.
+This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/graphql/connections.htm) model, the [Relay global object identification](/graphql/objectidentification.htm) model, and the [Relay input object mutation](/graphql/mutations.htm) are all available.
 
 To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v5.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-Debugging.md
@@ -27,8 +27,8 @@ Relay DevTools is tool designed to help developers inspect their Relay state and
 
 - [Chrome Extension][extension] creates a Relay tab in the developer tools interface for debugging apps in Chrome
 
-![Store Explorer](/relay/img/docs/store-explorer-updated.png)
-![Mutations View](/relay/img/docs/mutations-view-updated.png)
+![Store Explorer](/img/docs/store-explorer-updated.png)
+![Mutations View](/img/docs/mutations-view-updated.png)
 
 [extension]:https://chrome.google.com/webstore/detail/relay-developer-tools/ncedobpgnmkhcmnnkcimnobpfepidadl
 [app]: https://www.npmjs.com/package/relay-devtools


### PR DESCRIPTION
## Summary

When moving the domain from facebook.github.io/relay to relay.dev, some paths still had the `/relay/` base path. E.g. see the broken images on https://relay.dev/docs/en/relay-debugging#tools and links on https://relay.dev/docs/en/graphql-server-specification

This PR updates the links for all versions of the docs.

## Test Plan

Screenshots show up now.

<img width="1508" alt="Screen Shot 2019-08-03 at 1 01 39 PM" src="https://user-images.githubusercontent.com/1315101/62416462-26d85100-b5f0-11e9-8d4b-ceacf7a2c6ef.png">
