### PR TITLE
Remove flattening from distributed modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,70 +12,6 @@
 const babel = require('gulp-babel');
 const babelOptions = require('./scripts/getBabelOptions')({
   ast: false,
-  moduleMap: {
-    '@babel/core': '@babel/core',
-    '@babel/parser': '@babel/parser',
-    '@babel/polyfill': '@babel/polyfill',
-    '@babel/traverse': '@babel/traverse',
-    '@babel/types': '@babel/types',
-    '@babel/plugin-proposal-nullish-coalescing-operator':
-      '@babel/plugin-proposal-nullish-coalescing-operator',
-    '@babel/plugin-proposal-optional-chaining':
-      '@babel/plugin-proposal-optional-chaining',
-    '@babel/plugin-transform-runtime': '@babel/plugin-transform-runtime',
-    '@babel/plugin-transform-flow-strip-types':
-      '@babel/plugin-transform-flow-strip-types',
-    '@babel/generator': '@babel/generator',
-    '@babel/generator/lib/printer': '@babel/generator/lib/printer',
-    '@babel/runtime/helpers/assertThisInitialized':
-      '@babel/runtime/helpers/assertThisInitialized',
-    '@babel/runtime/helpers/asyncToGenerator':
-      '@babel/runtime/helpers/asyncToGenerator',
-    '@babel/runtime/helpers/classCallCheck':
-      '@babel/runtime/helpers/classCallCheck',
-    '@babel/runtime/helpers/defineProperty':
-      '@babel/runtime/helpers/defineProperty',
-    '@babel/runtime/helpers/extends': '@babel/runtime/helpers/extends',
-    '@babel/runtime/helpers/inherits': '@babel/runtime/helpers/inherits',
-    '@babel/runtime/helpers/inheritsLoose':
-      '@babel/runtime/helpers/inheritsLoose',
-    '@babel/runtime/helpers/interopRequireDefault':
-      '@babel/runtime/helpers/interopRequireDefault',
-    '@babel/runtime/helpers/objectSpread':
-      '@babel/runtime/helpers/objectSpread',
-    '@babel/runtime/helpers/objectWithoutProperties':
-      '@babel/runtime/helpers/objectWithoutProperties',
-    '@babel/runtime/helpers/objectWithoutPropertiesLoose':
-      '@babel/runtime/helpers/objectWithoutPropertiesLoose',
-    '@babel/runtime/helpers/possibleConstructorReturn':
-      '@babel/runtime/helpers/possibleConstructorReturn',
-    '@babel/runtime/helpers/toConsumableArray':
-      '@babel/runtime/helpers/toConsumableArray',
-    'babel-plugin-macros': 'babel-plugin-macros',
-    chalk: 'chalk',
-    child_process: 'child_process',
-    cosmiconfig: 'cosmiconfig',
-    crypto: 'crypto',
-    'fast-glob': 'fast-glob',
-    'fb-watchman': 'fb-watchman',
-    fs: 'fs',
-    graphql: 'graphql',
-    immutable: 'immutable',
-    net: 'net',
-    os: 'os',
-    path: 'path',
-    process: 'process',
-    react: 'react',
-    'react-lifecycles-compat': 'react-lifecycles-compat',
-    'relay-compiler': 'relay-compiler',
-    RelayRuntime: 'relay-runtime',
-    'relay-runtime': 'relay-runtime',
-    'relay-test-utils': 'relay-test-utils',
-    'relay-test-utils-internal': 'relay-test-utils-internal',
-    signedsource: 'signedsource',
-    util: 'util',
-    yargs: 'yargs',
-  },
   plugins: [
     '@babel/plugin-transform-flow-strip-types',
     '@babel/plugin-transform-runtime',
@@ -90,7 +26,6 @@ const babelOptions = require('./scripts/getBabelOptions')({
   sourceType: 'script',
 });
 const del = require('del');
-const flatten = require('gulp-flatten');
 const fs = require('fs');
 const gulp = require('gulp');
 const chmod = require('gulp-chmod');
@@ -300,7 +235,6 @@ const modules = gulp.parallel(
           })
           .pipe(once())
           .pipe(babel(babelOptions))
-          .pipe(flatten())
           .pipe(gulp.dest(path.join(DIST, build.package, 'lib')));
       },
   ),
