### PR TITLE
[rust-compiler] add interner crate

### DIFF
--- a/compiler/crates/interner/Cargo.toml
+++ b/compiler/crates/interner/Cargo.toml
@@ -1,0 +1,10 @@
+[project]
+name = "interner"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies]
+fnv = "1.0.6"
+lazy_static = "1.4.0"
+parking_lot = "0.10.0"
+serde = { version = "1.0.104", features = ["derive"] }

--- a/compiler/crates/interner/README.md
+++ b/compiler/crates/interner/README.md
@@ -1,0 +1,3 @@
+# interner
+
+Traits and utilities for efficiently interning arbitrary Rust types. The intended usage is to provide a small, cheap-to-copy/compare value that can be substituted for a larger value. A common example is for symbols in source code (e.g. identifiers, field names, argument names in GraphQL), but also other identifier-like information such as structs that might map a FIle+NameWithinFile struct.

--- a/compiler/crates/interner/src/bytes.rs
+++ b/compiler/crates/interner/src/bytes.rs
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::types::{Intern, RawInternKey};
+use fnv::FnvHashMap;
+use lazy_static::lazy_static;
+use parking_lot::RwLock;
+use serde::{Deserialize, Deserializer};
+use std::fmt;
+use std::sync::Arc;
+
+/// Slices of bytes intern as BytesKey
+impl Intern for &[u8] {
+    type Key = BytesKey;
+
+    fn intern(self) -> Self::Key {
+        BytesKey(BYTES_TABLE.intern(self))
+    }
+}
+
+/// Owned strings intern as StringKey, with the interning
+/// based on the raw bytes of the string
+impl Intern for String {
+    type Key = StringKey;
+
+    fn intern(self) -> Self::Key {
+        StringKey(BYTES_TABLE.intern(self.as_bytes()))
+    }
+}
+
+/// Str (slices) intern as StringKey, with the interning
+/// based on the raw bytes of the str.
+impl Intern for &str {
+    type Key = StringKey;
+
+    fn intern(self) -> Self::Key {
+        StringKey(BYTES_TABLE.intern(self.as_bytes()))
+    }
+}
+
+/// Interned bytes
+#[derive(Copy, Clone, Eq, Ord, Hash, PartialEq, PartialOrd)]
+pub struct BytesKey(RawInternKey);
+
+impl BytesKey {
+    pub fn lookup(self) -> &'static [u8] {
+        BYTES_TABLE.lookup(self.0)
+    }
+}
+
+impl fmt::Debug for BytesKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bytes_value = self.lookup();
+        write!(f, "{:?}", bytes_value)
+    }
+}
+
+/// An interned string
+#[derive(Copy, Clone, Eq, Ord, Hash, PartialEq, PartialOrd)]
+pub struct StringKey(RawInternKey);
+
+impl StringKey {
+    /// Get a reference to the original str.
+    pub fn lookup(self) -> &'static str {
+        let bytes = BYTES_TABLE.lookup(self.0);
+        // This is safe because the bytes we are converting originally came
+        // from a str when we interned it: the only way to get a StringKey is
+        // to intern an (already valid) string, so if we have a StringKey then
+        // its bytes must be valid UTF-8.
+        unsafe { std::str::from_utf8_unchecked(bytes) }
+    }
+
+    /// Convert the interned string key into an interned bytes key. Because
+    /// strings intern as their raw bytes, this is an O(1) operation.
+    /// Note the reverse (BytesKey.as_str) is a fallible operation since
+    /// the bytes may not be valid UTF-8.
+    pub fn as_bytes(self) -> BytesKey {
+        BytesKey(self.0)
+    }
+}
+
+impl fmt::Debug for StringKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str_value = self.lookup();
+        write!(f, "{:?}", str_value)
+    }
+}
+
+impl fmt::Display for StringKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str_value = self.lookup();
+        write!(f, "{}", str_value)
+    }
+}
+
+impl<'de> Deserialize<'de> for StringKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(deserializer).map(|s: String| s.intern())
+    }
+}
+
+// Static table used in the bytes/str Intern implementations
+lazy_static! {
+    static ref BYTES_TABLE: BytesTable = BytesTable::new();
+}
+
+/// Similar to the generic `InternTable` but customized for sequences of raw bytes (and strings).
+pub struct BytesTable {
+    data: Arc<RwLock<BytesTableData>>,
+}
+
+impl BytesTable {
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(BytesTableData::new())),
+        }
+    }
+
+    pub fn intern(&self, value: &[u8]) -> RawInternKey {
+        if let Some(prev) = self.data.read().get(&value) {
+            return prev;
+        }
+        let mut writer = self.data.write();
+        writer.intern(value)
+    }
+
+    pub fn lookup(&self, key: RawInternKey) -> &'static [u8] {
+        self.data.read().lookup(key)
+    }
+}
+
+/// BytesTableData is similar to InternTableData but customized for sequences
+/// of raw bytes (and notably, strings).
+struct BytesTableData {
+    // Raw data storage, allocated in large chunks
+    buffer: Option<&'static mut [u8]>,
+    // Reverse mapping of index=>value, used to convert an
+    // interned key back to (a reference to) its value
+    items: Vec<&'static [u8]>,
+    // Mapping of values to their interned indices
+    table: FnvHashMap<&'static [u8], RawInternKey>,
+}
+
+impl BytesTableData {
+    const BUFFER_SIZE: usize = 4096;
+
+    pub fn new() -> Self {
+        Self {
+            buffer: Some(Self::new_buffer()),
+            items: Default::default(),
+            table: Default::default(),
+        }
+    }
+
+    fn new_buffer() -> &'static mut [u8] {
+        Box::leak(Box::new([0; Self::BUFFER_SIZE]))
+    }
+
+    pub fn get(&self, value: &[u8]) -> Option<RawInternKey> {
+        self.table.get(value).cloned()
+    }
+
+    // Copy the byte slice into 'static memory by appending it to a buffer, if there is room.
+    // If the buffer fills up and the value is small, start over with a new buffer.
+    // If the value is large, just give it its own memory.
+    fn alloc(&mut self, value: &[u8]) -> &'static [u8] {
+        let len = value.len();
+
+        let mut buffer = self.buffer.take().unwrap();
+        if len > buffer.len() {
+            if len >= Self::BUFFER_SIZE / 16 {
+                // This byte slice is so big it can just have its own memory.
+                self.buffer = Some(buffer);
+                return Box::leak(value.into());
+            } else {
+                buffer = Self::new_buffer()
+            }
+        }
+
+        let (mem, remaining) = buffer.split_at_mut(len);
+        mem.copy_from_slice(value);
+        self.buffer = Some(remaining);
+
+        mem
+    }
+
+    pub fn intern(&mut self, value: &[u8]) -> RawInternKey {
+        // If there's an existing value return it
+        if let Some(prev) = self.get(&value) {
+            return prev;
+        }
+
+        // Otherwise intern
+        let key = RawInternKey::new(self.items.len());
+        let static_bytes = self.alloc(value);
+        self.items.push(static_bytes);
+        self.table.insert(static_bytes, key);
+
+        key
+    }
+
+    pub fn lookup(&self, key: RawInternKey) -> &'static [u8] {
+        let index = key.as_usize();
+        self.items[index]
+    }
+}

