### PR TITLE
Fix typo in RelayHooks-ApiReference.md

### DIFF
--- a/website/versioned_docs/version-experimental/RelayHooks-ApiReference.md
+++ b/website/versioned_docs/version-experimental/RelayHooks-ApiReference.md
@@ -626,5 +626,5 @@ fetchQuery<AppQuery>(
 
 #### Behavior
 
-* `fetchQuery` will automatically save th fetched data to the in-memory Relay store, and notify any components subscribed to the relevant data.
+* `fetchQuery` will automatically save the fetched data to the in-memory Relay store, and notify any components subscribed to the relevant data.
 * `fetchQuery` will ***NOT*** retain the data for the query, meaning that it is not guaranteed that the data will remain saved in the Relay store at any point after the request completes. If you wish to make sure that the data is retained outside of the scope of the request, you need to call `environment.retain()` directly on the query to ensure it doesn't get deleted. See our section on [Controlling Relay's GC Policy](a-guided-tour-of-relay/#controlling-relays-garbage-collection-policy) for more details.


### PR DESCRIPTION
see also: https://github.com/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee