### PR TITLE
Add Black Lives Matter banner

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -33,17 +33,25 @@ Button.defaultProps = {
 class HomeSplash extends React.Component {
   render() {
     return (
-      <div className="homeContainer">
-        <div className="homeSplashFade">
-          <div className="logo">
-            <img src={siteConfig.baseUrl + 'img/relay-white.svg'} />
-          </div>
-          <div className="wrapper homeWrapper">
-            <h2 className="projectTitle">
-              {siteConfig.title}
-              <small>{siteConfig.tagline}</small>
-              <small>{siteConfig.subtagline}</small>
-            </h2>
+      <div>
+        <div className="homeContainer homeContainerWrapper homeBanner">
+          Black Lives Matter.{' '}
+          <a target="_blank" href="https://support.eji.org/give/153413/#!/donation/checkout">
+            Support the Equal Justice Initiative
+          </a>.
+        </div>
+        <div className="homeContainer">
+          <div className="homeSplashFade">
+            <div className="logo">
+              <img src={siteConfig.baseUrl + 'img/relay-white.svg'} />
+            </div>
+            <div className="wrapper homeWrapper">
+              <h2 className="projectTitle">
+                {siteConfig.title}
+                <small>{siteConfig.tagline}</small>
+                <small>{siteConfig.subtagline}</small>
+              </h2>
+            </div>
           </div>
         </div>
       </div>

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -25,6 +25,15 @@
 .homeContainer .homeWrapper {
   padding: 10em 1em;
 }
+.homeBanner {
+  color: white;
+  font-size: 20px;
+  text-align: center;
+}
+.homeBanner a {
+  color: white;
+  text-decoration: underline;
+}
 .logo {
   position: absolute;
   opacity: 0.1;


### PR DESCRIPTION
Similar to the Docusaurus and React sites.

![image](https://user-images.githubusercontent.com/91933/83577479-1da66200-a4e9-11ea-9102-2a57498c7ed3.png)

React's version, for reference:

![image](https://user-images.githubusercontent.com/91933/83577491-27c86080-a4e9-11ea-8d8c-392ea0638320.png)

It seems harder to show it above the menubar with Docusaurus, so I placed it underneath instead. This is consistent with what the Docusaurus site itself is doing.