--- a/compiler/crates/interner/src/generic.rs
+++ b/compiler/crates/interner/src/generic.rs
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::types::{InternKey, RawInternKey};
+use fnv::FnvHashMap;
+use parking_lot::RwLock;
+use std::mem::MaybeUninit;
+use std::sync::Arc;
+
+/// An interner implementation that can be used to intern new values and lookup
+/// the value of previously interned keys.
+pub struct InternTable<K, V: 'static> {
+    data: Arc<RwLock<InternTableData<K, V>>>,
+}
+
+impl<K, V> Default for InternTable<K, V>
+where
+    K: InternKey + Clone,
+    V: std::cmp::Eq + std::hash::Hash + Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> InternTable<K, V>
+where
+    K: InternKey + Clone,
+    V: std::cmp::Eq + std::hash::Hash + Clone,
+{
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(InternTableData::new())),
+        }
+    }
+
+    pub fn intern(&self, value: V) -> K {
+        if let Some(prev) = self.data.read().get(&value) {
+            return prev;
+        }
+        let mut writer = self.data.write();
+        writer.intern(value)
+    }
+
+    pub fn lookup(&self, key: K) -> &'static V {
+        self.data.read().lookup(key)
+    }
+}
+
+/// Internal data used for public InternTable type.
+struct InternTableData<K, V: 'static> {
+    // Raw data storage, allocated in large chunks
+    buffer: Option<&'static mut [MaybeUninit<V>]>,
+    // Reverse mapping of index=>value, used to convert an
+    // interned key back to (a reference to) its value
+    items: Vec<&'static V>,
+    // Mapping of values to their interned indices
+    table: FnvHashMap<&'static V, K>,
+}
+
+// For some reason making this a const of InternTableData's impl block triggers
+// an error that the size isn't known at compile time, but moving it here works:
+// shrug, this works.
+const INTERN_TABLE_BUFFER_SIZE: usize = 1000;
+
+impl<K, V> InternTableData<K, V>
+where
+    K: InternKey + Clone,
+    V: std::cmp::Eq + std::hash::Hash + Clone,
+{
+    pub fn new() -> Self {
+        Self {
+            buffer: Some(Self::new_buffer()),
+            items: Default::default(),
+            table: Default::default(),
+        }
+    }
+
+    fn new_buffer() -> &'static mut [MaybeUninit<V>] {
+        // Create an uninitialized slice of values and leak it
+        // to promote it to the static lifetime
+        let buffer: [MaybeUninit<V>; INTERN_TABLE_BUFFER_SIZE] =
+            unsafe { MaybeUninit::uninit().assume_init() };
+        Box::leak(Box::new(buffer))
+    }
+
+    pub fn get(&self, value: &V) -> Option<K> {
+        self.table.get(value).cloned()
+    }
+
+    pub fn intern(&mut self, value: V) -> K {
+        // If there's an existing value return it
+        if let Some(prev) = self.get(&value) {
+            return prev;
+        }
+        // Ensure that there is sufficient space in the buffer for another item
+        let mut buffer = self.buffer.take().unwrap();
+        if buffer.is_empty() {
+            buffer = Self::new_buffer();
+        }
+        // Split the buffer into a pointer to the first element and the remainder
+        // of the slice, writing the new element into the first element pointer
+        let (dest_ptr, remaining) = buffer.split_first_mut().unwrap();
+        unsafe { std::ptr::write(dest_ptr, MaybeUninit::new(value)) };
+
+        // Cast the mutable pointer to immutable
+        let dest_ptr: &'static V = unsafe { &*dest_ptr.as_ptr() };
+
+        // Create a key for this entry and update both the intern/lookup
+        // mappings
+        let key = K::from_raw(RawInternKey::new(self.items.len()));
+        self.items.push(&dest_ptr);
+        self.table.insert(&dest_ptr, key.clone());
+        self.buffer = Some(remaining);
+        key
+    }
+
+    pub fn lookup(&self, key: K) -> &'static V {
+        let index = key.into_raw().as_usize();
+        self.items[index]
+    }
+}

