### PR TITLE
[js-compiler] add test for explicit null argument

### DIFF
--- a/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
+++ b/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
@@ -3856,6 +3856,81 @@ Fragment {
 }
 `;
 
+exports[`compileRelayArtifacts matches expected output: explicit-null-argument.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query Test {
+  node(id: null) {
+    __typename
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+Request {
+  fragment: Fragment {
+    name: "Test",
+    type: "Query",
+    metadata: null,
+    argumentDefinitions: [],
+    selections: [
+      LinkedField {
+        alias: null,
+        name: "node",
+        storageKey: null,
+        args: null,
+        concreteType: null,
+        plural: false,
+        selections: [
+          ScalarField {
+            alias: null,
+            name: "__typename",
+            args: null,
+            storageKey: null,
+          },
+        ],
+      },
+    ],
+  },
+  operation: Operation {
+    name: "Test",
+    argumentDefinitions: [],
+    selections: [
+      LinkedField {
+        alias: null,
+        name: "node",
+        storageKey: null,
+        args: null,
+        concreteType: null,
+        plural: false,
+        selections: [
+          ScalarField {
+            alias: null,
+            name: "__typename",
+            args: null,
+            storageKey: null,
+          },
+          ScalarField {
+            alias: null,
+            name: "id",
+            args: null,
+            storageKey: null,
+          },
+        ],
+      },
+    ],
+  },
+}
+
+QUERY:
+
+query Test {
+  node {
+    __typename
+    id
+  }
+}
+
+`;
+
 exports[`compileRelayArtifacts matches expected output: false-positive-circular-fragment-reference-regression.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 query TestQuery {

--- a/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
+++ b/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
@@ -3859,6 +3859,7 @@ Fragment {
 exports[`compileRelayArtifacts matches expected output: explicit-null-argument.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 query Test {
+  # The compiler currently strips this null which isn't right.
   node(id: null) {
     __typename
   }

--- a/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/explicit-null-argument.graphql
+++ b/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/explicit-null-argument.graphql
@@ -1,0 +1,5 @@
+query Test {
+  node(id: null) {
+    __typename
+  }
+}

--- a/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/explicit-null-argument.graphql
+++ b/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/explicit-null-argument.graphql
@@ -1,4 +1,5 @@
 query Test {
+  # The compiler currently strips this null which isn't right.
   node(id: null) {
     __typename
   }


### PR DESCRIPTION
Adds a test for the (incorrect) behavior that null arguments to fields are stripped by the compiler.