### PR TITLE
Publish master releases from CI to NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build and Tests
+    name: Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8, 10, 12]
+        node-version: [8.x, 10.x, 12.x]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 12.x
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
       - name: Test dependencies
@@ -41,8 +41,31 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 12.x
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
       - name: Flow
         run: yarn run typecheck
+
+  master-release:
+    name: Publish master tag to npm
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'master'
+    needs: [build, lint, typecheck]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+          registry-url: https://registry.npmjs.org/
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts
+      - name: Build master version
+        run:  RELEASE_COMMIT_SHA=${{github.sha}} yarn gulp masterrelease
+      - name: Publish to npm
+        run: |
+          for pkg in dist/*; do
+            npm publish "$pkg" --tag master
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Adds a GitHub action that runs only on pushes to the master branch on facebook/relay. This step pushes a build to the master tag on npm which can be installed with `yarn add relay-runtime@master` or similar.
The master releases have a version like `0.0.0-master-62d0ae50` which includes the Git commit hash for easy reference.

Test Plan:
So far, I did a few test releases to https://www.npmjs.com/package/release-test-react-relay?activeTab=versions, but to test the final code, we'll have to push this.