### PR TITLE
Curry printRequireModuleDependency with extension; add relative ./ path

### DIFF
--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -24,8 +24,8 @@ import type {FormatModule} from '../language/RelayLanguagePluginInterface';
 import type CodegenDirectory from './CodegenDirectory';
 import type {GeneratedNode} from 'relay-runtime';
 
-function printRequireModuleDependency(moduleName: string): string {
-  return `require('${moduleName}')`;
+function printRequireModuleDependency(extension: string): string => string {
+  return moduleName => `require('./${moduleName + extension}')`;
 }
 
 function getConcreteType(node: GeneratedNode): string {
@@ -56,7 +56,7 @@ async function writeRelayGeneratedFile(
   extension: string,
   printModuleDependency: (
     moduleName: string,
-  ) => string = printRequireModuleDependency,
+  ) => string = printRequireModuleDependency(extension),
   shouldRepersist: boolean,
 ): Promise<?GeneratedNode> {
   let generatedNode = _generatedNode;
@@ -70,6 +70,7 @@ async function writeRelayGeneratedFile(
     platform != null && platform.length > 0
       ? moduleName + '.' + platform
       : moduleName;
+
   const filename = platformName + '.' + extension;
   const typeName = getConcreteType(generatedNode);
 


### PR DESCRIPTION
Suggested fix for https://github.com/facebook/relay/issues/2713