### PR TITLE
[lint] exclude rust compiler from eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+compiler/
 dist/
 docs/
 **/node_modules/


### PR DESCRIPTION
This should fix CI which picked up some (intentionally) invalid JS tests files in the snapshot assets.