### PR TITLE
feat: WeakMap when environments are referenced

### DIFF
--- a/packages/relay-experimental/FragmentResource.js
+++ b/packages/relay-experimental/FragmentResource.js
@@ -437,7 +437,7 @@ function createFragmentResource(environment: IEnvironment): FragmentResource {
   return new FragmentResourceImpl(environment);
 }
 
-const dataResources: Map<IEnvironment, FragmentResource> = new Map();
+const dataResources: WeakMap<IEnvironment, FragmentResource> = new WeakMap();
 function getFragmentResourceForEnvironment(
   environment: IEnvironment,
 ): FragmentResourceImpl {

--- a/packages/relay-experimental/FragmentResource.js
+++ b/packages/relay-experimental/FragmentResource.js
@@ -42,6 +42,12 @@ type FragmentResourceCache = Cache<
   Error | Promise<mixed> | SingularOrPluralSnapshot,
 >;
 
+const WEAKMAP_SUPPORTED = typeof WeakMap === 'function';
+interface IMap<K, V> {
+  get(key: K): V | void;
+  set(key: K, value: V): IMap<K, V>;
+}
+
 type SingularOrPluralSnapshot = Snapshot | $ReadOnlyArray<Snapshot>;
 opaque type FragmentResult: {data: mixed, ...} = {|
   cacheKey: string,
@@ -437,7 +443,10 @@ function createFragmentResource(environment: IEnvironment): FragmentResource {
   return new FragmentResourceImpl(environment);
 }
 
-const dataResources: WeakMap<IEnvironment, FragmentResource> = new WeakMap();
+const dataResources: IMap<IEnvironment, FragmentResource> = WEAKMAP_SUPPORTED
+  ? new WeakMap()
+  : new Map();
+
 function getFragmentResourceForEnvironment(
   environment: IEnvironment,
 ): FragmentResourceImpl {

--- a/packages/relay-experimental/QueryResource.js
+++ b/packages/relay-experimental/QueryResource.js
@@ -527,7 +527,7 @@ function createQueryResource(environment: IEnvironment): QueryResource {
   return new QueryResourceImpl(environment);
 }
 
-const dataResources: WeakMap<IEnvironment, FragmentResource> = new WeakMap();
+const dataResources: WeakMap<IEnvironment, QueryResource> = new WeakMap();
 function getQueryResourceForEnvironment(
   environment: IEnvironment,
 ): QueryResourceImpl {

--- a/packages/relay-experimental/QueryResource.js
+++ b/packages/relay-experimental/QueryResource.js
@@ -66,6 +66,12 @@ opaque type QueryResult: {
   operation: OperationDescriptor,
 |};
 
+const WEAKMAP_SUPPORTED = typeof WeakMap === 'function';
+interface IMap<K, V> {
+  get(key: K): V | void;
+  set(key: K, value: V): IMap<K, V>;
+}
+
 function getQueryCacheKey(
   operation: OperationDescriptor,
   fetchPolicy: FetchPolicy,
@@ -527,7 +533,10 @@ function createQueryResource(environment: IEnvironment): QueryResource {
   return new QueryResourceImpl(environment);
 }
 
-const dataResources: WeakMap<IEnvironment, QueryResource> = new WeakMap();
+const dataResources: IMap<IEnvironment, QueryResource> = WEAKMAP_SUPPORTED
+  ? new WeakMap()
+  : new Map();
+
 function getQueryResourceForEnvironment(
   environment: IEnvironment,
 ): QueryResourceImpl {

--- a/packages/relay-experimental/QueryResource.js
+++ b/packages/relay-experimental/QueryResource.js
@@ -527,7 +527,7 @@ function createQueryResource(environment: IEnvironment): QueryResource {
   return new QueryResourceImpl(environment);
 }
 
-const dataResources: Map<IEnvironment, QueryResource> = new Map();
+const dataResources: WeakMap<IEnvironment, FragmentResource> = new WeakMap();
 function getQueryResourceForEnvironment(
   environment: IEnvironment,
 ): QueryResourceImpl {

--- a/packages/relay-runtime/query/fetchQueryInternal.js
+++ b/packages/relay-runtime/query/fetchQueryInternal.js
@@ -34,7 +34,11 @@ type RequestCacheEntry = {|
   +subscription: Subscription,
 |};
 
-const requestCachesByEnvironment = new Map();
+const WEAKMAP_SUPPORTED = typeof WeakMap === 'function';
+
+const requestCachesByEnvironment = WEAKMAP_SUPPORTED
+  ? new WeakMap()
+  : new Map();
 
 /**
  * Fetches the given query and variables on the provided environment,


### PR DESCRIPTION
With this PR I aim to address the situation where environments are removed, but never garbage collected as references are held onto in this Map.

A simple case could be:

```js
const MyApp = () => {

	const [environment, setEnvironment] = useState(new Environment({ network, store }));

	useEffect(() => {
		setTimeout(() => {
			setEnvironment(new Environment({ network, store }));
		}, 1e3);
	}, []);

	return (<RelayEnvironmentProvider environment={environment}>
		<MyComponentTreeWith_A_useFragment/>
	</RelayEnvironmentProvider>);
};
```

as you'll find from that example, the `dataResources` map will be forever growing, with nothing clearing.

fixes: #3013