--- a/compiler/crates/interner/src/lib.rs
+++ b/compiler/crates/interner/src/lib.rs
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
+
+mod bytes;
+mod generic;
+mod macros;
+#[cfg(test)]
+mod tests;
+mod types;
+
+pub use bytes::{BytesKey, StringKey};
+pub use generic::InternTable;
+pub use types::{Intern, InternKey, RawInternKey};

--- a/compiler/crates/interner/src/macros.rs
+++ b/compiler/crates/interner/src/macros.rs
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// Macro to implement an interner for an arbitrary type.
+/// Given `intern!(<Foo> as <FooKey>);`, this macro will implement the
+/// `Intern` trait for `<Foo>`, interning it a generated `<FooKey>` wrapper
+/// type. Calling `FooKey::lookup()` will return a reference to the original
+/// `<Foo>` value.
+///
+/// # Example
+///
+/// ```ignore
+/// use common::{Intern, intern, StringKey};
+/// pub struct User {
+///   name: StringKey,
+/// }
+/// intern!(User as UserKey); // defines the `UserKey` type
+///
+/// let name: StringKey = "Joe".intern();
+/// let user: User = User { name };
+/// let user_key: UserKey = user.intern();
+/// ```
+///
+#[macro_export]
+macro_rules! intern {
+    ($name:ident as $alias:ident) => {
+        use crate::{Intern, InternKey, InternTable, RawInternKey};
+        use lazy_static::lazy_static;
+
+        /// Global interning table for this type
+        lazy_static! {
+            static ref INTERN_TABLE: InternTable<$alias, $name> = InternTable::new();
+        }
+
+        /// Wrapper type for the intern key
+        #[derive(Copy, Clone, Debug, Eq, Ord, Hash, PartialEq, PartialOrd)]
+        pub struct $alias(RawInternKey);
+
+        impl InternKey for $alias {
+            type Value = $name;
+
+            fn from_raw(raw: RawInternKey) -> Self {
+                Self(raw)
+            }
+
+            fn into_raw(self) -> RawInternKey {
+                self.0
+            }
+
+            fn lookup(self) -> &'static Self::Value {
+                INTERN_TABLE.lookup(self)
+            }
+        }
+
+        /// The type interns into the generated key type
+        impl Intern for $name {
+            type Key = $alias;
+
+            fn intern(self) -> Self::Key {
+                INTERN_TABLE.intern(self)
+            }
+        }
+    };
+}

