### PR TITLE
[rust-compiler] add graphql-transforms crate

### DIFF
--- a/compiler/crates/graphql-transforms/Cargo.toml
+++ b/compiler/crates/graphql-transforms/Cargo.toml
@@ -1,0 +1,16 @@
+[project]
+name = "graphql-transforms"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies]
+common = { path = "../common" }
+interner = { path = "../interner" }
+graphql-ir = { path = "../graphql-ir" }
+schema = { path = "../schema" }
+
+[dev-dependencies]
+fixture-tests = { path = "../fixture-tests" }
+graphql-syntax = { path = "../graphql-syntax" }
+graphql-printer = { path = "../graphql-printer" }
+test-schema = { path = "../test-schema" }

--- a/compiler/crates/graphql-transforms/src/compiler_context.rs
+++ b/compiler/crates/graphql-transforms/src/compiler_context.rs
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use graphql_ir::{ExecutableDefinition, FragmentDefinition, OperationDefinition};
+use interner::StringKey;
+use schema::Schema;
+use std::collections::HashMap;
+
+/// A collection of all documents that are being compiled.
+#[derive(Debug)]
+pub struct CompilerContext<'s> {
+    schema: &'s Schema,
+    fragments: HashMap<StringKey, FragmentDefinition>,
+    operations: Vec<OperationDefinition>,
+}
+
+impl<'s> CompilerContext<'s> {
+    pub fn new(schema: &'s Schema) -> Self {
+        Self {
+            schema,
+            fragments: Default::default(),
+            operations: Default::default(),
+        }
+    }
+
+    pub fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    pub fn from_definitions(schema: &'s Schema, definitions: Vec<ExecutableDefinition>) -> Self {
+        let mut operations = vec![];
+        let mut fragments: HashMap<StringKey, FragmentDefinition> = HashMap::new();
+        for definition in definitions {
+            match definition {
+                ExecutableDefinition::Operation(operation) => {
+                    operations.push(operation);
+                }
+                ExecutableDefinition::Fragment(fragment) => {
+                    fragments.insert(fragment.name.item, fragment);
+                }
+            }
+        }
+        Self {
+            schema,
+            fragments,
+            operations,
+        }
+    }
+
+    pub fn insert_fragment(&mut self, fragment: FragmentDefinition) {
+        let name = fragment.name.item;
+        if let Some(previous) = self.fragments.insert(name, fragment) {
+            panic!(
+                "Can only insert '{}' once. Had {:?} and trying to insert {:?}.",
+                name, previous, self.fragments[&name]
+            );
+        };
+    }
+
+    pub fn fragment(&self, name: StringKey) -> Option<&FragmentDefinition> {
+        self.fragments.get(&name)
+    }
+
+    pub fn insert_operation(&mut self, operation: OperationDefinition) {
+        self.operations.push(operation);
+    }
+
+    pub fn operations(&self) -> impl Iterator<Item = &OperationDefinition> {
+        self.operations.iter()
+    }
+
+    pub fn fragments(&self) -> impl Iterator<Item = &FragmentDefinition> {
+        self.fragments.values()
+    }
+
+    pub fn document_count(&self) -> usize {
+        self.fragments.len() + self.operations.len()
+    }
+}

