### PR TITLE
Add option in Environment to handle stripped nulls in payload

### DIFF
--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -65,7 +65,7 @@ import type {
 export type EnvironmentConfig = {|
   +configName?: string,
   +handlerProvider?: ?HandlerProvider,
-  +handleStrippedNulls?: boolean,
+  +treatMissingFieldsAsNull?: boolean,
   +log?: ?LogFunction,
   +operationLoader?: ?OperationLoader,
   +network: INetwork,
@@ -96,7 +96,7 @@ class RelayModernEnvironment implements IEnvironment {
   _missingFieldHandlers: ?$ReadOnlyArray<MissingFieldHandler>;
   _operationTracker: OperationTracker;
   _getDataID: GetDataID;
-  _handleStrippedNulls: boolean;
+  _treatMissingFieldsAsNull: boolean;
   _operationExecutions: Map<string, ActiveState>;
   +options: mixed;
   +_isServer: boolean;
@@ -106,7 +106,7 @@ class RelayModernEnvironment implements IEnvironment {
     const handlerProvider = config.handlerProvider
       ? config.handlerProvider
       : RelayDefaultHandlerProvider;
-    this._handleStrippedNulls = config.handleStrippedNulls || false;
+    this._treatMissingFieldsAsNull = config.treatMissingFieldsAsNull ?? false;
     const operationLoader = config.operationLoader;
     if (__DEV__) {
       if (operationLoader != null) {
@@ -225,7 +225,7 @@ class RelayModernEnvironment implements IEnvironment {
         updater: null,
         operationTracker: this._operationTracker,
         getDataID: this._getDataID,
-        handleStrippedNulls: this._handleStrippedNulls,
+        treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
       });
       return () => executor.cancel();
     }).subscribe({});
@@ -265,7 +265,7 @@ class RelayModernEnvironment implements IEnvironment {
         operationTracker: this._operationTracker,
         getDataID: this._getDataID,
         isClientPayload: true,
-        handleStrippedNulls: this._handleStrippedNulls,
+        treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
       });
       return () => executor.cancel();
     }).subscribe({});
@@ -351,7 +351,7 @@ class RelayModernEnvironment implements IEnvironment {
         updater,
         operationTracker: this._operationTracker,
         getDataID: this._getDataID,
-        handleStrippedNulls: this._handleStrippedNulls,
+        treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
       });
       return () => executor.cancel();
     }).do(logObserver);
@@ -413,7 +413,7 @@ class RelayModernEnvironment implements IEnvironment {
         updater,
         operationTracker: this._operationTracker,
         getDataID: this._getDataID,
-        handleStrippedNulls: this._handleStrippedNulls,
+        treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
       });
       return () => executor.cancel();
     }).do(logObserver);
@@ -448,7 +448,7 @@ class RelayModernEnvironment implements IEnvironment {
         source,
         store: this._store,
         getDataID: this._getDataID,
-        handleStrippedNulls: this._handleStrippedNulls,
+        treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
       });
       return () => executor.cancel();
     });

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -65,6 +65,7 @@ import type {
 export type EnvironmentConfig = {|
   +configName?: string,
   +handlerProvider?: ?HandlerProvider,
+  +handleStrippedNulls?: boolean,
   +log?: ?LogFunction,
   +operationLoader?: ?OperationLoader,
   +network: INetwork,
@@ -95,6 +96,7 @@ class RelayModernEnvironment implements IEnvironment {
   _missingFieldHandlers: ?$ReadOnlyArray<MissingFieldHandler>;
   _operationTracker: OperationTracker;
   _getDataID: GetDataID;
+  _handleStrippedNulls: boolean;
   _operationExecutions: Map<string, ActiveState>;
   +options: mixed;
   +_isServer: boolean;
@@ -104,6 +106,7 @@ class RelayModernEnvironment implements IEnvironment {
     const handlerProvider = config.handlerProvider
       ? config.handlerProvider
       : RelayDefaultHandlerProvider;
+    this._handleStrippedNulls = config.handleStrippedNulls || false;
     const operationLoader = config.operationLoader;
     if (__DEV__) {
       if (operationLoader != null) {
@@ -222,6 +225,7 @@ class RelayModernEnvironment implements IEnvironment {
         updater: null,
         operationTracker: this._operationTracker,
         getDataID: this._getDataID,
+        handleStrippedNulls: this._handleStrippedNulls,
       });
       return () => executor.cancel();
     }).subscribe({});
@@ -261,6 +265,7 @@ class RelayModernEnvironment implements IEnvironment {
         operationTracker: this._operationTracker,
         getDataID: this._getDataID,
         isClientPayload: true,
+        handleStrippedNulls: this._handleStrippedNulls,
       });
       return () => executor.cancel();
     }).subscribe({});
