### PR TITLE
Update flow type for errors in commitMutation

### DIFF
--- a/docs/Modern-Mutations.md
+++ b/docs/Modern-Mutations.md
@@ -21,7 +21,7 @@ commitMutation(
   config: {
     mutation: GraphQLTaggedNode,
     variables: {[name: string]: mixed},
-    onCompleted?: ?(response: ?Object, errors: ?Array<Error>) => void,
+    onCompleted?: ?(response: ?Object, errors: ?Array<PayloadError>) => void,
     onError?: ?(error: Error) => void,
     optimisticResponse?: Object,
     optimisticUpdater?: ?(store: RecordSourceSelectorProxy) => void,


### PR DESCRIPTION
According to [the code](https://github.com/facebook/relay/blob/292b1e81933286e2096e85fd80ee5d03073f23ea/packages/relay-runtime/mutations/commitMutation.js#L69), the type should be `PayloadError` instead of `Error`. It also makes it clear that `errors` is not a list of plain JS `Error`s.