### PR TITLE
[rust-compiler] add graphql-syntax crate

### DIFF
--- a/compiler/crates/graphql-syntax/Cargo.toml
+++ b/compiler/crates/graphql-syntax/Cargo.toml
@@ -1,0 +1,12 @@
+[project]
+name = "graphql-syntax"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies]
+common = { path = "../common" }
+interner = { path = "../interner" }
+thiserror = "1.0.9"
+
+[dev-dependencies]
+fixture-tests = { path = "../fixture-tests" }

--- a/compiler/crates/graphql-syntax/README.md
+++ b/compiler/crates/graphql-syntax/README.md
@@ -1,0 +1,7 @@
+# graphql_syntax
+
+Lexer, parser, and CST (concrete syntax tree) for the executable subset of GraphQL syntax.
+
+## Development
+
+Note that snapshots can be updated by running tests with the `UPDATE_SNAPSHOTS=1` environment variable set.

--- a/compiler/crates/graphql-syntax/src/char_constants.rs
+++ b/compiler/crates/graphql-syntax/src/char_constants.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// wrap in a module and re-export everything to disable unused code
+// warnings for many constants at once
+#[allow(dead_code)]
+mod chars {
+    pub const AMPERSAND: char = '&';
+    pub const ASTERISK: char = '*';
+    pub const AT: char = '@'; // @
+    pub const BACKSLASH: char = '\\';
+    pub const BACKSPACE: char = '\x08'; // \b
+    pub const BACKTICK: char = '`';
+    pub const BYTE_ORDER_MARK: char = '\u{FEFF}';
+    pub const CARET: char = '^';
+    pub const CARRIAGE_RETURN: char = '\x0D';
+    pub const CLOSE_BRACE: char = '}';
+    pub const CLOSE_BRACKET: char = ']';
+    pub const CLOSE_PAREN: char = ')';
+    pub const COLON: char = ':';
+    pub const COMMA: char = ',';
+    pub const DIGIT_0: char = '0';
+    pub const DIGIT_1: char = '1';
+    pub const DIGIT_2: char = '2';
+    pub const DIGIT_3: char = '3';
+    pub const DIGIT_4: char = '4';
+    pub const DIGIT_5: char = '5';
+    pub const DIGIT_6: char = '6';
+    pub const DIGIT_7: char = '7';
+    pub const DIGIT_8: char = '8';
+    pub const DIGIT_9: char = '9';
+    pub const PERIOD: char = '.';
+    pub const DOUBLE_QUOTE: char = '"';
+    pub const EQUALS: char = '=';
+    pub const EXCLAMATION: char = '!';
+    pub const FORM_FEED: char = '\x0C'; // \f
+    pub const GREATER_THAN: char = '>'; // >
+    pub const HASH: char = '#'; // #
+    pub const LESS_THAN: char = '<'; // <
+    pub const LINE_FEED: char = '\x0A';
+    pub const LINE_SEPARATOR: char = '\u{2028}';
+    pub const MINUS: char = '-'; // -
+    pub const NULL: char = '\x00';
+    pub const OPEN_BRACE: char = '{';
+    pub const OPEN_BRACKET: char = '[';
+    pub const OPEN_PAREN: char = '(';
+    pub const PARAGRAPH_SEPARATOR: char = '\u{2029}';
+    pub const PERCENT: char = '%';
+    pub const PIPE: char = '|';
+    pub const PLUS: char = '+';
+    pub const QUESTION: char = '?';
+    pub const SEMICOLON: char = ';';
+    pub const SINGLE_QUOTE: char = '\'';
+    pub const SLASH: char = '/';
+    pub const SPACE: char = ' ';
+    pub const TAB: char = '\t';
+    pub const TILDE: char = '~';
+    pub const VERTICAL_TAB: char = '\x0B'; // \v
+    pub const CHAR_A: char = 'A';
+    pub const CHAR_B: char = 'B';
+    pub const CHAR_E: char = 'E';
+    pub const CHAR_F: char = 'F';
+    pub const CHAR_O: char = 'O';
+    pub const CHAR_X: char = 'X';
+    pub const CHAR_Z: char = 'Z';
+    pub const CHAR_LOWER_A: char = 'a';
+    pub const CHAR_LOWER_E: char = 'e';
+    pub const CHAR_LOWER_Z: char = 'z';
+    pub const DOLLAR: char = '$';
+    pub const UNDERSCORE: char = '_';
+    pub const MAX_ASCII_CHAR: char = '\x7F';
+}
+pub use chars::*;

