### PR TITLE
Docs: Remove link to nonexistent RelayValidator

### DIFF
--- a/packages/relay-compiler/README.md
+++ b/packages/relay-compiler/README.md
@@ -16,8 +16,6 @@ You can build your own version of the Compiler by adding your own `FileWriter`, 
 
 * You can add additional `IRTransforms` by extending the basic [`RelayIRTransforms`](./core/RelayIRTransforms.js).
 
-* Similarly, you can add additional validation rules by extending [`RelayValidator`](./core/RelayValidator.js).
-
 * A sample `FileWriter` can be found [HERE](./codegen/RelayFileWriter.js).
 
 To actually run your compiler, you will also need a script to assemble all the above components. A sample file can be found [HERE](./bin/RelayCompilerBin.js).


### PR DESCRIPTION
Link doesn't work, `RelayValidator` was removed here: https://github.com/facebook/relay/commit/15e8d2201fdad47596e1acfb3a5daa3fb7511a8e