### PR TITLE
Allow language plugin to add schema extensions.

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -32,7 +32,7 @@ const {
   fragmentTransforms,
   printTransforms,
   queryTransforms,
-  schemaExtensions,
+  schemaExtensions: relaySchemaExtensions,
 } = RelayIRTransforms;
 
 import type {ScalarTypeMapping} from '../language/javascript/RelayFlowTypeTransformers';
@@ -290,6 +290,9 @@ function getCodegenRunner(config: Config): CodegenRunner {
     include: config.include,
     exclude: [path.relative(config.src, config.schema)].concat(config.exclude),
   };
+  const schemaExtensions = languagePlugin.schemaExtensions
+    ? [...languagePlugin.schemaExtensions, ...relaySchemaExtensions]
+    : relaySchemaExtensions;
   const parserConfigs = {
     [sourceParserName]: {
       baseDir: config.src,
@@ -386,6 +389,9 @@ function getRelayFileWriter(
         return id;
       };
     }
+    const schemaExtensions = languagePlugin.schemaExtensions
+      ? [...languagePlugin.schemaExtensions, ...relaySchemaExtensions]
+      : relaySchemaExtensions;
     const results = await RelayFileWriter.writeAll({
       config: {
         baseDir,

--- a/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+++ b/packages/relay-compiler/language/RelayLanguagePluginInterface.js
@@ -36,6 +36,7 @@ export type PluginInterface = {
   findGraphQLTags: GraphQLTagFinder,
   formatModule: FormatModule,
   typeGenerator: TypeGenerator,
+  schemaExtensions?: $ReadOnlyArray<string>,
 };
 
 /**


### PR DESCRIPTION
This allows the language plugin to add schema extensions to the compiler. It's allowed to add its own transforms as of now, but there's no way of adding schema extensions in addition to the transforms as of now. This diff fixes that.