### PR TITLE
fix(paginationVariables): UNSTABLE_extraVariables warning

### DIFF
--- a/packages/relay-experimental/__tests__/getPaginationVariables-test.js
+++ b/packages/relay-experimental/__tests__/getPaginationVariables-test.js
@@ -30,6 +30,7 @@ describe('getPaginationVariables', () => {
           10,
           'cursor-1',
           {order_by: 'LAST_NAME'},
+          {},
           {forward: null, backward: null, path: []},
         ),
       ).toThrowError(
@@ -43,6 +44,7 @@ describe('getPaginationVariables', () => {
           10,
           'cursor-1',
           {order_by: 'LAST_NAME'},
+          {},
           // $FlowFixMe
           {forward: {count: null, cursor: 'after'}, backward: null, path: []},
         ),
@@ -60,6 +62,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {forward: {count: 'count', cursor: 'cursor'}, backward: null, path: []},
       );
       expect(variables).toEqual({
@@ -73,6 +76,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {forward: {count: 'first', cursor: 'after'}, backward: null, path: []},
       );
       expect(variables).toEqual({
@@ -86,6 +90,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {
           forward: {count: 'customCountVar', cursor: 'customCursorVar'},
           backward: null,
@@ -107,6 +112,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {
           forward: {count: 'first', cursor: 'after'},
           backward: {count: 'last', cursor: 'before'},
@@ -127,6 +133,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {
           forward: {count: 'first', cursor: 'after'},
           // $FlowFixMe
@@ -155,6 +162,7 @@ describe('getPaginationVariables', () => {
           10,
           'cursor-1',
           {order_by: 'LAST_NAME'},
+          {},
           {forward: null, backward: null, path: []},
         ),
       ).toThrowError(
@@ -168,6 +176,7 @@ describe('getPaginationVariables', () => {
           10,
           'cursor-1',
           {order_by: 'LAST_NAME'},
+          {},
           // $FlowFixMe
           {forward: null, backward: {count: null, cursor: 'before'}, path: []},
         ),
@@ -185,6 +194,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {forward: null, backward: {count: 'count', cursor: 'cursor'}, path: []},
       );
       expect(variables).toEqual({
@@ -198,6 +208,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {forward: null, backward: {count: 'last', cursor: 'before'}, path: []},
       );
       expect(variables).toEqual({
@@ -211,6 +222,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {
           forward: null,
           backward: {count: 'customCountVar', cursor: 'customCursorVar'},
@@ -232,6 +244,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {
           forward: {count: 'first', cursor: 'after'},
           backward: {count: 'last', cursor: 'before'},
@@ -252,6 +265,7 @@ describe('getPaginationVariables', () => {
         10,
         'cursor-1',
         {order_by: 'LAST_NAME'},
+        {},
         {
           // $FlowFixMe
           forward: {count: null, cursor: 'after'},

--- a/packages/relay-experimental/getPaginationVariables.js
+++ b/packages/relay-experimental/getPaginationVariables.js
@@ -24,6 +24,7 @@ function getPaginationVariables(
   count: number,
   cursor: ?string,
   baseVariables: Variables,
+  extraVariables: ?Variables,
   paginationMetadata: ReaderPaginationMetadata,
 ): {[string]: mixed, ...} {
   const {
@@ -39,20 +40,24 @@ function getPaginationVariables(
       'Relay: Expected backward pagination metadata to be available. ' +
         "If you're seeing this, this is likely a bug in Relay.",
     );
-    warning(
-      !baseVariables.hasOwnProperty(backwardMetadata.cursor),
-      'Relay: `UNSTABLE_extraVariables` provided by caller should not ' +
-        'contain cursor variable `%s`. This variable is automatically ' +
-        'determined by Relay.',
-      backwardMetadata.cursor,
-    );
-    warning(
-      !baseVariables.hasOwnProperty(backwardMetadata.count),
-      'Relay: `UNSTABLE_extraVariables` provided by caller should not ' +
-        'contain count variable `%s`. This variable is automatically ' +
-        'determined by Relay.',
-      backwardMetadata.count,
-    );
+
+    if (extraVariables) {
+      warning(
+        !extraVariables.hasOwnProperty(backwardMetadata.cursor),
+        'Relay: `UNSTABLE_extraVariables` provided by caller should not ' +
+          'contain cursor variable `%s`. This variable is automatically ' +
+          'determined by Relay.',
+        backwardMetadata.cursor,
+      );
+      warning(
+        !extraVariables.hasOwnProperty(backwardMetadata.count),
+        'Relay: `UNSTABLE_extraVariables` provided by caller should not ' +
+          'contain count variable `%s`. This variable is automatically ' +
+          'determined by Relay.',
+        backwardMetadata.count,
+      );
+    }
+
     const paginationVariables = {
       ...baseVariables,
       [backwardMetadata.cursor]: cursor,
@@ -74,20 +79,24 @@ function getPaginationVariables(
     'Relay: Expected forward pagination metadata to be available. ' +
       "If you're seeing this, this is likely a bug in Relay.",
   );
-  warning(
-    !baseVariables.hasOwnProperty(forwardMetadata.cursor),
-    'Relay: `UNSTABLE_extraVariables` provided by caller should not ' +
-      'contain cursor variable `%s`. This variable is automatically ' +
-      'determined by Relay.',
-    forwardMetadata.cursor,
-  );
-  warning(
-    !baseVariables.hasOwnProperty(forwardMetadata.count),
-    'Relay: `UNSTABLE_extraVariables` provided by caller should not ' +
-      'contain count variable `%s`. This variable is automatically ' +
-      'determined by Relay.',
-    forwardMetadata.count,
-  );
+
+  if (extraVariables) {
+    warning(
+      !extraVariables.hasOwnProperty(forwardMetadata.cursor),
+      'Relay: `UNSTABLE_extraVariables` provided by caller should not ' +
+        'contain cursor variable `%s`. This variable is automatically ' +
+        'determined by Relay.',
+      forwardMetadata.cursor,
+    );
+    warning(
+      !extraVariables.hasOwnProperty(forwardMetadata.count),
+      'Relay: `UNSTABLE_extraVariables` provided by caller should not ' +
+        'contain count variable `%s`. This variable is automatically ' +
+        'determined by Relay.',
+      forwardMetadata.count,
+    );
+  }
+
   const paginationVariables = {
     ...baseVariables,
     [forwardMetadata.cursor]: cursor,

--- a/packages/relay-experimental/useLoadMoreFunction.js
+++ b/packages/relay-experimental/useLoadMoreFunction.js
@@ -205,6 +205,7 @@ function useLoadMoreFunction<TQuery: OperationType>(
         count,
         cursor,
         baseVariables,
+        extraVariables,
         paginationMetadata,
       );
 


### PR DESCRIPTION
Right now when i call `loadNext` from `usePaginationFragment`, i get the next warning:

`index.js:1437 Warning: Relay: UNSTABLE_extraVariables provided by caller should not contain count variable first. This variable is automatically determined by Relay.`

That is because getPaginationVariables.js evaluate baseVariables after extraVariables  is merged with parentVariables and fragmentVariables in useLoadMoreFunction.js.

Fix:

1. Pass extraVariables to getPaginationVariables and evaluate if extraVariables has count or cursor instead of baseVariables