@@ -363,7 +297,7 @@ builds.forEach(build => {
     build.bins.forEach(bin => {
       binsTasks.push(function binsTask() {
         return gulp
-          .src(path.join(DIST, build.package, 'lib', bin.entry))
+          .src(path.join(DIST, build.package, 'lib', 'bin', bin.entry))
           .pipe(buildDist(bin.output, bin, /* isProduction */ false))
           .pipe(header(SCRIPT_HASHBANG + PRODUCTION_HEADER))
           .pipe(chmod(0o755))

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "gulp": "4.0.0",
     "gulp-babel": "8.0.0",
     "gulp-chmod": "2.0.0",
-    "gulp-flatten": "0.4.0",
     "gulp-header": "2.0.7",
     "gulp-once": "2.0.3",
     "gulp-util": "3.0.8",

--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -29,6 +29,7 @@ module.exports = function(options) {
     {
       map: {
         ErrorUtils: 'fbjs/lib/ErrorUtils',
+        Promise: 'fbjs/lib/Promise',
         areEqual: 'fbjs/lib/areEqual',
         emptyFunction: 'fbjs/lib/emptyFunction',
         forEachObject: 'fbjs/lib/forEachObject',

--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -13,7 +13,6 @@ module.exports = function(options) {
   options = Object.assign(
     {
       env: 'production',
-      moduleMap: {},
       plugins: [],
     },
     options,
@@ -25,20 +24,21 @@ module.exports = function(options) {
     stripDEV: options.env === 'production',
   });
 
-  // The module rewrite transform needs to be positioned relative to fbjs's
-  // many other transforms.
-  const moduleMap = Object.assign(
-    {},
-    require('fbjs/module-map'),
-    options.moduleMap,
-  );
-  // TODO: Delete `nullthrows` from fbjs.
-  moduleMap.nullthrows = 'nullthrows';
-
   fbjsPreset.presets[0].plugins.push([
     require('./rewrite-modules'),
     {
-      map: moduleMap,
+      map: {
+        ErrorUtils: 'fbjs/lib/ErrorUtils',
+        areEqual: 'fbjs/lib/areEqual',
+        emptyFunction: 'fbjs/lib/emptyFunction',
+        forEachObject: 'fbjs/lib/forEachObject',
+        invariant: 'fbjs/lib/invariant',
+        mapObject: 'fbjs/lib/mapObject',
+        removeFromArray: 'fbjs/lib/removeFromArray',
+        resolveImmediate: 'fbjs/lib/resolveImmediate',
+        sprintf: 'fbjs/lib/sprintf',
+        warning: 'fbjs/lib/warning',
+      },
     },
   ]);
 

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -19,12 +19,6 @@ const babelOptions = getBabelOptions({
   env: 'test',
   // Tests use a Promise polfill so they can use jest.runAllTimers().
   autoImport: true,
-  moduleMap: {
-    '@babel/parser': '@babel/parser',
-    immutable: 'immutable',
-    react: 'react',
-    'react-test-renderer': 'react-test-renderer',
-  },
   plugins: [
     '@babel/plugin-transform-flow-strip-types',
     '@babel/plugin-transform-runtime',

--- a/scripts/rewrite-modules.js
+++ b/scripts/rewrite-modules.js
@@ -17,21 +17,12 @@ const path = require('path');
  * file names in require statements.
  */
 
-/**
- * Rewrites module string literals according to the `map` and `prefix` options.
- * This allows other npm packages to be published and used directly without
- * being a part of the same build.
- */
 function mapModule(state, module) {
   var moduleMap = state.opts.map || {};
   if (moduleMap.hasOwnProperty(module)) {
     return moduleMap[module];
   }
-  // Jest understands the haste module system, so leave modules intact.
-  if (process.env.NODE_ENV === 'test') {
-    return;
-  }
-  return './' + path.basename(module);
+  return null;
 }
 
 var jestMethods = [
@@ -43,7 +34,7 @@ var jestMethods = [
 ];
 
 function isJestProperty(t, property) {
-  return t.isIdentifier(property) && jestMethods.indexOf(property.name) !== -1;
+  return t.isIdentifier(property) && jestMethods.includes(property.name);
 }
 
 module.exports = function(babel) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3314,14 +3314,6 @@ gulp-cli@^2.0.0:
     v8flags "^3.0.1"
     yargs "^7.1.0"
 
-gulp-flatten@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/gulp-flatten/-/gulp-flatten-0.4.0.tgz#d9ac819416c30fd5dfb3dea9da79c83a1bcd61d1"
-  integrity sha512-eg4spVTAiv1xXmugyaCxWne1oPtNG0UHEtABx5W8ScLiqAYceyYm6GYA36x0Qh8KOIXmAZV97L2aYGnKREG3Sg==
-  dependencies:
-    plugin-error "^0.1.2"
-    through2 "^2.0.0"
-
 gulp-header@2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/gulp-header/-/gulp-header-2.0.7.tgz#07505740eb432e8d2bb2af68744858dabaaf491b"


### PR DESCRIPTION
This changes the packaging to preserve relative paths. This helps reduce
the amount of magic require rewriting during the build process.

The downside is that this is a breaking change for folks who require internal modules (`require('relay-runtime/lib/whatever')`).

The node_module layout now looks like this (shortened):

```
dist/relay-runtime
+-- index.js
+-- lib
│   +-- handlers
│   │   +-- RelayDefaultHandlerProvider.js
│   │   +-- RelayDefaultMissingFieldHandlers.js
│   │   \-- connection
│   │       +-- RelayConnectionHandler.js
│   │       \-- RelayConnectionInterface.js
│   +-- index.js
│   +-- mutations
│   │   +-- RelayRecordSourceSelectorProxy.js
│   │   \-- validateMutation.js
│   +-- network
│   │   +-- ConvertToExecuteFunction.js
│   │   +-- RelayNetwork.js
│   │   \-- createRelayNetworkLogger.js
+-- package.json
+-- relay-runtime.js
\-- relay-runtime.min.js
```