--- a/compiler/crates/graphql-transforms/src/generate_typename.rs
+++ b/compiler/crates/graphql-transforms/src/generate_typename.rs
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::compiler_context::CompilerContext;
+use common::Spanned;
+use graphql_ir::{
+    FragmentSpread, InlineFragment, LinkedField, ScalarField, Selection, Transformed, Transformer,
+};
+use schema::{Schema, Type};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Transform to add the `__typename` field to any LinkedField that both a) returns an
+/// abstract type and b) does not already directly query `__typename`.
+pub fn generate_typename<'s>(ctx: &'s CompilerContext<'s>) -> CompilerContext<'s> {
+    let mut next_context = CompilerContext::new(ctx.schema());
+    let mut transform = GenerateTypenameTransform::new(ctx);
+    for operation in ctx.operations() {
+        match transform.transform_operation(operation) {
+            Transformed::Delete => {}
+            Transformed::Keep => next_context.insert_operation(operation.clone()),
+            Transformed::Replace(replacement) => next_context.insert_operation(replacement),
+        }
+    }
+    for fragment in ctx.fragments() {
+        match transform.transform_fragment(fragment) {
+            Transformed::Delete => {}
+            Transformed::Keep => next_context.insert_fragment(fragment.clone()),
+            Transformed::Replace(replacement) => next_context.insert_fragment(replacement),
+        }
+    }
+    next_context
+}
+
+// Note on correctness: the PointerAddress here is calculated from addresses of the input
+// context. Because those value are still referenced, that memory cannot be freed/
+// reused for the lifetime of the transform.
+type Seen = HashMap<PointerAddress, Transformed<Arc<InlineFragment>>>;
+
+struct GenerateTypenameTransform<'s> {
+    ctx: &'s CompilerContext<'s>,
+    seen: Seen,
+}
+
+impl<'s> GenerateTypenameTransform<'s> {
+    fn new(ctx: &'s CompilerContext<'s>) -> Self {
+        Self {
+            ctx,
+            seen: Default::default(),
+        }
+    }
+}
+
+impl<'s> Transformer for GenerateTypenameTransform<'s> {
+    const NAME: &'static str = "GenerateTypenameTransform";
+    const VISIT_ARGUMENTS: bool = false;
+    const VISIT_DIRECTIVES: bool = false;
+
+    fn transform_linked_field(&mut self, field: &LinkedField) -> Transformed<Arc<LinkedField>> {
+        let schema = self.ctx.schema();
+        let selections = self.transform_selections(&field.selections);
+        let field_definition = schema.field(field.definition.item);
+        let is_abstract = match field_definition.type_.inner() {
+            Type::Interface(_) => true,
+            Type::Union(_) => true,
+            Type::Object(_) => false,
+            _ => unreachable!("Parent type of a field must be an interface, union, or object"),
+        };
+        let selections = if is_abstract && !has_typename_field(schema, &field.selections) {
+            let mut next_selections = Vec::with_capacity(field.selections.len() + 1);
+            next_selections.push(Selection::ScalarField(Arc::new(ScalarField {
+                alias: None,
+                definition: Spanned::new(field.definition.span, schema.typename_field()),
+                arguments: Default::default(),
+                directives: Default::default(),
+            })));
+            if let Some(selections) = selections {
+                next_selections.extend(selections.into_iter())
+            } else {
+                next_selections.extend(field.selections.iter().cloned());
+            }
+            Some(next_selections)
+        } else {
+            selections
+        };
+        match selections {
+            None => Transformed::Keep,
+            Some(selections) => Transformed::Replace(Arc::new(LinkedField {
+                alias: field.alias,
+                definition: field.definition,
+                arguments: field.arguments.clone(),
+                directives: field.directives.clone(),
+                selections,
+            })),
+        }
+    }
+
+    fn transform_inline_fragment(
+        &mut self,
+        fragment: &InlineFragment,
+    ) -> Transformed<Arc<InlineFragment>> {
+        let key = PointerAddress::new(fragment);
+        if let Some(prev) = self.seen.get(&key) {
+            return prev.clone();
+        }
+        self.seen.insert(key, Transformed::Delete);
+        let selections = self.transform_selections(&fragment.selections);
+        let result = match selections {
+            None => Transformed::Keep,
+            Some(selections) => Transformed::Replace(Arc::new(InlineFragment {
+                type_condition: fragment.type_condition,
+                directives: fragment.directives.clone(),
+                selections,
+            })),
+        };
+        self.seen.insert(key, result.clone());
+        result
+    }
+
+    fn transform_scalar_field(&mut self, _field: &ScalarField) -> Transformed<Arc<ScalarField>> {
+        Transformed::Keep
+    }
+
+    fn transform_fragment_spread(
+        &mut self,
+        _spread: &FragmentSpread,
+    ) -> Transformed<Arc<FragmentSpread>> {
+        Transformed::Keep
+    }
+}
+
+fn has_typename_field(schema: &Schema, selections: &[Selection]) -> bool {
+    let typename_field = schema.typename_field();
+    selections.iter().any(|x| match x {
+        Selection::ScalarField(child) => {
+            child.alias.is_none() && child.definition.item == typename_field
+        }
+        _ => false,
+    })
+}
+
+// A wrapper type that allows comparing pointer equality of references. Two
+// `PointerAddress` values are equal if they point to the same memory location.
+//
+// This type is _sound_, but misuse can easily lead to logical bugs if the memory
+// of one PointerAddress could not have been freed and reused for a subsequent
+// PointerAddress.
+#[derive(Hash, Eq, PartialEq, Clone, Copy)]
+struct PointerAddress(usize);
+
+impl PointerAddress {
+    pub fn new<T>(ptr: &T) -> Self {
+        let ptr_address: usize = unsafe { std::mem::transmute(ptr) };
+        Self(ptr_address)
+    }
+}

