### PR TITLE
Update type to match with example of query

### DIFF
--- a/docs/Modern-LocalStateManagement.md
+++ b/docs/Modern-LocalStateManagement.md
@@ -25,7 +25,7 @@ For example, we can create a new type called `Note`:
 
 ```graphql
 type Note {
-  ID: ID!
+  id: ID!
   title: String
   body: String
 }


### PR DESCRIPTION
Changed attribute "ID: ID!" into "id: ID!" to match with queries where id attribute is in lowercase.