### PR TITLE
[easy] clean up title of QueryRenderer docs

### DIFF
--- a/docs/Modern-QueryRenderer.md
+++ b/docs/Modern-QueryRenderer.md
@@ -1,6 +1,6 @@
 ---
 id: query-renderer
-title: <QueryRenderer />
+title: QueryRenderer
 ---
 
 A `QueryRenderer` is a React Component at the root of a Relay component tree. It takes a query, fetches the given query, and uses the `render` prop to render the resulting data.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -51,7 +51,7 @@
         "title": "Persisted Queries"
       },
       "query-renderer": {
-        "title": "<QueryRenderer />"
+        "title": "QueryRenderer"
       },
       "refetch-container": {
         "title": "Refetch Container"


### PR DESCRIPTION
None of the other React pages have the `< />` wrapper and it just doesn't look clean in the side bar.