### PR TITLE
Local state documentation

### DIFF
--- a/docs/Community-LearningResources.md
+++ b/docs/Community-LearningResources.md
@@ -60,8 +60,13 @@ https://babangsund.com/relay_local_state_management/
 
 ## Relay Modern: Local State Management, part 2
 
-How to manage blobal state and localStorage persistence on the client, using Relay.
+How to manage global state and localStorage persistence on the client, using Relay.
 https://babangsund.com/relay_local_state_management_2/
+
+## Relay Modern: Local State Management, part 3
+
+Using LocalQueryRenderer and local state to manage nested fragments.
+https://babangsund.com/relay_local_state_management_3/
 
 # Network Layer
 

--- a/docs/Community-LearningResources.md
+++ b/docs/Community-LearningResources.md
@@ -53,6 +53,16 @@ https://medium.com/entria/wrangling-the-client-store-with-the-relay-modern-updat
 How to update your UI before server responds.
 https://medium.com/entria/relay-modern-optimistic-update-a09ba22d83c9
 
+## Relay Modern: Local State Management, part 1
+
+How to create a controlled input using Relay.
+https://babangsund.com/relay_local_state_management/
+
+## Relay Modern: Local State Management, part 2
+
+How to manage blobal state and localStorage persistence on the client, using Relay.
+https://babangsund.com/relay_local_state_management_2/
+
 # Network Layer
 
 ## Relay Modern: Network Deep Dive

--- a/docs/Modern-GraphQLInRelay.md
+++ b/docs/Modern-GraphQLInRelay.md
@@ -1,5 +1,6 @@
 ---
-id: graphql-in-relay title: GraphQL in Relay
+id: graphql-in-relay
+title: GraphQL in Relay
 ---
 
 Table of Contents:
@@ -258,7 +259,7 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 The Relay Compiler fully supports client-side schema extensions, which allows you to extend the server schema and define additional GraphQL types on the client. Relay expects the client schema to be located in your `--src` directory.
 
-For example, let's create `./src/clientSchema.graphql` and define a new GraphQL type. Let's call it `Setting`:
+For example, let's create `./src/clientSchema.graphql` and define a new GraphQL type called `Setting`:
 
 ```graphql
 type Setting {

--- a/docs/Modern-GraphQLInRelay.md
+++ b/docs/Modern-GraphQLInRelay.md
@@ -1,6 +1,5 @@
 ---
-id: graphql-in-relay
-title: GraphQL in Relay
+id: graphql-in-relay title: GraphQL in Relay
 ---
 
 Table of Contents:
@@ -254,6 +253,43 @@ However the Relay Compiler also automatically generates [Flow](https://flow.org)
 ```javascript
 import type {DictionaryComponent_word} from './__generated__/DictionaryComponent_word.graphql';
 ```
+
+### Client schema extensions
+
+The Relay Compiler fully supports client-side schema extensions, which allows you to extend the server schema and define additional GraphQL types on the client. Relay expects the client schema to be located in your `--src` directory.
+
+For example, let's create `./src/clientSchema.graphql` and define a new GraphQL type. Let's call it `Setting`:
+
+```graphql
+type Setting {
+  name: String!
+  active: Boolean!
+}
+```
+
+Assuming the server schema `./schema.graphql`:
+
+```graphql
+schema {
+  query: Root
+}
+
+type Root {
+  title: String!
+}
+```
+
+We can then extend existing server types in the client schema `./src/clientSchema.graphql` with our new `Setting` type, like so: 
+
+```graphql
+extend type Root {
+  settings: [Setting]
+}
+```
+
+Any fields specified in the client schema, can be fetched as client-side data from the [Relay Store](./relay-store) by using [a QueryRenderer](./query-renderer).
+
+For more details, refer to the [Local state management section](./local-state-management.html).
 
 ### Advanced usage
 

--- a/docs/Modern-GraphQLInRelay.md
+++ b/docs/Modern-GraphQLInRelay.md
@@ -257,9 +257,9 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Client schema extensions
 
-The Relay Compiler fully supports client-side schema extensions, which allows you to extend the server schema and define additional GraphQL types on the client. Relay expects the client schema to be located in your `--src` directory.
+The Relay Compiler fully supports client-side schema extensions, which allows you to extend the server schema by defining additional GraphQL types and fields on the client. Relay expects the client schema to be located in your `--src` directory.
 
-For example, let's create `./src/clientSchema.graphql` and define a new GraphQL type called `Setting`:
+For example, let's create `./src/clientSchema.graphql` and define a new type called `Setting`:
 
 ```graphql
 type Setting {
@@ -288,7 +288,7 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched as client-side data from the [Relay Store](./relay-store) by using [a QueryRenderer](./query-renderer).
+Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by requesting it in a query.
 
 For more details, refer to the [Local state management section](./local-state-management.html).
 

--- a/docs/Modern-LocalStateManagement.md
+++ b/docs/Modern-LocalStateManagement.md
@@ -118,6 +118,13 @@ function createUserNote() {
     //Create a new note record.
     const newNoteRecord = store.create(dataID, 'Note');
 
+    // Tell garbage collection to retain the record
+    environment.retain({
+      dataID,
+      variables: {},
+      node: { selections: [] }
+    });
+
     // Add the record to the users list of notes.
     user.setLinkedRecords([...userNoteRecords, newNoteRecord], 'notes');
   });

