### PR TITLE
Update community maintained list of users link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We actively welcome pull requests, learn how to [contribute](./.github/CONTRIBUT
 
 ## Users
 
-We have a [community-maintained list](./USERS.md) of people and projects using Relay in production.
+We have a [community-maintained list](https://relay.dev/en/users) of people and projects using Relay in production.
 
 ## License
 


### PR DESCRIPTION
We removed the USERS.md in favor of the list in the website, this
updates the stale link in the README.md.

Closes #2896

Thanks @davegoldblatt for noticing!