@@ -346,6 +351,7 @@ class RelayModernEnvironment implements IEnvironment {
         updater,
         operationTracker: this._operationTracker,
         getDataID: this._getDataID,
+        handleStrippedNulls: this._handleStrippedNulls,
       });
       return () => executor.cancel();
     }).do(logObserver);
@@ -407,6 +413,7 @@ class RelayModernEnvironment implements IEnvironment {
         updater,
         operationTracker: this._operationTracker,
         getDataID: this._getDataID,
+        handleStrippedNulls: this._handleStrippedNulls,
       });
       return () => executor.cancel();
     }).do(logObserver);
@@ -441,6 +448,7 @@ class RelayModernEnvironment implements IEnvironment {
         source,
         store: this._store,
         getDataID: this._getDataID,
+        handleStrippedNulls: this._handleStrippedNulls,
       });
       return () => executor.cancel();
     });

--- a/packages/relay-runtime/store/RelayModernQueryExecutor.js
+++ b/packages/relay-runtime/store/RelayModernQueryExecutor.js
@@ -63,7 +63,7 @@ import type {NormalizationOptions} from './RelayResponseNormalizer';
 
 export type ExecuteConfig = {|
   +getDataID: GetDataID,
-  +handleStrippedNulls: boolean,
+  +treatMissingFieldsAsNull: boolean,
   +operation: OperationDescriptor,
   +operationExecutions: Map<string, ActiveState>,
   +operationLoader: ?OperationLoader,
@@ -114,7 +114,7 @@ function execute(config: ExecuteConfig): Executor {
  */
 class Executor {
   _getDataID: GetDataID;
-  _handleStrippedNulls: boolean;
+  _treatMissingFieldsAsNull: boolean;
   _incrementalPayloadsPending: boolean;
   _incrementalResults: Map<Label, Map<PathKey, IncrementalResults>>;
   _nextSubscriptionId: number;
@@ -150,12 +150,12 @@ class Executor {
     store,
     updater,
     operationTracker,
-    handleStrippedNulls,
+    treatMissingFieldsAsNull,
     getDataID,
     isClientPayload,
   }: ExecuteConfig): void {
     this._getDataID = getDataID;
-    this._handleStrippedNulls = handleStrippedNulls;
+    this._treatMissingFieldsAsNull = treatMissingFieldsAsNull;
     this._incrementalPayloadsPending = false;
     this._incrementalResults = new Map();
     this._nextSubscriptionId = 0;
@@ -442,7 +442,7 @@ class Executor {
           getDataID: this._getDataID,
           path: [],
           request: this._operation.request,
-          handleStrippedNulls: false,
+          treatMissingFieldsAsNull: false,
         },
       );
       validateOptimisticResponsePayload(payload);
@@ -520,7 +520,7 @@ class Executor {
         getDataID: this._getDataID,
         path: moduleImportPayload.path,
         request: this._operation.request,
-        handleStrippedNulls: this._handleStrippedNulls,
+        treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
       },
     );
   }
@@ -593,7 +593,7 @@ class Executor {
         ROOT_TYPE,
         {
           getDataID: this._getDataID,
-          handleStrippedNulls: this._handleStrippedNulls,
+          treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
           path: [],
           request: this._operation.request,
         },
@@ -972,7 +972,7 @@ class Executor {
         getDataID: this._getDataID,
         path: placeholder.path,
         request: this._operation.request,
-        handleStrippedNulls: this._handleStrippedNulls,
+        treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
       },
     );
     this._publishQueue.commitPayload(this._operation, relayPayload);
