### PR TITLE
Docs: reformat community learning resources

### DIFF
--- a/docs/Community-LearningResources.md
+++ b/docs/Community-LearningResources.md
@@ -3,84 +3,43 @@ id: community-learning-resources
 title: Community Learning Resources
 ---
 
-## Relay Modern Learning Blog Posts Thread on Twitter
-https://twitter.com/sseraphini/status/1078595758801203202
+## Relay example projects
 
-## Relay examples - common patterns explained via code and videos
-https://github.com/kiwicom/relay-example
+These projects serve as an example of how to use Relay in real world applications. Some of them are even with educational videos.
 
-## Sample project how to use React and Relay
-https://github.com/juffalow/react-relay-example
+- https://github.com/adeira/relay-example
+- https://github.com/juffalow/react-relay-example
 
-# Basics
+## Learn basics
 
-## Relay Modern: What is a fragment?
+Here, you will find articles written by Relay community. They are touching basic topic which are necessary for your daily work.
 
-Basic explanation of what is a fragment and what it is used for
-https://medium.com/@sibelius/relay-modern-what-is-a-fragment-c70f164c2469
+- [What is a fragment? Basic explanation of what is a fragment and what it is used for](https://medium.com/@sibelius/relay-modern-what-is-a-fragment-c70f164c2469) (by @sibelius)
+- [Relay anti-patterns. What you should avoid doing when using Relay concepts](https://medium.com/entria/relay-apollo-anti-pattern-d9f4dea47738) (by Entria)
+- [Insights of how Relay Modern has improved a lot since Relay Classic](https://medium.com/entria/relay-is-just-getting-better-54112ffc1a9e) (by Entria)
+- [How to use @argumentsDefinitions to define local variables to your fragments](https://medium.com/entria/relay-modern-argumentdefinitions-d53769dbb95d) (by Entria)
+- [How to paginate using a Refetch Container. You can use a refetch container to paginate as well, just use renderVariables correctly](https://medium.com/entria/relay-modern-pagination-using-refetch-container-editing-a07c6b33ae4e) (by Entria)
 
-## Relay Modern anti-pattern
+## About Relay Store
 
-What you should avoid doing when using Relay concepts
-https://medium.com/entria/relay-apollo-anti-pattern-d9f4dea47738
+- [How Relay Modern stores your data](https://medium.com/@sibelius/relay-modern-the-relay-store-8984cd148798) (by @sibelius)
+- [Deep Dive of Updater Relay Store function. How to update your store properly after a mutation or subscription](https://medium.com/entria/wrangling-the-client-store-with-the-relay-modern-updater-function-5c32149a71ac) (by Entria)
+- [Optimistic Update: how to update your UI before server responds](https://medium.com/entria/relay-modern-optimistic-update-a09ba22d83c9) (by Entria)
+- [Local State Management, part 1 - how to create a controlled input using Relay](https://babangsund.com/relay_local_state_management/) (by @babangsund)
+- [Local State Management, part 2 - how to manage global state and localStorage persistence on the client, using Relay](https://babangsund.com/relay_local_state_management_2/) (by @babangsund)
+- [Local State Management, part 3 - using LocalQueryRenderer and local state to manage nested fragments](https://babangsund.com/relay_local_state_management_3/) (by @babangsund)
 
-## Relay Modern is just getting better
 
-Some insights of how Relay Modern has improved a lot since Relay Classic
-https://medium.com/entria/relay-is-just-getting-better-54112ffc1a9e
 
-## Relay Modern: @argumentDefinitions
+## Network Layer
 
-How to use @argumentsDefinitions to define local variables to your fragments
-https://medium.com/entria/relay-modern-argumentdefinitions-d53769dbb95d
+- [Relay Network Deep Dive - how to incrementally improve your network layer to manage complex data fetching requirements](https://medium.com/entria/relay-modern-network-deep-dive-ec187629dfd3) (by Entria)
 
-## Relay Modern: How to paginate using a Refetch Container
+## Relay Configuration
 
-You can use a refetch container to paginate as well, just use renderVariables correctly
-https://medium.com/entria/relay-modern-pagination-using-refetch-container-editing-a07c6b33ae4e
+- [Relay Modern with TypeScript - how to configure Relay Modern to make it with TypeScript](https://medium.com/@sibelius/relay-modern-migration-to-typescript-c26ab0ee749c) (by @sibelius)
 
-# Relay Store
+## Miscellaneous
 
-## Relay Modern: the Relay Store
-
-How Relay Modern stores your data
-https://medium.com/@sibelius/relay-modern-the-relay-store-8984cd148798
-
-## Relay Modern: Deep Dive of Updater Relay Store function
-
-How to update your store properly after a mutation or subscription
-https://medium.com/entria/wrangling-the-client-store-with-the-relay-modern-updater-function-5c32149a71ac
-
-## Relay Modern: Optimistic Update
-
-How to update your UI before server responds.
-https://medium.com/entria/relay-modern-optimistic-update-a09ba22d83c9
-
-## Relay Modern: Local State Management, part 1
-
-How to create a controlled input using Relay.
-https://babangsund.com/relay_local_state_management/
-
-## Relay Modern: Local State Management, part 2
-
-How to manage global state and localStorage persistence on the client, using Relay.
-https://babangsund.com/relay_local_state_management_2/
-
-## Relay Modern: Local State Management, part 3
-
-Using LocalQueryRenderer and local state to manage nested fragments.
-https://babangsund.com/relay_local_state_management_3/
-
-# Network Layer
-
-## Relay Modern: Network Deep Dive
-
-How to incrementally improve your network layer to manage complex data fetching requirements
-https://medium.com/entria/relay-modern-network-deep-dive-ec187629dfd3
-
-# Configuration
-
-## Relay Modern with TypeScript
-
-How to configure Relay Modern to make it with TypeScript
-https://medium.com/@sibelius/relay-modern-migration-to-typescript-c26ab0ee749c
+- [Relay Modern Learning Blog Posts Thread on Twitter](https://twitter.com/sseraphini/status/1078595758801203202)
+- [Collection of random thoughts and discoveries around Relay](https://mrtnzlml.com/docs/relay)

--- a/website/versioned_docs/version-v7.0.0/Community-LearningResources.md
+++ b/website/versioned_docs/version-v7.0.0/Community-LearningResources.md
@@ -4,84 +4,43 @@ title: Community Learning Resources
 original_id: community-learning-resources
 ---
 
-## Relay Modern Learning Blog Posts Thread on Twitter
-https://twitter.com/sseraphini/status/1078595758801203202
+## Relay example projects
 
-## Relay examples - common patterns explained via code and videos
-https://github.com/kiwicom/relay-example
+These projects serve as an example of how to use Relay in real world applications. Some of them are even with educational videos.
 
-## Sample project how to use React and Relay
-https://github.com/juffalow/react-relay-example
+- https://github.com/adeira/relay-example
+- https://github.com/juffalow/react-relay-example
 
-# Basics
+## Learn basics
 
-## Relay Modern: What is a fragment?
+Here, you will find articles written by Relay community. They are touching basic topic which are necessary for your daily work.
 
-Basic explanation of what is a fragment and what it is used for
-https://medium.com/@sibelius/relay-modern-what-is-a-fragment-c70f164c2469
+- [What is a fragment? Basic explanation of what is a fragment and what it is used for](https://medium.com/@sibelius/relay-modern-what-is-a-fragment-c70f164c2469) (by @sibelius)
+- [Relay anti-patterns. What you should avoid doing when using Relay concepts](https://medium.com/entria/relay-apollo-anti-pattern-d9f4dea47738) (by Entria)
+- [Insights of how Relay Modern has improved a lot since Relay Classic](https://medium.com/entria/relay-is-just-getting-better-54112ffc1a9e) (by Entria)
+- [How to use @argumentsDefinitions to define local variables to your fragments](https://medium.com/entria/relay-modern-argumentdefinitions-d53769dbb95d) (by Entria)
+- [How to paginate using a Refetch Container. You can use a refetch container to paginate as well, just use renderVariables correctly](https://medium.com/entria/relay-modern-pagination-using-refetch-container-editing-a07c6b33ae4e) (by Entria)
 
-## Relay Modern anti-pattern
+## About Relay Store
 
-What you should avoid doing when using Relay concepts
-https://medium.com/entria/relay-apollo-anti-pattern-d9f4dea47738
+- [How Relay Modern stores your data](https://medium.com/@sibelius/relay-modern-the-relay-store-8984cd148798) (by @sibelius)
+- [Deep Dive of Updater Relay Store function. How to update your store properly after a mutation or subscription](https://medium.com/entria/wrangling-the-client-store-with-the-relay-modern-updater-function-5c32149a71ac) (by Entria)
+- [Optimistic Update: how to update your UI before server responds](https://medium.com/entria/relay-modern-optimistic-update-a09ba22d83c9) (by Entria)
+- [Local State Management, part 1 - how to create a controlled input using Relay](https://babangsund.com/relay_local_state_management/) (by @babangsund)
+- [Local State Management, part 2 - how to manage global state and localStorage persistence on the client, using Relay](https://babangsund.com/relay_local_state_management_2/) (by @babangsund)
+- [Local State Management, part 3 - using LocalQueryRenderer and local state to manage nested fragments](https://babangsund.com/relay_local_state_management_3/) (by @babangsund)
 
-## Relay Modern is just getting better
 
-Some insights of how Relay Modern has improved a lot since Relay Classic
-https://medium.com/entria/relay-is-just-getting-better-54112ffc1a9e
 
-## Relay Modern: @argumentDefinitions
+## Network Layer
 
-How to use @argumentsDefinitions to define local variables to your fragments
-https://medium.com/entria/relay-modern-argumentdefinitions-d53769dbb95d
+- [Relay Network Deep Dive - how to incrementally improve your network layer to manage complex data fetching requirements](https://medium.com/entria/relay-modern-network-deep-dive-ec187629dfd3) (by Entria)
 
-## Relay Modern: How to paginate using a Refetch Container
+## Relay Configuration
 
-You can use a refetch container to paginate as well, just use renderVariables correctly
-https://medium.com/entria/relay-modern-pagination-using-refetch-container-editing-a07c6b33ae4e
+- [Relay Modern with TypeScript - how to configure Relay Modern to make it with TypeScript](https://medium.com/@sibelius/relay-modern-migration-to-typescript-c26ab0ee749c) (by @sibelius)
 
-# Relay Store
+## Miscellaneous
 
-## Relay Modern: the Relay Store
-
-How Relay Modern stores your data
-https://medium.com/@sibelius/relay-modern-the-relay-store-8984cd148798
-
-## Relay Modern: Deep Dive of Updater Relay Store function
-
-How to update your store properly after a mutation or subscription
-https://medium.com/entria/wrangling-the-client-store-with-the-relay-modern-updater-function-5c32149a71ac
-
-## Relay Modern: Optimistic Update
-
-How to update your UI before server responds.
-https://medium.com/entria/relay-modern-optimistic-update-a09ba22d83c9
-
-## Relay Modern: Local State Management, part 1
-
-How to create a controlled input using Relay.
-https://babangsund.com/relay_local_state_management/
-
-## Relay Modern: Local State Management, part 2
-
-How to manage global state and localStorage persistence on the client, using Relay.
-https://babangsund.com/relay_local_state_management_2/
-
-## Relay Modern: Local State Management, part 3
-
-Using LocalQueryRenderer and local state to manage nested fragments.
-https://babangsund.com/relay_local_state_management_3/
-
-# Network Layer
-
-## Relay Modern: Network Deep Dive
-
-How to incrementally improve your network layer to manage complex data fetching requirements
-https://medium.com/entria/relay-modern-network-deep-dive-ec187629dfd3
-
-# Configuration
-
-## Relay Modern with TypeScript
-
-How to configure Relay Modern to make it with TypeScript
-https://medium.com/@sibelius/relay-modern-migration-to-typescript-c26ab0ee749c
+- [Relay Modern Learning Blog Posts Thread on Twitter](https://twitter.com/sseraphini/status/1078595758801203202)
+- [Collection of random thoughts and discoveries around Relay](https://mrtnzlml.com/docs/relay)


### PR DESCRIPTION
This is my attempt to fix the Community Learning Resources page which was a bit messy. I also updated our old kiwicom/relay-example link which was moved under Aderia GH organization as well as added my personal living document about Relay into miscellaneous.

Before: https://relay.dev/docs/en/community-learning-resources

After:

<img width="1583" alt="Screenshot 2019-10-22 at 22 12 25" src="https://user-images.githubusercontent.com/978368/67354003-9ee05400-f519-11e9-996c-d9bba10faf03.png">
