### PR TITLE
Relay Compiler: use strict CLI validation

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -144,6 +144,7 @@ const argv = yargs
   // Apply externally loaded config through the yargs API so that we can leverage yargs' defaults and have them show up
   // in the help banner.
   .config(config)
+  .strict()
   .help().argv;
 
 // Start the application


### PR DESCRIPTION
This will prevent calling Relay Compiler with unsupported arguments (`relay-compiler --unknown`). See: http://yargs.js.org/docs/#api-strictenabledtrue