### PR TITLE
Make .graphql extension be a part of the language plugin

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -336,7 +336,7 @@ function getCodegenRunner(config: Config): CodegenRunner {
         persistQueryFunction,
       ),
       isGeneratedFile: (filePath: string) =>
-        filePath.endsWith('.graphql.' + outputExtension) &&
+        filePath.endsWith('.' + outputExtension) &&
         filePath.includes(generatedDirectoryName),
       parser: sourceParserName,
       baseParsers: ['graphql'],

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -252,7 +252,7 @@ describe('RelayCompilerMain', () => {
         ...options,
         language: 'javascript',
       });
-      const config = codegenRunner.writerConfigs.js;
+      const config = codegenRunner.writerConfigs['graphql.js'];
       expect(codegenRunner.parserConfigs[config.parser]).not.toBeUndefined();
     });
 
@@ -261,7 +261,7 @@ describe('RelayCompilerMain', () => {
         ...options,
         customScalars: {URL: 'String'},
       });
-      const config = codegenRunner.writerConfigs.js;
+      const config = codegenRunner.writerConfigs['graphql.js'];
       const writeFiles = config.writeFiles;
       writeFiles({onlyValidate: true});
       expect(RelayFileWriter.writeAll).toHaveBeenCalledWith(
@@ -334,7 +334,7 @@ describe('RelayCompilerMain', () => {
           ...options,
           language: 'javascript',
         });
-        const config = codegenRunner.writerConfigs.js;
+        const config = codegenRunner.writerConfigs['graphql.js'];
         expect(codegenRunner.parserConfigs[config.parser]).not.toBeUndefined();
       });
 
@@ -343,7 +343,7 @@ describe('RelayCompilerMain', () => {
           ...options,
           customScalars: {URL: 'String'},
         });
-        const config = codegenRunner.writerConfigs.js;
+        const config = codegenRunner.writerConfigs['graphql.js'];
         const writeFiles = config.writeFiles;
         writeFiles({onlyValidate: true});
         expect(RelayFileWriter.writeAll).toHaveBeenCalledWith(

--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -69,9 +69,9 @@ async function writeRelayGeneratedFile(
   // Copy to const so Flow can refine.
   const persistQuery = _persistQuery;
   const moduleName =
-    (generatedNode.kind === 'Request'
+    generatedNode.kind === 'Request'
       ? generatedNode.params.name
-      : generatedNode.name) + '.graphql';
+      : generatedNode.name;
 
   const filename = moduleName + '.' + extension;
   const queryParametersFilename =

--- a/packages/relay-compiler/language/javascript/RelayLanguagePluginJavaScript.js
+++ b/packages/relay-compiler/language/javascript/RelayLanguagePluginJavaScript.js
@@ -22,7 +22,7 @@ import type {PluginInterface} from '../RelayLanguagePluginInterface';
 
 module.exports = (): PluginInterface => ({
   inputExtensions: ['js', 'jsx'],
-  outputExtension: 'js',
+  outputExtension: 'graphql.js',
   typeGenerator: RelayFlowGenerator,
   formatModule: formatGeneratedModule,
   findGraphQLTags: find,


### PR DESCRIPTION
This makes it possible to use the language plugin interface in java.

Background:

Relay will generate the file "MyFragment.graphql.java" and a class "MyFragment.graphql". This is however not valid java code, dots "." is not allow in class names.

It's possible to change the class name programatically to solve that problem, but then we will have a public class that do not match the name of the file, which as a result is going to create a java compilation error.