@@ -1187,7 +1187,7 @@ class Executor {
       getDataID: this._getDataID,
       path: [...normalizationPath, responseKey, String(itemIndex)],
       request: this._operation.request,
-      handleStrippedNulls: this._handleStrippedNulls,
+      treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
     });
     return {
       fieldPayloads,

--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -70,7 +70,7 @@ export type GetDataID = (
 
 export type NormalizationOptions = {|
   +getDataID: GetDataID,
-  +handleStrippedNulls: boolean,
+  +treatMissingFieldsAsNull: boolean,
   +path?: $ReadOnlyArray<string>,
   +request: RequestDescriptor,
 |};
@@ -102,7 +102,7 @@ function normalize(
 class RelayResponseNormalizer {
   _getDataId: GetDataID;
   _handleFieldPayloads: Array<HandleFieldPayload>;
-  _handleStrippedNulls: boolean;
+  _treatMissingFieldsAsNull: boolean;
   _incrementalPlaceholders: Array<IncrementalDataPlaceholder>;
   _isClientExtension: boolean;
   _moduleImportPayloads: Array<ModuleImportPayload>;
@@ -118,7 +118,7 @@ class RelayResponseNormalizer {
   ) {
     this._getDataId = options.getDataID;
     this._handleFieldPayloads = [];
-    this._handleStrippedNulls = options.handleStrippedNulls;
+    this._treatMissingFieldsAsNull = options.treatMissingFieldsAsNull;
     this._incrementalPlaceholders = [];
     this._isClientExtension = false;
     this._moduleImportPayloads = [];
@@ -354,7 +354,7 @@ class RelayResponseNormalizer {
     const storageKey = getStorageKey(selection, this._variables);
     const fieldValue = data[responseKey];
     if (fieldValue == null) {
-      if (!this._handleStrippedNulls && fieldValue === undefined) {
+      if (!this._treatMissingFieldsAsNull && fieldValue === undefined) {
         // Fields that are missing in the response are not set on the record.
         // There are three main cases where this can occur:
         // - Inside a client extension: the server will not generally return

--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -70,6 +70,7 @@ export type GetDataID = (
 
 export type NormalizationOptions = {|
   +getDataID: GetDataID,
+  +handleStrippedNulls: boolean,
   +path?: $ReadOnlyArray<string>,
   +request: RequestDescriptor,
 |};
@@ -101,6 +102,7 @@ function normalize(
 class RelayResponseNormalizer {
   _getDataId: GetDataID;
   _handleFieldPayloads: Array<HandleFieldPayload>;
+  _handleStrippedNulls: boolean;
   _incrementalPlaceholders: Array<IncrementalDataPlaceholder>;
   _isClientExtension: boolean;
   _moduleImportPayloads: Array<ModuleImportPayload>;
@@ -116,6 +118,7 @@ class RelayResponseNormalizer {
   ) {
     this._getDataId = options.getDataID;
     this._handleFieldPayloads = [];
+    this._handleStrippedNulls = options.handleStrippedNulls;
     this._incrementalPlaceholders = [];
     this._isClientExtension = false;
     this._moduleImportPayloads = [];
@@ -351,7 +354,7 @@ class RelayResponseNormalizer {
     const storageKey = getStorageKey(selection, this._variables);
     const fieldValue = data[responseKey];
     if (fieldValue == null) {
-      if (fieldValue === undefined) {
+      if (!this._handleStrippedNulls && fieldValue === undefined) {
         // Fields that are missing in the response are not set on the record.
         // There are three main cases where this can occur:
         // - Inside a client extension: the server will not generally return

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutation-test.js
@@ -461,7 +461,7 @@ describe('executeMutation()', () => {
     ).toBe(null);
   });
 
-  it('does not handle stripped nulls on optimistic response, even when handling stripped nulls option is true', () => {
+  it('does not fill missing fields from optimistic response with nulls, even when treatMissingFieldsAsNull is enabled', () => {
     operation = createOperationDescriptor(
       CreateCommentWithSpreadMutation,
       variables,
@@ -476,7 +476,7 @@ describe('executeMutation()', () => {
     environment = new RelayModernEnvironment({
       network: RelayNetwork.create(fetch),
       store,
-      handleStrippedNulls: true,
+      treatMissingFieldsAsNull: true,
     });
 
     const snapshot = environment.lookup(selector);
@@ -490,6 +490,7 @@ describe('executeMutation()', () => {
           commentCreate: {
             comment: {
               id: commentID,
+              // body is missing in this response
             },
           },
         },
@@ -501,8 +502,9 @@ describe('executeMutation()', () => {
     expect(callback.mock.calls.length).toBe(1);
     expect(callback.mock.calls[0][0].data).toEqual({
       id: commentID,
-      body: undefined,
+      body: undefined, // even if treatMissingFieldsAsNull is enabled, this is not filled with null
     });
+    // and thus the snapshot has missing data
     expect(callback.mock.calls[0][0].isMissingData).toEqual(true);
   });
 });


### PR DESCRIPTION
Adding the feature to handle stripped nulls in responses as an environment option, passing it through to the query executor and then to the response normalizer, which actually does the job of writing the fields with nulls or not based on the flag.

In the QueryExecutor, I explicitly passed the value to `false` when processing optimistic responses. I noticed that this path is not only used for optimistic responses defined in cases such as `commitMutation`, but also executed when the server may send an optimistic response using an extension. I think this case should still be stripping nulls, as those are coming from the server (if I understood correctly). Would love to confirm this and change the code so that I take into account that case (and change the test I added).

Also pass the value through for all the other async cases, such as defer, streams, module imports. I'm not very familiar with how those work and how they should play along with this option, so I'd appreciate some feedback. Based on [this comment](https://github.com/facebook/relay/issues/3052#issuecomment-602788832), it seems that based on how they are traversed it should not be an issue.

Finally, if this approach seems to be the way to go, happy to work on adding documentation for this (would love pointers on where would be the best place to put this).

Fixes https://github.com/facebook/relay/issues/3052