--- a/compiler/crates/graphql-transforms/src/inline_fragments.rs
+++ b/compiler/crates/graphql-transforms/src/inline_fragments.rs
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::compiler_context::CompilerContext;
+use graphql_ir::{
+    FragmentSpread, InlineFragment, ScalarField, Selection, Transformed, Transformer,
+};
+use interner::StringKey;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub fn inline_fragments<'s>(ctx: &'s CompilerContext<'s>) -> CompilerContext<'s> {
+    let mut next_context = CompilerContext::new(ctx.schema());
+    let mut transformer = InlineFragmentsTransform::new(ctx);
+    for operation in ctx.operations() {
+        match transformer.transform_operation(operation) {
+            Transformed::Delete => {}
+            Transformed::Keep => next_context.insert_operation(operation.clone()),
+            Transformed::Replace(replacement) => next_context.insert_operation(replacement),
+        }
+    }
+    next_context
+}
+
+type Seen = HashMap<StringKey, Arc<InlineFragment>>;
+
+struct InlineFragmentsTransform<'s> {
+    ctx: &'s CompilerContext<'s>,
+    seen: Seen,
+}
+
+impl<'s> InlineFragmentsTransform<'s> {
+    fn new(ctx: &'s CompilerContext<'s>) -> Self {
+        Self {
+            ctx,
+            seen: Default::default(),
+        }
+    }
+
+    fn transform_fragment_spread(&mut self, spread: &FragmentSpread) -> Arc<InlineFragment> {
+        // If we've already created an InlineFragment for this fragment name before,
+        // share it
+        if let Some(prev) = self.seen.get(&spread.fragment.item) {
+            return prev.clone();
+        };
+        // Otherwise create the InlineFragment equivalent of the fragment (recursively
+        // inlining its contents). To guard against cycles, store a dummy value
+        // that we overwrite once we finish.
+        self.seen.insert(
+            spread.fragment.item,
+            Arc::new(InlineFragment {
+                type_condition: None,
+                directives: Default::default(),
+                selections: Default::default(),
+            }),
+        );
+        let fragment = self.ctx.fragment(spread.fragment.item).unwrap();
+        let selections = self.transform_selections(&fragment.selections);
+        let result = Arc::new(InlineFragment {
+            type_condition: Some(fragment.type_condition),
+            directives: fragment.directives.clone(),
+            selections: selections.unwrap_or_else(|| fragment.selections.clone()),
+        });
+        self.seen.insert(spread.fragment.item, result.clone());
+        result
+    }
+}
+
+impl<'s> Transformer for InlineFragmentsTransform<'s> {
+    const NAME: &'static str = "InlineFragmentsTransform";
+    const VISIT_ARGUMENTS: bool = false;
+    const VISIT_DIRECTIVES: bool = false;
+
+    fn transform_selection(&mut self, selection: &Selection) -> Transformed<Selection> {
+        match selection {
+            Selection::FragmentSpread(selection) => Transformed::Replace(
+                Selection::InlineFragment(self.transform_fragment_spread(selection)),
+            ),
+            _ => self.super_selection(selection),
+        }
+    }
+
+    fn transform_scalar_field(&mut self, _field: &ScalarField) -> Transformed<Arc<ScalarField>> {
+        Transformed::Keep
+    }
+}

