### PR TITLE
Update Modern-NetworkLayer.md

### DIFF
--- a/docs/Modern-NetworkLayer.md
+++ b/docs/Modern-NetworkLayer.md
@@ -66,7 +66,8 @@ import {
   RecordSource,
   Store,
 } from 'relay-runtime';
-import RelayQueryResponseCache from 'relay-runtime/lib/RelayQueryResponseCache';
+import { QueryResponseCache as RelayQueryResponseCache } from 'relay-runtime/lib';
+// or import RelayQueryResponseCache from 'relay-runtime/lib/network/RelayQueryResponseCache';
 
 const oneMinute = 60 * 1000;
 const cache = new RelayQueryResponseCache({ size: 250, ttl: oneMinute });


### PR DESCRIPTION
In one of my old projects, the structure of `relay-runtime/lib` is:
* *file.js*
* *file.js*
* RelayQueryResponseCache.js
* *file.js*

But with the new version (`6.0.0`) the `relay-runtime/lib` is changed to:
* folder
* folder
* network
  * RelayQueryResponseCache.js
  * *file.js*
* index.js

So the import doesn't work like the old one anymore.