### PR TITLE
Ensure explicit Flow open object syntax works

### DIFF
--- a/packages/relay-compiler/codegen/CodegenWatcher.js
+++ b/packages/relay-compiler/codegen/CodegenWatcher.js
@@ -25,13 +25,14 @@ export type WatchmanExpression = $ReadOnlyArray<string | WatchmanExpression>;
 
 export type FileFilter = (file: File) => boolean;
 
-type WatchmanChange = {
+type WatchmanChange = {|
   name: string,
   exists: boolean,
   'content.sha1hex': ?string,
-};
+|};
 type WatchmanChanges = {
   files?: $ReadOnlyArray<WatchmanChange>,
+  ...
 };
 
 async function queryFiles(
@@ -106,7 +107,7 @@ async function queryFilepaths(
 async function watch(
   baseDir: string,
   expression: WatchmanExpression,
-  callback: (changes: WatchmanChanges) => any,
+  callback: (changes: WatchmanChanges) => mixed,
 ): Promise<void> {
   return await Profiler.waitFor('Watchman:subscribe', async () => {
     const client = new GraphQLWatchmanClient();

--- a/packages/relay-runtime/store/createRelayContext.js
+++ b/packages/relay-runtime/store/createRelayContext.js
@@ -20,6 +20,7 @@ import typeof {createContext} from 'react';
 type React = {
   createContext: createContext<RelayContext | null>,
   version: string,
+  ...
 };
 
 let relayContext: ?React$Context<RelayContext | null>;


### PR DESCRIPTION
Flow is migrating to explicitly marking open objects (with unknown additional properties) with `...`. This makes sure we can handle this in both the runtime and compiler by introducing the first usage of this syntax.