--- a/docs/Modern-LocalStateManagement.md
+++ b/docs/Modern-LocalStateManagement.md
@@ -42,7 +42,7 @@ extend type User {
 ## Querying local state
 
 Accessing local data is no different from querying your GraphQL server.  
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with her name and the list of notes.
+Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their name and the list of notes.
 
 ```javascript
 // Example.js
@@ -125,7 +125,7 @@ function createUserNote() {
       node: { selections: [] }
     });
 
-    // Add the record to the users list of notes.
+    // Add the record to the user's list of notes.
     user.setLinkedRecords([...userNoteRecords, newNoteRecord], 'notes');
   });
 }

--- a/docs/Modern-LocalStateManagement.md
+++ b/docs/Modern-LocalStateManagement.md
@@ -41,8 +41,10 @@ extend type User {
 
 ## Querying local state
 
-Accessing local data is no different from querying your GraphQL server.  
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their name and the list of notes.
+Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
+The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
+
+Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js

--- a/docs/Modern-LocalStateManagement.md
+++ b/docs/Modern-LocalStateManagement.md
@@ -105,7 +105,7 @@ To build upon the previous example, let's try creating, updating and deleting a 
 ```javascript
 import {commitLocalUpdate} from 'react-relay';
 
-let tempId = 0;
+let tempID = 0;
 
 function createUserNote() {
   commitLocalUpdate(environment, store => {
@@ -113,12 +113,12 @@ function createUserNote() {
     const userNoteRecords = user.getLinkedRecords('notes') || [];
 
     // Create a unique ID.
-    const dataID = `client:Note:${tempId++}`;
+    const dataID = `client:Note:${tempID++}`;
 
     //Create a new note record.
     const newNoteRecord = store.create(dataID, 'Note');
 
-    // Tell garbage collection to retain the record
+    // Tell garbage collection to retain the record.
     environment.retain({
       dataID,
       variables: {},
@@ -140,8 +140,8 @@ function updateUserNote(dataID, body, title) {
   commitLocalUpdate(environment, store => {
     const note = store.get(dataID);
 
-    note.setValue(body, "body");
-    note.setValue(title, "title")
+    note.setValue(body, 'body');
+    note.setValue(title, 'title')
   });
 }
 ```
@@ -179,7 +179,7 @@ import {commitLocalUpdate} from 'react-relay';
 commitLocalUpdate(environment, store => {
   const user = store.getRoot().getLinkedRecord('viewer');
 
-  // initialize user notes to an empty array
-  user.setLinkedRecords([], "notes");
+  // initialize user notes to an empty array.
+  user.setLinkedRecords([], 'notes');
 });
 ```

--- a/docs/Modern-LocalStateManagement.md
+++ b/docs/Modern-LocalStateManagement.md
@@ -3,4 +3,176 @@ id: local-state-management
 title: Local State Management
 ---
 
-Relay compiler [supports client-side extensions](./graphql-in-relay#client-schema-extensions), which allows you to define client-side fields and types that can be used to extend the server schema.
+Relay can be used to read and write local data, and act as a single source of truth for *all* data in your client application.  
+The Relay Compiler fully supports client-side extensions of the schema, which allows you to define local fields and types.  
+
+Table of Contents:
+
+- [Extending the client schema](#extending-the-client-schema)
+- [Querying local state](#querying-local-state)
+- [Mutating local state](#mutating-local-state)
+- [Initial local state](#initial-local-state)
+
+## Extending the client schema
+
+To extend the server schema, create a new `.graphql` file inside your `--src` directory.  
+Let's call it `./src/clientSchema.graphql`.
+
+This schema describes what local data can be queried on the client.  
+It can even be used to extend an existing server schema.
+
+For example, we can create a new type called `Note`:
+
+```graphql
+type Note {
+  ID: ID!
+  title: String
+  body: String
+}
+```
+
+And then extend the server schema type `User`, with a list of `Note`, called `notes`.
+
+```graphql
+extend type User {
+  notes: [Note]
+}
+```
+
+## Querying local state
+
+Accessing local data is no different from querying your GraphQL server.  
+Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with her name and the list of notes.
+
+```javascript
+// Example.js
+import React from 'react';
+import { QueryRenderer, graphql } from 'react-relay';
+
+const renderQuery = ({error, props}) => {
+  if (error) {
+    return <div>{error.message}</div>;
+  } else if (props) {
+    return (
+      <div>
+        {props.viewer.notes.map(({id, title, body}) => (
+          <div key={id}>
+            {title}
+          </div>
+          <div key={id}>
+            {body}
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return <div>Loading</div>;
+}
+  
+const Example = (props) => {
+  return (
+    <QueryRenderer
+      render={renderQuery}
+      environment={environment}
+      query={graphql`
+        query ExampleQuery {
+          viewer {
+            id
+            name
+            notes {
+              id
+              title
+              body
+            }
+          }
+        }
+      `}
+    />
+  );
+}
+```
+
+## Mutating local state
+
+All local data lives in the [Relay Store](./relay-store).  
+Updating local state can be done with any `updater` function.
+The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
+
+To build upon the previous example, let's try creating, updating and deleting a `Note` from the list of `notes` on `User`.
+
+### Create
+
+```javascript
+import {commitLocalUpdate} from 'react-relay';
+
+let tempId = 0;
+
+function createUserNote() {
+  commitLocalUpdate(environment, store => {
+    const user = store.getRoot().getLinkedRecord('viewer');
+    const userNoteRecords = user.getLinkedRecords('notes') || [];
+
+    // Create a unique ID.
+    const dataID = `client:Note:${tempId++}`;
+
+    //Create a new note record.
+    const newNoteRecord = store.create(dataID, 'Note');
+
+    // Add the record to the users list of notes.
+    user.setLinkedRecords([...userNoteRecords, newNoteRecord], 'notes');
+  });
+}
+```
+
+### Update
+
+```javascript
+import {commitLocalUpdate} from 'react-relay';
+
+function updateUserNote(dataID, body, title) {
+  commitLocalUpdate(environment, store => {
+    const note = store.get(dataID);
+
+    note.setValue(body, "body");
+    note.setValue(title, "title")
+  });
+}
+```
+
+### Delete
+
+```javascript
+import {commitLocalUpdate} from 'react-relay';
+
+function deleteUserNote(dataID) {
+  commitLocalUpdate(environment, store => {
+    const user = store.getRoot().getLinkedRecord('viewer');
+    const userNoteRecords = user.getLinkedRecords('notes');
+
+    // Remove the note from the list of user notes.
+    const newUserNoteRecords = userNoteRecords.filter(x => x.getDataID() !== dataID);
+
+    // Delete the note from the store.
+    store.delete(dataID);
+
+    // Set the new list of notes.
+    user.setLinkedRecords(newUserNoteRecords, 'notes');
+  });
+}
+```
+
+## Initial local state
+
+All new client-side schema fields default to `undefined` value. Often however, you will want to set the initial state before querying local data.
+You can use an updater function via `commitLocalUpdate` to prime local state.
+
+```javascript
+import {commitLocalUpdate} from 'react-relay';
+
+commitLocalUpdate(environment, store => {
+  const user = store.getRoot().getLinkedRecord('viewer');
+
+  // initialize user notes to an empty array
+  user.setLinkedRecords([], "notes");
+});
+```

--- a/docs/Modern-LocalStateManagement.md
+++ b/docs/Modern-LocalStateManagement.md
@@ -1,0 +1,6 @@
+---
+id: local-state-management
+title: Local State Management
+---
+
+Relay compiler [supports client-side extensions](./graphql-in-relay#client-schema-extensions), which allows you to define client-side fields and types that can be used to extend the server schema.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -35,6 +35,9 @@
       "graphql-in-relay": {
         "title": "GraphQL in Relay"
       },
+      "local-state-management": {
+        "title": "Local State Management"
+      },
       "mutations": {
         "title": "Mutations"
       },
@@ -409,6 +412,9 @@
       },
       "version-v4.0.0/version-v4.0.0-graphql-in-relay": {
         "title": "GraphQL in Relay"
+      },
+      "version-v4.0.0/version-v4.0.0-local-state-management": {
+        "title": "Local State Management"
       },
       "version-v4.0.0/version-v4.0.0-mutations": {
         "title": "Mutations"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -25,7 +25,8 @@
       "graphql-server-specification",
       "persisted-queries",
       "type-emission",
-      "testing-relay-components"
+      "testing-relay-components",
+      "local-state-management"
     ],
     "Principles & Architecture": [
       "thinking-in-graphql",

--- a/website/versioned_docs/version-v4.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-GraphQLInRelay.md
@@ -256,6 +256,43 @@ However the Relay Compiler also automatically generates [Flow](https://flow.org)
 import type {DictionaryComponent_word} from './__generated__/DictionaryComponent_word.graphql';
 ```
 
+### Client schema extensions
+
+The Relay Compiler fully supports client-side schema extensions, which allows you to extend the server schema and define additional GraphQL types on the client. Relay expects the client schema to be located in your `--src` directory.
+
+For example, let's create `./src/clientSchema.graphql` and define a new GraphQL type. Let's call it `Setting`:
+
+```graphql
+type Setting {
+  name: String!
+  active: Boolean!
+}
+```
+
+Assuming the server schema `./schema.graphql`:
+
+```graphql
+schema {
+  query: Root
+}
+
+type Root {
+  title: String!
+}
+```
+
+We can then extend existing server types in the client schema `./src/clientSchema.graphql` with our new `Setting` type, like so: 
+
+```graphql
+extend type Root {
+  settings: [Setting]
+}
+```
+
+Any fields specified in the client schema, can be fetched as client-side data from the [Relay Store](./relay-store) by using [a QueryRenderer](./query-renderer).
+
+For more details, refer to the [Local state management section](./local-state-management.html).
+
 ### Advanced usage
 
 In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.

--- a/website/versioned_docs/version-v4.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-GraphQLInRelay.md
@@ -258,9 +258,9 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Client schema extensions
 
-The Relay Compiler fully supports client-side schema extensions, which allows you to extend the server schema and define additional GraphQL types on the client. Relay expects the client schema to be located in your `--src` directory.
+The Relay Compiler fully supports client-side schema extensions, which allows you to extend the server schema by defining additional GraphQL types and fields on the client. Relay expects the client schema to be located in your `--src` directory.
 
-For example, let's create `./src/clientSchema.graphql` and define a new GraphQL type. Let's call it `Setting`:
+For example, let's create `./src/clientSchema.graphql` and define a new type called `Setting`:
 
 ```graphql
 type Setting {
@@ -289,7 +289,7 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched as client-side data from the [Relay Store](./relay-store) by using [a QueryRenderer](./query-renderer).
+Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by requesting it in a query.
 
 For more details, refer to the [Local state management section](./local-state-management.html).
 

--- a/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
@@ -43,7 +43,7 @@ extend type User {
 ## Querying local state
 
 Accessing local data is no different from querying your GraphQL server.  
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with her name and the list of notes.
+Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their name and the list of notes.
 
 ```javascript
 // Example.js
@@ -126,7 +126,7 @@ function createUserNote() {
       node: { selections: [] }
     });
 
-    // Add the record to the users list of notes.
+    // Add the record to the user's list of notes.
     user.setLinkedRecords([...userNoteRecords, newNoteRecord], 'notes');
   });
 }

--- a/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
@@ -106,7 +106,7 @@ To build upon the previous example, let's try creating, updating and deleting a 
 ```javascript
 import {commitLocalUpdate} from 'react-relay';
 
-let tempId = 0;
+let tempID = 0;
 
 function createUserNote() {
   commitLocalUpdate(environment, store => {
@@ -114,10 +114,17 @@ function createUserNote() {
     const userNoteRecords = user.getLinkedRecords('notes') || [];
 
     // Create a unique ID.
-    const dataID = `client:Note:${tempId++}`;
+    const dataID = `client:Note:${tempID++}`;
 
     //Create a new note record.
     const newNoteRecord = store.create(dataID, 'Note');
+
+    // Tell garbage collection to retain the record.
+    environment.retain({
+      dataID,
+      variables: {},
+      node: { selections: [] }
+    });
 
     // Add the record to the users list of notes.
     user.setLinkedRecords([...userNoteRecords, newNoteRecord], 'notes');
@@ -134,8 +141,8 @@ function updateUserNote(dataID, body, title) {
   commitLocalUpdate(environment, store => {
     const note = store.get(dataID);
 
-    note.setValue(body, "body");
-    note.setValue(title, "title")
+    note.setValue(body, 'body');
+    note.setValue(title, 'title')
   });
 }
 ```
@@ -173,7 +180,7 @@ import {commitLocalUpdate} from 'react-relay';
 commitLocalUpdate(environment, store => {
   const user = store.getRoot().getLinkedRecord('viewer');
 
-  // initialize user notes to an empty array
-  user.setLinkedRecords([], "notes");
+  // initialize user notes to an empty array.
+  user.setLinkedRecords([], 'notes');
 });
 ```

--- a/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
@@ -1,0 +1,7 @@
+---
+id: version-v4.0.0-local-state-management
+title: Local State Management
+original_id: local-state-management
+---
+
+Relay compiler [supports client-side extensions](./graphql-in-relay#client-schema-extensions), which allows you to define client-side fields and types that can be used to extend the server schema.

--- a/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
@@ -4,4 +4,176 @@ title: Local State Management
 original_id: local-state-management
 ---
 
-Relay compiler [supports client-side extensions](./graphql-in-relay#client-schema-extensions), which allows you to define client-side fields and types that can be used to extend the server schema.
+Relay can be used to read and write local data, and act as a single source of truth for *all* data in your client application.  
+The Relay Compiler fully supports client-side extensions of the schema, which allows you to define local fields and types.  
+
+Table of Contents:
+
+- [Extending the client schema](#extending-the-client-schema)
+- [Querying local state](#querying-local-state)
+- [Mutating local state](#mutating-local-state)
+- [Initial local state](#initial-local-state)
+
+## Extending the client schema
+
+To extend the server schema, create a new `.graphql` file inside your `--src` directory.  
+Let's call it `./src/clientSchema.graphql`.
+
+This schema describes what local data can be queried on the client.  
+It can even be used to extend an existing server schema.
+
+For example, we can create a new type called `Note`:
+
+```graphql
+type Note {
+  ID: ID!
+  title: String
+  body: String
+}
+```
+
+And then extend the server schema type `User`, with a list of `Note`, called `notes`.
+
+```graphql
+extend type User {
+  notes: [Note]
+}
+```
+
+## Querying local state
+
+Accessing local data is no different from querying your GraphQL server.  
+Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with her name and the list of notes.
+
+```javascript
+// Example.js
+import React from 'react';
+import { QueryRenderer, graphql } from 'react-relay';
+
+const renderQuery = ({error, props}) => {
+  if (error) {
+    return <div>{error.message}</div>;
+  } else if (props) {
+    return (
+      <div>
+        {props.viewer.notes.map(({id, title, body}) => (
+          <div key={id}>
+            {title}
+          </div>
+          <div key={id}>
+            {body}
+          </div>
+        ))}
+      </div>
+    );
+  }
+  return <div>Loading</div>;
+}
+  
+const Example = (props) => {
+  return (
+    <QueryRenderer
+      render={renderQuery}
+      environment={environment}
+      query={graphql`
+        query ExampleQuery {
+          viewer {
+            id
+            name
+            notes {
+              id
+              title
+              body
+            }
+          }
+        }
+      `}
+    />
+  );
+}
+```
+
+## Mutating local state
+
+All local data lives in the [Relay Store](./relay-store).  
+Updating local state can be done with any `updater` function.
+The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
+
+To build upon the previous example, let's try creating, updating and deleting a `Note` from the list of `notes` on `User`.
+
+### Create
+
+```javascript
+import {commitLocalUpdate} from 'react-relay';
+
+let tempId = 0;
+
+function createUserNote() {
+  commitLocalUpdate(environment, store => {
+    const user = store.getRoot().getLinkedRecord('viewer');
+    const userNoteRecords = user.getLinkedRecords('notes') || [];
+
+    // Create a unique ID.
+    const dataID = `client:Note:${tempId++}`;
+
+    //Create a new note record.
+    const newNoteRecord = store.create(dataID, 'Note');
+
+    // Add the record to the users list of notes.
+    user.setLinkedRecords([...userNoteRecords, newNoteRecord], 'notes');
+  });
+}
+```
+
+### Update
+
+```javascript
+import {commitLocalUpdate} from 'react-relay';
+
+function updateUserNote(dataID, body, title) {
+  commitLocalUpdate(environment, store => {
+    const note = store.get(dataID);
+
+    note.setValue(body, "body");
+    note.setValue(title, "title")
+  });
+}
+```
+
+### Delete
+
+```javascript
+import {commitLocalUpdate} from 'react-relay';
+
+function deleteUserNote(dataID) {
+  commitLocalUpdate(environment, store => {
+    const user = store.getRoot().getLinkedRecord('viewer');
+    const userNoteRecords = user.getLinkedRecords('notes');
+
+    // Remove the note from the list of user notes.
+    const newUserNoteRecords = userNoteRecords.filter(x => x.getDataID() !== dataID);
+
+    // Delete the note from the store.
+    store.delete(dataID);
+
+    // Set the new list of notes.
+    user.setLinkedRecords(newUserNoteRecords, 'notes');
+  });
+}
+```
+
+## Initial local state
+
+All new client-side schema fields default to `undefined` value. Often however, you will want to set the initial state before querying local data.
+You can use an updater function via `commitLocalUpdate` to prime local state.
+
+```javascript
+import {commitLocalUpdate} from 'react-relay';
+
+commitLocalUpdate(environment, store => {
+  const user = store.getRoot().getLinkedRecord('viewer');
+
+  // initialize user notes to an empty array
+  user.setLinkedRecords([], "notes");
+});
+```

--- a/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
@@ -42,8 +42,10 @@ extend type User {
 
 ## Querying local state
 
-Accessing local data is no different from querying your GraphQL server.  
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their name and the list of notes.
+Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
+The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
+
+Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js

--- a/website/versioned_sidebars/version-v4.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-v4.0.0-sidebars.json
@@ -25,7 +25,8 @@
       "version-v4.0.0-graphql-server-specification",
       "version-v4.0.0-persisted-queries",
       "version-v4.0.0-type-emission",
-      "version-v4.0.0-testing-relay-components"
+      "version-v4.0.0-testing-relay-components",
+      "version-v4.0.0-local-state-management"
     ],
     "Principles & Architecture": [
       "version-v4.0.0-thinking-in-graphql",


### PR DESCRIPTION
Well, writing official documentation is quite different from writing a blog post. 😉 
I've tried to mimic the style of the Relay documentation best I could, while retaining the information I think is important.

In the https://relay.dev/docs/en/graphql-in-relay API reference, I've added a brief section on _Client schema extensions_, and linked to an in-depth guide on local state management at _/local-state-management._

I've included this documentation for v4 and up.

Please feel free to let me know if you think something is confusing, or if I've left something out. 🙂 