### PR TITLE
Relay Compiler: setup external config conditionally

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const yargs = require('yargs');
+const _yargs = require('yargs');
 
 const {main} = require('./RelayCompilerMain');
 
@@ -130,22 +130,25 @@ const options = {
   },
 };
 
-// Load external config
-const config = RelayConfig && RelayConfig.loadConfig();
-
 // Parse CLI args
-const argv = yargs
+let yargs = _yargs
   .usage(
     'Create Relay generated files\n\n' +
       '$0 --schema <path> --src <path> [--watch]',
   )
-  // $FlowFixMe - TODO @alloy (OSS): Fix non-existent 'object' type for parsing customScalars config
   .options(options)
+  .strict();
+
+// Load external config
+const config = RelayConfig && RelayConfig.loadConfig();
+if (config) {
   // Apply externally loaded config through the yargs API so that we can leverage yargs' defaults and have them show up
-  // in the help banner.
-  .config(config)
-  .strict()
-  .help().argv;
+  // in the help banner. We add it conditionally otherwise yargs would add new option `--config` which is confusing for
+  // Relay users (it's not Relay Config file).
+  yargs = yargs.config(config);
+}
+
+const argv = yargs.help().argv;
 
 // Start the application
 main(argv).catch(error => {


### PR DESCRIPTION
Relay Config package doesn't exist in every project which results in `yargs.config(undefined)` call. Unfortunately, yargs adds a new `--config` option for these cases. However, this option is not specified by Relay Compiler so it confuses people. I am not sure if it's a bug or feature though because technically it's fine as well. I'd argue that it's better to hide it and expose it manually (when needed) because now it's sometimes available and sometimes not.