### PR TITLE
Fix bug with treatMissingFieldsAsNull flag and client extensions

### DIFF
--- a/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
@@ -1542,6 +1542,57 @@ describe('RelayResponseNormalizer', () => {
       expect(recordSource.toJSON()).toEqual(result);
     });
 
+    it('skips client fields not present in the payload but present in the store when treatMissingFieldsAsNull is true', () => {
+      const recordSource = new RelayRecordSourceMapImpl({
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          firstName: 'Alice',
+          nickname: 'ecilA',
+        },
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'node(id:"1")': {__ref: '1'},
+        },
+      });
+      normalize(
+        recordSource,
+        createNormalizationSelector(StrippedQuery.operation, ROOT_ID, {
+          id: '1',
+          size: 32,
+        }),
+        payload,
+        {...defaultOptions, treatMissingFieldsAsNull: true},
+      );
+      const result = {
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          firstName: 'Bob',
+          nickname: 'ecilA',
+        },
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'node(id:"1")': {__ref: '1'},
+        },
+      };
+      expect(recordSource.toJSON()).toEqual(result);
+      normalize(
+        recordSource,
+        createNormalizationSelector(StrippedQuery.operation, ROOT_ID, {
+          id: '1',
+          size: 32,
+        }),
+        payload,
+        defaultOptions,
+      );
+      expect(recordSource.toJSON()).toEqual(result);
+    });
+
     it('skips client fields not present in the payload or store', () => {
       const recordSource = new RelayRecordSourceMapImpl({
         '1': {


### PR DESCRIPTION
I ran into a bug when using `treatMissingFieldsAsNull`, which has to do with the exceptions where a missing field is actually allowed: client extensions and fields on abstract types.

The issue I ran into was with the former, but I also fixed the problem for the latter.

The problem was that when selecting client fields in a fragment that ends up in a query, the normalization process will attempt to write to it with a `null`. This is not right, as we would be resetting what's already in the store for client fields. Moreover, if selecting the `__id` client field, this would even throw an error, as it's not allowed to write null to that field.