### PR TITLE
[nit] Updated Modern-RefetchContainer.md to fix an error in `createRefetchContainer` sample code

### DIFF
--- a/docs/Modern-RefetchContainer.md
+++ b/docs/Modern-RefetchContainer.md
@@ -121,12 +121,14 @@ class TodoItem extends React.Component {
 
 export default createRefetchContainer(
   TodoItem,
-  graphql`
-    fragment TodoItem_item on Todo {
-      text
-      isComplete
-    }
-  `,
+  {
+    item: graphql`
+      fragment TodoItem_item on Todo {
+        text
+        isComplete
+      }
+    `
+  },
   graphql`
     # Refetch query to be fetched upon calling `refetch`.
     # Notice that we re-use our fragment and the shape of this query matches our fragment spec.


### PR DESCRIPTION
At line 124, the error in sample code will result in exception 
```
could not create relay container for ..., expected a set of GraphQL fragments, got `function(){[native code]}` instead
```