### PR TITLE
Disable global request cache when QueryRenderer runs on a server

### DIFF
--- a/packages/react-relay/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/ReactRelayQueryRenderer.js
@@ -52,7 +52,7 @@ export type RenderProps<T> = {|
  * constructor. If a request is already in flight from a previous call to the
  * constructor, just reuse the query fetcher and wait for the response.
  */
-const requestCache = {};
+let requestCache = {};
 
 export type Props = {|
   cacheConfig?: ?CacheConfig,
@@ -103,6 +103,13 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
 
     let queryFetcher;
     let requestCacheKey;
+
+    // If there's not window, we're on the server and do not want a global
+    // request cache to persist.
+    if (typeof window !== 'object') {
+      requestCache = {};
+    }
+
     if (props.query) {
       const {query} = props;
 

--- a/packages/react-relay/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/ReactRelayQueryRenderer.js
@@ -114,7 +114,7 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
     let requestCacheKey;
 
     // When server-side rendering the global request cache should not persist.
-    if (!isBrowser) {
+    if (!isBrowser()) {
       requestCache = {};
     }
 

--- a/packages/react-relay/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/ReactRelayQueryRenderer.js
@@ -54,6 +54,15 @@ export type RenderProps<T> = {|
  */
 let requestCache = {};
 
+/**
+ * isBrowser will be true in *real* browser environments. Unfortunately,
+ * the best way to detect this in all environments is to use `new Function`.
+ * As a result, eslint needs to be disabled on this to allow for eval.
+ */
+const isBrowser = new Function( // eslint-disable-line
+  'try {return this===window;}catch(e){ return false;}',
+);
+
 export type Props = {|
   cacheConfig?: ?CacheConfig,
   fetchPolicy?: FetchPolicy,
@@ -104,9 +113,8 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
     let queryFetcher;
     let requestCacheKey;
 
-    // If there's not window, we're on the server and do not want a global
-    // request cache to persist.
-    if (typeof window !== 'object') {
+    // When server-side rendering the global request cache should not persist.
+    if (!isBrowser) {
       requestCache = {};
     }
 

--- a/packages/react-relay/ReactRelayQueryRenderer.js
+++ b/packages/react-relay/ReactRelayQueryRenderer.js
@@ -60,7 +60,7 @@ let requestCache = {};
  * As a result, eslint needs to be disabled on this to allow for eval.
  */
 const isBrowser = new Function( // eslint-disable-line
-  'try {return this===window;}catch(e){ return false;}',
+  'try { return this===window; }catch(e){ return false; }',
 );
 
 export type Props = {|
@@ -114,7 +114,12 @@ class ReactRelayQueryRenderer extends React.Component<Props, State> {
     let requestCacheKey;
 
     // When server-side rendering the global request cache should not persist.
-    if (!isBrowser()) {
+    // However, when running unit tests it should persist just as it would in
+    // the browser.
+    if (
+      !isBrowser() &&
+      (typeof process === 'object' && process.env.NODE_ENV !== 'test')
+    ) {
       requestCache = {};
     }
 

--- a/packages/relay-runtime/query/fetchQueryInternal.js
+++ b/packages/relay-runtime/query/fetchQueryInternal.js
@@ -32,7 +32,7 @@ type RequestCacheEntry = {|
   +subscription: Subscription,
 |};
 
-const requestCachesByEnvironment = new Map();
+const requestCachesByEnvironment = new WeakMap();
 
 /**
  * Fetches the given query and variables on the provided environment,


### PR DESCRIPTION
This is an immediate fix to the issue discussed here: https://github.com/facebook/relay/issues/2566