### PR TITLE
Remove node 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
     env: TEST=1
   - node_js: '10'
     env: TEST=1
-  - node_js: '8'
-    env: TEST=1
   - node_js: '12'
     env: TYPECHECK=1
   - node_js: '12'


### PR DESCRIPTION
Node 8 is out of maintenance, let's remove it from the CI matrix.

`graphql-js` also no longer supports it: https://github.com/graphql/graphql-js/blob/a6c50deb671ba4197d6370dcca8a717a24d93435/package.json#L24

See: https://nodejs.org/en/about/releases/

Test Plan:
CI