### PR TITLE
Add an option to generate esmodule imports/exports in babel-plugin-relay & relay-compiler

### DIFF
--- a/packages/babel-plugin-relay/BabelPluginRelay.js
+++ b/packages/babel-plugin-relay/BabelPluginRelay.js
@@ -32,6 +32,9 @@ export type RelayPluginOptions = {
 
   // Directory as specified by artifactDirectory when running relay-compiler
   artifactDirectory?: string,
+
+  // Generate output with esmodule imports instead of commonjs requires
+  esmodules?: boolean,
 };
 
 export type BabelState = {

--- a/packages/babel-plugin-relay/__tests__/BabelPluginRelay-modern-esmodule-test.js
+++ b/packages/babel-plugin-relay/__tests__/BabelPluginRelay-modern-esmodule-test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+const transformerWithOptions = require('./transformerWithOptions');
+
+const {generateTestsFromFixtures} = require('relay-test-utils-internal');
+
+generateTestsFromFixtures(
+  `${__dirname}/fixtures`,
+  transformerWithOptions({
+    esmodules: true,
+  }),
+);

--- a/packages/babel-plugin-relay/__tests__/__snapshots__/BabelPluginRelay-modern-esmodule-test.js.snap
+++ b/packages/babel-plugin-relay/__tests__/__snapshots__/BabelPluginRelay-modern-esmodule-test.js.snap
@@ -1,0 +1,273 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`matches expected output: fragment.txt 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const {graphql} = require('relay-runtime');
+
+const testFragment = graphql\`
+  fragment TestFragment on User {
+    __typename
+  }
+\`;
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+import _TestFragment from "./__generated__/TestFragment.graphql";
+
+const {
+  graphql
+} = require('relay-runtime');
+
+const testFragment = function () {
+  return _TestFragment;
+};
+`;
+
+exports[`matches expected output: memoize-inner-scope.txt 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+function SomeTopLevelView() {
+  const _graphql = 'unrelated';
+
+  return (
+    <View>
+      <QueryRenderer
+        environment={RelayEnvironment}
+        query={graphql\`
+          query ExampleQuery($id: ID!) {
+            node(id: $id) {
+              ...ProfilePic_user
+            }
+          }
+        \`}
+        variables={{id: '12345'}}
+      />
+    </View>
+  );
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+var _graphql2;
+
+import _ExampleQuery from "./__generated__/ExampleQuery.graphql";
+
+function SomeTopLevelView() {
+  const _graphql = 'unrelated';
+  return <View>
+      <QueryRenderer environment={RelayEnvironment} query={_graphql2 || (_graphql2 = function () {
+      return _ExampleQuery;
+    })} variables={{
+      id: '12345'
+    }} />
+    </View>;
+}
+`;
+
+exports[`matches expected output: mutation.txt 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const {graphql} = require('relay-runtime');
+
+const testMutation = graphql\`
+  mutation TestMutation($input: CommentCreateInput!) {
+    commentCreate(input: $input) {
+      __typename
+    }
+  }
+\`;
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+import _TestMutation from "./__generated__/TestMutation.graphql";
+
+const {
+  graphql
+} = require('relay-runtime');
+
+const testMutation = function () {
+  return _TestMutation;
+};
+`;
+
+exports[`matches expected output: query.txt 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const {graphql} = require('relay-runtime');
+
+const testQuery = graphql\`
+  query TestQuery {
+    __typename
+  }
+\`;
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+import _TestQuery from "./__generated__/TestQuery.graphql";
+
+const {
+  graphql
+} = require('relay-runtime');
+
+const testQuery = function () {
+  return _TestQuery;
+};
+`;
+
+exports[`matches expected output: too-many-fragments.error.txt 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ */
+
+'use strict';
+
+const RelayCompatContainer = require('RelayCompatContainer');
+const graphql = require('graphql');
+
+const CompatProfile = () => null;
+
+module.exports = RelayCompatContainer.createContainer(CompatProfile, {
+  user: graphql\`
+    fragment CompatProfile_user on User {
+      name
+    }
+
+    fragment CompatProfile_viewer on User {
+      name
+    }
+  \`,
+});
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+THROWN EXCEPTION:
+
+Error: BabelPluginRelay: Expected exactly one definition per graphql tag.
+`;
+
+exports[`matches expected output: unexpected-fragment.error.txt 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const {graphql} = require('relay-runtime');
+
+const testMutation = graphql\`
+  mutation CompatCommentCreateMutation($input: CommentCreateInput!) {
+    commentCreate(input: $input) {
+      viewer {
+        actor {
+          id
+          ...CompatProfilePic_user
+        }
+      }
+    }
+  }
+
+  fragment Whoopsie_key on User {
+    name
+  }
+\`;
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+THROWN EXCEPTION:
+
+Error: BabelPluginRelay: Expected exactly one definition per graphql tag.
+`;
+
+exports[`matches expected output: unexpected-operation.error.txt 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const {graphql} = require('relay-runtime');
+
+const testFragment = graphql\`
+  fragment CompatProfile_user on User {
+    name
+  }
+
+  query Whoopsie {
+    name
+  }
+\`;
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+THROWN EXCEPTION:
+
+Error: BabelPluginRelay: Expected exactly one definition per graphql tag.
+`;

--- a/packages/babel-plugin-relay/compileGraphQLTag.js
+++ b/packages/babel-plugin-relay/compileGraphQLTag.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const createModernNode = require('./createModernNode');
+const getTopScope = require('./getTopScope');
 
 import type {BabelState} from './BabelPluginRelay';
 import type {DocumentNode} from 'graphql';
@@ -51,26 +52,24 @@ function createAST(t, state, path, graphqlDefinition) {
   const artifactDirectory = state.opts && state.opts.artifactDirectory;
   const buildCommand =
     (state.opts && state.opts.buildCommand) || 'relay-compiler';
+  const esmodules = state.opts && state.opts.esmodules;
 
   // Fallback is 'true'
   const isDevelopment =
     (process.env.BABEL_ENV || process.env.NODE_ENV) !== 'production';
 
-  return createModernNode(t, graphqlDefinition, state, {
+  return createModernNode(t, path, graphqlDefinition, state, {
     artifactDirectory,
     buildCommand,
     isDevelopment,
     isHasteMode,
     isDevVariable,
+    esmodules,
   });
 }
 
 function replaceMemoized(t, path, ast) {
-  let topScope = path.scope;
-  while (topScope.parent) {
-    topScope = topScope.parent;
-  }
-
+  const topScope = getTopScope(path);
   if (path.scope === topScope) {
     path.replaceWith(ast);
   } else {

--- a/packages/babel-plugin-relay/getTopScope.js
+++ b/packages/babel-plugin-relay/getTopScope.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+function getTopScope(path: Object): Object {
+  let topScope = path.scope;
+  while (topScope.parent) {
+    topScope = topScope.parent;
+  }
+  return topScope;
+}
+
+module.exports = getTopScope;

--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -125,6 +125,13 @@ const options = {
       '--customScalars.URL=String)',
     type: 'object',
   },
+  esmodules: {
+    describe:
+      'Flag which changes the compiler output to use esmodule imports ' +
+      'instead of commonjs requires.',
+    type: 'boolean',
+    default: false,
+  },
 };
 
 // Load external config

--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -65,6 +65,7 @@ export type Config = {|
   persistFunction?: ?string | ?((text: string) => Promise<string>),
   artifactDirectory?: ?string,
   customScalars?: ScalarTypeMapping,
+  esmodules?: ?boolean,
 |};
 
 function buildWatchExpression(config: {
@@ -284,6 +285,7 @@ function getCodegenRunner(config: Config): CodegenRunner {
       ? path.resolve(process.cwd(), providedArtifactDirectory)
       : null;
   const generatedDirectoryName = artifactDirectory || '__generated__';
+  const esmodules = config.esmodules ?? false;
   const sourceSearchOptions = {
     extensions: inputExtensions,
     include: config.include,
@@ -329,6 +331,7 @@ function getCodegenRunner(config: Config): CodegenRunner {
         config.persistOutput,
         config.customScalars,
         persistQueryFunction,
+        esmodules,
       ),
       isGeneratedFile: (filePath: string) =>
         filePath.endsWith('.graphql.' + outputExtension) &&
@@ -363,6 +366,7 @@ function getRelayFileWriter(
   persistedQueryPath?: ?string,
   customScalars?: ScalarTypeMapping,
   persistFunction?: ?(text: string) => Promise<string>,
+  esmodules: boolean,
 ) {
   return async ({
     onlyValidate,
@@ -408,6 +412,7 @@ function getRelayFileWriter(
         typeGenerator: languagePlugin.typeGenerator,
         outputDir,
         persistQuery,
+        esmodules,
       },
       onlyValidate,
       schema,

--- a/packages/relay-compiler/codegen/RelayFileWriter.js
+++ b/packages/relay-compiler/codegen/RelayFileWriter.js
@@ -76,6 +76,7 @@ export type WriterConfig = {
   },
   printModuleDependency?: string => string,
   repersist?: boolean,
+  esmodules: boolean,
 };
 
 function compileAll({
@@ -342,6 +343,7 @@ function writeAll({
             writerConfig.extension,
             writerConfig.printModuleDependency,
             writerConfig.repersist ?? false,
+            writerConfig.esmodules,
           );
         }),
       );

--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -58,6 +58,7 @@ async function writeRelayGeneratedFile(
     moduleName: string,
   ) => string = printRequireModuleDependency,
   shouldRepersist: boolean,
+  esmodules: boolean,
 ): Promise<?GeneratedNode> {
   let generatedNode = _generatedNode;
   // Copy to const so Flow can refine.
@@ -146,6 +147,7 @@ async function writeRelayGeneratedFile(
     ),
     sourceHash,
     node: generatedNode,
+    esmodules,
   });
   codegenDir.writeFile(filename, moduleText, shouldRepersist);
   return generatedNode;

--- a/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+++ b/packages/relay-compiler/language/RelayLanguagePluginInterface.js
@@ -175,6 +175,11 @@ export type FormatModule = ({|
    * The generated node being written.
    */
   node: GeneratedNode,
+
+  /**
+   * Flag which enables esmodule import output instead of commonjs requires.
+   */
+  esmodules: boolean,
 |}) => string;
 
 /**

--- a/packages/relay-compiler/language/javascript/formatGeneratedModule.js
+++ b/packages/relay-compiler/language/javascript/formatGeneratedModule.js
@@ -12,6 +12,47 @@
 
 import type {FormatModule} from '../RelayLanguagePluginInterface';
 
+// ESModule support is achieved via a regex replacement of the require statements.
+// this is super hacky but this was the simplest solution with the current compiler
+// architecture
+const requireRegex = /require\('(.*)'\)/g;
+
+const getImportedQueryTargets = concreteText => {
+  let matches;
+  let output = [];
+  while ((matches = requireRegex.exec(concreteText))) {
+    output.push(matches[1]);
+  }
+  return output;
+};
+
+const buildModuleIdentifierMap = importPaths => {
+  const result = {};
+  importPaths.forEach(path => {
+    const identifier = path.replace(/[^a-zA-Z]/g, '_');
+    result[path] = identifier;
+  });
+  return result;
+};
+
+const printExternalQueryImports = moduleIdentifierMap => {
+  let result = [];
+  Object.keys(moduleIdentifierMap).forEach(path => {
+    const id = moduleIdentifierMap[path];
+    result.push(`import ${id} from '${path}';`);
+  });
+  return result.join('\n');
+};
+
+const replaceRequiresWithImportIdentifiers = (
+  concreteText,
+  moduleIdentifierMap,
+) => {
+  return concreteText.replace(requireRegex, (_, path) => {
+    return moduleIdentifierMap[path];
+  });
+};
+
 const formatGeneratedModule: FormatModule = ({
   moduleName,
   documentType,
@@ -20,12 +61,28 @@ const formatGeneratedModule: FormatModule = ({
   typeText,
   hash,
   sourceHash,
+  esmodules,
 }) => {
   const documentTypeImport = documentType
     ? `import type { ${documentType} } from 'relay-runtime';`
     : '';
   const docTextComment = docText ? '\n/*\n' + docText.trim() + '\n*/\n' : '';
   const hashText = hash ? `\n * ${hash}` : '';
+
+  let exportText = 'module.exports = node';
+  let topLevelQueryImport = undefined;
+  if (esmodules) {
+    const importPaths = getImportedQueryTargets(concreteText);
+    const moduleIdentifierMap = buildModuleIdentifierMap(importPaths);
+
+    exportText = 'export default node;';
+    topLevelQueryImport = printExternalQueryImports(moduleIdentifierMap);
+    concreteText = replaceRequiresWithImportIdentifiers(
+      concreteText,
+      moduleIdentifierMap,
+    );
+  }
+
   return `/**
  * ${'@'}flow${hashText}
  */
@@ -38,12 +95,12 @@ const formatGeneratedModule: FormatModule = ({
 ${documentTypeImport}
 ${typeText || ''}
 */
-
+${topLevelQueryImport || ''}
 ${docTextComment}
 const node/*: ${documentType || 'empty'}*/ = ${concreteText};
 // prettier-ignore
 (node/*: any*/).hash = '${sourceHash}';
-module.exports = node;
+${exportText}
 `;
 };
 


### PR DESCRIPTION
In order to be compatible with bundlers like rollup, which without extra configuration does not support commonjs modules, so this PR adds an `esmodules` option to both `babel-plugin-relay` and `relay-compiler` so that it can generate es modules instead of commonjs. The new config option in both packages will default to `esmodules: false` so this shouldn't (hopefully) be a breaking change.