### PR TITLE
Compiler: fix validation of required fields with default values

### DIFF
--- a/packages/relay-compiler/transforms/ValidateRequiredArgumentsTransform.js
+++ b/packages/relay-compiler/transforms/ValidateRequiredArgumentsTransform.js
@@ -110,7 +110,11 @@ function validateRequiredArgumentsOnNode(
 ): void {
   const nodeArgsSet = new Set(node.args.map(arg => arg.name));
   for (const arg of definitionArgs) {
-    if (schema.isNonNull(arg.type) && !nodeArgsSet.has(arg.name)) {
+    if (
+      arg.defaultValue == null &&
+      schema.isNonNull(arg.type) &&
+      !nodeArgsSet.has(arg.name)
+    ) {
       throw createUserError(
         `Required argument '${arg.name}: ${schema.getTypeString(arg.type)}' ` +
           `is missing on '${node.name}' in '${rootNode.name}'.`,

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/ValidateRequiredArgumentsTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/ValidateRequiredArgumentsTransform-test.js.snap
@@ -89,6 +89,21 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 PASSED
 `;
 
+exports[`validateRelayRequiredArguments-test matches expected output: default-argument-on-field.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query TestQuery {
+  node {
+    hometown {
+      a: nameWithDefaultArgs
+      b: nameWithDefaultArgs(capitalize: true)
+    }
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+PASSED
+`;
+
 exports[`validateRelayRequiredArguments-test matches expected output: missing-argument-on-directive.invalid.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 # expected-to-throw

--- a/packages/relay-compiler/transforms/__tests__/fixtures/required-arguments/default-argument-on-field.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/required-arguments/default-argument-on-field.graphql
@@ -1,0 +1,8 @@
+query TestQuery {
+  node {
+    hometown {
+      a: nameWithDefaultArgs
+      b: nameWithDefaultArgs(capitalize: true)
+    }
+  }
+}

--- a/packages/relay-test-utils-internal/testschema.graphql
+++ b/packages/relay-test-utils-internal/testschema.graphql
@@ -608,6 +608,7 @@ type Page implements Node & Actor {
   username: String
   viewerSavedState: String
   nameWithArgs(capitalize: Boolean!): String
+  nameWithDefaultArgs(capitalize: Boolean! = false): String
 }
 
 type PageInfo {


### PR DESCRIPTION
Previously, Relay Compiler threw an error incorrectly on fields with required values AND default values defined in the schema. This change takes the default values into account so that you don't have to specify them in the operation/fragment definition.

Closes: https://github.com/facebook/relay/issues/2894