--- a/compiler/crates/graphql-syntax/src/lexer.rs
+++ b/compiler/crates/graphql-syntax/src/lexer.rs
@@ -1,0 +1,504 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::char_constants::*;
+use crate::lexer_position::LexerPosition;
+use crate::syntax_node::Token;
+use crate::token_kind::TokenKind;
+use common::Span;
+
+/// Lexer for the *executable* subset of the GraphQL specification:
+/// https://github.com/graphql/graphql-spec/blob/master/spec/Appendix%20B%20--%20Grammar%20Summary.md
+///
+/// Lazily transforms a source str into a sequence of `Token`s that encode leading trivia,
+/// a kind, trailing trivia, and inner/outer spans (outer includes the span of the trivia,
+/// inner excludes the spans of the trivia).
+#[derive(Clone, Debug)]
+pub struct Lexer<'a> {
+    position: LexerPosition<'a>,
+    source: &'a str,
+}
+
+impl<'a> Lexer<'a> {
+    pub fn new(source: &'a str) -> Self {
+        Lexer {
+            position: LexerPosition::new(source),
+            source,
+        }
+    }
+
+    /// Advance the lexer and return the next token.
+    pub fn next(&mut self) -> Token {
+        let start = self.position.index();
+        self.skip_leading_trivia();
+        let inner_start = self.position.index();
+        let kind = self.next_kind();
+        let inner_span = Span::new(inner_start, self.position.index() - inner_start);
+        self.skip_trailing_trivia();
+        let span = Span::new(start, self.position.index() - start);
+        Token {
+            span,
+            kind,
+            inner_span,
+        }
+    }
+
+    fn peek(&self) -> TokenKind {
+        let mut clone = self.clone();
+        clone.next_kind()
+    }
+
+    fn next_kind(&mut self) -> TokenKind {
+        let ch = self.position.next();
+        match ch {
+            LINE_FEED => TokenKind::NewLine,
+            CARRIAGE_RETURN => {
+                self.position.eat(LINE_FEED);
+                TokenKind::NewLine
+            }
+            TAB | SPACE => {
+                self.position.skip_while(is_non_newline_whitespace);
+                TokenKind::Whitespace
+            }
+            AT => TokenKind::At,
+            CLOSE_BRACE => TokenKind::CloseBrace,
+            CLOSE_BRACKET => TokenKind::CloseBracket,
+            CLOSE_PAREN => TokenKind::CloseParen,
+            COLON => TokenKind::Colon,
+            COMMA => TokenKind::Comma,
+            DOUBLE_QUOTE => self.lex_string_literal_rest(),
+            EQUALS => TokenKind::Equals,
+            EXCLAMATION => TokenKind::Exclamation,
+            HASH => self.lex_comment(),
+            NULL => TokenKind::EndOfFile,
+            OPEN_BRACE => TokenKind::OpenBrace,
+            OPEN_BRACKET => TokenKind::OpenBracket,
+            OPEN_PAREN => TokenKind::OpenParen,
+            PIPE => TokenKind::Pipe,
+            PERIOD => {
+                // It's invalid to have anything other than exactly '...', but since period
+                // has no other meaning we can recover in the parser.
+                let peek = self.position.peek();
+                if peek == PERIOD {
+                    self.position.next();
+                    if self.position.peek() == PERIOD {
+                        self.position.next();
+                        TokenKind::Spread
+                    } else {
+                        TokenKind::PeriodPeriod
+                    }
+                } else if is_digit(peek) {
+                    self.position.next();
+                    self.lex_number_error()
+                } else {
+                    TokenKind::Period
+                }
+            }
+            DOLLAR => self.lex_variable_identifier_rest(),
+            MINUS => self.lex_number_literal_rest(ch),
+            PLUS => self.lex_number_error(),
+            ch if is_digit(ch) => self.lex_number_literal_rest(ch),
+            ch if is_identifier_start(ch) => self.lex_identifer_rest(),
+            _ => self.lex_error(),
+        }
+    }
+
+    /// Skips over all insignificant tokens (including newlines) up to the start of
+    /// the next significant token,
+    fn skip_leading_trivia(&mut self) {
+        let mut clone = self.clone();
+        loop {
+            match clone.peek() {
+                TokenKind::NewLine
+                | TokenKind::SingleLineComment
+                | TokenKind::Whitespace
+                | TokenKind::Comma => {
+                    // intentionally ignore since we know the result is valid
+                    let _ = clone.next_kind();
+                }
+                _ => {
+                    self.position = clone.position;
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Skips over all insigificant tokens up to the next newline
+    fn skip_trailing_trivia(&mut self) {
+        let mut clone = self.clone();
+        loop {
+            match clone.peek() {
+                TokenKind::SingleLineComment | TokenKind::Whitespace | TokenKind::Comma => {
+                    // intentionally ignore since we know the result is valid
+                    let _ = clone.next_kind();
+                }
+                _ => {
+                    self.position = clone.position;
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Skips any remaining invalid tokens (expected to be called after
+    /// encountering the first invalid token), recording the error details
+    /// and returning a token error.
+    fn lex_error(&mut self) -> TokenKind {
+        let mut position = self.position.clone();
+        loop {
+            match position.peek() {
+                LINE_FEED | CARRIAGE_RETURN | TAB | SPACE | AT | CLOSE_BRACE | CLOSE_BRACKET
+                | CLOSE_PAREN | COLON | COMMA | DOUBLE_QUOTE | EQUALS | EXCLAMATION | HASH
+                | MINUS | NULL | OPEN_BRACE | OPEN_BRACKET | OPEN_PAREN | PIPE | PLUS | PERIOD
+                | DOLLAR => break,
+                ch => {
+                    if is_digit(ch) || is_identifier_start(ch) {
+                        break;
+                    } else {
+                        position.next(); // consume the invalid char
+                        continue;
+                    }
+                }
+            };
+        }
+        self.position = position;
+        TokenKind::ErrorUnsupportedCharacterSequence
+    }
+
+    /// Skips any remaining number-like characters (digits, period, plus/minus, exponent, or
+    /// identifier).
+    fn lex_number_error(&mut self) -> TokenKind {
+        let mut position = self.position.clone();
+        loop {
+            let ch = position.peek();
+            match ch {
+                PERIOD | PLUS | MINUS => {
+                    position.next();
+                    continue;
+                }
+                _ => {
+                    if is_digit(ch) || is_identifier_start(ch) {
+                        position.next();
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+            };
+        }
+        self.position = position;
+        TokenKind::ErrorUnsupportedNumberLiteral
+    }
+
+    /// Comment :: # CommentChar*
+    ///
+    /// CommentChar :: SourceCharacter but not LineTerminator
+    fn lex_comment(&mut self) -> TokenKind {
+        loop {
+            match self.position.peek() {
+                LINE_FEED | CARRIAGE_RETURN | NULL => return TokenKind::SingleLineComment,
+                _ => {
+                    self.position.next();
+                }
+            }
+        }
+    }
+
+    /// Lexes the remainder of an identifer (after the leading '$' char).
+    ///
+    /// Variable : $ Name
+    fn lex_variable_identifier_rest(&mut self) -> TokenKind {
+        if !is_identifier_start(self.position.peek()) {
+            TokenKind::ErrorInvalidVariableIdentifier
+        } else {
+            self.position.next(); // skip identifier start
+            self.position.skip_while(is_identifer_part);
+            TokenKind::VariableIdentifier
+        }
+    }
+
+    /// Lexes the remainder of an identifer (after the first char).
+    ///
+    /// Name :: /[_A-Za-z][_0-9A-Za-z]*/
+    fn lex_identifer_rest(&mut self) -> TokenKind {
+        self.position.skip_while(is_identifer_part);
+        TokenKind::Identifier
+    }
+
+    /// Lexes the remainder of a string literal (after the leading double quote)
+    ///
+    /// StringValue ::
+    ///     " StringCharacter* "
+    ///     """ BlockStringCharacter* """
+    ///
+    /// StringCharacter ::
+    ///     SourceCharacter but not " or \ or LineTerminator
+    ///     \u EscapedUnicode
+    ///     \ EscapedCharacter
+    ///
+    /// EscapedUnicode :: /[0-9A-Fa-f]{4}/
+    ///
+    /// EscapedCharacter :: one of " \ / b f n r t
+    ///
+    /// BlockStringCharacter ::
+    ///     SourceCharacter but not """ or \"""
+    ///     \"""
+    /// Note: Block string values are interpreted to exclude blank initial and trailing lines and uniform indentation with {BlockStringValue()}.
+    ///
+    /// SourceCharacter :: /[\u0009\u000A\u000D\u0020-\uFFFF]/
+    fn lex_string_literal_rest(&mut self) -> TokenKind {
+        // TODO T60450344: full string literal support
+        if self.position.peek() == DOUBLE_QUOTE && self.position.peek_offset(1) == DOUBLE_QUOTE {
+            unimplemented!("TODO T60450344: support for triple-quoted strings")
+        }
+        loop {
+            match self.position.next() {
+                NULL => {
+                    return TokenKind::ErrorUnterminatedStringLiteral;
+                }
+                BACKSLASH => match self.position.next() {
+                    '"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't' => continue,
+                    'u' => unimplemented!("TODO T60450344: handle unicode escape sequence"),
+                    NULL => {
+                        return TokenKind::ErrorUnterminatedStringLiteral;
+                    }
+                    ch => unimplemented!("TODO T60450344: handle unknown escape sequence {:?}", ch),
+                },
+                DOUBLE_QUOTE => return TokenKind::StringLiteral,
+                _ => continue,
+            }
+        }
+    }
+
+    /// Lexes the remainder of a number, after consuming the provided character
+    ///
+    /// IntValue :: IntegerPart
+    ///
+    /// IntegerPart ::
+    ///     NegativeSign? 0
+    ///     NegativeSign? NonZeroDigit Digit*
+    ///
+    /// NegativeSign :: -
+    ///
+    /// Digit :: one of 0 1 2 3 4 5 6 7 8 9
+    ///
+    /// NonZeroDigit :: Digit but not 0
+    ///
+    /// FloatValue ::
+    ///     IntegerPart FractionalPart
+    ///     IntegerPart ExponentPart
+    ///     IntegerPart FractionalPart ExponentPart
+    ///
+    /// FractionalPart :: . Digit+
+    ///
+    /// ExponentPart :: ExponentIndicator Sign? Digit+
+    ///
+    /// ExponentIndicator :: one of e E
+    ///
+    /// Sign :: one of + -
+    ///
+    fn lex_number_literal_rest(&mut self, consumed_ch: char) -> TokenKind {
+        let mut ch = consumed_ch;
+        let mut is_float = false;
+
+        if ch == MINUS {
+            ch = self.position.next();
+        }
+
+        if ch == DIGIT_0 {
+            ch = self.position.peek();
+            if is_digit(ch) {
+                return self.lex_number_error();
+            }
+        } else if is_digit(ch) {
+            // Skip any additional digits
+            self.position.skip_while(is_digit);
+            ch = self.position.peek();
+        } else {
+            return self.lex_number_error();
+        }
+
+        if ch == PERIOD {
+            self.position.next(); // Consume the period
+            is_float = true;
+            if self.read_digits().is_err() {
+                return self.lex_number_error();
+            }
+            ch = self.position.peek();
+        }
+
+        if ch == CHAR_E || ch == CHAR_LOWER_E {
+            is_float = true;
+            self.position.next(); // Consume the E
+            ch = self.position.peek();
+            if ch == MINUS || ch == PLUS {
+                self.position.next(); // Consume the sign
+            }
+            if self.read_digits().is_err() {
+                return self.lex_number_error();
+            }
+            ch = self.position.peek();
+        }
+
+        if ch == PERIOD || is_identifier_start(ch) {
+            return self.lex_number_error();
+        }
+
+        if is_float {
+            TokenKind::FloatLiteral
+        } else {
+            TokenKind::IntegerLiteral
+        }
+    }
+
+    /// Consumes all consecutive digits, or errors if the next character is not a digit.
+    fn read_digits(&mut self) -> Result<(), ()> {
+        let ch = self.position.peek();
+        if !is_digit(ch) {
+            Err(())
+        } else {
+            self.position.skip_while(is_digit);
+            Ok(())
+        }
+    }
+}
+
+fn is_digit(ch: char) -> bool {
+    ch >= DIGIT_0 && ch <= DIGIT_9
+}
+
+fn is_identifier_start(ch: char) -> bool {
+    (ch >= CHAR_A && ch <= CHAR_Z) || (ch >= CHAR_LOWER_A && ch <= CHAR_LOWER_Z) || ch == UNDERSCORE
+}
+
+fn is_identifer_part(ch: char) -> bool {
+    is_identifier_start(ch) || is_digit(ch)
+}
+
+fn is_non_newline_whitespace(ch: char) -> bool {
+    match ch {
+        SPACE | TAB | VERTICAL_TAB | FORM_FEED => true,
+        _ => false,
+    }
+}
+
+#[allow(dead_code)]
+fn is_newline(ch: char) -> bool {
+    match ch {
+        LINE_FEED | CARRIAGE_RETURN | LINE_SEPARATOR | PARAGRAPH_SEPARATOR => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! assert_token {
+        ($src:expr, $kind:expr, $start:expr, $length:expr) => {
+            assert_eq!(
+                Lexer::new($src).next(),
+                $crate::syntax_node::Token {
+                    span: Span::new($start, $length),
+                    inner_span: Span::new($start, $length),
+                    kind: $kind
+                },
+                "Testing the lexing of string '{}'",
+                $src
+            );
+        };
+        ($src:expr, $kind:expr, $start:expr, $length:expr, $inner_start:expr, $inner_length: expr) => {
+            assert_eq!(
+                Lexer::new($src).next(),
+                $crate::syntax_node::Token {
+                    span: Span::new($start, $length),
+                    inner_span: Span::new($inner_start, $inner_length),
+                    kind: $kind
+                },
+                "Testing the lexing of string '{}'",
+                $src
+            );
+        };
+    }
+
+    #[test]
+    fn test_number_successes() {
+        assert_token!("4", TokenKind::IntegerLiteral, 0, 1);
+        assert_token!("4.123", TokenKind::FloatLiteral, 0, 5);
+        assert_token!("-4", TokenKind::IntegerLiteral, 0, 2);
+        assert_token!("9", TokenKind::IntegerLiteral, 0, 1);
+        assert_token!("0", TokenKind::IntegerLiteral, 0, 1);
+        assert_token!("-4.123", TokenKind::FloatLiteral, 0, 6);
+        assert_token!("0.123", TokenKind::FloatLiteral, 0, 5);
+        assert_token!("123e4", TokenKind::FloatLiteral, 0, 5);
+        assert_token!("123E4", TokenKind::FloatLiteral, 0, 5);
+        assert_token!("123e-4", TokenKind::FloatLiteral, 0, 6);
+        assert_token!("123e+4", TokenKind::FloatLiteral, 0, 6);
+        assert_token!("-1.123e4", TokenKind::FloatLiteral, 0, 8);
+        assert_token!("-1.123E4", TokenKind::FloatLiteral, 0, 8);
+        assert_token!("-1.123e-4", TokenKind::FloatLiteral, 0, 9);
+        assert_token!("-1.123e+4", TokenKind::FloatLiteral, 0, 9);
+        assert_token!("-1.123e4567", TokenKind::FloatLiteral, 0, 11);
+        assert_token!("-0", TokenKind::IntegerLiteral, 0, 2);
+    }
+
+    #[test]
+    fn test_number_failures() {
+        assert_token!("00", TokenKind::ErrorUnsupportedNumberLiteral, 0, 2);
+        assert_token!("01", TokenKind::ErrorUnsupportedNumberLiteral, 0, 2);
+        assert_token!("-01", TokenKind::ErrorUnsupportedNumberLiteral, 0, 3);
+        assert_token!("+1", TokenKind::ErrorUnsupportedNumberLiteral, 0, 2);
+        assert_token!("01.23", TokenKind::ErrorUnsupportedNumberLiteral, 0, 5);
+        assert_token!("1.", TokenKind::ErrorUnsupportedNumberLiteral, 0, 2);
+        assert_token!("1e", TokenKind::ErrorUnsupportedNumberLiteral, 0, 2);
+        assert_token!("1.e1", TokenKind::ErrorUnsupportedNumberLiteral, 0, 4);
+        assert_token!("1.A", TokenKind::ErrorUnsupportedNumberLiteral, 0, 3);
+        assert_token!("-A", TokenKind::ErrorUnsupportedNumberLiteral, 0, 2);
+        assert_token!("1.0e", TokenKind::ErrorUnsupportedNumberLiteral, 0, 4);
+        assert_token!("1.0eA", TokenKind::ErrorUnsupportedNumberLiteral, 0, 5);
+        assert_token!("1.2e3e", TokenKind::ErrorUnsupportedNumberLiteral, 0, 6);
+        assert_token!("1.2e3.4", TokenKind::ErrorUnsupportedNumberLiteral, 0, 7);
+        assert_token!("1.23.4", TokenKind::ErrorUnsupportedNumberLiteral, 0, 6);
+        assert_token!(".123", TokenKind::ErrorUnsupportedNumberLiteral, 0, 4);
+
+        // check that we don't consume trailing valid items
+        assert_token!("1.23.4{}", TokenKind::ErrorUnsupportedNumberLiteral, 0, 6);
+        assert_token!(
+            "1.23.4 {}",
+            TokenKind::ErrorUnsupportedNumberLiteral,
+            0,
+            7,
+            0,
+            6
+        );
+        assert_token!(
+            "1.23.4 []",
+            TokenKind::ErrorUnsupportedNumberLiteral,
+            0,
+            7,
+            0,
+            6
+        );
+        assert_token!(
+            "1.23.4 foo",
+            TokenKind::ErrorUnsupportedNumberLiteral,
+            0,
+            7,
+            0,
+            6
+        );
+        assert_token!(
+            "1.23.4 $foo",
+            TokenKind::ErrorUnsupportedNumberLiteral,
+            0,
+            7,
+            0,
+            6
+        );
+    }
+}

--- a/compiler/crates/graphql-syntax/src/lexer_position.rs
+++ b/compiler/crates/graphql-syntax/src/lexer_position.rs
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::str::Chars;
+
+use crate::char_constants::NULL;
+
+/// A wrapper over a Chars iterator that stores the (byte) index into the
+/// chars source.
+#[derive(Clone, Debug)]
+pub struct LexerPosition<'a> {
+    chars: Chars<'a>,
+    index: usize,
+}
+
+impl<'a> LexerPosition<'a> {
+    pub fn new(source: &'a str) -> Self {
+        LexerPosition {
+            chars: source.chars(),
+            index: 0,
+        }
+    }
+
+    /// Returns the *start* index of the next() char of the LexerPosition's source.
+    /// To determine the start and (exclusive) end indices of the next char, use e.g.
+    /// ```ignore
+    /// let position = LexerPosition::new(source_str);
+    /// let start = position.index();
+    /// let ch = position.next();
+    /// let end = position.index();
+    /// assert_eq!(ch.to_string(), source_str[start..end]);
+    /// ```
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// If the end of the source has not been reached, returns the next character and
+    /// advances the position. Otherwise does not advance and returns NULL.
+    pub fn next(&mut self) -> char {
+        match self.chars.next() {
+            Some(ch) => {
+                self.index += ch.len_utf8();
+                ch
+            }
+            None => NULL,
+        }
+    }
+
+    /// If the next char is the expected char, advances this position and returns true.
+    /// Otherwise (not the expected char) does not advance and returns false.
+    pub fn eat(&mut self, expected: char) -> bool {
+        let mut clone = self.clone();
+        if clone.next() == expected {
+            self.index = clone.index;
+            self.chars = clone.chars;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the next character w/o advancing the position.
+    pub fn peek(&self) -> char {
+        self.peek_offset(0)
+    }
+
+    /// Look ahead a given number of characters, where 0 is equivalent to peek()
+    pub fn peek_offset(&self, offset: usize) -> char {
+        self.chars.clone().nth(offset).unwrap_or(NULL)
+    }
+
+    /// Advance while the predicate returns true, leaving the position at the
+    /// first character for which the predicate would return false.
+    pub fn skip_while<F>(&mut self, predicate: F)
+    where
+        F: Fn(char) -> bool,
+    {
+        let mut clone = self.clone();
+        loop {
+            let ch = clone.peek();
+            if ch == NULL || !predicate(ch) {
+                break;
+            }
+            clone.next();
+        }
+        self.chars = clone.chars;
+        self.index = clone.index;
+    }
+}

--- a/compiler/crates/graphql-syntax/src/lib.rs
+++ b/compiler/crates/graphql-syntax/src/lib.rs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
+#![allow(clippy::large_enum_variant)]
+
+mod char_constants;
+mod lexer;
+mod lexer_position;
+mod parser;
+mod syntax_error;
+mod syntax_node;
+mod token_kind;
+
+pub use syntax_error::{SyntaxError, SyntaxErrorKind};
+pub use syntax_node::*;
+
+use crate::parser::Parser;
+
+pub fn parse(source: &str, file: &str) -> SyntaxResult<Document> {
+    let parser = Parser::new(source, file);
+    parser.parse_document()
+}
+
+pub fn parse_type(source: &str, file: &str) -> SyntaxResult<TypeAnnotation> {
+    let parser = Parser::new(source, file);
+    parser.parse_type()
+}

--- a/compiler/crates/graphql-syntax/src/parser.rs
+++ b/compiler/crates/graphql-syntax/src/parser.rs
@@ -1,0 +1,870 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::lexer::Lexer;
+use crate::syntax_error::{SyntaxError, SyntaxErrorKind};
+use crate::syntax_node::*;
+use crate::token_kind::TokenKind;
+use common::{FileKey, Location, Span};
+use interner::Intern;
+
+#[derive(Clone, Debug)]
+pub struct Parser<'a> {
+    current: Token,
+    lexer: Lexer<'a>,
+    errors: Vec<SyntaxError>,
+    file: FileKey,
+    source: &'a str,
+}
+
+/// Parser for the *executable* subset of the GraphQL specification:
+/// https://github.com/graphql/graphql-spec/blob/master/spec/Appendix%20B%20--%20Grammar%20Summary.md
+impl<'a> Parser<'a> {
+    pub fn new(source: &'a str, file: &'a str) -> Self {
+        // To enable fast lookahead the parser needs to store at least the 'kind' (TokenKind)
+        // of the next token: the simplest option is to store the full current token, but
+        // the Parser requires an initial value. Rather than incur runtime/code overhead
+        // of dealing with an Option or UnsafeCell, the constructor uses a dummy token
+        // value to construct the Parser, then immediately advance()s to move to the
+        // first real token.
+        let lexer = Lexer::new(source);
+        let dummy = Token {
+            span: Span::empty(),
+            kind: TokenKind::EndOfFile,
+            inner_span: Span::empty(),
+        };
+        let mut parser = Parser {
+            current: dummy,
+            lexer,
+            errors: Vec::new(),
+            file: FileKey::new(file),
+            source,
+        };
+        // Advance to the first real token before doing any work
+        parser.parse_token();
+        parser
+    }
+
+    pub fn parse_document(mut self) -> SyntaxResult<Document> {
+        let document = self.parse_document_impl();
+        let _ = self.parse_kind(TokenKind::EndOfFile);
+        if self.errors.is_empty() {
+            Ok(document.unwrap())
+        } else {
+            Err(self.errors)
+        }
+    }
+
+    pub fn parse_type(mut self) -> SyntaxResult<TypeAnnotation> {
+        let type_annotation = self.parse_type_annotation();
+        let _ = self.parse_kind(TokenKind::EndOfFile);
+        if self.errors.is_empty() {
+            Ok(type_annotation.unwrap())
+        } else {
+            Err(self.errors)
+        }
+    }
+
+    // Document / Definitions
+
+    /// Document : Definition+
+    fn parse_document_impl(&mut self) -> ParseResult<Document> {
+        let start = self.index();
+        let definitions = self.parse_list(|s| s.peek_definition(), |s| s.parse_definition())?;
+        let length = self.index() - start;
+        let span = Span::new(start, length);
+        Ok(Document { span, definitions })
+    }
+
+    /// Definition :
+    /// [x] ExecutableDefinition
+    /// []  TypeSystemDefinition
+    /// []  TypeSystemExtension
+    fn peek_definition(&self) -> bool {
+        let token = self.peek();
+        match token.kind {
+            TokenKind::OpenBrace => true, // unnamed query
+            TokenKind::Identifier => match self.source(&token) {
+                "query" => true,
+                "mutation" => true,
+                "fragment" => true,
+                "subscription" => true,
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
+    /// Definition :
+    /// [x] ExecutableDefinition
+    /// []  TypeSystemDefinition
+    /// []  TypeSystemExtension
+    fn parse_definition(&mut self) -> ParseResult<ExecutableDefinition> {
+        let token = self.peek();
+        let source = self.source(&token);
+        match (token.kind, source) {
+            (TokenKind::OpenBrace, _) => Ok(ExecutableDefinition::Operation(
+                self.parse_operation_definition()?,
+            )),
+            (TokenKind::Identifier, "query")
+            | (TokenKind::Identifier, "mutation")
+            | (TokenKind::Identifier, "subscription") => Ok(ExecutableDefinition::Operation(
+                self.parse_operation_definition()?,
+            )),
+            (TokenKind::Identifier, "fragment") => Ok(ExecutableDefinition::Fragment(
+                self.parse_fragment_definition()?,
+            )),
+            _ => {
+                let error = SyntaxError::new(SyntaxErrorKind::ExpectedDefinition, token.span);
+                self.record_error(error.clone());
+                Err(error)
+            }
+        }
+    }
+
+    /// FragmentDefinition : fragment FragmentName TypeCondition Directives? SelectionSet
+    fn parse_fragment_definition(&mut self) -> ParseResult<FragmentDefinition> {
+        let start = self.index();
+        let fragment = self.parse_keyword("fragment")?;
+        let name = self.parse_identifier()?;
+        let type_condition = self.parse_type_condition()?;
+        let directives = self.parse_directives()?;
+        let selections = self.parse_selections()?;
+        let length = self.index() - start;
+        let span = Span::new(start, length);
+        Ok(FragmentDefinition {
+            location: Location::new(self.file, span),
+            fragment,
+            name,
+            type_condition,
+            directives,
+            selections,
+        })
+    }
+
+    /// OperationDefinition :
+    ///     OperationType Name? VariableDefinitions? Directives? SelectionSet
+    ///     SelectionSet
+    fn parse_operation_definition(&mut self) -> ParseResult<OperationDefinition> {
+        let start = self.index();
+        // Special case: anonymous query
+        if self.peek_token_kind() == TokenKind::OpenBrace {
+            let selections = self.parse_selections()?;
+            let span = Span::new(start, self.index() - start);
+            return Ok(OperationDefinition {
+                location: Location::new(self.file, span),
+                operation: None,
+                name: None,
+                variable_definitions: None,
+                directives: Vec::new(),
+                selections,
+            });
+        }
+        // Otherwise requires operation type and name
+        let maybe_operation_token = self.peek();
+        let operation = match (
+            maybe_operation_token.kind,
+            self.source(&maybe_operation_token),
+        ) {
+            (TokenKind::Identifier, "mutation") => (self.parse_token(), OperationKind::Mutation),
+            (TokenKind::Identifier, "query") => (self.parse_token(), OperationKind::Query),
+            (TokenKind::Identifier, "subscription") => {
+                (self.parse_token(), OperationKind::Subscription)
+            }
+            _ => {
+                let error = SyntaxError::new(
+                    SyntaxErrorKind::ExpectedOperationKind,
+                    maybe_operation_token.span,
+                );
+                self.record_error(error.clone());
+                return Err(error);
+            }
+        };
+        let name = if self.peek_token_kind() == TokenKind::Identifier {
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
+        let variable_definitions =
+            self.parse_optional_delimited_list(TokenKind::OpenParen, TokenKind::CloseParen, |s| {
+                s.parse_variable_definition()
+            })?;
+        let directives = self.parse_directives()?;
+        let selections = self.parse_selections()?;
+        let span = Span::new(start, self.index() - start);
+        Ok(OperationDefinition {
+            location: Location::new(self.file, span),
+            operation: Some(operation),
+            name,
+            variable_definitions,
+            directives,
+            selections,
+        })
+    }
+
+    /// VariableDefinition : Variable : Type DefaultValue? Directives[Const]?
+    fn parse_variable_definition(&mut self) -> ParseResult<VariableDefinition> {
+        let start = self.index();
+        let name = self.parse_variable_identifier()?;
+        let colon = self.parse_kind(TokenKind::Colon)?;
+        let type_ = self.parse_type_annotation()?;
+        let default_value = if self.peek_token_kind() == TokenKind::Equals {
+            Some(self.parse_default_value()?)
+        } else {
+            None
+        };
+        let directives = self.parse_directives()?;
+        let length = self.index() - start;
+        let span = Span::new(start, length);
+        Ok(VariableDefinition {
+            span,
+            name,
+            colon,
+            type_,
+            default_value,
+            directives,
+        })
+    }
+
+    /// DefaultValue : = Value[Const]
+    fn parse_default_value(&mut self) -> ParseResult<DefaultValue> {
+        let start = self.index();
+        let equals = self.parse_kind(TokenKind::Equals)?;
+        let value = self.parse_constant_value()?;
+        let span = Span::new(start, self.index() - start);
+        Ok(DefaultValue {
+            span,
+            equals,
+            value,
+        })
+    }
+
+    /// Type :
+    ///     NamedType
+    ///     ListType
+    ///     NonNullType
+    fn parse_type_annotation(&mut self) -> ParseResult<TypeAnnotation> {
+        let start = self.index();
+        let token = self.peek();
+        let type_annotation = match token.kind {
+            TokenKind::Identifier => TypeAnnotation::Named(self.parse_identifier()?),
+            TokenKind::OpenBracket => {
+                let open = self.parse_kind(TokenKind::OpenBracket)?;
+                let type_ = self.parse_type_annotation()?;
+                let close = self.parse_kind(TokenKind::CloseBracket)?;
+                TypeAnnotation::List(Box::new(ListTypeAnnotation {
+                    span: Span::new(start, self.index() - start),
+                    open,
+                    type_,
+                    close,
+                }))
+            }
+            _ => {
+                let error = SyntaxError::new(SyntaxErrorKind::ExpectedTypeAnnotation, token.span);
+                self.record_error(error.clone());
+                return Err(error);
+            }
+        };
+        if self.peek_token_kind() == TokenKind::Exclamation {
+            let exclamation = self.parse_kind(TokenKind::Exclamation)?;
+            Ok(TypeAnnotation::NonNull(Box::new(NonNullTypeAnnotation {
+                span: Span::new(start, self.index() - start),
+                type_: type_annotation,
+                exclamation,
+            })))
+        } else {
+            Ok(type_annotation)
+        }
+    }
+
+    /// Directives[Const] : Directive[?Const]+
+    fn parse_directives(&mut self) -> Result<Vec<Directive>, SyntaxError> {
+        if self.peek_token_kind() == TokenKind::At {
+            self.parse_list(|s| s.peek_kind(TokenKind::At), |s| s.parse_directive())
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    /// Directive[Const] : @ Name Arguments[?Const]?
+    fn parse_directive(&mut self) -> ParseResult<Directive> {
+        let start = self.index();
+        let at = self.parse_kind(TokenKind::At)?;
+        let name = self.parse_identifier()?;
+        let arguments = self.parse_optional_arguments()?;
+        let length = self.index() - start;
+        let span = Span::new(start, length);
+        Ok(Directive {
+            span,
+            at,
+            name,
+            arguments,
+        })
+    }
+
+    /// TypeCondition : on NamedType
+    /// NamedType : Name
+    fn parse_type_condition(&mut self) -> ParseResult<TypeCondition> {
+        let start = self.index();
+        let on = self.parse_keyword("on")?;
+        let type_ = self.parse_identifier()?;
+        Ok(TypeCondition {
+            span: Span::new(start, self.index() - start),
+            on,
+            type_,
+        })
+    }
+
+    /// SelectionSet : { Selection+ }
+    fn parse_selections(&mut self) -> ParseResult<List<Selection>> {
+        self.parse_delimited_list(TokenKind::OpenBrace, TokenKind::CloseBrace, |s| {
+            s.parse_selection()
+        })
+    }
+
+    /// Selection :
+    ///     Field
+    ///     FragmentSpread
+    ///     InlineFragment
+    fn parse_selection(&mut self) -> ParseResult<Selection> {
+        let token = self.peek();
+        match token.kind {
+            TokenKind::Spread => self.parse_spread(),
+            TokenKind::Identifier => self.parse_field(),
+            // hint for invalid spreads
+            TokenKind::Period | TokenKind::PeriodPeriod => {
+                let error = SyntaxError::new(SyntaxErrorKind::ExpectedSpread, token.span);
+                self.record_error(error.clone());
+                Err(error)
+            }
+            _ => {
+                let error = SyntaxError::new(SyntaxErrorKind::ExpectedSelection, token.span);
+                self.record_error(error.clone());
+                Err(error)
+            }
+        }
+    }
+
+    /// Field : Alias? Name Arguments? Directives? SelectionSet?
+    fn parse_field(&mut self) -> ParseResult<Selection> {
+        let start = self.index();
+        let name = self.parse_identifier()?;
+        let (name, alias) = if self.peek_token_kind() == TokenKind::Colon {
+            let colon = self.parse_kind(TokenKind::Colon)?;
+            let alias = name;
+            let name = self.parse_identifier()?;
+            (
+                name,
+                Some(Alias {
+                    span: Span::new(start, self.index() - start),
+                    alias,
+                    colon,
+                }),
+            )
+        } else {
+            (name, None)
+        };
+        let arguments = self.parse_optional_arguments()?;
+        let directives = self.parse_directives()?;
+        if self.peek_token_kind() == TokenKind::OpenBrace {
+            let selections = self.parse_selections()?;
+            Ok(Selection::LinkedField(LinkedField {
+                span: Span::new(start, self.index() - start),
+                alias,
+                name,
+                arguments,
+                directives,
+                selections,
+            }))
+        } else {
+            Ok(Selection::ScalarField(ScalarField {
+                span: Span::new(start, self.index() - start),
+                alias,
+                name,
+                arguments,
+                directives,
+            }))
+        }
+    }
+
+    /// FragmentSpread : ... FragmentName Directives?
+    /// InlineFragment : ... TypeCondition? Directives? SelectionSet
+    fn parse_spread(&mut self) -> ParseResult<Selection> {
+        let start = self.index();
+        let spread = self.parse_kind(TokenKind::Spread)?;
+        let is_on_keyword = self.peek_keyword("on");
+        if !is_on_keyword && self.peek_token_kind() == TokenKind::Identifier {
+            // fragment spread
+            let name = self.parse_identifier()?;
+            let directives = self.parse_directives()?;
+            Ok(Selection::FragmentSpread(FragmentSpread {
+                span: Span::new(start, self.index() - start),
+                spread,
+                name,
+                directives,
+            }))
+        } else {
+            // inline fragment with or without a type condition
+            let type_condition = if is_on_keyword {
+                Some(self.parse_type_condition()?)
+            } else {
+                None
+            };
+            let directives = self.parse_directives()?;
+            let selections = self.parse_selections()?;
+            Ok(Selection::InlineFragment(InlineFragment {
+                span: Span::new(start, self.index() - start),
+                spread,
+                type_condition,
+                directives,
+                selections,
+            }))
+        }
+    }
+
+    /// Arguments[Const] : ( Argument[?Const]+ )
+    fn parse_arguments(&mut self) -> ParseResult<List<Argument>> {
+        self.parse_delimited_list(TokenKind::OpenParen, TokenKind::CloseParen, |s| {
+            s.parse_argument()
+        })
+    }
+
+    /// Arguments?
+    fn parse_optional_arguments(&mut self) -> ParseResult<Option<List<Argument>>> {
+        if self.peek_token_kind() == TokenKind::OpenParen {
+            Ok(Some(self.parse_arguments()?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Argument[Const] : Name : Value[?Const]
+    fn parse_argument(&mut self) -> ParseResult<Argument> {
+        let start = self.index();
+        let name = self.parse_identifier()?;
+        let colon = self.parse_kind(TokenKind::Colon)?;
+        let value = self.parse_value()?;
+        let span = Span::new(start, self.index() - start);
+        Ok(Argument {
+            span,
+            name,
+            colon,
+            value,
+        })
+    }
+
+    /// Value[?Const] :
+    ///     [~Const] Variable
+    ///     ListValue[?Const]
+    ///     ObjectValue[?Const]
+    // (delegated):
+    ///     IntValue
+    ///     FloatValue
+    ///     StringValue
+    ///     BooleanValue
+    ///     NullValue
+    ///     EnumValue
+    fn parse_value(&mut self) -> ParseResult<Value> {
+        let token = self.peek();
+        match token.kind {
+            TokenKind::OpenBracket => {
+                let list = self.parse_delimited_list(
+                    TokenKind::OpenBracket,
+                    TokenKind::CloseBracket,
+                    |s| s.parse_value(),
+                )?;
+                // Promote a Value::List() with all constant items to Value::Constant()
+                if list.items.iter().all(|x| x.is_constant()) {
+                    let mut constants = Vec::with_capacity(list.items.len());
+                    for item in list.items {
+                        match item {
+                            Value::Constant(c) => {
+                                constants.push(c);
+                            }
+                            _ => unreachable!("Already checked all items are constant"),
+                        }
+                    }
+                    Ok(Value::Constant(ConstantValue::List(List {
+                        span: list.span,
+                        start: list.start,
+                        items: constants,
+                        end: list.end,
+                    })))
+                } else {
+                    Ok(Value::List(list))
+                }
+            }
+            TokenKind::OpenBrace => {
+                let list =
+                    self.parse_delimited_list(TokenKind::OpenBrace, TokenKind::CloseBrace, |s| {
+                        s.parse_argument()
+                    })?;
+                // Promote a Value::Object() with all constant values to Value::Constant()
+                if list.items.iter().all(|x| x.value.is_constant()) {
+                    let mut arguments = Vec::with_capacity(list.items.len());
+                    for argument in list.items {
+                        let value = match argument.value {
+                            Value::Constant(c) => c,
+                            _ => unreachable!("Already checked all items are constant"),
+                        };
+                        arguments.push(ConstantArgument {
+                            span: argument.span,
+                            name: argument.name,
+                            colon: argument.colon,
+                            value,
+                        });
+                    }
+                    Ok(Value::Constant(ConstantValue::Object(List {
+                        span: list.span,
+                        start: list.start,
+                        items: arguments,
+                        end: list.end,
+                    })))
+                } else {
+                    Ok(Value::Object(list))
+                }
+            }
+            TokenKind::VariableIdentifier => Ok(Value::Variable(self.parse_variable_identifier()?)),
+            TokenKind::ErrorInvalidVariableIdentifier => {
+                let error = SyntaxError::new(SyntaxErrorKind::ExpectedVariable, token.span);
+                self.record_error(error.clone());
+                Err(error)
+            }
+            _ => Ok(Value::Constant(self.parse_literal_value()?)),
+        }
+    }
+
+    // Constant Values
+
+    /// Value[Const=true] :
+    ///     IntValue
+    ///     FloatValue
+    ///     StringValue
+    ///     BooleanValue
+    ///     NullValue
+    ///     EnumValue
+    ///     ListValue[Const=true]
+    ///     ObjectValue[Const=true]
+    fn parse_constant_value(&mut self) -> ParseResult<ConstantValue> {
+        match self.peek_token_kind() {
+            TokenKind::OpenBracket => Ok(ConstantValue::List(self.parse_delimited_list(
+                TokenKind::OpenBracket,
+                TokenKind::CloseBracket,
+                |s| s.parse_constant_value(),
+            )?)),
+            TokenKind::OpenBrace => Ok(ConstantValue::Object(self.parse_delimited_list(
+                TokenKind::OpenBrace,
+                TokenKind::CloseBrace,
+                |s| s.parse_constant_argument(),
+            )?)),
+            _ => self.parse_literal_value(),
+        }
+    }
+
+    /// Argument[Const=true] : Name : Value[Const=true]
+    fn parse_constant_argument(&mut self) -> ParseResult<ConstantArgument> {
+        let start = self.index();
+        let name = self.parse_identifier()?;
+        let colon = self.parse_kind(TokenKind::Colon)?;
+        let value = self.parse_constant_value()?;
+        let span = Span::new(start, self.index() - start);
+        Ok(ConstantArgument {
+            span,
+            name,
+            colon,
+            value,
+        })
+    }
+
+    /// IntValue
+    /// FloatValue
+    /// StringValue
+    /// BooleanValue
+    /// NullValue
+    /// EnumValue
+    fn parse_literal_value(&mut self) -> ParseResult<ConstantValue> {
+        let token = self.parse_token();
+        let source = self.source(&token);
+        match &token.kind {
+            TokenKind::StringLiteral => {
+                let value = source[1..source.len() - 1].to_string();
+                Ok(ConstantValue::String(StringNode {
+                    token,
+                    value: value.intern(),
+                }))
+            }
+            TokenKind::IntegerLiteral => {
+                let value = source.parse::<i64>();
+                match value {
+                    Ok(value) => Ok(ConstantValue::Int(IntNode { token, value })),
+                    Err(_) => {
+                        let error = SyntaxError::new(SyntaxErrorKind::InvalidInteger, token.span);
+                        self.record_error(error.clone());
+                        Err(error)
+                    }
+                }
+            }
+            TokenKind::FloatLiteral => {
+                let value = source.parse::<f64>();
+                match value {
+                    Ok(value) => Ok(ConstantValue::Float(FloatNode {
+                        token,
+                        value: FloatValue::new(value),
+                    })),
+                    Err(_) => {
+                        let error = SyntaxError::new(SyntaxErrorKind::InvalidFloat, token.span);
+                        self.record_error(error.clone());
+                        Err(error)
+                    }
+                }
+            }
+            TokenKind::Identifier => Ok(match source {
+                "true" => ConstantValue::Boolean(BooleanNode { token, value: true }),
+                "false" => ConstantValue::Boolean(BooleanNode {
+                    token,
+                    value: false,
+                }),
+                "null" => ConstantValue::Null(token),
+                _ => ConstantValue::Enum(EnumNode {
+                    token,
+                    value: source.intern(),
+                }),
+            }),
+            TokenKind::ErrorUnsupportedNumberLiteral => {
+                let error = SyntaxError::new(SyntaxErrorKind::InvalidNumberLiteral, token.span);
+                self.record_error(error.clone());
+                Err(error)
+            }
+            _ => {
+                let error = SyntaxError::new(SyntaxErrorKind::ExpectedConstantValue, token.span);
+                self.record_error(error.clone());
+                Err(error)
+            }
+        }
+    }
+
+    /// Variable : $ Name
+    fn parse_variable_identifier(&mut self) -> ParseResult<VariableIdentifier> {
+        let token = self.parse_token();
+        let Span { start, length } = token.inner_span;
+        let source = &self.source[start + 1..start + length];
+        let span = token.span;
+        if token.kind == TokenKind::VariableIdentifier {
+            Ok(VariableIdentifier {
+                span,
+                token,
+                name: source.intern(),
+            })
+        } else {
+            let error = SyntaxError::new(
+                SyntaxErrorKind::Expected(TokenKind::VariableIdentifier),
+                span,
+            );
+            self.record_error(error.clone());
+            Err(error)
+        }
+    }
+
+    /// Name :: /[_A-Za-z][_0-9A-Za-z]*/
+    fn parse_identifier(&mut self) -> ParseResult<Identifier> {
+        let token = self.parse_token();
+        let source = self.source(&token);
+        let span = token.span;
+        match token.kind {
+            TokenKind::Identifier => Ok(Identifier {
+                span,
+                token,
+                value: source.intern(),
+            }),
+            _ => {
+                let error =
+                    SyntaxError::new(SyntaxErrorKind::Expected(TokenKind::Identifier), span);
+                self.record_error(error.clone());
+                Err(error)
+            }
+        }
+    }
+
+    // Helpers
+
+    /// <item>*
+    fn parse_list<T, F1, F2>(&mut self, peek: F1, parse: F2) -> Result<Vec<T>, SyntaxError>
+    where
+        F1: Fn(&mut Self) -> bool,
+        F2: Fn(&mut Self) -> ParseResult<T>,
+    {
+        let mut items = vec![];
+        loop {
+            if peek(self) {
+                let item = parse(self)?;
+                items.push(item);
+            } else {
+                break;
+            }
+        }
+        Ok(items)
+    }
+
+    /// Parse delimited items into a `Vec`
+    /// <start> <item>* <end>
+    fn parse_delimited_items<T, F>(
+        &mut self,
+        start_kind: TokenKind,
+        end_kind: TokenKind,
+        parse: F,
+    ) -> ParseResult<(Token, Vec<T>, Token)>
+    where
+        F: Fn(&mut Self) -> ParseResult<T>,
+    {
+        let start = self.parse_kind(start_kind)?;
+        let mut items = vec![];
+        while !self.peek_kind(end_kind) {
+            items.push(parse(self)?);
+        }
+        let end = self.parse_kind(end_kind)?;
+        Ok((start, items, end))
+    }
+
+    /// Parse delimited items into a `List`
+    /// <start> <item>* <end>
+    fn parse_delimited_list<T, F>(
+        &mut self,
+        start_kind: TokenKind,
+        end_kind: TokenKind,
+        parse: F,
+    ) -> ParseResult<List<T>>
+    where
+        F: Fn(&mut Self) -> ParseResult<T>,
+    {
+        let span_start = self.index();
+        let (start, items, end) = self.parse_delimited_items(start_kind, end_kind, parse)?;
+        let length = self.index() - span_start;
+        let span = Span::new(span_start, length);
+        Ok(List {
+            span,
+            start,
+            items,
+            end,
+        })
+    }
+
+    /// (<start> <item>* <end>)?
+    fn parse_optional_delimited_list<T, F>(
+        &mut self,
+        start_kind: TokenKind,
+        end_kind: TokenKind,
+        parse: F,
+    ) -> ParseResult<Option<List<T>>>
+    where
+        F: Fn(&mut Self) -> ParseResult<T>,
+    {
+        if self.peek_token_kind() == start_kind {
+            Ok(Some(
+                self.parse_delimited_list(start_kind, end_kind, parse)?,
+            ))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// A &str for the source of the inner span of the given token.
+    fn source(&self, token: &Token) -> &str {
+        let Span { start, length } = token.inner_span;
+        &self.source[start..start + length]
+    }
+
+    /// Peek at the next token
+    fn peek(&self) -> &Token {
+        &self.current
+    }
+
+    /// Return true if the next token has the expected kind
+    fn peek_kind(&self, expected: TokenKind) -> bool {
+        self.peek_token_kind() == expected
+    }
+
+    /// Peek at the kind of the next token
+    fn peek_token_kind(&self) -> TokenKind {
+        self.current.kind
+    }
+
+    /// Parse the next token, succeeding if it has the expected kind and failing
+    /// otherwise.
+    fn parse_kind(&mut self, expected: TokenKind) -> ParseResult<Token> {
+        let start = self.index();
+        let token = self.parse_token();
+        if token.kind == expected {
+            Ok(token)
+        } else {
+            let length = self.index() - start;
+            let error = SyntaxError::new(
+                SyntaxErrorKind::Expected(expected),
+                Span::new(start, length),
+            );
+            self.record_error(error.clone());
+            Err(error)
+        }
+    }
+
+    /// Return true if the current token is an Identifier matching the given keyword.
+    fn peek_keyword(&self, expected: &'static str) -> bool {
+        self.peek_kind(TokenKind::Identifier) && self.source(self.peek()) == expected
+    }
+
+    /// Parse the next token, succeeding if it is an Identifier that matches the
+    /// given keyword
+    fn parse_keyword(&mut self, expected: &'static str) -> ParseResult<Token> {
+        let token = self.parse_kind(TokenKind::Identifier)?;
+        if self.source(&token) == expected {
+            Ok(token)
+        } else {
+            Err(SyntaxError::new(
+                SyntaxErrorKind::ExpectedKeyword(expected),
+                token.inner_span,
+            ))
+        }
+    }
+
+    /// Get the byte offset of the *start* of the current token
+    fn index(&self) -> usize {
+        self.current.span.start
+    }
+
+    /// Get the next token (and advance)
+    fn parse_token(&mut self) -> Token {
+        // Skip over (and record) any invalid tokens until either a valid token or an EOF is encountered
+        loop {
+            let next = self.lexer.next();
+            match next.kind {
+                TokenKind::ErrorUnsupportedCharacterSequence => {
+                    let error = SyntaxError::new(SyntaxErrorKind::UnsupportedCharacter, next.span);
+                    self.record_error(error);
+                }
+                TokenKind::ErrorUnterminatedStringLiteral => {
+                    let error = SyntaxError::new(SyntaxErrorKind::UnterminatedString, next.span);
+                    self.record_error(error);
+                    return std::mem::replace(
+                        &mut self.current,
+                        Token {
+                            kind: TokenKind::EndOfFile,
+                            ..next
+                        },
+                    );
+                }
+                _ => {
+                    return std::mem::replace(&mut self.current, next);
+                }
+            }
+        }
+    }
+
+    fn record_error(&mut self, error: SyntaxError) {
+        // NOTE: Useful for debugging parse errors:
+        // panic!("{:?}", error);
+        self.errors.push(error);
+    }
+}

--- a/compiler/crates/graphql-syntax/src/syntax_error.rs
+++ b/compiler/crates/graphql-syntax/src/syntax_error.rs
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::token_kind::TokenKind;
+use common::Span;
+use std::fmt;
+use thiserror::Error;
+
+#[derive(Clone, Error, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[error("Syntax error: {kind} at {span:?}")]
+pub struct SyntaxError {
+    pub kind: SyntaxErrorKind,
+    pub span: Span,
+}
+
+impl SyntaxError {
+    pub fn new(kind: SyntaxErrorKind, span: Span) -> Self {
+        Self { kind, span }
+    }
+
+    pub fn print(&self, source: &str) -> String {
+        format!("Error: {} at {}", self.kind, self.span.print(source))
+    }
+}
+
+impl fmt::Debug for SyntaxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("Error: {} at {:?}", self.kind, self.span))
+    }
+}
+
+#[derive(Clone, Debug, Error, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum SyntaxErrorKind {
+    #[error("Expected a {0}")]
+    Expected(TokenKind),
+    #[error("Expected a selection: field, inline fragment, or fragment spread")]
+    ExpectedSelection,
+    #[error("Expected a fragment, mutation, query, or subscription definition")]
+    ExpectedDefinition,
+    #[error("Expected a 'mutation', 'query', or 'subscription' keyword")]
+    ExpectedOperationKind,
+    #[error("Expected the keyword {0}")]
+    ExpectedKeyword(&'static str),
+    #[error("Expected a constant value (boolean, integer, float, string, null, list, or object")]
+    ExpectedConstantValue,
+    #[error("Expected a type annotation (e.g. '<Type>', '[Type]', 'Type!', etc)")]
+    ExpectedTypeAnnotation,
+    #[error("Expected a variable ('$<name>')")]
+    ExpectedVariable,
+    #[error("Expected a spread ('...')")]
+    ExpectedSpread,
+    #[error("Invalid floating point value")]
+    InvalidFloat,
+    #[error("Invalid integer value")]
+    InvalidInteger,
+    #[error("Invalid number value, expected an int or float")]
+    InvalidNumberLiteral,
+    #[error("Unsupported character")]
+    UnsupportedCharacter,
+    #[error("Unterminated string literal")]
+    UnterminatedString,
+}

--- a/compiler/crates/graphql-syntax/src/syntax_node.rs
+++ b/compiler/crates/graphql-syntax/src/syntax_node.rs
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::syntax_error::SyntaxError;
+use crate::token_kind::TokenKind;
+use common::{Location, Span, Spanned};
+use interner::StringKey;
+use std::fmt;
+
+pub type SyntaxResult<T> = Result<T, Vec<SyntaxError>>;
+pub type ParseResult<T> = Result<T, SyntaxError>;
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Document {
+    pub span: Span,
+    pub definitions: Vec<ExecutableDefinition>,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum ExecutableDefinition {
+    Operation(OperationDefinition),
+    Fragment(FragmentDefinition),
+}
+
+impl ExecutableDefinition {
+    pub fn location(&self) -> Location {
+        match self {
+            ExecutableDefinition::Operation(node) => node.location.clone(),
+            ExecutableDefinition::Fragment(node) => node.location.clone(),
+        }
+    }
+}
+
+impl fmt::Debug for ExecutableDefinition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExecutableDefinition::Operation(node) => f.write_fmt(format_args!("{:#?}", node)),
+            ExecutableDefinition::Fragment(node) => f.write_fmt(format_args!("{:#?}", node)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct OperationDefinition {
+    pub location: Location,
+    pub operation: Option<(Token, OperationKind)>,
+    pub name: Option<Identifier>,
+    pub variable_definitions: Option<List<VariableDefinition>>,
+    pub directives: Vec<Directive>,
+    pub selections: List<Selection>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum OperationKind {
+    Query,
+    Mutation,
+    Subscription,
+}
+
+impl fmt::Display for OperationKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OperationKind::Query => f.write_str("query"),
+            OperationKind::Mutation => f.write_str("mutation"),
+            OperationKind::Subscription => f.write_str("subscription"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct FragmentDefinition {
+    pub location: Location,
+    pub fragment: Token,
+    pub name: Identifier,
+    // pub variable_definitions: Option<List<VariableDefinition>>,
+    pub type_condition: TypeCondition,
+    pub directives: Vec<Directive>,
+    pub selections: List<Selection>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct VariableDefinition {
+    pub span: Span,
+    pub name: VariableIdentifier,
+    pub colon: Token,
+    pub type_: TypeAnnotation,
+    pub default_value: Option<DefaultValue>,
+    pub directives: Vec<Directive>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Directive {
+    pub span: Span,
+    pub at: Token,
+    pub name: Identifier,
+    pub arguments: Option<List<Argument>>,
+}
+
+// Primitive Types
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct List<T> {
+    pub span: Span,
+    pub start: Token,
+    pub items: Vec<T>,
+    pub end: Token,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Argument {
+    pub span: Span,
+    pub name: Identifier,
+    pub colon: Token,
+    pub value: Value,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Alias {
+    pub span: Span,
+    pub alias: Identifier,
+    pub colon: Token,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct TypeCondition {
+    pub span: Span,
+    pub on: Token,
+    pub type_: Identifier,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Token {
+    pub span: Span,
+    pub inner_span: Span,
+    pub kind: TokenKind,
+}
+
+impl fmt::Debug for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("Token");
+        s.field(
+            "span",
+            // TODO: switch to span's default
+            &format!("{}:{}", self.span.start, self.span.start + self.span.length),
+        );
+        s.field("kind", &self.kind);
+        s.finish()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct VariableIdentifier {
+    pub span: Span,
+    pub token: Token,
+    pub name: StringKey,
+}
+
+impl VariableIdentifier {
+    pub fn spanned_name(&self) -> Spanned<StringKey> {
+        Spanned::new(self.span, self.name)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Identifier {
+    pub span: Span,
+    pub token: Token,
+    pub value: StringKey,
+}
+
+impl Identifier {
+    pub fn spanned_name(&self) -> Spanned<StringKey> {
+        Spanned::new(self.span, self.value)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct DefaultValue {
+    pub span: Span,
+    pub equals: Token,
+    pub value: ConstantValue,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum ConstantValue {
+    Int(IntNode),
+    Float(FloatNode),
+    String(StringNode),
+    Boolean(BooleanNode),
+    Null(Token),
+    Enum(EnumNode),
+    List(List<ConstantValue>),
+    Object(List<ConstantArgument>),
+}
+
+impl ConstantValue {
+    pub fn span(&self) -> Span {
+        match self {
+            ConstantValue::Int(value) => value.token.span,
+            ConstantValue::Float(value) => value.token.span,
+            ConstantValue::String(value) => value.token.span,
+            ConstantValue::Boolean(value) => value.token.span,
+            ConstantValue::Null(value) => value.span,
+            ConstantValue::Enum(value) => value.token.span,
+            ConstantValue::List(value) => value.span,
+            ConstantValue::Object(value) => value.span,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ConstantArgument {
+    pub span: Span,
+    pub name: Identifier,
+    pub colon: Token,
+    pub value: ConstantValue,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct IntNode {
+    pub token: Token,
+    pub value: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct FloatNode {
+    pub token: Token,
+    pub value: FloatValue,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct StringNode {
+    pub token: Token,
+    pub value: StringKey,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct EnumNode {
+    pub token: Token,
+    pub value: StringKey,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct BooleanNode {
+    pub token: Token,
+    pub value: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Value {
+    Constant(ConstantValue),
+    Variable(VariableIdentifier),
+    List(List<Value>),
+    Object(List<Argument>),
+}
+
+impl Value {
+    pub fn is_constant(&self) -> bool {
+        match self {
+            Value::Constant(..) => true,
+            _ => false,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        match self {
+            Value::Constant(value) => value.span(),
+            Value::Variable(value) => value.span,
+            Value::List(value) => value.span,
+            Value::Object(value) => value.span,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct FloatValue(u64);
+
+impl FloatValue {
+    pub fn new(v: f64) -> Self {
+        Self(v.to_bits())
+    }
+
+    pub fn as_float(self) -> f64 {
+        f64::from_bits(self.0)
+    }
+}
+
+impl fmt::Debug for FloatValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}", self.as_float()))
+    }
+}
+
+impl fmt::Display for FloatValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}", self.as_float()))
+    }
+}
+
+impl std::convert::From<i64> for FloatValue {
+    fn from(value: i64) -> Self {
+        FloatValue::new(value as f64)
+    }
+}
+
+// Types
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum TypeAnnotation {
+    Named(Identifier),
+    List(Box<ListTypeAnnotation>),
+    NonNull(Box<NonNullTypeAnnotation>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ListTypeAnnotation {
+    pub span: Span,
+    pub open: Token,
+    pub type_: TypeAnnotation,
+    pub close: Token,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct NonNullTypeAnnotation {
+    pub span: Span,
+    pub type_: TypeAnnotation,
+    pub exclamation: Token,
+}
+
+// Selections
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Selection {
+    FragmentSpread(FragmentSpread),
+    InlineFragment(InlineFragment),
+    LinkedField(LinkedField),
+    ScalarField(ScalarField),
+}
+
+impl Selection {
+    pub fn span(&self) -> Span {
+        match self {
+            Selection::FragmentSpread(node) => node.span,
+            Selection::InlineFragment(node) => node.span,
+            Selection::LinkedField(node) => node.span,
+            Selection::ScalarField(node) => node.span,
+        }
+    }
+}
+
+impl fmt::Debug for Selection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Selection::FragmentSpread(node) => f.write_fmt(format_args!("{:#?}", node)),
+            Selection::InlineFragment(node) => f.write_fmt(format_args!("{:#?}", node)),
+            Selection::LinkedField(node) => f.write_fmt(format_args!("{:#?}", node)),
+            Selection::ScalarField(node) => f.write_fmt(format_args!("{:#?}", node)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct FragmentSpread {
+    pub span: Span,
+    pub spread: Token,
+    pub name: Identifier,
+    pub directives: Vec<Directive>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct InlineFragment {
+    pub span: Span,
+    pub spread: Token,
+    pub type_condition: Option<TypeCondition>,
+    pub directives: Vec<Directive>,
+    pub selections: List<Selection>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct LinkedField {
+    pub span: Span,
+    pub alias: Option<Alias>,
+    pub name: Identifier,
+    pub arguments: Option<List<Argument>>,
+    pub directives: Vec<Directive>,
+    pub selections: List<Selection>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ScalarField {
+    pub span: Span,
+    pub alias: Option<Alias>,
+    pub name: Identifier,
+    pub arguments: Option<List<Argument>>,
+    pub directives: Vec<Directive>,
+}

--- a/compiler/crates/graphql-syntax/src/token_kind.rs
+++ b/compiler/crates/graphql-syntax/src/token_kind.rs
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::fmt;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum TokenKind {
+    // Errors
+    ErrorInvalidVariableIdentifier,
+    ErrorUnsupportedCharacterSequence,
+    ErrorUnterminatedStringLiteral,
+    ErrorUnsupportedNumberLiteral,
+
+    // Valid tokens
+    Ampersand,
+    At,
+    CloseBrace,
+    CloseBracket,
+    CloseParen,
+    Colon,
+    Comma,
+    Dollar,
+    EndOfFile,
+    Equals,
+    Exclamation,
+    FloatLiteral,
+    Identifier,
+    IntegerLiteral,
+    NewLine,
+    OpenBrace,
+    OpenBracket,
+    OpenParen,
+    Period,
+    PeriodPeriod,
+    Pipe,
+    Plus,
+    SingleLineComment,
+    Spread,
+    StringLiteral,
+    VariableIdentifier,
+    Whitespace,
+}
+
+impl fmt::Display for TokenKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            TokenKind::Ampersand => "ampersand ('&')",
+            TokenKind::At => "at ('@')",
+            TokenKind::CloseBrace => "closing brace ('}')",
+            TokenKind::CloseBracket => "closing bracket (']')",
+            TokenKind::CloseParen => "closing paren (')')",
+            TokenKind::Colon => "colon (':')",
+            TokenKind::Comma => "comma (',')",
+            TokenKind::EndOfFile => "end of file",
+            TokenKind::Equals => "equals ('=')",
+            TokenKind::ErrorInvalidVariableIdentifier => {
+                "invalid variable identifier ('$' followed by invalid  character)"
+            }
+            TokenKind::ErrorUnsupportedCharacterSequence => "unsupported character(s)",
+            TokenKind::ErrorUnterminatedStringLiteral => "unterminated string literal ('\"...\"')",
+            TokenKind::ErrorUnsupportedNumberLiteral => "unsupported number (int or float) literal",
+            TokenKind::Exclamation => "exclamation mark ('!')",
+            TokenKind::FloatLiteral => "floating point value (e.g. '3.14')",
+            TokenKind::Identifier => "non-variable identifier (e.g. 'x' or 'Foo')",
+            TokenKind::IntegerLiteral => "integer value (e.g. '0' or '42')",
+            TokenKind::NewLine => "newline ('\\n' or '\\r\\n)",
+            TokenKind::OpenBrace => "open brace ('{')",
+            TokenKind::OpenBracket => "open bracket ('[')",
+            TokenKind::OpenParen => "open parenthesis ('(')",
+            TokenKind::Period => "period ('.')",
+            TokenKind::PeriodPeriod => "double period ('..')",
+            TokenKind::Pipe => "pipe ('|')",
+            TokenKind::Plus => "plus ('+')",
+            TokenKind::SingleLineComment => "single line comment ('//...')",
+            TokenKind::Spread => "spread ('...')",
+            TokenKind::StringLiteral => "string literal (e.g. '\"...\"')",
+            TokenKind::VariableIdentifier => "variable name ('$...', e.g. '$id')",
+            TokenKind::Whitespace => "whitespace (tab, space, etc)",
+            TokenKind::Dollar => "dollar ('$')",
+        };
+        f.write_str(message)
+    }
+}

--- a/compiler/crates/graphql-syntax/tests/parse/fixtures/invalid_number.expected
+++ b/compiler/crates/graphql-syntax/tests/parse/fixtures/invalid_number.expected
@@ -1,0 +1,14 @@
+==================================== INPUT ====================================
+# expected-to-throw
+query TestQuery {
+    friends(first: 1.23.4) {
+        count
+    }
+}
+==================================== ERROR ====================================
+Error: Invalid number value, expected an int or float at 2:19:
+    friends(first: 1.23.4) {
+
+
+Error: Expected a end of file at 2:25:
+    friends(first: 1.23.4) {

--- a/compiler/crates/graphql-syntax/tests/parse/fixtures/invalid_number.graphql
+++ b/compiler/crates/graphql-syntax/tests/parse/fixtures/invalid_number.graphql
@@ -1,0 +1,6 @@
+# expected-to-throw
+query TestQuery {
+    friends(first: 1.23.4) {
+        count
+    }
+}

--- a/compiler/crates/graphql-syntax/tests/parse/fixtures/keyword_as_name.expected
+++ b/compiler/crates/graphql-syntax/tests/parse/fixtures/keyword_as_name.expected
@@ -1,0 +1,101 @@
+==================================== INPUT ====================================
+query KeywordAsName {
+  search_results(query: "test")
+}
+==================================== OUTPUT ===================================
+Document {
+    span: 0:55,
+    definitions: [
+        OperationDefinition {
+            location: "keyword_as_name.graphql":0:55,
+            operation: Some(
+                (
+                    Token {
+                        span: "0:6",
+                        kind: Identifier,
+                    },
+                    Query,
+                ),
+            ),
+            name: Some(
+                Identifier {
+                    span: 6:20,
+                    token: Token {
+                        span: "6:20",
+                        kind: Identifier,
+                    },
+                    value: "KeywordAsName",
+                },
+            ),
+            variable_definitions: None,
+            directives: [],
+            selections: List {
+                span: 20:55,
+                start: Token {
+                    span: "20:21",
+                    kind: OpenBrace,
+                },
+                items: [
+                    ScalarField {
+                        span: 21:53,
+                        alias: None,
+                        name: Identifier {
+                            span: 21:38,
+                            token: Token {
+                                span: "21:38",
+                                kind: Identifier,
+                            },
+                            value: "search_results",
+                        },
+                        arguments: Some(
+                            List {
+                                span: 38:53,
+                                start: Token {
+                                    span: "38:39",
+                                    kind: OpenParen,
+                                },
+                                items: [
+                                    Argument {
+                                        span: 39:52,
+                                        name: Identifier {
+                                            span: 39:44,
+                                            token: Token {
+                                                span: "39:44",
+                                                kind: Identifier,
+                                            },
+                                            value: "query",
+                                        },
+                                        colon: Token {
+                                            span: "44:46",
+                                            kind: Colon,
+                                        },
+                                        value: Constant(
+                                            String(
+                                                StringNode {
+                                                    token: Token {
+                                                        span: "46:52",
+                                                        kind: StringLiteral,
+                                                    },
+                                                    value: "test",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ],
+                                end: Token {
+                                    span: "52:53",
+                                    kind: CloseParen,
+                                },
+                            },
+                        ),
+                        directives: [],
+                    },
+                ],
+                end: Token {
+                    span: "53:55",
+                    kind: CloseBrace,
+                },
+            },
+        },
+    ],
+}

--- a/compiler/crates/graphql-syntax/tests/parse/fixtures/keyword_as_name.graphql
+++ b/compiler/crates/graphql-syntax/tests/parse/fixtures/keyword_as_name.graphql
@@ -1,0 +1,3 @@
+query KeywordAsName {
+  search_results(query: "test")
+}

--- a/compiler/crates/graphql-syntax/tests/parse/fixtures/kitchen-sink.expected
+++ b/compiler/crates/graphql-syntax/tests/parse/fixtures/kitchen-sink.expected
@@ -1,0 +1,1658 @@
+==================================== INPUT ====================================
+query queryName($foo: ComplexType, $site: Site = MOBILE) @onQuery {
+  whoever123is: node(id: [-12, 345]) {
+    id
+    ... on User @onInlineFragment {
+      field2 {
+        id
+        alias: field1(first: 10, after: $foo) @include(if: $foo) {
+          id
+          ...frag @onFragmentSpread
+        }
+      }
+    }
+    ... @skip(unless: $foo) {
+      id
+    }
+    ... {
+      id
+    }
+  }
+}
+
+mutation likeStory @onMutation {
+  like(story: 123) @onField {
+    story {
+      id @onField
+    }
+  }
+}
+
+subscription StoryLikeSubscription($input: StoryLikeSubscribeInput)
+  @onSubscription {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+
+# fragment frag on Friend @onFragmentDefinition {
+#   foo(size: $size, bar: $b, obj: {key: "value", block: """
+
+#       block string uses \"""
+
+#   """})
+# }
+fragment frag on Friend @onFragmentDefinition {
+  foo(size: $size, bar: $b, obj: {key: "value", block: "todo: block string!"})
+  id
+  __typename
+}
+
+{
+  unnamed(truthy: true, falsy: false, nullish: null)
+  query
+}
+
+query {
+  __typename
+}
+==================================== OUTPUT ===================================
+Document {
+    span: 0:1123,
+    definitions: [
+        OperationDefinition {
+            location: "kitchen-sink.graphql":0:391,
+            operation: Some(
+                (
+                    Token {
+                        span: "0:6",
+                        kind: Identifier,
+                    },
+                    Query,
+                ),
+            ),
+            name: Some(
+                Identifier {
+                    span: 6:15,
+                    token: Token {
+                        span: "6:15",
+                        kind: Identifier,
+                    },
+                    value: "queryName",
+                },
+            ),
+            variable_definitions: Some(
+                List {
+                    span: 15:57,
+                    start: Token {
+                        span: "15:16",
+                        kind: OpenParen,
+                    },
+                    items: [
+                        VariableDefinition {
+                            span: 16:35,
+                            name: VariableIdentifier {
+                                span: 16:20,
+                                token: Token {
+                                    span: "16:20",
+                                    kind: VariableIdentifier,
+                                },
+                                name: "foo",
+                            },
+                            colon: Token {
+                                span: "20:22",
+                                kind: Colon,
+                            },
+                            type_: Named(
+                                Identifier {
+                                    span: 22:35,
+                                    token: Token {
+                                        span: "22:35",
+                                        kind: Identifier,
+                                    },
+                                    value: "ComplexType",
+                                },
+                            ),
+                            default_value: None,
+                            directives: [],
+                        },
+                        VariableDefinition {
+                            span: 35:55,
+                            name: VariableIdentifier {
+                                span: 35:40,
+                                token: Token {
+                                    span: "35:40",
+                                    kind: VariableIdentifier,
+                                },
+                                name: "site",
+                            },
+                            colon: Token {
+                                span: "40:42",
+                                kind: Colon,
+                            },
+                            type_: Named(
+                                Identifier {
+                                    span: 42:47,
+                                    token: Token {
+                                        span: "42:47",
+                                        kind: Identifier,
+                                    },
+                                    value: "Site",
+                                },
+                            ),
+                            default_value: Some(
+                                DefaultValue {
+                                    span: 47:55,
+                                    equals: Token {
+                                        span: "47:49",
+                                        kind: Equals,
+                                    },
+                                    value: Enum(
+                                        EnumNode {
+                                            token: Token {
+                                                span: "49:55",
+                                                kind: Identifier,
+                                            },
+                                            value: "MOBILE",
+                                        },
+                                    ),
+                                },
+                            ),
+                            directives: [],
+                        },
+                    ],
+                    end: Token {
+                        span: "55:57",
+                        kind: CloseParen,
+                    },
+                },
+            ),
+            directives: [
+                Directive {
+                    span: 57:66,
+                    at: Token {
+                        span: "57:58",
+                        kind: At,
+                    },
+                    name: Identifier {
+                        span: 58:66,
+                        token: Token {
+                            span: "58:66",
+                            kind: Identifier,
+                        },
+                        value: "onQuery",
+                    },
+                    arguments: None,
+                },
+            ],
+            selections: List {
+                span: 66:391,
+                start: Token {
+                    span: "66:67",
+                    kind: OpenBrace,
+                },
+                items: [
+                    LinkedField {
+                        span: 67:389,
+                        alias: Some(
+                            Alias {
+                                span: 67:88,
+                                alias: Identifier {
+                                    span: 67:82,
+                                    token: Token {
+                                        span: "67:82",
+                                        kind: Identifier,
+                                    },
+                                    value: "whoever123is",
+                                },
+                                colon: Token {
+                                    span: "82:84",
+                                    kind: Colon,
+                                },
+                            },
+                        ),
+                        name: Identifier {
+                            span: 84:88,
+                            token: Token {
+                                span: "84:88",
+                                kind: Identifier,
+                            },
+                            value: "node",
+                        },
+                        arguments: Some(
+                            List {
+                                span: 88:105,
+                                start: Token {
+                                    span: "88:89",
+                                    kind: OpenParen,
+                                },
+                                items: [
+                                    Argument {
+                                        span: 89:103,
+                                        name: Identifier {
+                                            span: 89:91,
+                                            token: Token {
+                                                span: "89:91",
+                                                kind: Identifier,
+                                            },
+                                            value: "id",
+                                        },
+                                        colon: Token {
+                                            span: "91:93",
+                                            kind: Colon,
+                                        },
+                                        value: Constant(
+                                            List(
+                                                List {
+                                                    span: 93:103,
+                                                    start: Token {
+                                                        span: "93:94",
+                                                        kind: OpenBracket,
+                                                    },
+                                                    items: [
+                                                        Int(
+                                                            IntNode {
+                                                                token: Token {
+                                                                    span: "94:99",
+                                                                    kind: IntegerLiteral,
+                                                                },
+                                                                value: -12,
+                                                            },
+                                                        ),
+                                                        Int(
+                                                            IntNode {
+                                                                token: Token {
+                                                                    span: "99:102",
+                                                                    kind: IntegerLiteral,
+                                                                },
+                                                                value: 345,
+                                                            },
+                                                        ),
+                                                    ],
+                                                    end: Token {
+                                                        span: "102:103",
+                                                        kind: CloseBracket,
+                                                    },
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ],
+                                end: Token {
+                                    span: "103:105",
+                                    kind: CloseParen,
+                                },
+                            },
+                        ),
+                        directives: [],
+                        selections: List {
+                            span: 105:389,
+                            start: Token {
+                                span: "105:106",
+                                kind: OpenBrace,
+                            },
+                            items: [
+                                ScalarField {
+                                    span: 106:113,
+                                    alias: None,
+                                    name: Identifier {
+                                        span: 106:113,
+                                        token: Token {
+                                            span: "106:113",
+                                            kind: Identifier,
+                                        },
+                                        value: "id",
+                                    },
+                                    arguments: None,
+                                    directives: [],
+                                },
+                                InlineFragment {
+                                    span: 113:315,
+                                    spread: Token {
+                                        span: "113:122",
+                                        kind: Spread,
+                                    },
+                                    type_condition: Some(
+                                        TypeCondition {
+                                            span: 122:130,
+                                            on: Token {
+                                                span: "122:125",
+                                                kind: Identifier,
+                                            },
+                                            type_: Identifier {
+                                                span: 125:130,
+                                                token: Token {
+                                                    span: "125:130",
+                                                    kind: Identifier,
+                                                },
+                                                value: "User",
+                                            },
+                                        },
+                                    ),
+                                    directives: [
+                                        Directive {
+                                            span: 130:148,
+                                            at: Token {
+                                                span: "130:131",
+                                                kind: At,
+                                            },
+                                            name: Identifier {
+                                                span: 131:148,
+                                                token: Token {
+                                                    span: "131:148",
+                                                    kind: Identifier,
+                                                },
+                                                value: "onInlineFragment",
+                                            },
+                                            arguments: None,
+                                        },
+                                    ],
+                                    selections: List {
+                                        span: 148:315,
+                                        start: Token {
+                                            span: "148:149",
+                                            kind: OpenBrace,
+                                        },
+                                        items: [
+                                            LinkedField {
+                                                span: 149:309,
+                                                alias: None,
+                                                name: Identifier {
+                                                    span: 149:163,
+                                                    token: Token {
+                                                        span: "149:163",
+                                                        kind: Identifier,
+                                                    },
+                                                    value: "field2",
+                                                },
+                                                arguments: None,
+                                                directives: [],
+                                                selections: List {
+                                                    span: 163:309,
+                                                    start: Token {
+                                                        span: "163:164",
+                                                        kind: OpenBrace,
+                                                    },
+                                                    items: [
+                                                        ScalarField {
+                                                            span: 164:175,
+                                                            alias: None,
+                                                            name: Identifier {
+                                                                span: 164:175,
+                                                                token: Token {
+                                                                    span: "164:175",
+                                                                    kind: Identifier,
+                                                                },
+                                                                value: "id",
+                                                            },
+                                                            arguments: None,
+                                                            directives: [],
+                                                        },
+                                                        LinkedField {
+                                                            span: 175:301,
+                                                            alias: Some(
+                                                                Alias {
+                                                                    span: 175:197,
+                                                                    alias: Identifier {
+                                                                        span: 175:189,
+                                                                        token: Token {
+                                                                            span: "175:189",
+                                                                            kind: Identifier,
+                                                                        },
+                                                                        value: "alias",
+                                                                    },
+                                                                    colon: Token {
+                                                                        span: "189:191",
+                                                                        kind: Colon,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            name: Identifier {
+                                                                span: 191:197,
+                                                                token: Token {
+                                                                    span: "191:197",
+                                                                    kind: Identifier,
+                                                                },
+                                                                value: "field1",
+                                                            },
+                                                            arguments: Some(
+                                                                List {
+                                                                    span: 197:222,
+                                                                    start: Token {
+                                                                        span: "197:198",
+                                                                        kind: OpenParen,
+                                                                    },
+                                                                    items: [
+                                                                        Argument {
+                                                                            span: 198:209,
+                                                                            name: Identifier {
+                                                                                span: 198:203,
+                                                                                token: Token {
+                                                                                    span: "198:203",
+                                                                                    kind: Identifier,
+                                                                                },
+                                                                                value: "first",
+                                                                            },
+                                                                            colon: Token {
+                                                                                span: "203:205",
+                                                                                kind: Colon,
+                                                                            },
+                                                                            value: Constant(
+                                                                                Int(
+                                                                                    IntNode {
+                                                                                        token: Token {
+                                                                                            span: "205:209",
+                                                                                            kind: IntegerLiteral,
+                                                                                        },
+                                                                                        value: 10,
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                        Argument {
+                                                                            span: 209:220,
+                                                                            name: Identifier {
+                                                                                span: 209:214,
+                                                                                token: Token {
+                                                                                    span: "209:214",
+                                                                                    kind: Identifier,
+                                                                                },
+                                                                                value: "after",
+                                                                            },
+                                                                            colon: Token {
+                                                                                span: "214:216",
+                                                                                kind: Colon,
+                                                                            },
+                                                                            value: Variable(
+                                                                                VariableIdentifier {
+                                                                                    span: 216:220,
+                                                                                    token: Token {
+                                                                                        span: "216:220",
+                                                                                        kind: VariableIdentifier,
+                                                                                    },
+                                                                                    name: "foo",
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                    end: Token {
+                                                                        span: "220:222",
+                                                                        kind: CloseParen,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            directives: [
+                                                                Directive {
+                                                                    span: 222:241,
+                                                                    at: Token {
+                                                                        span: "222:223",
+                                                                        kind: At,
+                                                                    },
+                                                                    name: Identifier {
+                                                                        span: 223:230,
+                                                                        token: Token {
+                                                                            span: "223:230",
+                                                                            kind: Identifier,
+                                                                        },
+                                                                        value: "include",
+                                                                    },
+                                                                    arguments: Some(
+                                                                        List {
+                                                                            span: 230:241,
+                                                                            start: Token {
+                                                                                span: "230:231",
+                                                                                kind: OpenParen,
+                                                                            },
+                                                                            items: [
+                                                                                Argument {
+                                                                                    span: 231:239,
+                                                                                    name: Identifier {
+                                                                                        span: 231:233,
+                                                                                        token: Token {
+                                                                                            span: "231:233",
+                                                                                            kind: Identifier,
+                                                                                        },
+                                                                                        value: "if",
+                                                                                    },
+                                                                                    colon: Token {
+                                                                                        span: "233:235",
+                                                                                        kind: Colon,
+                                                                                    },
+                                                                                    value: Variable(
+                                                                                        VariableIdentifier {
+                                                                                            span: 235:239,
+                                                                                            token: Token {
+                                                                                                span: "235:239",
+                                                                                                kind: VariableIdentifier,
+                                                                                            },
+                                                                                            name: "foo",
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                            ],
+                                                                            end: Token {
+                                                                                span: "239:241",
+                                                                                kind: CloseParen,
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                            selections: List {
+                                                                span: 241:301,
+                                                                start: Token {
+                                                                    span: "241:242",
+                                                                    kind: OpenBrace,
+                                                                },
+                                                                items: [
+                                                                    ScalarField {
+                                                                        span: 242:255,
+                                                                        alias: None,
+                                                                        name: Identifier {
+                                                                            span: 242:255,
+                                                                            token: Token {
+                                                                                span: "242:255",
+                                                                                kind: Identifier,
+                                                                            },
+                                                                            value: "id",
+                                                                        },
+                                                                        arguments: None,
+                                                                        directives: [],
+                                                                    },
+                                                                    FragmentSpread {
+                                                                        span: 255:291,
+                                                                        spread: Token {
+                                                                            span: "255:269",
+                                                                            kind: Spread,
+                                                                        },
+                                                                        name: Identifier {
+                                                                            span: 269:274,
+                                                                            token: Token {
+                                                                                span: "269:274",
+                                                                                kind: Identifier,
+                                                                            },
+                                                                            value: "frag",
+                                                                        },
+                                                                        directives: [
+                                                                            Directive {
+                                                                                span: 274:291,
+                                                                                at: Token {
+                                                                                    span: "274:275",
+                                                                                    kind: At,
+                                                                                },
+                                                                                name: Identifier {
+                                                                                    span: 275:291,
+                                                                                    token: Token {
+                                                                                        span: "275:291",
+                                                                                        kind: Identifier,
+                                                                                    },
+                                                                                    value: "onFragmentSpread",
+                                                                                },
+                                                                                arguments: None,
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                                end: Token {
+                                                                    span: "291:301",
+                                                                    kind: CloseBrace,
+                                                                },
+                                                            },
+                                                        },
+                                                    ],
+                                                    end: Token {
+                                                        span: "301:309",
+                                                        kind: CloseBrace,
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        end: Token {
+                                            span: "309:315",
+                                            kind: CloseBrace,
+                                        },
+                                    },
+                                },
+                                InlineFragment {
+                                    span: 315:360,
+                                    spread: Token {
+                                        span: "315:324",
+                                        kind: Spread,
+                                    },
+                                    type_condition: None,
+                                    directives: [
+                                        Directive {
+                                            span: 324:344,
+                                            at: Token {
+                                                span: "324:325",
+                                                kind: At,
+                                            },
+                                            name: Identifier {
+                                                span: 325:329,
+                                                token: Token {
+                                                    span: "325:329",
+                                                    kind: Identifier,
+                                                },
+                                                value: "skip",
+                                            },
+                                            arguments: Some(
+                                                List {
+                                                    span: 329:344,
+                                                    start: Token {
+                                                        span: "329:330",
+                                                        kind: OpenParen,
+                                                    },
+                                                    items: [
+                                                        Argument {
+                                                            span: 330:342,
+                                                            name: Identifier {
+                                                                span: 330:336,
+                                                                token: Token {
+                                                                    span: "330:336",
+                                                                    kind: Identifier,
+                                                                },
+                                                                value: "unless",
+                                                            },
+                                                            colon: Token {
+                                                                span: "336:338",
+                                                                kind: Colon,
+                                                            },
+                                                            value: Variable(
+                                                                VariableIdentifier {
+                                                                    span: 338:342,
+                                                                    token: Token {
+                                                                        span: "338:342",
+                                                                        kind: VariableIdentifier,
+                                                                    },
+                                                                    name: "foo",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                    end: Token {
+                                                        span: "342:344",
+                                                        kind: CloseParen,
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                    selections: List {
+                                        span: 344:360,
+                                        start: Token {
+                                            span: "344:345",
+                                            kind: OpenBrace,
+                                        },
+                                        items: [
+                                            ScalarField {
+                                                span: 345:354,
+                                                alias: None,
+                                                name: Identifier {
+                                                    span: 345:354,
+                                                    token: Token {
+                                                        span: "345:354",
+                                                        kind: Identifier,
+                                                    },
+                                                    value: "id",
+                                                },
+                                                arguments: None,
+                                                directives: [],
+                                            },
+                                        ],
+                                        end: Token {
+                                            span: "354:360",
+                                            kind: CloseBrace,
+                                        },
+                                    },
+                                },
+                                InlineFragment {
+                                    span: 360:385,
+                                    spread: Token {
+                                        span: "360:369",
+                                        kind: Spread,
+                                    },
+                                    type_condition: None,
+                                    directives: [],
+                                    selections: List {
+                                        span: 369:385,
+                                        start: Token {
+                                            span: "369:370",
+                                            kind: OpenBrace,
+                                        },
+                                        items: [
+                                            ScalarField {
+                                                span: 370:379,
+                                                alias: None,
+                                                name: Identifier {
+                                                    span: 370:379,
+                                                    token: Token {
+                                                        span: "370:379",
+                                                        kind: Identifier,
+                                                    },
+                                                    value: "id",
+                                                },
+                                                arguments: None,
+                                                directives: [],
+                                            },
+                                        ],
+                                        end: Token {
+                                            span: "379:385",
+                                            kind: CloseBrace,
+                                        },
+                                    },
+                                },
+                            ],
+                            end: Token {
+                                span: "385:389",
+                                kind: CloseBrace,
+                            },
+                        },
+                    },
+                ],
+                end: Token {
+                    span: "389:391",
+                    kind: CloseBrace,
+                },
+            },
+        },
+        OperationDefinition {
+            location: "kitchen-sink.graphql":391:497,
+            operation: Some(
+                (
+                    Token {
+                        span: "391:402",
+                        kind: Identifier,
+                    },
+                    Mutation,
+                ),
+            ),
+            name: Some(
+                Identifier {
+                    span: 402:412,
+                    token: Token {
+                        span: "402:412",
+                        kind: Identifier,
+                    },
+                    value: "likeStory",
+                },
+            ),
+            variable_definitions: None,
+            directives: [
+                Directive {
+                    span: 412:424,
+                    at: Token {
+                        span: "412:413",
+                        kind: At,
+                    },
+                    name: Identifier {
+                        span: 413:424,
+                        token: Token {
+                            span: "413:424",
+                            kind: Identifier,
+                        },
+                        value: "onMutation",
+                    },
+                    arguments: None,
+                },
+            ],
+            selections: List {
+                span: 424:497,
+                start: Token {
+                    span: "424:425",
+                    kind: OpenBrace,
+                },
+                items: [
+                    LinkedField {
+                        span: 425:495,
+                        alias: None,
+                        name: Identifier {
+                            span: 425:432,
+                            token: Token {
+                                span: "425:432",
+                                kind: Identifier,
+                            },
+                            value: "like",
+                        },
+                        arguments: Some(
+                            List {
+                                span: 432:445,
+                                start: Token {
+                                    span: "432:433",
+                                    kind: OpenParen,
+                                },
+                                items: [
+                                    Argument {
+                                        span: 433:443,
+                                        name: Identifier {
+                                            span: 433:438,
+                                            token: Token {
+                                                span: "433:438",
+                                                kind: Identifier,
+                                            },
+                                            value: "story",
+                                        },
+                                        colon: Token {
+                                            span: "438:440",
+                                            kind: Colon,
+                                        },
+                                        value: Constant(
+                                            Int(
+                                                IntNode {
+                                                    token: Token {
+                                                        span: "440:443",
+                                                        kind: IntegerLiteral,
+                                                    },
+                                                    value: 123,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ],
+                                end: Token {
+                                    span: "443:445",
+                                    kind: CloseParen,
+                                },
+                            },
+                        ),
+                        directives: [
+                            Directive {
+                                span: 445:454,
+                                at: Token {
+                                    span: "445:446",
+                                    kind: At,
+                                },
+                                name: Identifier {
+                                    span: 446:454,
+                                    token: Token {
+                                        span: "446:454",
+                                        kind: Identifier,
+                                    },
+                                    value: "onField",
+                                },
+                                arguments: None,
+                            },
+                        ],
+                        selections: List {
+                            span: 454:495,
+                            start: Token {
+                                span: "454:455",
+                                kind: OpenBrace,
+                            },
+                            items: [
+                                LinkedField {
+                                    span: 455:491,
+                                    alias: None,
+                                    name: Identifier {
+                                        span: 455:466,
+                                        token: Token {
+                                            span: "455:466",
+                                            kind: Identifier,
+                                        },
+                                        value: "story",
+                                    },
+                                    arguments: None,
+                                    directives: [],
+                                    selections: List {
+                                        span: 466:491,
+                                        start: Token {
+                                            span: "466:467",
+                                            kind: OpenBrace,
+                                        },
+                                        items: [
+                                            ScalarField {
+                                                span: 467:485,
+                                                alias: None,
+                                                name: Identifier {
+                                                    span: 467:477,
+                                                    token: Token {
+                                                        span: "467:477",
+                                                        kind: Identifier,
+                                                    },
+                                                    value: "id",
+                                                },
+                                                arguments: None,
+                                                directives: [
+                                                    Directive {
+                                                        span: 477:485,
+                                                        at: Token {
+                                                            span: "477:478",
+                                                            kind: At,
+                                                        },
+                                                        name: Identifier {
+                                                            span: 478:485,
+                                                            token: Token {
+                                                                span: "478:485",
+                                                                kind: Identifier,
+                                                            },
+                                                            value: "onField",
+                                                        },
+                                                        arguments: None,
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                        end: Token {
+                                            span: "485:491",
+                                            kind: CloseBrace,
+                                        },
+                                    },
+                                },
+                            ],
+                            end: Token {
+                                span: "491:495",
+                                kind: CloseBrace,
+                            },
+                        },
+                    },
+                ],
+                end: Token {
+                    span: "495:497",
+                    kind: CloseBrace,
+                },
+            },
+        },
+        OperationDefinition {
+            location: "kitchen-sink.graphql":497:727,
+            operation: Some(
+                (
+                    Token {
+                        span: "497:512",
+                        kind: Identifier,
+                    },
+                    Subscription,
+                ),
+            ),
+            name: Some(
+                Identifier {
+                    span: 512:533,
+                    token: Token {
+                        span: "512:533",
+                        kind: Identifier,
+                    },
+                    value: "StoryLikeSubscription",
+                },
+            ),
+            variable_definitions: Some(
+                List {
+                    span: 533:566,
+                    start: Token {
+                        span: "533:534",
+                        kind: OpenParen,
+                    },
+                    items: [
+                        VariableDefinition {
+                            span: 534:565,
+                            name: VariableIdentifier {
+                                span: 534:540,
+                                token: Token {
+                                    span: "534:540",
+                                    kind: VariableIdentifier,
+                                },
+                                name: "input",
+                            },
+                            colon: Token {
+                                span: "540:542",
+                                kind: Colon,
+                            },
+                            type_: Named(
+                                Identifier {
+                                    span: 542:565,
+                                    token: Token {
+                                        span: "542:565",
+                                        kind: Identifier,
+                                    },
+                                    value: "StoryLikeSubscribeInput",
+                                },
+                            ),
+                            default_value: None,
+                            directives: [],
+                        },
+                    ],
+                    end: Token {
+                        span: "565:566",
+                        kind: CloseParen,
+                    },
+                },
+            ),
+            directives: [
+                Directive {
+                    span: 566:585,
+                    at: Token {
+                        span: "566:570",
+                        kind: At,
+                    },
+                    name: Identifier {
+                        span: 570:585,
+                        token: Token {
+                            span: "570:585",
+                            kind: Identifier,
+                        },
+                        value: "onSubscription",
+                    },
+                    arguments: None,
+                },
+            ],
+            selections: List {
+                span: 585:727,
+                start: Token {
+                    span: "585:586",
+                    kind: OpenBrace,
+                },
+                items: [
+                    LinkedField {
+                        span: 586:725,
+                        alias: None,
+                        name: Identifier {
+                            span: 586:607,
+                            token: Token {
+                                span: "586:607",
+                                kind: Identifier,
+                            },
+                            value: "storyLikeSubscribe",
+                        },
+                        arguments: Some(
+                            List {
+                                span: 607:623,
+                                start: Token {
+                                    span: "607:608",
+                                    kind: OpenParen,
+                                },
+                                items: [
+                                    Argument {
+                                        span: 608:621,
+                                        name: Identifier {
+                                            span: 608:613,
+                                            token: Token {
+                                                span: "608:613",
+                                                kind: Identifier,
+                                            },
+                                            value: "input",
+                                        },
+                                        colon: Token {
+                                            span: "613:615",
+                                            kind: Colon,
+                                        },
+                                        value: Variable(
+                                            VariableIdentifier {
+                                                span: 615:621,
+                                                token: Token {
+                                                    span: "615:621",
+                                                    kind: VariableIdentifier,
+                                                },
+                                                name: "input",
+                                            },
+                                        ),
+                                    },
+                                ],
+                                end: Token {
+                                    span: "621:623",
+                                    kind: CloseParen,
+                                },
+                            },
+                        ),
+                        directives: [],
+                        selections: List {
+                            span: 623:725,
+                            start: Token {
+                                span: "623:624",
+                                kind: OpenBrace,
+                            },
+                            items: [
+                                LinkedField {
+                                    span: 624:721,
+                                    alias: None,
+                                    name: Identifier {
+                                        span: 624:635,
+                                        token: Token {
+                                            span: "624:635",
+                                            kind: Identifier,
+                                        },
+                                        value: "story",
+                                    },
+                                    arguments: None,
+                                    directives: [],
+                                    selections: List {
+                                        span: 635:721,
+                                        start: Token {
+                                            span: "635:636",
+                                            kind: OpenBrace,
+                                        },
+                                        items: [
+                                            LinkedField {
+                                                span: 636:673,
+                                                alias: None,
+                                                name: Identifier {
+                                                    span: 636:650,
+                                                    token: Token {
+                                                        span: "636:650",
+                                                        kind: Identifier,
+                                                    },
+                                                    value: "likers",
+                                                },
+                                                arguments: None,
+                                                directives: [],
+                                                selections: List {
+                                                    span: 650:673,
+                                                    start: Token {
+                                                        span: "650:651",
+                                                        kind: OpenBrace,
+                                                    },
+                                                    items: [
+                                                        ScalarField {
+                                                            span: 651:665,
+                                                            alias: None,
+                                                            name: Identifier {
+                                                                span: 651:665,
+                                                                token: Token {
+                                                                    span: "651:665",
+                                                                    kind: Identifier,
+                                                                },
+                                                                value: "count",
+                                                            },
+                                                            arguments: None,
+                                                            directives: [],
+                                                        },
+                                                    ],
+                                                    end: Token {
+                                                        span: "665:673",
+                                                        kind: CloseBrace,
+                                                    },
+                                                },
+                                            },
+                                            LinkedField {
+                                                span: 673:715,
+                                                alias: None,
+                                                name: Identifier {
+                                                    span: 673:693,
+                                                    token: Token {
+                                                        span: "673:693",
+                                                        kind: Identifier,
+                                                    },
+                                                    value: "likeSentence",
+                                                },
+                                                arguments: None,
+                                                directives: [],
+                                                selections: List {
+                                                    span: 693:715,
+                                                    start: Token {
+                                                        span: "693:694",
+                                                        kind: OpenBrace,
+                                                    },
+                                                    items: [
+                                                        ScalarField {
+                                                            span: 694:707,
+                                                            alias: None,
+                                                            name: Identifier {
+                                                                span: 694:707,
+                                                                token: Token {
+                                                                    span: "694:707",
+                                                                    kind: Identifier,
+                                                                },
+                                                                value: "text",
+                                                            },
+                                                            arguments: None,
+                                                            directives: [],
+                                                        },
+                                                    ],
+                                                    end: Token {
+                                                        span: "707:715",
+                                                        kind: CloseBrace,
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        end: Token {
+                                            span: "715:721",
+                                            kind: CloseBrace,
+                                        },
+                                    },
+                                },
+                            ],
+                            end: Token {
+                                span: "721:725",
+                                kind: CloseBrace,
+                            },
+                        },
+                    },
+                ],
+                end: Token {
+                    span: "725:727",
+                    kind: CloseBrace,
+                },
+            },
+        },
+        FragmentDefinition {
+            location: "kitchen-sink.graphql":727:1033,
+            fragment: Token {
+                span: "727:896",
+                kind: Identifier,
+            },
+            name: Identifier {
+                span: 896:901,
+                token: Token {
+                    span: "896:901",
+                    kind: Identifier,
+                },
+                value: "frag",
+            },
+            type_condition: TypeCondition {
+                span: 901:911,
+                on: Token {
+                    span: "901:904",
+                    kind: Identifier,
+                },
+                type_: Identifier {
+                    span: 904:911,
+                    token: Token {
+                        span: "904:911",
+                        kind: Identifier,
+                    },
+                    value: "Friend",
+                },
+            },
+            directives: [
+                Directive {
+                    span: 911:933,
+                    at: Token {
+                        span: "911:912",
+                        kind: At,
+                    },
+                    name: Identifier {
+                        span: 912:933,
+                        token: Token {
+                            span: "912:933",
+                            kind: Identifier,
+                        },
+                        value: "onFragmentDefinition",
+                    },
+                    arguments: None,
+                },
+            ],
+            selections: List {
+                span: 933:1033,
+                start: Token {
+                    span: "933:934",
+                    kind: OpenBrace,
+                },
+                items: [
+                    ScalarField {
+                        span: 934:1013,
+                        alias: None,
+                        name: Identifier {
+                            span: 934:940,
+                            token: Token {
+                                span: "934:940",
+                                kind: Identifier,
+                            },
+                            value: "foo",
+                        },
+                        arguments: Some(
+                            List {
+                                span: 940:1013,
+                                start: Token {
+                                    span: "940:941",
+                                    kind: OpenParen,
+                                },
+                                items: [
+                                    Argument {
+                                        span: 941:954,
+                                        name: Identifier {
+                                            span: 941:945,
+                                            token: Token {
+                                                span: "941:945",
+                                                kind: Identifier,
+                                            },
+                                            value: "size",
+                                        },
+                                        colon: Token {
+                                            span: "945:947",
+                                            kind: Colon,
+                                        },
+                                        value: Variable(
+                                            VariableIdentifier {
+                                                span: 947:954,
+                                                token: Token {
+                                                    span: "947:954",
+                                                    kind: VariableIdentifier,
+                                                },
+                                                name: "size",
+                                            },
+                                        ),
+                                    },
+                                    Argument {
+                                        span: 954:963,
+                                        name: Identifier {
+                                            span: 954:957,
+                                            token: Token {
+                                                span: "954:957",
+                                                kind: Identifier,
+                                            },
+                                            value: "bar",
+                                        },
+                                        colon: Token {
+                                            span: "957:959",
+                                            kind: Colon,
+                                        },
+                                        value: Variable(
+                                            VariableIdentifier {
+                                                span: 959:963,
+                                                token: Token {
+                                                    span: "959:963",
+                                                    kind: VariableIdentifier,
+                                                },
+                                                name: "b",
+                                            },
+                                        ),
+                                    },
+                                    Argument {
+                                        span: 963:1012,
+                                        name: Identifier {
+                                            span: 963:966,
+                                            token: Token {
+                                                span: "963:966",
+                                                kind: Identifier,
+                                            },
+                                            value: "obj",
+                                        },
+                                        colon: Token {
+                                            span: "966:968",
+                                            kind: Colon,
+                                        },
+                                        value: Constant(
+                                            Object(
+                                                List {
+                                                    span: 968:1012,
+                                                    start: Token {
+                                                        span: "968:969",
+                                                        kind: OpenBrace,
+                                                    },
+                                                    items: [
+                                                        ConstantArgument {
+                                                            span: 969:983,
+                                                            name: Identifier {
+                                                                span: 969:972,
+                                                                token: Token {
+                                                                    span: "969:972",
+                                                                    kind: Identifier,
+                                                                },
+                                                                value: "key",
+                                                            },
+                                                            colon: Token {
+                                                                span: "972:974",
+                                                                kind: Colon,
+                                                            },
+                                                            value: String(
+                                                                StringNode {
+                                                                    token: Token {
+                                                                        span: "974:983",
+                                                                        kind: StringLiteral,
+                                                                    },
+                                                                    value: "value",
+                                                                },
+                                                            ),
+                                                        },
+                                                        ConstantArgument {
+                                                            span: 983:1011,
+                                                            name: Identifier {
+                                                                span: 983:988,
+                                                                token: Token {
+                                                                    span: "983:988",
+                                                                    kind: Identifier,
+                                                                },
+                                                                value: "block",
+                                                            },
+                                                            colon: Token {
+                                                                span: "988:990",
+                                                                kind: Colon,
+                                                            },
+                                                            value: String(
+                                                                StringNode {
+                                                                    token: Token {
+                                                                        span: "990:1011",
+                                                                        kind: StringLiteral,
+                                                                    },
+                                                                    value: "todo: block string!",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                    end: Token {
+                                                        span: "1011:1012",
+                                                        kind: CloseBrace,
+                                                    },
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ],
+                                end: Token {
+                                    span: "1012:1013",
+                                    kind: CloseParen,
+                                },
+                            },
+                        ),
+                        directives: [],
+                    },
+                    ScalarField {
+                        span: 1013:1018,
+                        alias: None,
+                        name: Identifier {
+                            span: 1013:1018,
+                            token: Token {
+                                span: "1013:1018",
+                                kind: Identifier,
+                            },
+                            value: "id",
+                        },
+                        arguments: None,
+                        directives: [],
+                    },
+                    ScalarField {
+                        span: 1018:1031,
+                        alias: None,
+                        name: Identifier {
+                            span: 1018:1031,
+                            token: Token {
+                                span: "1018:1031",
+                                kind: Identifier,
+                            },
+                            value: "__typename",
+                        },
+                        arguments: None,
+                        directives: [],
+                    },
+                ],
+                end: Token {
+                    span: "1031:1033",
+                    kind: CloseBrace,
+                },
+            },
+        },
+        OperationDefinition {
+            location: "kitchen-sink.graphql":1033:1099,
+            operation: None,
+            name: None,
+            variable_definitions: None,
+            directives: [],
+            selections: List {
+                span: 1033:1099,
+                start: Token {
+                    span: "1033:1036",
+                    kind: OpenBrace,
+                },
+                items: [
+                    ScalarField {
+                        span: 1036:1089,
+                        alias: None,
+                        name: Identifier {
+                            span: 1036:1046,
+                            token: Token {
+                                span: "1036:1046",
+                                kind: Identifier,
+                            },
+                            value: "unnamed",
+                        },
+                        arguments: Some(
+                            List {
+                                span: 1046:1089,
+                                start: Token {
+                                    span: "1046:1047",
+                                    kind: OpenParen,
+                                },
+                                items: [
+                                    Argument {
+                                        span: 1047:1061,
+                                        name: Identifier {
+                                            span: 1047:1053,
+                                            token: Token {
+                                                span: "1047:1053",
+                                                kind: Identifier,
+                                            },
+                                            value: "truthy",
+                                        },
+                                        colon: Token {
+                                            span: "1053:1055",
+                                            kind: Colon,
+                                        },
+                                        value: Constant(
+                                            Boolean(
+                                                BooleanNode {
+                                                    token: Token {
+                                                        span: "1055:1061",
+                                                        kind: Identifier,
+                                                    },
+                                                    value: true,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                    Argument {
+                                        span: 1061:1075,
+                                        name: Identifier {
+                                            span: 1061:1066,
+                                            token: Token {
+                                                span: "1061:1066",
+                                                kind: Identifier,
+                                            },
+                                            value: "falsy",
+                                        },
+                                        colon: Token {
+                                            span: "1066:1068",
+                                            kind: Colon,
+                                        },
+                                        value: Constant(
+                                            Boolean(
+                                                BooleanNode {
+                                                    token: Token {
+                                                        span: "1068:1075",
+                                                        kind: Identifier,
+                                                    },
+                                                    value: false,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                    Argument {
+                                        span: 1075:1088,
+                                        name: Identifier {
+                                            span: 1075:1082,
+                                            token: Token {
+                                                span: "1075:1082",
+                                                kind: Identifier,
+                                            },
+                                            value: "nullish",
+                                        },
+                                        colon: Token {
+                                            span: "1082:1084",
+                                            kind: Colon,
+                                        },
+                                        value: Constant(
+                                            Null(
+                                                Token {
+                                                    span: "1084:1088",
+                                                    kind: Identifier,
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ],
+                                end: Token {
+                                    span: "1088:1089",
+                                    kind: CloseParen,
+                                },
+                            },
+                        ),
+                        directives: [],
+                    },
+                    ScalarField {
+                        span: 1089:1097,
+                        alias: None,
+                        name: Identifier {
+                            span: 1089:1097,
+                            token: Token {
+                                span: "1089:1097",
+                                kind: Identifier,
+                            },
+                            value: "query",
+                        },
+                        arguments: None,
+                        directives: [],
+                    },
+                ],
+                end: Token {
+                    span: "1097:1099",
+                    kind: CloseBrace,
+                },
+            },
+        },
+        OperationDefinition {
+            location: "kitchen-sink.graphql":1099:1123,
+            operation: Some(
+                (
+                    Token {
+                        span: "1099:1107",
+                        kind: Identifier,
+                    },
+                    Query,
+                ),
+            ),
+            name: None,
+            variable_definitions: None,
+            directives: [],
+            selections: List {
+                span: 1107:1123,
+                start: Token {
+                    span: "1107:1108",
+                    kind: OpenBrace,
+                },
+                items: [
+                    ScalarField {
+                        span: 1108:1121,
+                        alias: None,
+                        name: Identifier {
+                            span: 1108:1121,
+                            token: Token {
+                                span: "1108:1121",
+                                kind: Identifier,
+                            },
+                            value: "__typename",
+                        },
+                        arguments: None,
+                        directives: [],
+                    },
+                ],
+                end: Token {
+                    span: "1121:1123",
+                    kind: CloseBrace,
+                },
+            },
+        },
+    ],
+}

--- a/compiler/crates/graphql-syntax/tests/parse/fixtures/kitchen-sink.graphql
+++ b/compiler/crates/graphql-syntax/tests/parse/fixtures/kitchen-sink.graphql
@@ -1,0 +1,64 @@
+query queryName($foo: ComplexType, $site: Site = MOBILE) @onQuery {
+  whoever123is: node(id: [-12, 345]) {
+    id
+    ... on User @onInlineFragment {
+      field2 {
+        id
+        alias: field1(first: 10, after: $foo) @include(if: $foo) {
+          id
+          ...frag @onFragmentSpread
+        }
+      }
+    }
+    ... @skip(unless: $foo) {
+      id
+    }
+    ... {
+      id
+    }
+  }
+}
+
+mutation likeStory @onMutation {
+  like(story: 123) @onField {
+    story {
+      id @onField
+    }
+  }
+}
+
+subscription StoryLikeSubscription($input: StoryLikeSubscribeInput)
+  @onSubscription {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+
+# fragment frag on Friend @onFragmentDefinition {
+#   foo(size: $size, bar: $b, obj: {key: "value", block: """
+
+#       block string uses \"""
+
+#   """})
+# }
+fragment frag on Friend @onFragmentDefinition {
+  foo(size: $size, bar: $b, obj: {key: "value", block: "todo: block string!"})
+  id
+  __typename
+}
+
+{
+  unnamed(truthy: true, falsy: false, nullish: null)
+  query
+}
+
+query {
+  __typename
+}

--- a/compiler/crates/graphql-syntax/tests/parse/fixtures/list_of_enum.expected
+++ b/compiler/crates/graphql-syntax/tests/parse/fixtures/list_of_enum.expected
@@ -1,0 +1,123 @@
+==================================== INPUT ====================================
+fragment TestFrag on MyType {
+  issues(orderby: [LAST_UPDATED])
+}
+==================================== OUTPUT ===================================
+Document {
+    span: 0:65,
+    definitions: [
+        FragmentDefinition {
+            location: "list_of_enum.graphql":0:65,
+            fragment: Token {
+                span: "0:9",
+                kind: Identifier,
+            },
+            name: Identifier {
+                span: 9:18,
+                token: Token {
+                    span: "9:18",
+                    kind: Identifier,
+                },
+                value: "TestFrag",
+            },
+            type_condition: TypeCondition {
+                span: 18:28,
+                on: Token {
+                    span: "18:21",
+                    kind: Identifier,
+                },
+                type_: Identifier {
+                    span: 21:28,
+                    token: Token {
+                        span: "21:28",
+                        kind: Identifier,
+                    },
+                    value: "MyType",
+                },
+            },
+            directives: [],
+            selections: List {
+                span: 28:65,
+                start: Token {
+                    span: "28:29",
+                    kind: OpenBrace,
+                },
+                items: [
+                    ScalarField {
+                        span: 29:63,
+                        alias: None,
+                        name: Identifier {
+                            span: 29:38,
+                            token: Token {
+                                span: "29:38",
+                                kind: Identifier,
+                            },
+                            value: "issues",
+                        },
+                        arguments: Some(
+                            List {
+                                span: 38:63,
+                                start: Token {
+                                    span: "38:39",
+                                    kind: OpenParen,
+                                },
+                                items: [
+                                    Argument {
+                                        span: 39:62,
+                                        name: Identifier {
+                                            span: 39:46,
+                                            token: Token {
+                                                span: "39:46",
+                                                kind: Identifier,
+                                            },
+                                            value: "orderby",
+                                        },
+                                        colon: Token {
+                                            span: "46:48",
+                                            kind: Colon,
+                                        },
+                                        value: Constant(
+                                            List(
+                                                List {
+                                                    span: 48:62,
+                                                    start: Token {
+                                                        span: "48:49",
+                                                        kind: OpenBracket,
+                                                    },
+                                                    items: [
+                                                        Enum(
+                                                            EnumNode {
+                                                                token: Token {
+                                                                    span: "49:61",
+                                                                    kind: Identifier,
+                                                                },
+                                                                value: "LAST_UPDATED",
+                                                            },
+                                                        ),
+                                                    ],
+                                                    end: Token {
+                                                        span: "61:62",
+                                                        kind: CloseBracket,
+                                                    },
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ],
+                                end: Token {
+                                    span: "62:63",
+                                    kind: CloseParen,
+                                },
+                            },
+                        ),
+                        directives: [],
+                    },
+                ],
+                end: Token {
+                    span: "63:65",
+                    kind: CloseBrace,
+                },
+            },
+        },
+    ],
+}

--- a/compiler/crates/graphql-syntax/tests/parse/fixtures/list_of_enum.graphql
+++ b/compiler/crates/graphql-syntax/tests/parse/fixtures/list_of_enum.graphql
@@ -1,0 +1,3 @@
+fragment TestFrag on MyType {
+  issues(orderby: [LAST_UPDATED])
+}

--- a/compiler/crates/graphql-syntax/tests/parse/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse/mod.rs
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use fixture_tests::Fixture;
+use graphql_syntax::parse;
+
+pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
+    parse(fixture.content, fixture.file_name)
+        .map(|x| format!("{:#?}", x))
+        .map_err(|errors| {
+            errors
+                .into_iter()
+                .map(|error| error.print(fixture.content))
+                .collect::<Vec<_>>()
+                .join("\n\n")
+        })
+}

--- a/compiler/crates/graphql-syntax/tests/parse_test.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_test.rs
@@ -1,0 +1,34 @@
+// @generated SignedSource<<09e50c55635d10f9893ddfd7ec8b5f54>>
+
+mod parse;
+
+use parse::transform_fixture;
+use fixture_tests::test_fixture;
+
+#[test]
+fn invalid_number() {
+    let input = include_str!("parse/fixtures/invalid_number.graphql");
+    let expected = include_str!("parse/fixtures/invalid_number.expected");
+    test_fixture(transform_fixture, "invalid_number.graphql", "parse/fixtures/invalid_number.expected", input, expected);
+}
+
+#[test]
+fn keyword_as_name() {
+    let input = include_str!("parse/fixtures/keyword_as_name.graphql");
+    let expected = include_str!("parse/fixtures/keyword_as_name.expected");
+    test_fixture(transform_fixture, "keyword_as_name.graphql", "parse/fixtures/keyword_as_name.expected", input, expected);
+}
+
+#[test]
+fn kitchen_sink() {
+    let input = include_str!("parse/fixtures/kitchen-sink.graphql");
+    let expected = include_str!("parse/fixtures/kitchen-sink.expected");
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "parse/fixtures/kitchen-sink.expected", input, expected);
+}
+
+#[test]
+fn list_of_enum() {
+    let input = include_str!("parse/fixtures/list_of_enum.graphql");
+    let expected = include_str!("parse/fixtures/list_of_enum.expected");
+    test_fixture(transform_fixture, "list_of_enum.graphql", "parse/fixtures/list_of_enum.expected", input, expected);
+}


### PR DESCRIPTION
Adds graphql-syntax, a crate for lexing/parsing *executable* definitions (but not schema definitions, we may merge the schema/definition parsers later). This crate creates full-fidelity ASTs which capture information about the location of trivia (comments, whitespace, commas) as well as all nodes in the tree. Additionally, the crate focuses on providing useful messages even in the presence of lexical or grammatical errors - it can report multiple lexing errors, detect common issues such as incorrect number of periods in a spread ('..' instead of '...') or invalid number literals.

This crate implements the majority of the spec, but there are some unimplemented features that may be added later.