### PR TITLE
Docs: Remove excess curly brace on "GraphQL in Relay" page

### DIFF
--- a/docs/Modern-GraphQLInRelay.md
+++ b/docs/Modern-GraphQLInRelay.md
@@ -80,7 +80,7 @@ fragment TodoItems_items on TodoItem @relay(plural: true) {
   text
 }`;
 
-// Plural fragment usage: note the parent type is a list of items (`[TodoItem}]`)
+// Plural fragment usage: note the parent type is a list of items (`TodoItem[]`)
 fragment TodoApp_app on App {
   items {
     // parent type is a list here


### PR DESCRIPTION
I removed the excess opening curly brace. I also moved the opening square bracket, so that it becomes a valid TypeScript type with which readers are likely more familiar with