### PR TITLE
Optional updater parameter for commitPayload

### DIFF
--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -240,7 +240,11 @@ class RelayModernEnvironment implements IEnvironment {
     );
   }
 
-  commitPayload(operation: OperationDescriptor, payload: PayloadData, updater: ?StoreUpdater = null): void {
+  commitPayload(
+    operation: OperationDescriptor,
+    payload: PayloadData,
+    updater: ?SelectorStoreUpdater = null,
+  ): void {
     RelayObservable.create(sink => {
       const executor = RelayModernQueryExecutor.execute({
         operation: operation,

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -240,7 +240,7 @@ class RelayModernEnvironment implements IEnvironment {
     );
   }
 
-  commitPayload(operation: OperationDescriptor, payload: PayloadData, updater?: StoreUpdater = null): void {
+  commitPayload(operation: OperationDescriptor, payload: PayloadData, updater: ?StoreUpdater = null): void {
     RelayObservable.create(sink => {
       const executor = RelayModernQueryExecutor.execute({
         operation: operation,

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -240,7 +240,7 @@ class RelayModernEnvironment implements IEnvironment {
     );
   }
 
-  commitPayload(operation: OperationDescriptor, payload: PayloadData): void {
+  commitPayload(operation: OperationDescriptor, payload: PayloadData, updater?: StoreUpdater = null): void {
     RelayObservable.create(sink => {
       const executor = RelayModernQueryExecutor.execute({
         operation: operation,
@@ -254,7 +254,7 @@ class RelayModernEnvironment implements IEnvironment {
           data: payload,
         }),
         store: this._store,
-        updater: null,
+        updater,
         operationTracker: this._operationTracker,
         getDataID: this._getDataID,
         isClientPayload: true,

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -508,7 +508,7 @@ export interface IEnvironment {
   commitPayload(
     operationDescriptor: OperationDescriptor,
     payload: PayloadData,
-    updater?: ?SelectorStoreUpdater,
+    updater: ?StoreUpdater,
   ): void;
 
   /**

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -508,6 +508,7 @@ export interface IEnvironment {
   commitPayload(
     operationDescriptor: OperationDescriptor,
     payload: PayloadData,
+    updater?: ?SelectorStoreUpdater,
   ): void;
 
   /**

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -508,7 +508,7 @@ export interface IEnvironment {
   commitPayload(
     operationDescriptor: OperationDescriptor,
     payload: PayloadData,
-    updater: ?StoreUpdater,
+    updater: ?SelectorStoreUpdater,
   ): void;
 
   /**

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
@@ -268,7 +268,12 @@ describe('commitPayload()', () => {
       },
       proxyStore => {
         const record = proxyStore.getRootField('me');
-        record.setValue(record.getValue('name').toUpperCase(), 'name');
+        if (record !== null && record !== undefined) {
+          const name = record.getValue('name');
+          if (typeof name === 'string') {
+            record.setValue(name.toUpperCase(), 'name');
+          }
+        }
       },
     );
     expect(callback.mock.calls.length).toBe(1);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
@@ -251,4 +251,31 @@ describe('commitPayload()', () => {
       'ActorQuery',
     );
   });
+
+  it('applies optional updater function', () => {
+    const callback = jest.fn();
+    const snapshot = environment.lookup(operation.fragment);
+    environment.subscribe(snapshot, callback);
+
+    environment.commitPayload(
+      operation,
+      {
+        me: {
+          id: '4',
+          __typename: 'User',
+          name: 'Zuck',
+        },
+      },
+      proxyStore => {
+        const record = proxyStore.getRootField('me');
+        record.setValue(record.getValue('name').toUpperCase(), 'name');
+      },
+    );
+    expect(callback.mock.calls.length).toBe(1);
+    expect(callback.mock.calls[0][0].data).toEqual({
+      me: {
+        name: 'ZUCK',
+      },
+    });
+  });
 });


### PR DESCRIPTION
Allows us optionally pass an `updater` to `commitPayload`.

The app I'm currently working on relies on numerous updaters, I need to be able to re-use them while making normalising data from sources outside of relay easily.

Example code:
```
import createNoteUpdater from "Relay/Updaters/createNote"

// ...
const payload = { create_note: { id: 123, text: "hello" } }

modernEnvironment.commitPayload(
  createOperationDescriptor(CreateNoteMutation, {}),
  payload,
  createNoteUpdater
);
```

I've noticed it referenced in a type here as part of `PublishQueue`:
https://github.com/facebook/relay/blob/8c51286848313ef6b3dc09abaa81aa9b44bd17de/packages/relay-runtime/store/RelayStoreTypes.js#L829-L833

while the type definition under `IEnvironment` doesn't offer the same flexibility:
https://github.com/facebook/relay/blob/8c51286848313ef6b3dc09abaa81aa9b44bd17de/packages/relay-runtime/store/RelayStoreTypes.js#L508-L511