### PR TITLE
Remove fbjs usage: emptyFunction, forEachObject, removeFromArray

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,7 +12,6 @@ module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
 module.system.haste.paths.blacklist=.*/__tests__/.*
 module.system.haste.paths.blacklist=.*/__mocks__/.*
 module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/fbjs/lib/.*
-module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/fbjs/lib/emptyFunction\\.js\\.flow
 
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable

--- a/packages/react-relay/ReactRelayPaginationContainer.js
+++ b/packages/react-relay/ReactRelayPaginationContainer.js
@@ -16,7 +16,6 @@ const ReactRelayQueryFetcher = require('./ReactRelayQueryFetcher');
 
 const areEqual = require('areEqual');
 const buildReactRelayContainer = require('./buildReactRelayContainer');
-const forEachObject = require('forEachObject');
 const invariant = require('invariant');
 const warning = require('warning');
 
@@ -679,7 +678,7 @@ function createContainerWithFragments<
       // For extra safety, we make sure the rootVariables include the
       // variables from all owners in this fragmentSpec, even though they
       // should all point to the same owner
-      forEachObject(fragments, (__, key) => {
+      Object.keys(fragments).forEach(key => {
         const fragmentOwner = fragmentOwners[key];
         const fragmentOwnerVariables = Array.isArray(fragmentOwner)
           ? fragmentOwner[0]?.variables ?? {}

--- a/packages/react-relay/ReactRelayTestMocker.js
+++ b/packages/react-relay/ReactRelayTestMocker.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const areEqual = require('areEqual');
-const emptyFunction = require('emptyFunction');
 const invariant = require('invariant');
 const warning = require('warning');
 
@@ -134,8 +133,8 @@ class ReactRelayTestMocker {
    */
   _mockNetworkLayer(env: IEnvironment): IEnvironment {
     const fetch = (request, variables, cacheConfig) => {
-      let resolve = emptyFunction;
-      let reject = emptyFunction;
+      let resolve;
+      let reject;
       const promise = new Promise((res, rej) => {
         resolve = res;
         reject = rej;

--- a/packages/relay-runtime/util/RelayProfiler.js
+++ b/packages/relay-runtime/util/RelayProfiler.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-const removeFromArray = require('removeFromArray');
-
 type Handler = (name: string, callback: () => void) => void;
 type ProfileHandler = (name: string, state?: any) => (error?: Error) => void;
 
@@ -273,5 +271,12 @@ const RelayProfiler = {
     }
   },
 };
+
+function removeFromArray<T>(array: Array<T>, element: T): void {
+  var index = array.indexOf(element);
+  if (index !== -1) {
+    array.splice(index, 1);
+  }
+}
 
 module.exports = RelayProfiler;

--- a/packages/relay-runtime/util/RelayProfiler.js
+++ b/packages/relay-runtime/util/RelayProfiler.js
@@ -10,11 +10,12 @@
 
 'use strict';
 
-const emptyFunction = require('emptyFunction');
 const removeFromArray = require('removeFromArray');
 
 type Handler = (name: string, callback: () => void) => void;
 type ProfileHandler = (name: string, state?: any) => (error?: Error) => void;
+
+function emptyFunction() {}
 
 const aggregateHandlersByName: {[name: string]: Array<Handler>} = {
   '*': [],

--- a/packages/relay-runtime/util/__mocks__/RelayProfiler.js
+++ b/packages/relay-runtime/util/__mocks__/RelayProfiler.js
@@ -9,18 +9,15 @@
 
 'use strict';
 
-const emptyFunction = require('emptyFunction');
-const forEachObject = require('forEachObject');
-
 const RelayProfiler = {
   instrumentMethods: jest.fn((object, names) => {
-    forEachObject(names, (name, key) => {
+    for (const [key, name] of Object.entries(names)) {
       object[key] = RelayProfiler.instrument(name, object[key]);
-    });
+    }
   }),
   instrument: jest.fn((name, handler) => {
-    handler.attachHandler = emptyFunction;
-    handler.detachHandler = emptyFunction;
+    handler.attachHandler = () => {};
+    handler.detachHandler = () => {};
     return handler;
   }),
   attachAggregateHandler: jest.fn(),

--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -31,8 +31,6 @@ module.exports = function(options) {
         ErrorUtils: 'fbjs/lib/ErrorUtils',
         Promise: 'fbjs/lib/Promise',
         areEqual: 'fbjs/lib/areEqual',
-        emptyFunction: 'fbjs/lib/emptyFunction',
-        forEachObject: 'fbjs/lib/forEachObject',
         invariant: 'fbjs/lib/invariant',
         mapObject: 'fbjs/lib/mapObject',
         removeFromArray: 'fbjs/lib/removeFromArray',

--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -33,7 +33,6 @@ module.exports = function(options) {
         areEqual: 'fbjs/lib/areEqual',
         invariant: 'fbjs/lib/invariant',
         mapObject: 'fbjs/lib/mapObject',
-        removeFromArray: 'fbjs/lib/removeFromArray',
         resolveImmediate: 'fbjs/lib/resolveImmediate',
         sprintf: 'fbjs/lib/sprintf',
         warning: 'fbjs/lib/warning',


### PR DESCRIPTION
We just use a small set of dependencies from fbjs that are just as clean when we don't depend on them.