### PR TITLE
Remove Object.assign polyfill for scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "immutable": "~3.7.6",
     "jest": "^24.8.0",
     "nullthrows": "^1.1.1",
-    "object-assign": "4.1.1",
     "prettier": "1.17.0",
     "promise-polyfill": "6.1.0",
     "react": "16.9.0",

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -9,7 +9,6 @@
 
 'use strict';
 
-const assign = require('object-assign');
 const babel = require('@babel/core');
 const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
 const getBabelOptions = require('../getBabelOptions');
@@ -31,7 +30,7 @@ const babelOptions = getBabelOptions({
 
 module.exports = {
   process: function(src, filename) {
-    const options = assign({}, babelOptions, {
+    const options = Object.assign({}, babelOptions, {
       filename: filename,
       retainLines: true,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5289,15 +5289,15 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@4.1.1, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-
 object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
   integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
+
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
We only use this `object-assign` dependency for scripts. The native
`Object.assign` is supported at least since node 8 which is our minimum.

Test Plan:
Travis CI