### PR TITLE
Remove babel-plugin-relay from Jest babel config

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  * @format
  */
 
@@ -15,7 +14,6 @@ const babel = require('@babel/core');
 const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
 const getBabelOptions = require('../getBabelOptions');
 const path = require('path');
-const testSchemaPath = require('../../dist/relay-test-utils-internal/lib/RelayTestSchemaPath');
 
 const babelOptions = getBabelOptions({
   env: 'test',
@@ -48,7 +46,6 @@ module.exports = {
 
   getCacheKey: createCacheKeyFunction([
     __filename,
-    testSchemaPath,
     // We cannot have trailing commas in this file for node < 8
     // prettier-ignore
     path.join(

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-const BabelPluginRelay = require('../../dist/babel-plugin-relay');
-
 const assign = require('object-assign');
 const babel = require('@babel/core');
 const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
@@ -30,15 +28,6 @@ const babelOptions = getBabelOptions({
     ReactTestRenderer: 'react-test-renderer',
   },
   plugins: [
-    [
-      BabelPluginRelay,
-      {
-        compat: true,
-        haste: true,
-        substituteVariables: true,
-        schema: testSchemaPath,
-      },
-    ],
     '@babel/plugin-transform-flow-strip-types',
     '@babel/plugin-transform-runtime',
     '@babel/plugin-proposal-nullish-coalescing-operator',


### PR DESCRIPTION
The tests don't rely on the compiler being run and just transform
directly if they need to.