### PR TITLE
Allow non-nullable Viewer field in ViewerQueryGenerator

### DIFF
--- a/packages/relay-compiler/transforms/query-generators/ViewerQueryGenerator.js
+++ b/packages/relay-compiler/transforms/query-generators/ViewerQueryGenerator.js
@@ -37,12 +37,13 @@ function buildRefetchOperation(
   const viewerField = schema.getFieldConfig(
     schema.expectField(queryType, VIEWER_FIELD_NAME),
   );
+  const viewerFieldType = schema.getNullableType(viewerField.type);
   if (
     !(
       viewerType &&
       schema.isObject(viewerType) &&
-      schema.isObject(viewerField.type) &&
-      schema.areEqualTypes(viewerField.type, viewerType) &&
+      schema.isObject(viewerFieldType) &&
+      schema.areEqualTypes(viewerFieldType, viewerType) &&
       viewerField.args.length === 0 &&
       schema.areEqualTypes(fragment.type, viewerType)
     )
@@ -78,7 +79,7 @@ function buildRefetchOperation(
           metadata: null,
           name: VIEWER_FIELD_NAME,
           selections: [buildFragmentSpread(fragment)],
-          type: schema.assertLinkedFieldType(viewerType),
+          type: schema.assertLinkedFieldType(viewerField.type),
         },
       ],
       type: queryType,


### PR DESCRIPTION
This adds support for non-nullable `Viewer` field by using `getNullableType` before using the type of the viewer field.

Also make sure that when generating the refetch operation we use the actual type of the field (`viewerField.type` instead of `viewerType`) to ensure nullability matches the one in the schema.