### PR TITLE
feat: allow RelayFileWriter to specify the filesystem object

### DIFF
--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -11,13 +11,13 @@
 'use strict';
 
 const ASTConvert = require('../core/ASTConvert');
-const CodegenDirectory = require('../codegen/CodegenDirectory');
 const CompilerContext = require('../core/GraphQLCompilerContext');
 const Profiler = require('../core/GraphQLCompilerProfiler');
 const RelayParser = require('../core/RelayParser');
 const RelayValidator = require('../core/RelayValidator');
 const SchemaUtils = require('../core/GraphQLSchemaUtils');
 
+const CodegenDirectory = require('./CodegenDirectory');
 const compileRelayArtifacts = require('./compileRelayArtifacts');
 const crypto = require('crypto');
 const graphql = require('graphql');
@@ -31,15 +31,16 @@ const {
 } = require('../core/GraphQLDerivedFromMetadata');
 const {Map: ImmutableMap} = require('immutable');
 
+import type {DocumentNode, GraphQLSchema, ValidationContext} from 'graphql';
 import type {
   FormatModule,
   TypeGenerator,
 } from '../language/RelayLanguagePluginInterface';
 import type {ScalarTypeMapping} from '../language/javascript/RelayFlowTypeTransformers';
 import type {GraphQLReporter as Reporter} from '../reporters/GraphQLReporter';
+import type {Filesystem} from './CodegenDirectory';
 import type {SourceControl} from './SourceControl';
 import type {RelayCompilerTransforms} from './compileRelayArtifacts';
-import type {DocumentNode, GraphQLSchema, ValidationContext} from 'graphql';
 
 const {isExecutableDefinitionAST} = SchemaUtils;
 
@@ -75,6 +76,7 @@ export type WriterConfig = {
     LOCAL_RULES?: $ReadOnlyArray<ValidationRule>,
   },
   printModuleDependency?: string => string,
+  filesystem?: Filesystem,
   repersist?: boolean,
 };
 
@@ -259,6 +261,7 @@ function writeAll({
     const addCodegenDir = dirPath => {
       const codegenDir = new CodegenDirectory(dirPath, {
         onlyValidate: onlyValidate,
+        filesystem: writerConfig.filesystem,
       });
       allOutputDirectories.set(dirPath, codegenDir);
       return codegenDir;


### PR DESCRIPTION
👋 Hopefully this is an uncontroversial addition. Tools like webpack provide their own wrappers around the fs object, By being able to pass it it webpack integrations can take advantage of the larger webpack cache