### PR TITLE
Fallback to non watch mode instead of crashing

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -232,7 +232,10 @@ async function getWatchConfig(config: Config): Promise<Config> {
 
   if (config.watch) {
     if (!watchman) {
-      throw new Error('Watchman is required to watch for changes.');
+      console.error(
+        'Watchman is required to watch for changes. Running with watch mode disabled.',
+      );
+      return {...config, watch: false, watchman: false};
     }
     if (!module.exports.hasWatchmanRootFile(config.src)) {
       throw new Error(

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -170,10 +170,19 @@ describe('RelayCompilerMain', () => {
       expect(result.watchman).toEqual(false);
     });
 
-    it('throws when enabling watch mode but disabling watchman', async () => {
-      await expect(
-        getWatchConfig({...config, watch: true, watchman: false}),
-      ).rejects.toThrowError(/watchman is required/i);
+    it('logs when enabling watch mode but disabling watchman', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const watchConfig = await getWatchConfig({
+        ...config,
+        watch: true,
+        watchman: false,
+      });
+      expect(spy).toBeCalledTimes(1);
+      expect(spy.mock.calls[0][0]).toBe(
+        'Watchman is required to watch for changes. Running with watch mode disabled.',
+      );
+      expect(watchConfig.watch).toBe(false);
+      expect(watchConfig.watchman).toBe(false);
     });
 
     it('throws when enabling watch mode but not having a watchman root file', async () => {
@@ -186,11 +195,20 @@ describe('RelayCompilerMain', () => {
       spy.mockRestore();
     });
 
-    it('throws when enabling watch mode but watchman not being available', async () => {
+    it('logs when enabling watch mode but watchman is not available', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
       isWatchmanAvailable.mockImplementationOnce(() => Promise.resolve(false));
-      await expect(
-        getWatchConfig({...config, watch: true, watchman: true}),
-      ).rejects.toThrowError(/watchman is required/i);
+      const watchConfig = await getWatchConfig({
+        ...config,
+        watch: true,
+        watchman: true,
+      });
+      expect(spy).toBeCalledTimes(2);
+      expect(spy.mock.calls[0][0]).toBe(
+        'Watchman is required to watch for changes. Running with watch mode disabled.',
+      );
+      expect(watchConfig.watch).toBe(false);
+      expect(watchConfig.watchman).toBe(false);
     });
 
     describe('watch mode hint', () => {


### PR DESCRIPTION
Changes the compiler to not error if `--watch` is passed and watchman is not installed. It's convenient for things like the example app to just be able to call the compiler with `--watch` and not crash if the user happens to not have watchman installed.