--- a/compiler/crates/graphql-transforms/src/lib.rs
+++ b/compiler/crates/graphql-transforms/src/lib.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
+
+mod compiler_context;
+mod generate_typename;
+mod inline_fragments;
+mod sort_selections;
+
+pub use compiler_context::CompilerContext;
+pub use generate_typename::generate_typename;
+pub use inline_fragments::inline_fragments;
+pub use sort_selections::sort_selections;

--- a/compiler/crates/graphql-transforms/src/sort_selections.rs
+++ b/compiler/crates/graphql-transforms/src/sort_selections.rs
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::compiler_context::CompilerContext;
+use graphql_ir::{FragmentDefinition, InlineFragment, LinkedField, OperationDefinition, Selection};
+use std::sync::Arc;
+
+///
+/// Sorts selections in the fragments and queries (and their selections)
+///
+pub fn sort_selections<'s>(ctx: &'s CompilerContext<'s>) -> CompilerContext<'s> {
+    let mut next_context = CompilerContext::new(ctx.schema());
+    for fragment in ctx.fragments() {
+        next_context.insert_fragment(transform_fragment(ctx, fragment));
+    }
+    for operation in ctx.operations() {
+        next_context.insert_operation(transform_operation(ctx, operation));
+    }
+    next_context
+}
+
+fn transform_fragment(
+    ctx: &CompilerContext<'_>,
+    fragment: &FragmentDefinition,
+) -> FragmentDefinition {
+    FragmentDefinition {
+        name: fragment.name,
+        type_condition: fragment.type_condition,
+        directives: fragment.directives.clone(),
+        variable_definitions: fragment.variable_definitions.clone(),
+        used_global_variables: fragment.used_global_variables.clone(),
+        selections: transform_selections(ctx, &mut fragment.selections.clone()),
+    }
+}
+
+fn transform_operation(
+    ctx: &CompilerContext<'_>,
+    operation: &OperationDefinition,
+) -> OperationDefinition {
+    OperationDefinition {
+        kind: operation.kind.clone(),
+        name: operation.name,
+        type_: operation.type_,
+        directives: operation.directives.clone(),
+        variable_definitions: operation.variable_definitions.clone(),
+        selections: transform_selections(ctx, &mut operation.selections.clone()),
+    }
+}
+
+fn transfrom_inline_fragment(
+    ctx: &CompilerContext<'_>,
+    node: &InlineFragment,
+) -> Arc<InlineFragment> {
+    Arc::new(InlineFragment {
+        type_condition: node.type_condition,
+        directives: node.directives.clone(),
+        selections: transform_selections(ctx, &mut node.selections.clone()),
+    })
+}
+
+fn transfrom_linked_field(ctx: &CompilerContext<'_>, node: &LinkedField) -> Arc<LinkedField> {
+    Arc::new(LinkedField {
+        alias: node.alias,
+        definition: node.definition,
+        arguments: node.arguments.clone(),
+        directives: node.directives.clone(),
+        selections: transform_selections(ctx, &mut node.selections.clone()),
+    })
+}
+
+fn transform_selections(
+    ctx: &CompilerContext<'_>,
+    selections: &mut Vec<Selection>,
+) -> Vec<Selection> {
+    selections.sort_unstable();
+
+    selections
+        .iter_mut()
+        .map(|selection| match selection {
+            Selection::ScalarField(_) => selection.clone(),
+            Selection::FragmentSpread(_) => selection.clone(),
+            Selection::LinkedField(node) => {
+                Selection::LinkedField(transfrom_linked_field(ctx, node))
+            }
+            Selection::InlineFragment(node) => {
+                Selection::InlineFragment(transfrom_inline_fragment(ctx, node))
+            }
+        })
+        .collect()
+}

