### PR TITLE
Update RelayModern-flowtest

### DIFF
--- a/packages/react-relay/__flowtests__/RelayModern-flowtest.js
+++ b/packages/react-relay/__flowtests__/RelayModern-flowtest.js
@@ -12,7 +12,7 @@
 
 const React = require('react');
 
-const nullthrows = require('nullthrows');
+declare function nullthrows<T>(x: ?T): T;
 
 const {
   createContainer: createFragmentContainer,
@@ -206,39 +206,15 @@ declare var aComplexUserRef: {
 // $FlowExpectedError - optional, not nullable!
 <PluralTest users={usersRef} nullableUsers={null} optionalUsers={null} />;
 
-class AnyTest extends React.Component<{
+class AnyTest extends React.Component<{|
   anything: any,
-  anyFunction: Function,
-  optionalFunction?: Function,
-  maybeFunction: ?Function,
-  optionalMaybeFunction?: ?Function,
-  anyObject: Object,
-}> {}
-AnyTest = createFragmentContainer(AnyTest, {});
+|}> {}
+const AnyTestContainer = createFragmentContainer(AnyTest, {});
 
-<AnyTest
-  anything={42}
-  anyFunction={() => {}}
-  maybeFunction={null}
-  anyObject={{}}
-/>;
-<AnyTest
-  anything={42}
-  anyFunction={() => {}}
-  maybeFunction={() => {}}
-  anyObject={{}}
-/>;
-// $FlowExpectedError - optional function cannot be null
-<AnyTest
-  anything={42}
-  anyFunction={() => {}}
-  optionalFunction={() => {}}
-  anyObject={{}}
-/>;
-// $FlowExpectedError - can't pass {} for a Function
-<AnyTest
-  anything={42}
-  anyFunction={{}}
-  maybeFunction={() => {}}
-  anyObject={{}}
-/>;
+<AnyTest anything={42} />;
+<AnyTest anything={null} />;
+<AnyTest anything={() => {}} />;
+// $FlowExpectedError - any other prop can not be passed
+<AnyTest anything={null} anythingElse={42} />;
+// $FlowExpectedError - anything has to be passed
+<AnyTest />;


### PR DESCRIPTION
`Function` and `Object` used to be somewhat hybrids of functions or objects and `any`. This changed at some point and broke these flow tests and made them pointless.

Removes the test cases for those odd `any`-ish objects.

Also replaces a `require('nullthrows')` with a simple flow declaration. The type of this module doesn't properly import in OSS.

Test Plan:
flow