### PR TITLE
[relay-compiler] add eagerESModules to yargs

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -130,6 +130,11 @@ const options = {
       '--customScalars.URL=String)',
     type: ('object': $FlowFixMe),
   },
+  eagerESModules: {
+    describe: 'This option enables emitting es modules artifacts.',
+    type: 'boolean',
+    default: false,
+  },
 };
 
 // Parse CLI args


### PR DESCRIPTION
Without this change I get the following error

```
Unknown argument: eagerESModules
```