### PR TITLE
[relay-compiler] Add repersist argument

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -98,6 +98,11 @@ const options = {
     type: 'string',
     array: false,
   },
+  repersist: {
+    describe: 'Run the persist function even if the query has not changed.',
+    type: 'boolean',
+    default: false,
+  },
   noFutureProofEnums: {
     describe:
       'This option controls whether or not a catch-all entry is added to enum type definitions ' +

--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -60,6 +60,7 @@ export type Config = {|
   eagerESModules?: boolean,
   language: string | PluginInitializer,
   persistFunction?: ?string | ?((text: string) => Promise<string>),
+  repersist: boolean,
   artifactDirectory?: ?string,
   customScalars?: ScalarTypeMapping,
 |};
@@ -346,6 +347,7 @@ function getCodegenRunner(config: Config): CodegenRunner {
         config.persistOutput,
         config.customScalars,
         persistQueryFunction,
+        config.repersist,
       ),
       isGeneratedFile: languagePlugin.isGeneratedFile
         ? languagePlugin.isGeneratedFile
@@ -380,6 +382,7 @@ function getRelayFileWriter(
   persistedQueryPath?: ?string,
   customScalars?: ScalarTypeMapping,
   persistFunction?: ?(text: string) => Promise<string>,
+  repersist?: boolean,
 ) {
   return async ({
     onlyValidate,
@@ -428,6 +431,7 @@ function getRelayFileWriter(
         typeGenerator: languagePlugin.typeGenerator,
         outputDir,
         persistQuery,
+        repersist,
       },
       onlyValidate,
       schema,

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -270,6 +270,21 @@ describe('RelayCompilerMain', () => {
         }),
       );
     });
+
+    it('configures the file writer with repersist', () => {
+      const codegenRunner = getCodegenRunner({
+        ...options,
+        repersist: true,
+      });
+      const config = codegenRunner.writerConfigs.js;
+      const writeFiles = config.writeFiles;
+      writeFiles({onlyValidate: true});
+      expect(RelayFileWriter.writeAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({repersist: true}),
+        }),
+      );
+    });
   });
 
   describe('getLanguagePlugin', () => {


### PR DESCRIPTION
`RelayFileWriter` has an option to regenerate persisted queries even if queries did not change but it is not currently exposed to the relay-compiler cli. This exposes the option with the --repersist flag.

## Test plan

- With all queries already generated delete the json file containing all query mappings.
- Run relay-compiler and check that the content of the queries file is an empty object.
- Apply this patch.
- Run relay-compiler **without** the repersist flag and check that the content of the queries file is still an empty object.
- Run relay-compiler **with** the repersist flag and check that the content of the queries file contains all queries.