### PR TITLE
Fix typo in Modern-LocalStateManagement.md

### DIFF
--- a/docs/Modern-LocalStateManagement.md
+++ b/docs/Modern-LocalStateManagement.md
@@ -13,7 +13,7 @@ Table of Contents:
 - [Mutating local state](#mutating-local-state)
 - [Initial local state](#initial-local-state)
 
-## Extending the client schema
+## Extending the server schema
 
 To extend the server schema, create a new `.graphql` file inside your `--src` directory.  
 Let's call it `./src/clientSchema.graphql`.


### PR DESCRIPTION
In the docs:

![image](https://user-images.githubusercontent.com/2091902/68068478-924bcf00-fd55-11e9-913f-f6de0f8b8a95.png)
