### PR TITLE
Update to remove dead link

### DIFF
--- a/docs/Introduction-Prerequisites.md
+++ b/docs/Introduction-Prerequisites.md
@@ -30,5 +30,4 @@ GraphQL is designed to support a wide range of data access patterns. In order to
 Any server can be taught to load a schema and speak GraphQL. Our [examples](https://github.com/relayjs/relay-examples) use Express.
 
 - **[express-graphql](https://github.com/graphql/express-graphql)** on [npm](https://www.npmjs.com/package/express-graphql)
-- **[graphql-up](https://github.com/graphcool/graphql-up)** on [npm](https://www.npmjs.com/package/graphql-up)
 - **[Graphcool](https://www.graph.cool/)** ([Quickstart tutorial](https://www.graph.cool/docs/quickstart/))


### PR DESCRIPTION
 - graphql-up appears to be a dead project.  The npm link still exists, but the github is gone.

I couldn't track down if the project moved or has a successor.

https://www.graph.cool/ appears to be sunsetting, so that will be gone soon as well.