### PR TITLE
feat data store abstraction & configuration

### DIFF
--- a/packages/relay-runtime/store/RelayMapStoreSource.js
+++ b/packages/relay-runtime/store/RelayMapStoreSource.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// flowlint ambiguous-object-type:error
+
+'use strict';
+
+import type {DataID} from '../util/RelayRuntimeTypes';
+import type {StoreSource} from './RelayStoreTypes';
+
+/**
+ * An implementation of the `StoreSource` interface (defined in
+ * `RelayStoreTypes`) that holds all records in memory (JS Map).
+ */
+class RelayMapStoreSource<I, T> implements StoreSource<I, T> {
+  _stores: Map<I, ?T>;
+
+  constructor() {
+    this._stores = new Map();
+  }
+
+  clear(): void {
+    this._stores = new Map();
+  }
+
+  delete(id: I): void {
+    this._stores.set(id, null);
+  }
+
+  get(id: I): ?T {
+    return this._stores.get(id);
+  }
+
+  getAllKeys(): Array<I> {
+    return Array.from(this._stores.keys());
+  }
+
+  has(id: I): boolean {
+    return this._stores.has(id);
+  }
+
+  remove(id: I): void {
+    this._stores.delete(id);
+  }
+
+  set(id: I, record: T): void {
+    this._stores.set(id, record);
+  }
+}
+
+module.exports = RelayMapStoreSource;

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -187,6 +187,19 @@ export interface FragmentSpecResolver {
 }
 
 /**
+ * A read-only interface for accessing cached store data.
+ */
+export interface StoreSource<I, T> {
+  clear(): void;
+  delete(id: I): void;
+  get(id: I): ?T;
+  getAllKeys(): Array<I>;
+  has(id: I): boolean;
+  remove(id: I): void;
+  set(id: I, record: T): void;
+}
+
+/**
  * A read-only interface for accessing cached graph data.
  */
 export interface RecordSource {


### PR DESCRIPTION
This PR allows you to manage the data that guarantees the consistency of the store in a similar way to how the source records are managed.

https://github.com/facebook/relay/issues/2829

its example of how this configuration can be used is given by the library is [wora/cache-persist](https://morrys.github.io/wora/docs/cache-persist.html) used in [react-relay-offline](https://github.com/morrys/react-relay-offline) to manage persistence and offline capabilities.

In short, `wora/cache-persist` is an object that allows you to manage interfacing with storage (localStorage, sessionStorage, indexedDB, AsyncStorage & any custom storage) in "synchronous" mode.
This result is achieved by combining:
 * the initial **restore** of data persisted in an inmemory object (this is asynchronous but a reconciliation is made between the initial state and the persisted state)
 * after restore, **data is read and written synchronously in the inmemory object** (optimizes performance)
 * each mutation of the object in memory is inserted in a **queue** managed asynchronously (the storage update interval is configurable, throttle default 500ms)
 * at the end of the interval a **merge** of the mutations is made in order to avoid repeated writing
 * the writes are grouped and the **multiSet** function of the storage is invoked (better performance if this function is natively implemented as for asyncstorage)
 * removals are grouped and the storage **multiRemove** function is invoked (better performance if this function is natively implemented as for asyncstorage)