### PR TITLE
Enable Flow types first and abstract locations

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -29,6 +29,9 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 experimental.well_formed_exports=true
+experimental.types_first=true
+experimental.abstract_locations=true
+experimental.cache_direct_dependents=true
 
 [lints]
 untyped-type-import=error


### PR DESCRIPTION
These are performance optimizations based based on strict exports.
This ensures we're compatible with these stricter settings internally.