### PR TITLE
Remove module rewrite for react and react-test-renderer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,7 @@ const babelOptions = require('./scripts/getBabelOptions')({
     os: 'os',
     path: 'path',
     process: 'process',
-    React: 'react',
+    react: 'react',
     'react-lifecycles-compat': 'react-lifecycles-compat',
     'relay-compiler': 'relay-compiler',
     RelayRuntime: 'relay-runtime',

--- a/packages/react-relay/ReactRelayContext.js
+++ b/packages/react-relay/ReactRelayContext.js
@@ -9,7 +9,7 @@
  */
 
 'use strict';
-const React = require('React');
+const React = require('react');
 
 const {
   __internal: {createRelayContext},

--- a/packages/react-relay/ReactRelayFragmentContainer.js
+++ b/packages/react-relay/ReactRelayFragmentContainer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 const areEqual = require('areEqual');
 const buildReactRelayContainer = require('./buildReactRelayContainer');

--- a/packages/react-relay/ReactRelayFragmentMockRenderer.js
+++ b/packages/react-relay/ReactRelayFragmentMockRenderer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('./ReactRelayContext');
 
 function ReactRelayFragmentMockRenderer(props: Object): React.Node {

--- a/packages/react-relay/ReactRelayLocalQueryRenderer.js
+++ b/packages/react-relay/ReactRelayLocalQueryRenderer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('./ReactRelayContext');
 
 const {useLayoutEffect, useState, useRef, useMemo} = React;

--- a/packages/react-relay/ReactRelayPaginationContainer.js
+++ b/packages/react-relay/ReactRelayPaginationContainer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('./ReactRelayContext');
 const ReactRelayQueryFetcher = require('./ReactRelayQueryFetcher');
 

--- a/packages/react-relay/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/ReactRelayQueryRenderer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('./ReactRelayContext');
 const ReactRelayQueryFetcher = require('./ReactRelayQueryFetcher');
 

--- a/packages/react-relay/ReactRelayRefetchContainer.js
+++ b/packages/react-relay/ReactRelayRefetchContainer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('./ReactRelayContext');
 const ReactRelayQueryFetcher = require('./ReactRelayQueryFetcher');
 

--- a/packages/react-relay/__flowtests__/ReactRelayFragmentContainer-flowtest.js
+++ b/packages/react-relay/__flowtests__/ReactRelayFragmentContainer-flowtest.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 const {
   createContainer: createFragmentContainer,

--- a/packages/react-relay/__flowtests__/ReactRelayPaginationContainer-flowtest.js
+++ b/packages/react-relay/__flowtests__/ReactRelayPaginationContainer-flowtest.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 const {
   createContainer: createPaginationContainer,

--- a/packages/react-relay/__flowtests__/ReactRelayRefetchContainer-flowtest.js
+++ b/packages/react-relay/__flowtests__/ReactRelayRefetchContainer-flowtest.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 const {
   createContainer: createRefetchContainer,

--- a/packages/react-relay/__flowtests__/RelayModern-flowtest.js
+++ b/packages/react-relay/__flowtests__/RelayModern-flowtest.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 const nullthrows = require('nullthrows');
 

--- a/packages/react-relay/__mocks__/RelayTestRenderer.js
+++ b/packages/react-relay/__mocks__/RelayTestRenderer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('../ReactRelayContext');
 
 const invariant = require('invariant');

--- a/packages/react-relay/__tests__/ReactRelayContainerUtils-test.js
+++ b/packages/react-relay/__tests__/ReactRelayContainerUtils-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 const {
   getComponentName,

--- a/packages/react-relay/__tests__/ReactRelayFragmentContainer-WithFragmentOwnership-test.js
+++ b/packages/react-relay/__tests__/ReactRelayFragmentContainer-WithFragmentOwnership-test.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('../ReactRelayContext');
 const ReactRelayFragmentContainer = require('../ReactRelayFragmentContainer');
-const ReactTestRenderer = require('ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 
 const {
   createReaderSelector,

--- a/packages/react-relay/__tests__/ReactRelayFragmentContainer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayFragmentContainer-test.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('../ReactRelayContext');
 const ReactRelayFragmentContainer = require('../ReactRelayFragmentContainer');
-const ReactTestRenderer = require('ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 
 const {
   createReaderSelector,

--- a/packages/react-relay/__tests__/ReactRelayFragmentMockRenderer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayFragmentMockRenderer-test.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayFragmentContainer = require('../ReactRelayFragmentContainer');
 const ReactRelayFragmentMockRenderer = require('../ReactRelayFragmentMockRenderer');
 const ReactRelayRefetchContainer = require('../ReactRelayRefetchContainer');
-const ReactTestRenderer = require('ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 
 const {createMockEnvironment} = require('relay-test-utils-internal');
 

--- a/packages/react-relay/__tests__/ReactRelayLocalQueryRenderer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayLocalQueryRenderer-test.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('../ReactRelayContext');
 const ReactRelayLocalQueryRenderer = require('../ReactRelayLocalQueryRenderer');
-const ReactTestRenderer = require('ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 
 const readContext = require('../readContext');
 

--- a/packages/react-relay/__tests__/ReactRelayPaginationContainer-WithFragmentOwnership-test.js
+++ b/packages/react-relay/__tests__/ReactRelayPaginationContainer-WithFragmentOwnership-test.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('../ReactRelayContext');
 const ReactRelayFragmentContainer = require('../ReactRelayFragmentContainer');
 const ReactRelayPaginationContainer = require('../ReactRelayPaginationContainer');
-const ReactTestRenderer = require('ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 
 const {
   ConnectionHandler,

--- a/packages/react-relay/__tests__/ReactRelayPaginationContainer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayPaginationContainer-test.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('../ReactRelayContext');
 const ReactRelayPaginationContainer = require('../ReactRelayPaginationContainer');
-const ReactTestRenderer = require('ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 
 const {
   createReaderSelector,

--- a/packages/react-relay/__tests__/ReactRelayQueryRenderer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayQueryRenderer-test.js
@@ -12,11 +12,11 @@
 
 jest.mock('scheduler', () => require('scheduler/unstable_mock'));
 
-const React = require('React');
+const React = require('react');
 const Scheduler = require('scheduler');
 const ReactRelayContext = require('../ReactRelayContext');
 const ReactRelayQueryRenderer = require('../ReactRelayQueryRenderer');
-const ReactTestRenderer = require('ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 
 const readContext = require('../readContext');
 

--- a/packages/react-relay/__tests__/ReactRelayRefetchContainer-WithFragmentOwnership-test.js
+++ b/packages/react-relay/__tests__/ReactRelayRefetchContainer-WithFragmentOwnership-test.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('../ReactRelayContext');
 const ReactRelayFragmentContainer = require('../ReactRelayFragmentContainer');
 const ReactRelayRefetchContainer = require('../ReactRelayRefetchContainer');
-const ReactTestRenderer = require('ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 
 const readContext = require('../readContext');
 

--- a/packages/react-relay/__tests__/ReactRelayRefetchContainer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayRefetchContainer-test.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('../ReactRelayContext');
 const ReactRelayRefetchContainer = require('../ReactRelayRefetchContainer');
-const ReactTestRenderer = require('ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 
 const readContext = require('../readContext');
 

--- a/packages/react-relay/__tests__/ReactRelayTestMocker-test.js
+++ b/packages/react-relay/__tests__/ReactRelayTestMocker-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 // $FlowFixMe - Types for react-test-renderer
 const ReactTestRenderer = require('react-test-renderer');
 const RelayTestUtils = require('relay-test-utils-internal');

--- a/packages/react-relay/buildReactRelayContainer.js
+++ b/packages/react-relay/buildReactRelayContainer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactRelayContext = require('./ReactRelayContext');
 
 const assertFragmentMap = require('./assertFragmentMap');

--- a/packages/react-relay/readContext.js
+++ b/packages/react-relay/readContext.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 const {ReactCurrentDispatcher, ReactCurrentOwner} =
   /* $FlowFixMe Flow doesn't know about React's internals for good reason,

--- a/packages/relay-runtime/store/createRelayContext.js
+++ b/packages/relay-runtime/store/createRelayContext.js
@@ -13,7 +13,14 @@
 const invariant = require('invariant');
 
 import type {RelayContext} from './RelayStoreTypes.js';
-import typeof React from 'React';
+import typeof {createContext} from 'react';
+
+// Ideally, we'd just import the type of the react module, but this causes Flow
+// problems internally.
+type React = {
+  createContext: createContext<RelayContext | null>,
+  version: string,
+};
 
 let relayContext: ?React$Context<RelayContext | null>;
 let firstReact: ?React;

--- a/packages/relay-test-utils/__tests__/RelayMockEnvironmentWithComponents-test.js
+++ b/packages/relay-test-utils/__tests__/RelayMockEnvironmentWithComponents-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 // $FlowFixMe - untyped import
 const ReactTestRenderer = require('react-test-renderer');
 

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -22,8 +22,8 @@ const babelOptions = getBabelOptions({
   moduleMap: {
     '@babel/parser': '@babel/parser',
     immutable: 'immutable',
-    React: 'react',
-    ReactTestRenderer: 'react-test-renderer',
+    react: 'react',
+    'react-test-renderer': 'react-test-renderer',
   },
   plugins: [
     '@babel/plugin-transform-flow-strip-types',


### PR DESCRIPTION
Removes the magic that replaces `require('React')` with
`require('react')` and instead update the requires directly.