### PR TITLE
fix(metadata): fix getRefetchMetadata to handle both commonjs and es …

### DIFF
--- a/packages/relay-experimental/getRefetchMetadata.js
+++ b/packages/relay-experimental/getRefetchMetadata.js
@@ -47,7 +47,8 @@ function getRefetchMetadata(
     fragmentNode.name,
   );
 
-  const refetchableRequest = refetchMetadata.operation;
+  // handle both commonjs and es modules
+  const refetchableRequest = refetchMetadata.operation.default ? refetchMetadata.operation.default : refetchMetadata.operation;
   const fragmentRefPathInResponse = refetchMetadata.fragmentPathInResult;
   invariant(
     typeof refetchableRequest !== 'string',


### PR DESCRIPTION
…modules, fix #2874

this is the same approach of relay-compiler

we could move this to a helper function