### PR TITLE
Remove single sprintf usage from RelayError

### DIFF
--- a/packages/relay-runtime/store/RelayModernQueryExecutor.js
+++ b/packages/relay-runtime/store/RelayModernQueryExecutor.js
@@ -244,12 +244,16 @@ class Executor {
     }
     if (response.data == null) {
       const {errors} = response;
+      const messages = errors
+        ? errors.map(({message}) => message).join('\n')
+        : '(No errors)';
       const error = RelayError.create(
         'RelayNetwork',
-        'No data returned for operation `%s`, got error(s):\n%s\n\nSee the error ' +
-          '`source` property for more information.',
-        this._operation.request.node.params.name,
-        errors ? errors.map(({message}) => message).join('\n') : '(No errors)',
+        'No data returned for operation `' +
+          this._operation.request.node.params.name +
+          '`, got error(s):\n' +
+          messages +
+          '\n\nSee the error `source` property for more information.',
       );
       (error: $FlowFixMe).source = {
         errors,

--- a/packages/relay-runtime/util/RelayError.js
+++ b/packages/relay-runtime/util/RelayError.js
@@ -10,36 +10,22 @@
 
 'use strict';
 
-const sprintf = require('sprintf');
-
-/**
- * @internal
- *
- * Factory methods for constructing errors in Relay.
- */
-const RelayError = {
-  create(name: string, format: string, ...args: Array<mixed>): Error {
-    return createError('mustfix', name, format, args);
-  },
-  createWarning(name: string, format: string, ...args: Array<mixed>): Error {
-    return createError('warn', name, format, args);
-  },
-};
-
 /**
  * @private
  */
-function createError(
-  type: string,
-  name: string,
-  format: string,
-  args: Array<mixed>,
-): Error {
-  const error = new Error(sprintf(format, ...args));
+function createError(type: string, name: string, message: string): Error {
+  const error = new Error(message);
   error.name = name;
   (error: any).type = type;
   (error: any).framesToPop = 2;
   return error;
 }
 
-module.exports = RelayError;
+module.exports = {
+  create(name: string, message: string): Error {
+    return createError('mustfix', name, message);
+  },
+  createWarning(name: string, message: string): Error {
+    return createError('warn', name, message);
+  },
+};

--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -34,7 +34,6 @@ module.exports = function(options) {
         invariant: 'fbjs/lib/invariant',
         mapObject: 'fbjs/lib/mapObject',
         resolveImmediate: 'fbjs/lib/resolveImmediate',
-        sprintf: 'fbjs/lib/sprintf',
         warning: 'fbjs/lib/warning',
       },
     },


### PR DESCRIPTION
We can just pass the formatted string to the RelayError functions directly.