### PR TITLE
[docs] Logo on website is overlapping page title fix

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -4,3 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+ @media only screen and (max-width: 1500px) {
+    .homeContainer .homeWrapper .projectLogo {
+        padding: 2em 0px 4em;
+    }
+}


### PR DESCRIPTION
This PR is to resolve issue [#2788](https://github.com/facebook/relay/issues/2788).

Added media query to fix issue where the project logo will overlap the title text on 1400px wide screens.