### PR TITLE
Make code examples on home page usable on codepen immediate after copy and paste

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -139,8 +139,10 @@ class Index extends React.Component {
                     {`
 import React from "react"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import environment from "./lib/createRelayEnvironment"
+import environment from "./lib/createRelayEnvironment" // Environment must fetch from an API that is public
 import ArtistHeader from “./ArtistHeader” // Below
+
+// The above must be requires via unpkg or similar ^
 
 // You can usually have use one query renderer per page
 // and it represents the root of a query


### PR DESCRIPTION
The code examples on the home page should be copy and pastable to codepen and be easily triable

This is why the imports must be made from a website or unpkg and the graphql api endpoint must be public

It's also important to slow down the copy and paste process some how, so that the serotonin release when seeing this for the first time is delayed

That's why I recommend to make it impossible to copy and paste the code examples on the home page via OS functionality

The copy button for every "file" should have a cooldown of 3 seconds or similar