### PR TITLE
Include LICENSE in every package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -247,7 +247,6 @@ builds.forEach(build => {
     function copyLicense() {
       return gulp
         .src(['LICENSE'])
-        .pipe(once())
         .pipe(gulp.dest(path.join(DIST, build.package)));
     },
     function copyTestschema() {


### PR DESCRIPTION
The `once()` call seems to memoize that it was already copied, but this memoization caused the license to only be included in the first package we're building.

I don't think it hurts to copy the `LICENSE` on every build, so just removing the `once()` call here.