--- a/compiler/crates/graphql-transforms/tests/generate_typename/fixtures/type-name-does-not-exist.expected
+++ b/compiler/crates/graphql-transforms/tests/generate_typename/fixtures/type-name-does-not-exist.expected
@@ -1,0 +1,87 @@
+==================================== INPUT ====================================
+query EasyTypeNameNotExistsQuery {
+  viewer {
+    newsFeed(first: 10) {
+      edges {
+        node {
+          id
+          message {
+            text
+          }
+          ...NonNodeStory_feedUnit
+        }
+      }
+    }
+  }
+}
+
+fragment NonNodeStory_feedUnit on FeedUnit {
+  id
+  actor {
+    name
+  }
+}
+
+query TypeNameNotExistsWithFlattenTransformQuery {
+  node(id: "123") {
+    comments(first: 10) {
+      edges {
+        node {
+          id
+          ...CommentFragment_comment
+        }
+      }
+    }
+  }
+}
+
+fragment CommentFragment_comment on Comment {
+  body {
+    text
+  }
+}
+==================================== OUTPUT ===================================
+fragment CommentFragment_comment on Comment {
+  body {
+    text
+  }
+}
+
+fragment NonNodeStory_feedUnit on FeedUnit {
+  id
+  actor {
+    __typename
+    name
+  }
+}
+
+query EasyTypeNameNotExistsQuery {
+  viewer {
+    newsFeed(first: 10) {
+      edges {
+        node {
+          __typename
+          id
+          message {
+            text
+          }
+          ...NonNodeStory_feedUnit
+        }
+      }
+    }
+  }
+}
+
+query TypeNameNotExistsWithFlattenTransformQuery {
+  node(id: "123") {
+    __typename
+    comments(first: 10) {
+      edges {
+        node {
+          id
+          ...CommentFragment_comment
+        }
+      }
+    }
+  }
+}

--- a/compiler/crates/graphql-transforms/tests/generate_typename/fixtures/type-name-does-not-exist.graphql
+++ b/compiler/crates/graphql-transforms/tests/generate_typename/fixtures/type-name-does-not-exist.graphql
@@ -1,0 +1,41 @@
+query EasyTypeNameNotExistsQuery {
+  viewer {
+    newsFeed(first: 10) {
+      edges {
+        node {
+          id
+          message {
+            text
+          }
+          ...NonNodeStory_feedUnit
+        }
+      }
+    }
+  }
+}
+
+fragment NonNodeStory_feedUnit on FeedUnit {
+  id
+  actor {
+    name
+  }
+}
+
+query TypeNameNotExistsWithFlattenTransformQuery {
+  node(id: "123") {
+    comments(first: 10) {
+      edges {
+        node {
+          id
+          ...CommentFragment_comment
+        }
+      }
+    }
+  }
+}
+
+fragment CommentFragment_comment on Comment {
+  body {
+    text
+  }
+}

--- a/compiler/crates/graphql-transforms/tests/generate_typename/fixtures/type-name-exists.expected
+++ b/compiler/crates/graphql-transforms/tests/generate_typename/fixtures/type-name-exists.expected
@@ -1,0 +1,91 @@
+==================================== INPUT ====================================
+query EasyTypeNameExistsQuery {
+  viewer {
+    newsFeed(first: 10) {
+      edges {
+        node {
+          id
+          __typename
+          message {
+            text
+          }
+          ...NonNodeStory_feedUnit
+        }
+      }
+    }
+  }
+}
+
+fragment NonNodeStory_feedUnit on FeedUnit {
+  __typename
+  id
+  actor {
+    name
+    __typename
+  }
+}
+
+query TypeNameExistsWithFlattenTransformQuery {
+  node(id: "123") {
+    comments(first: 10) {
+      edges {
+        node {
+          id
+          ...CommentFragment_comment
+        }
+      }
+    }
+  }
+}
+
+fragment CommentFragment_comment on Comment {
+  body {
+    text
+  }
+}
+==================================== OUTPUT ===================================
+fragment CommentFragment_comment on Comment {
+  body {
+    text
+  }
+}
+
+fragment NonNodeStory_feedUnit on FeedUnit {
+  __typename
+  id
+  actor {
+    name
+    __typename
+  }
+}
+
+query EasyTypeNameExistsQuery {
+  viewer {
+    newsFeed(first: 10) {
+      edges {
+        node {
+          id
+          __typename
+          message {
+            text
+          }
+          ...NonNodeStory_feedUnit
+        }
+      }
+    }
+  }
+}
+
+query TypeNameExistsWithFlattenTransformQuery {
+  node(id: "123") {
+    __typename
+    comments(first: 10) {
+      edges {
+        node {
+          id
+          ...CommentFragment_comment
+        }
+      }
+    }
+  }
+}

