### PR TITLE
relay-compiler no longer exports nullthrows

### DIFF
--- a/packages/relay-compiler/index.js
+++ b/packages/relay-compiler/index.js
@@ -45,7 +45,6 @@ const formatGeneratedModule = require('./language/javascript/formatGeneratedModu
 const getIdentifierForArgumentValue = require('./core/getIdentifierForArgumentValue');
 const getLiteralArgumentValues = require('./core/getLiteralArgumentValues');
 const getNormalizationOperationName = require('./core/getNormalizationOperationName');
-const nullthrows = require('./util/nullthrowsOSS');
 const writeRelayGeneratedFile = require('./codegen/writeRelayGeneratedFile');
 
 const {main} = require('./bin/RelayCompilerMain');
@@ -139,7 +138,6 @@ module.exports = {
   getIdentifierForArgumentValue,
   getNormalizationOperationName,
   getLiteralArgumentValues,
-  nullthrows,
 
   Parser: RelayParser,
   Schema: RelaySchema,

--- a/packages/relay-compiler/util/nullthrowsOSS.js
+++ b/packages/relay-compiler/util/nullthrowsOSS.js
@@ -7,18 +7,17 @@
  * @flow strict
  * @format
  */
+
 'use strict';
 
-var nullthrows: <T>(x: ?T, message?: string) => T = function<T>(
+function nullthrows<T>(
   x: ?T,
   message?: string = 'Got unexpected null or undefined',
 ): T {
-  if (x != null) {
-    return x;
+  if (x == null) {
+    throw new Error(message);
   }
-  var error = new Error(message);
-  (error: $FlowFixMe).framesToPop = 1; // Skip nullthrows own stack frame.
-  throw error;
-};
+  return x;
+}
 
 module.exports = nullthrows;


### PR DESCRIPTION
This was a bit of an odd export that we did for some old internal reason at some point. If someone needs this functionality, they should install the `nullthrows` module from npm.