### PR TITLE
Remove require rewrite for resolveImmediate

### DIFF
--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -33,7 +33,6 @@ module.exports = function(options) {
         areEqual: 'fbjs/lib/areEqual',
         invariant: 'fbjs/lib/invariant',
         mapObject: 'fbjs/lib/mapObject',
-        resolveImmediate: 'fbjs/lib/resolveImmediate',
         warning: 'fbjs/lib/warning',
       },
     },


### PR DESCRIPTION
This rewrite config is no longer needed since
https://github.com/facebook/relay/commit/5592001ffab930c4d94d02415e990fbc85eab47b
replaced this module.