### PR TITLE
Allow language plugin to specify how to generate refetchable operations module path

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -415,6 +415,7 @@ function getRelayFileWriter(
       documents,
       reporter,
       sourceControl,
+      languagePlugin,
     });
     if (queryMap != null && persistedQueryPath != null) {
       let object = {};

--- a/packages/relay-compiler/codegen/RelayCodeGenerator.js
+++ b/packages/relay-compiler/codegen/RelayCodeGenerator.js
@@ -21,6 +21,7 @@ import type {
   NormalizationSplitOperation,
   ReaderFragment,
 } from 'relay-runtime';
+import type {PluginInterface} from '../language/RelayLanguagePluginInterface';
 
 /**
  * @public
@@ -28,10 +29,22 @@ import type {
  * Converts a GraphQLIR node into a plain JS object representation that can be
  * used at runtime.
  */
-declare function generate(node: Fragment): ReaderFragment;
-declare function generate(node: Request): ConcreteRequest;
-declare function generate(node: SplitOperation): NormalizationSplitOperation;
-function generate(node: Fragment | Request | SplitOperation): any {
+declare function generate(
+  node: Fragment,
+  languagePlugin: PluginInterface,
+): ReaderFragment;
+declare function generate(
+  node: Request,
+  languagePlugin: PluginInterface,
+): ConcreteRequest;
+declare function generate(
+  node: SplitOperation,
+  languagePlugin: PluginInterface,
+): NormalizationSplitOperation;
+function generate(
+  node: Fragment | Request | SplitOperation,
+  languagePlugin: PluginInterface,
+): any {
   switch (node.kind) {
     case 'Fragment':
       if (node.metadata?.inlineData === true) {
@@ -40,11 +53,11 @@ function generate(node: Fragment | Request | SplitOperation): any {
           name: node.name,
         };
       }
-      return ReaderCodeGenerator.generate(node);
+      return ReaderCodeGenerator.generate(node, languagePlugin);
     case 'Request':
       return {
         kind: 'Request',
-        fragment: ReaderCodeGenerator.generate(node.fragment),
+        fragment: ReaderCodeGenerator.generate(node.fragment, languagePlugin),
         operation: NormalizationCodeGenerator.generate(node.root),
         params: {
           operationKind: node.root.operation,

--- a/packages/relay-compiler/codegen/__tests__/compileRelayArtifacts-test.js
+++ b/packages/relay-compiler/codegen/__tests__/compileRelayArtifacts-test.js
@@ -16,6 +16,7 @@ const CodeMarker = require('../../util/CodeMarker');
 const CompilerContext = require('../../core/GraphQLCompilerContext');
 const RelayIRTransforms = require('../../core/RelayIRTransforms');
 const RelayIRValidations = require('../../core/RelayIRValidations');
+const getLanguagePlugin = require('../../language/javascript/RelayLanguagePluginJavaScript');
 
 const compileRelayArtifacts = require('../compileRelayArtifacts');
 
@@ -47,12 +48,12 @@ describe('compileRelayArtifacts', () => {
       const compilerContext = new CompilerContext(TestSchema, schema).addAll(
         definitions,
       );
-      return compileRelayArtifacts(
-        compilerContext,
-        RelayIRTransforms,
-        undefined,
-        RelayIRValidations,
-      )
+      return compileRelayArtifacts({
+        context: compilerContext,
+        transforms: RelayIRTransforms,
+        validations: RelayIRValidations,
+        languagePlugin: getLanguagePlugin(),
+      })
         .map(([_definition, node]) => {
           if (node.kind === 'Request') {
             const {

--- a/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+++ b/packages/relay-compiler/language/RelayLanguagePluginInterface.js
@@ -35,6 +35,7 @@ export type PluginInterface = {
   findGraphQLTags: GraphQLTagFinder,
   formatModule: FormatModule,
   typeGenerator: TypeGenerator,
+  getRefetchOperationModuleImportPath?: (operationName: string) => string,
 };
 
 /**


### PR DESCRIPTION
This allows the language plugin to specify how to generate the module path for refetchable operations. It's needed for the same reason as https://github.com/facebook/relay/pull/2866 - when working with a language that does not allow `.` in module names, the language plugin needs a way to generate correct, working module names itself.

Most of the diff is due to passing the language plugin to where we need to use the new function.

Happy to hear any feedback/thoughts!