--- a/compiler/crates/graphql-transforms/tests/generate_typename/fixtures/type-name-exists.graphql
+++ b/compiler/crates/graphql-transforms/tests/generate_typename/fixtures/type-name-exists.graphql
@@ -1,0 +1,44 @@
+query EasyTypeNameExistsQuery {
+  viewer {
+    newsFeed(first: 10) {
+      edges {
+        node {
+          id
+          __typename
+          message {
+            text
+          }
+          ...NonNodeStory_feedUnit
+        }
+      }
+    }
+  }
+}
+
+fragment NonNodeStory_feedUnit on FeedUnit {
+  __typename
+  id
+  actor {
+    name
+    __typename
+  }
+}
+
+query TypeNameExistsWithFlattenTransformQuery {
+  node(id: "123") {
+    comments(first: 10) {
+      edges {
+        node {
+          id
+          ...CommentFragment_comment
+        }
+      }
+    }
+  }
+}
+
+fragment CommentFragment_comment on Comment {
+  body {
+    text
+  }
+}

--- a/compiler/crates/graphql-transforms/tests/generate_typename/mod.rs
+++ b/compiler/crates/graphql-transforms/tests/generate_typename/mod.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use fixture_tests::Fixture;
+use graphql_ir::build;
+use graphql_printer::{print_fragment, print_operation};
+use graphql_syntax::parse;
+use graphql_transforms::{generate_typename, CompilerContext};
+use test_schema::TEST_SCHEMA;
+
+pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
+    let ast = parse(fixture.content, fixture.file_name).unwrap();
+    let ir = build(&TEST_SCHEMA, ast.definitions).unwrap();
+    let context = CompilerContext::from_definitions(&TEST_SCHEMA, ir);
+
+    let next_context = generate_typename(&context);
+
+    assert_eq!(next_context.document_count(), context.document_count());
+
+    let mut printed = next_context
+        .operations()
+        .map(|def| print_operation(&TEST_SCHEMA, def))
+        .chain(
+            next_context
+                .fragments()
+                .map(|def| print_fragment(&TEST_SCHEMA, def)),
+        )
+        .collect::<Vec<_>>();
+    printed.sort();
+    Ok(printed.join("\n\n"))
+}

--- a/compiler/crates/graphql-transforms/tests/generate_typename_test.rs
+++ b/compiler/crates/graphql-transforms/tests/generate_typename_test.rs
@@ -1,0 +1,20 @@
+// @generated SignedSource<<4b9b772191dd8d40c7cb1a4239acad70>>
+
+mod generate_typename;
+
+use generate_typename::transform_fixture;
+use fixture_tests::test_fixture;
+
+#[test]
+fn type_name_does_not_exist() {
+    let input = include_str!("generate_typename/fixtures/type-name-does-not-exist.graphql");
+    let expected = include_str!("generate_typename/fixtures/type-name-does-not-exist.expected");
+    test_fixture(transform_fixture, "type-name-does-not-exist.graphql", "generate_typename/fixtures/type-name-does-not-exist.expected", input, expected);
+}
+
+#[test]
+fn type_name_exists() {
+    let input = include_str!("generate_typename/fixtures/type-name-exists.graphql");
+    let expected = include_str!("generate_typename/fixtures/type-name-exists.expected");
+    test_fixture(transform_fixture, "type-name-exists.graphql", "generate_typename/fixtures/type-name-exists.expected", input, expected);
+}

