### PR TITLE
Fixed typos on relay experimental package

### DIFF
--- a/packages/relay-experimental/__tests__/getPaginationVariables-test.js
+++ b/packages/relay-experimental/__tests__/getPaginationVariables-test.js
@@ -31,7 +31,7 @@ describe('getPaginationVariables', () => {
           {forward: null, backward: null, path: []},
         ),
       ).toThrowError(
-        /^Relay: Expected forward pagination metadata to be avialable/,
+        /^Relay: Expected forward pagination metadata to be available/,
       );
 
       // Assert output when forward metadata is malformed
@@ -45,7 +45,7 @@ describe('getPaginationVariables', () => {
           {forward: {count: null, cursor: 'after'}, backward: null, path: []},
         ),
       ).toThrowError(
-        /^Relay: Expected forward pagination metadata to be avialable/,
+        /^Relay: Expected forward pagination metadata to be available/,
       );
     });
 
@@ -156,7 +156,7 @@ describe('getPaginationVariables', () => {
           {forward: null, backward: null, path: []},
         ),
       ).toThrowError(
-        /^Relay: Expected backward pagination metadata to be avialable/,
+        /^Relay: Expected backward pagination metadata to be available/,
       );
 
       // Assert output when forward metadata is malformed
@@ -170,7 +170,7 @@ describe('getPaginationVariables', () => {
           {forward: null, backward: {count: null, cursor: 'before'}, path: []},
         ),
       ).toThrowError(
-        /^Relay: Expected backward pagination metadata to be avialable/,
+        /^Relay: Expected backward pagination metadata to be available/,
       );
     });
 

--- a/packages/relay-experimental/__tests__/useBlockingPaginationFragment-test.js
+++ b/packages/relay-experimental/__tests__/useBlockingPaginationFragment-test.js
@@ -3150,7 +3150,7 @@ describe('useBlockingPaginationFragment', () => {
         ]);
       });
 
-      it('updates after pagination if more results are avialable', () => {
+      it('updates after pagination if more results are available', () => {
         const callback = jest.fn();
         const renderer = renderFragment();
         expectFragmentResults([
@@ -3255,7 +3255,7 @@ describe('useBlockingPaginationFragment', () => {
         expect(callback).toBeCalledTimes(1);
       });
 
-      it('updates after pagination if no more results are avialable', () => {
+      it('updates after pagination if no more results are available', () => {
         const callback = jest.fn();
         const renderer = renderFragment();
         expectFragmentResults([

--- a/packages/relay-experimental/__tests__/useLegacyPaginationFragment-test.js
+++ b/packages/relay-experimental/__tests__/useLegacyPaginationFragment-test.js
@@ -2551,7 +2551,7 @@ describe('useLegacyPaginationFragment', () => {
         ]);
       });
 
-      it('updates after pagination if more results are avialable', () => {
+      it('updates after pagination if more results are available', () => {
         const callback = jest.fn();
         const renderer = renderFragment();
         expectFragmentResults([
@@ -2670,7 +2670,7 @@ describe('useLegacyPaginationFragment', () => {
         expect(callback).toBeCalledTimes(1);
       });
 
-      it('updates after pagination if no more results are avialable', () => {
+      it('updates after pagination if no more results are available', () => {
         const callback = jest.fn();
         const renderer = renderFragment();
         expectFragmentResults([

--- a/packages/relay-experimental/getPaginationVariables.js
+++ b/packages/relay-experimental/getPaginationVariables.js
@@ -33,7 +33,7 @@ function getPaginationVariables(
       backwardMetadata != null &&
         backwardMetadata.count != null &&
         backwardMetadata.cursor != null,
-      'Relay: Expected backward pagination metadata to be avialable. ' +
+      'Relay: Expected backward pagination metadata to be available. ' +
         "If you're seeing this, this is likely a bug in Relay.",
     );
     const paginationVariables = {
@@ -54,7 +54,7 @@ function getPaginationVariables(
     forwardMetadata != null &&
       forwardMetadata.count != null &&
       forwardMetadata.cursor != null,
-    'Relay: Expected forward pagination metadata to be avialable. ' +
+    'Relay: Expected forward pagination metadata to be available. ' +
       "If you're seeing this, this is likely a bug in Relay.",
   );
   const paginationVariables = {


### PR DESCRIPTION
While studying these packages found some typos.... I think it's very minor, but the less broken windows the better