### PR TITLE
Add cname field

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -169,6 +169,7 @@ const siteConfig = {
   url: 'https://relay.dev',
   baseUrl: '/',
   projectName: 'relay',
+  cname: 'relay.dev',
   users,
   editUrl: 'https://github.com/facebook/relay/edit/master/docs/',
   headerLinks: [


### PR DESCRIPTION
So that the GItHub settings CNAME field is set upon publish.