### PR TITLE
[docs] Only search in current version

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -154,6 +154,9 @@ const siteConfig = {
   algolia: {
     apiKey: '3d7d5825d50ea36bca0e6ad06c926f06',
     indexName: 'relay',
+    algoliaOptions: {
+      facetFilters: ['version:VERSION']
+    }
   },
   cleanUrl: true,
   scrollToTop: true,


### PR DESCRIPTION
Prevent showing search results across all doc versions and show only relevant links

<img width="718" alt="Screenshot 2019-09-19 at 22 23 36" src="https://user-images.githubusercontent.com/18208654/65278331-3114c700-db2c-11e9-9137-3f73b851b709.png">