--- a/compiler/crates/interner/src/tests.rs
+++ b/compiler/crates/interner/src/tests.rs
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use super::*;
+
+#[test]
+fn test_string_intern() {
+    let key: StringKey = "test".intern(); // str (reference)
+    let key2: StringKey = "test".to_owned().intern(); // String (owned)
+    assert_eq!(key2, key);
+    assert_eq!(key.lookup(), "test");
+
+    let key3: StringKey = "testx".to_owned().intern();
+    assert_ne!(key3, key);
+    assert_ne!(key3, key2);
+    assert_eq!(key3.lookup(), "testx");
+}
+
+#[test]
+fn test_bytes_intern() {
+    let key: BytesKey = b"test".intern();
+    let str_id: StringKey = "test".intern();
+    let key2: BytesKey = str_id.as_bytes();
+    assert_eq!(key2, key);
+    assert_eq!(key.lookup(), b"test");
+
+    let key3: BytesKey = b"testx".intern();
+    assert_ne!(key3, key);
+    assert_ne!(key3, key2);
+    assert_eq!(key3.lookup(), b"testx");
+}
+
+#[test]
+fn test_custom_intern() {
+    #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
+    pub struct User {
+        name: String,
+    }
+
+    intern!(User as UserKey);
+
+    let key: UserKey = User {
+        name: "Joe".to_owned(),
+    }
+    .intern();
+    let key2: UserKey = User {
+        name: "Joe".to_owned(),
+    }
+    .intern();
+    assert_eq!(key2, key);
+    assert_eq!(
+        key.lookup(),
+        &User {
+            name: "Joe".to_owned()
+        }
+    );
+
+    let key3: UserKey = User {
+        name: "Jan".to_owned(),
+    }
+    .intern();
+    assert_ne!(key3, key);
+    assert_ne!(key3, key2);
+    assert_eq!(
+        key3.lookup(),
+        &User {
+            name: "Jan".to_owned()
+        }
+    );
+}

--- a/compiler/crates/interner/src/types.rs
+++ b/compiler/crates/interner/src/types.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// A type that can be interned.
+pub trait Intern: std::cmp::Eq + std::hash::Hash + Clone {
+    type Key;
+
+    fn intern(self) -> Self::Key;
+}
+
+/// A raw interned key; this should always be wrapped in a type-specific wrapper
+/// that implements `InternKey`.
+#[derive(Copy, Clone, Debug, Eq, Ord, Hash, PartialEq, PartialOrd)]
+pub struct RawInternKey(usize);
+
+impl RawInternKey {
+    pub(crate) fn new(value: usize) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn as_usize(self) -> usize {
+        self.0
+    }
+}
+
+/// A type that acts as an intern key, uniquely identifying the original value
+/// as well as supporting fast lookup back to a reference to the original value.
+pub trait InternKey {
+    type Value;
+
+    fn from_raw(raw: RawInternKey) -> Self;
+
+    fn into_raw(self) -> RawInternKey;
+
+    fn lookup(self) -> &'static Self::Value;
+}


### PR DESCRIPTION
Adds the `interner` crate, which contains utilities for interning (hash-consing) slices of bytes, strings, and arbitrary values. 