### PR TITLE
Remove mapObject usage

### DIFF
--- a/flow-typed/fbjs.js.flow
+++ b/flow-typed/fbjs.js.flow
@@ -1,7 +1,3 @@
-declare module 'mapObject' {
-  declare module.exports: any;
-}
-
 declare module 'ErrorUtils' {
   declare module.exports: any;
 }

--- a/packages/react-relay/buildReactRelayContainer.js
+++ b/packages/react-relay/buildReactRelayContainer.js
@@ -15,7 +15,6 @@ const ReactRelayContext = require('./ReactRelayContext');
 
 const assertFragmentMap = require('./assertFragmentMap');
 const invariant = require('invariant');
-const mapObject = require('mapObject');
 const readContext = require('./readContext');
 
 const {
@@ -45,7 +44,10 @@ function buildReactRelayContainer<TBase: React$ComponentType<any>>(
   const containerName = getContainerName(ComponentClass);
   assertFragmentMap(getComponentName(ComponentClass), fragmentSpec);
 
-  const fragments = mapObject(fragmentSpec, getFragment);
+  const fragments = {};
+  for (const key in fragmentSpec) {
+    fragments[key] = getFragment(fragmentSpec[key]);
+  }
   const Container = createContainerWithFragments(ComponentClass, fragments);
   Container.displayName = containerName;
 

--- a/packages/relay-experimental/FragmentResource.js
+++ b/packages/relay-experimental/FragmentResource.js
@@ -14,7 +14,6 @@
 const LRUCache = require('./LRUCache');
 
 const invariant = require('invariant');
-const mapObject = require('mapObject');
 const warning = require('warning');
 
 const {
@@ -245,15 +244,16 @@ class FragmentResourceImpl {
     fragmentRefs: {[string]: mixed},
     componentDisplayName: string,
   ): {[string]: FragmentResult} {
-    return mapObject(fragmentNodes, (fragmentNode, fragmentKey) => {
-      const fragmentRef = fragmentRefs[fragmentKey];
-      return this.read(
-        fragmentNode,
-        fragmentRef,
+    const result = {};
+    for (const key in fragmentNodes) {
+      result[key] = this.read(
+        fragmentNodes[key],
+        fragmentRefs[key],
         componentDisplayName,
-        fragmentKey,
+        key,
       );
-    });
+    }
+    return result;
   }
 
   subscribe(fragmentResult: FragmentResult, callback: () => void): Disposable {
@@ -320,13 +320,12 @@ class FragmentResourceImpl {
     },
     callback: () => void,
   ): Disposable {
-    const disposables = mapObject(fragmentResults, fragmentResult => {
-      return this.subscribe(fragmentResult, callback);
-    });
+    const disposables = Object.keys(fragmentResults).map(key =>
+      this.subscribe(fragmentResults[key], callback),
+    );
     return {
       dispose: () => {
-        Object.keys(disposables).forEach(key => {
-          const disposable = disposables[key];
+        disposables.forEach(disposable => {
           disposable.dispose();
         });
       },

--- a/packages/relay-experimental/useFragmentNodes.js
+++ b/packages/relay-experimental/useFragmentNodes.js
@@ -11,7 +11,6 @@
 
 'use strict';
 
-const mapObject = require('mapObject');
 const useRelayEnvironment = require('./useRelayEnvironment');
 const warning = require('warning');
 
@@ -190,9 +189,10 @@ function useFragmentNodes<TFragmentSpec: {}>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mustResubscribeGenerationRef.current]);
 
-  const data = mapObject(fragmentSpecResult, (result, key) => {
+  const data = {};
+  for (const key in fragmentSpecResult) {
     if (__DEV__) {
-      if (props[key] != null && result.data == null) {
+      if (props[key] != null && fragmentSpecResult[key].data == null) {
         const fragmentName = fragmentNodes[key]?.name ?? 'Unknown fragment';
         warning(
           false,
@@ -208,8 +208,8 @@ function useFragmentNodes<TFragmentSpec: {}>(
         );
       }
     }
-    return result.data;
-  });
+    data[key] = fragmentSpecResult[key].data;
+  }
   return {
     // $FlowFixMe
     data,

--- a/packages/relay-runtime/store/RelayModernFragmentOwner.js
+++ b/packages/relay-runtime/store/RelayModernFragmentOwner.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const invariant = require('invariant');
-const mapObject = require('mapObject');
 
 const {FRAGMENT_OWNER_KEY} = require('./RelayStoreUtils');
 
@@ -71,14 +70,15 @@ function getFragmentOwners(
   fragmentNodes: {[string]: ReaderFragment},
   fragmentRefs: {[string]: mixed},
 ): {[string]: ?RequestDescriptor | Array<?RequestDescriptor>} {
-  return mapObject(fragmentNodes, (fragmentNode, key) => {
-    const fragmentRef = fragmentRefs[key];
-    return getFragmentOwner(
-      fragmentNode,
+  const fragmentOwners = {};
+  for (const key in fragmentNodes) {
+    fragmentOwners[key] = getFragmentOwner(
+      fragmentNodes[key],
       // $FlowFixMe - TODO T39154660 Use FragmentPointer type instead of mixed
-      fragmentRef,
+      fragmentRefs[key],
     );
-  });
+  }
+  return fragmentOwners;
 }
 
 module.exports = {getFragmentOwner, getFragmentOwners};

--- a/packages/relay-runtime/util/getFragmentSpecIdentifier.js
+++ b/packages/relay-runtime/util/getFragmentSpecIdentifier.js
@@ -12,8 +12,6 @@
 'use strict';
 
 const getFragmentIdentifier = require('./getFragmentIdentifier');
-const mapObject = require('mapObject');
-const stableCopy = require('./stableCopy');
 
 import type {ReaderFragment} from '../util/ReaderNode';
 
@@ -21,14 +19,15 @@ function getFragmentSpecIdentifier(
   fragmentNodes: {[string]: ReaderFragment},
   fragmentRefs: {[string]: mixed},
 ): string {
-  return JSON.stringify(
-    stableCopy(
-      mapObject(fragmentNodes, (fragmentNode, key) => {
-        const fragmentRef = fragmentRefs[key];
-        return getFragmentIdentifier(fragmentNode, fragmentRef);
-      }),
-    ),
-  );
+  return Object.keys(fragmentNodes)
+    .sort()
+    .map(
+      key =>
+        key +
+        ':' +
+        getFragmentIdentifier(fragmentNodes[key], fragmentRefs[key]),
+    )
+    .join(',');
 }
 
 module.exports = getFragmentSpecIdentifier;

--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -32,7 +32,6 @@ module.exports = function(options) {
         Promise: 'promise-polyfill',
         areEqual: 'fbjs/lib/areEqual',
         invariant: 'fbjs/lib/invariant',
-        mapObject: 'fbjs/lib/mapObject',
         warning: 'fbjs/lib/warning',
       },
     },


### PR DESCRIPTION
`mapObject` isn't type safe. Removing it from `getFragmentSpecIdentifier` should also be a small perf win.