--- a/compiler/crates/graphql-transforms/tests/inline_fragments/fixtures/inlines-nested-fragments.expected
+++ b/compiler/crates/graphql-transforms/tests/inline_fragments/fixtures/inlines-nested-fragments.expected
@@ -1,0 +1,62 @@
+==================================== INPUT ====================================
+query TestQuery($id: ID!) {
+  node(id: $id) {
+    id
+    ...ProfileWithFriends
+  }
+}
+
+fragment ProfileWithFriends on User {
+  id
+  firstName
+  lastName
+  ...ProfileWithoutFriends
+  friends(first: 10) {
+    edges {
+      node {
+        ...ProfileWithoutFriends
+      }
+    }
+  }
+}
+
+fragment ProfileWithoutFriends on User {
+  firstName
+  lastName
+  profilePicture(size: 128) {
+    uri
+  }
+}
+==================================== OUTPUT ===================================
+query TestQuery(
+  $id: ID!
+) {
+  node(id: $id) {
+    id
+    ... on User {
+      id
+      firstName
+      lastName
+      ... on User {
+        firstName
+        lastName
+        profilePicture(size: 128) {
+          uri
+        }
+      }
+      friends(first: 10) {
+        edges {
+          node {
+            ... on User {
+              firstName
+              lastName
+              profilePicture(size: 128) {
+                uri
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/compiler/crates/graphql-transforms/tests/inline_fragments/fixtures/inlines-nested-fragments.graphql
+++ b/compiler/crates/graphql-transforms/tests/inline_fragments/fixtures/inlines-nested-fragments.graphql
@@ -1,0 +1,28 @@
+query TestQuery($id: ID!) {
+  node(id: $id) {
+    id
+    ...ProfileWithFriends
+  }
+}
+
+fragment ProfileWithFriends on User {
+  id
+  firstName
+  lastName
+  ...ProfileWithoutFriends
+  friends(first: 10) {
+    edges {
+      node {
+        ...ProfileWithoutFriends
+      }
+    }
+  }
+}
+
+fragment ProfileWithoutFriends on User {
+  firstName
+  lastName
+  profilePicture(size: 128) {
+    uri
+  }
+}

--- a/compiler/crates/graphql-transforms/tests/inline_fragments/mod.rs
+++ b/compiler/crates/graphql-transforms/tests/inline_fragments/mod.rs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use fixture_tests::Fixture;
+use graphql_ir::build;
+use graphql_printer::print_operation;
+use graphql_syntax::parse;
+use graphql_transforms::{inline_fragments, CompilerContext};
+use test_schema::TEST_SCHEMA;
+
+pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
+    let ast = parse(fixture.content, fixture.file_name).unwrap();
+    let ir = build(&TEST_SCHEMA, ast.definitions).unwrap();
+    let context = CompilerContext::from_definitions(&TEST_SCHEMA, ir);
+
+    let next_context = inline_fragments(&context);
+
+    assert_eq!(next_context.fragments().count(), 0);
+    assert_eq!(
+        next_context.operations().count(),
+        context.operations().count()
+    );
+
+    let mut printed = next_context
+        .operations()
+        .map(|def| print_operation(&TEST_SCHEMA, def))
+        .collect::<Vec<_>>();
+    printed.sort();
+    Ok(printed.join("\n\n"))
+}

--- a/compiler/crates/graphql-transforms/tests/inline_fragments_test.rs
+++ b/compiler/crates/graphql-transforms/tests/inline_fragments_test.rs
@@ -1,0 +1,13 @@
+// @generated SignedSource<<9bc6cfd8a7845af0280e35c8f7d2c8ca>>
+
+mod inline_fragments;
+
+use inline_fragments::transform_fixture;
+use fixture_tests::test_fixture;
+
+#[test]
+fn inlines_nested_fragments() {
+    let input = include_str!("inline_fragments/fixtures/inlines-nested-fragments.graphql");
+    let expected = include_str!("inline_fragments/fixtures/inlines-nested-fragments.expected");
+    test_fixture(transform_fixture, "inlines-nested-fragments.graphql", "inline_fragments/fixtures/inlines-nested-fragments.expected", input, expected);
+}

--- a/compiler/crates/graphql-transforms/tests/sort_selections/fixtures/sort-selections-transform.expected
+++ b/compiler/crates/graphql-transforms/tests/sort_selections/fixtures/sort-selections-transform.expected
@@ -1,0 +1,60 @@
+==================================== INPUT ====================================
+fragment UserFragment on User {
+  name
+  address {
+    city
+  }
+  ...NestedFragment
+  ... on User {
+    name
+    address {
+      street
+    }
+    ...NestedFragment2
+  }
+}
+
+fragment NestedFragment on User {
+  profile_picture {
+    uri
+  }
+  name
+  body {
+    text
+  }
+}
+
+fragment NestedFragment2 on User {
+  name
+  canViewerLike
+}
+==================================== OUTPUT ===================================
+fragment NestedFragment on User {
+  body {
+    text
+  }
+  profile_picture {
+    uri
+  }
+  name
+}
+
+fragment NestedFragment2 on User {
+  name
+  canViewerLike
+}
+
+fragment UserFragment on User {
+  ...NestedFragment
+  ... on User {
+    ...NestedFragment2
+    address {
+      street
+    }
+    name
+  }
+  address {
+    city
+  }
+  name
+}

--- a/compiler/crates/graphql-transforms/tests/sort_selections/fixtures/sort-selections-transform.graphql
+++ b/compiler/crates/graphql-transforms/tests/sort_selections/fixtures/sort-selections-transform.graphql
@@ -1,0 +1,29 @@
+fragment UserFragment on User {
+  name
+  address {
+    city
+  }
+  ...NestedFragment
+  ... on User {
+    name
+    address {
+      street
+    }
+    ...NestedFragment2
+  }
+}
+
+fragment NestedFragment on User {
+  profile_picture {
+    uri
+  }
+  name
+  body {
+    text
+  }
+}
+
+fragment NestedFragment2 on User {
+  name
+  canViewerLike
+}

--- a/compiler/crates/graphql-transforms/tests/sort_selections/mod.rs
+++ b/compiler/crates/graphql-transforms/tests/sort_selections/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use fixture_tests::Fixture;
+use graphql_ir::build;
+use graphql_printer::print_fragment;
+use graphql_syntax::parse;
+use graphql_transforms::{sort_selections, CompilerContext};
+use test_schema::TEST_SCHEMA;
+
+pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
+    let ast = parse(fixture.content, fixture.file_name).unwrap();
+    let ir = build(&TEST_SCHEMA, ast.definitions).unwrap();
+    let context = CompilerContext::from_definitions(&TEST_SCHEMA, ir);
+    let next_context = sort_selections(&context);
+
+    assert_eq!(
+        next_context.fragments().count(),
+        context.fragments().count()
+    );
+    let mut printed = next_context
+        .fragments()
+        .map(|def| print_fragment(&TEST_SCHEMA, def))
+        .collect::<Vec<_>>();
+    printed.sort();
+    Ok(printed.join("\n\n"))
+}

--- a/compiler/crates/graphql-transforms/tests/sort_selections_test.rs
+++ b/compiler/crates/graphql-transforms/tests/sort_selections_test.rs
@@ -1,0 +1,13 @@
+// @generated SignedSource<<8b5811fb68ab2dec3e74463ff65df5c5>>
+
+mod sort_selections;
+
+use sort_selections::transform_fixture;
+use fixture_tests::test_fixture;
+
+#[test]
+fn sort_selections_transform() {
+    let input = include_str!("sort_selections/fixtures/sort-selections-transform.graphql");
+    let expected = include_str!("sort_selections/fixtures/sort-selections-transform.expected");
+    test_fixture(transform_fixture, "sort-selections-transform.graphql", "sort_selections/fixtures/sort-selections-transform.expected", input, expected);
+}


### PR DESCRIPTION
Adds the `graphql-transforms` crate, which includes a few IR->IR transforms that we've converted so far. 