### PR TITLE
relay-runtime: fix flow type of RelayRecordSourceObjectImpl

### DIFF
--- a/packages/relay-runtime/store/RelayRecordSourceObjectImpl.js
+++ b/packages/relay-runtime/store/RelayRecordSourceObjectImpl.js
@@ -68,7 +68,7 @@ class RelayRecordSourceObjectImpl implements MutableRecordSource {
     return Object.keys(this._records).length;
   }
 
-  toJSON(): Object {
+  toJSON(): RecordMap {
     return this._records;
   }
 }


### PR DESCRIPTION
Hello good people 👋 

I would like to fix the return type of `toJSON` function as it doesn't match the rest of `RelayRecordSourceObjectImpl`