### PR TITLE
Support ScalarHandle in DataChecker

### DIFF
--- a/packages/relay-runtime/store/DataChecker.js
+++ b/packages/relay-runtime/store/DataChecker.js
@@ -21,6 +21,7 @@ const RelayRecordSourceProxy = require('../mutations/RelayRecordSourceProxy');
 const RelayStoreUtils = require('./RelayStoreUtils');
 
 const cloneRelayHandleSourceField = require('./cloneRelayHandleSourceField');
+const cloneRelayScalarHandleSourceField = require('./cloneRelayScalarHandleSourceField');
 const invariant = require('invariant');
 
 const {isClientID} = require('./ClientID');
@@ -342,7 +343,7 @@ class DataChecker {
           }
           break;
         }
-        case LINKED_HANDLE:
+        case LINKED_HANDLE: {
           // Handles have no selections themselves; traverse the original field
           // where the handle was set-up instead.
           const handleField = cloneRelayHandleSourceField(
@@ -356,6 +357,17 @@ class DataChecker {
             this._checkLink(handleField, dataID);
           }
           break;
+        }
+        case SCALAR_HANDLE: {
+          const handleField = cloneRelayScalarHandleSourceField(
+            selection,
+            selections,
+            this._variables,
+          );
+
+          this._checkScalar(handleField, dataID);
+          break;
+        }
         case MODULE_IMPORT:
           this._checkModuleImport(selection, dataID);
           break;
@@ -363,7 +375,6 @@ class DataChecker {
         case STREAM:
           this._traverseSelections(selection.selections, dataID);
           break;
-        case SCALAR_HANDLE:
         case FRAGMENT_SPREAD:
           invariant(
             false,

--- a/packages/relay-runtime/store/__tests__/DataChecker-test.js
+++ b/packages/relay-runtime/store/__tests__/DataChecker-test.js
@@ -204,7 +204,7 @@ describe('check()', () => {
     expect(target.size()).toBe(0);
   });
 
-  it('reads handle fields', () => {
+  it('reads handle fields in fragment', () => {
     const handleKey = getRelayHandleKey('test', null, 'profilePicture');
     const data = {
       '1': {
@@ -244,6 +244,361 @@ describe('check()', () => {
     );
     expect(status).toEqual({
       status: 'available',
+      mostRecentlyInvalidatedAt: null,
+    });
+    expect(target.size()).toBe(0);
+  });
+
+  it('reads handle fields in fragment and checks missing', () => {
+    const handleKey = getRelayHandleKey('test', null, 'profilePicture');
+    const data = {
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        'profilePicture(size:32)': {__ref: 'client:1'},
+        // missing [handleKey] field
+      },
+      'client:1': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+      },
+      'client:3': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+      },
+    };
+    const source = RelayRecordSource.create(data);
+    const target = RelayRecordSource.create();
+    const {Fragment} = generateAndCompile(`
+      fragment Fragment on User {
+        profilePicture(size: 32) @__clientField(handle: "test") {
+          uri
+        }
+      }
+    `);
+    const status = check(
+      source,
+      target,
+      createNormalizationSelector(Fragment, '1', {}),
+      [],
+      null,
+      defaultGetDataID,
+    );
+    expect(status).toEqual({
+      status: 'missing',
+      mostRecentlyInvalidatedAt: null,
+    });
+    expect(target.size()).toBe(0);
+  });
+
+  it('reads handle fields in fragment and checks missing sub field', () => {
+    const handleKey = getRelayHandleKey('test', null, 'profilePicture');
+    const data = {
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        'profilePicture(size:32)': {__ref: 'client:1'},
+        [handleKey]: {__ref: 'client:3'},
+      },
+      'client:1': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+      },
+      'client:3': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        // uri field is missing
+      },
+    };
+    const source = RelayRecordSource.create(data);
+    const target = RelayRecordSource.create();
+    const {Fragment} = generateAndCompile(`
+      fragment Fragment on User {
+        profilePicture(size: 32) @__clientField(handle: "test") {
+          uri
+        }
+      }
+    `);
+
+    const status = check(
+      source,
+      target,
+      createNormalizationSelector(Fragment, '1', {}),
+      [],
+      null,
+      defaultGetDataID,
+    );
+    expect(status).toEqual({
+      status: 'missing',
+      mostRecentlyInvalidatedAt: null,
+    });
+    expect(target.size()).toBe(0);
+  });
+
+  it('reads handle fields in operation', () => {
+    const handleKey = getRelayHandleKey('test', null, 'profilePicture');
+    const data = {
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        'profilePicture(size:32)': {__ref: 'client:1'},
+        [handleKey]: {__ref: 'client:3'},
+      },
+      'client:1': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+      },
+      'client:3': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+      },
+    };
+    const source = RelayRecordSource.create(data);
+    const target = RelayRecordSource.create();
+    // LinkedHandle selectors are only generated for a the normalization
+    // code for a query
+    const {Query} = generateAndCompile(`
+      query Query {
+        me {
+          profilePicture(size: 32) @__clientField(handle: "test") {
+            uri
+          }
+        }
+      }
+    `);
+
+    const status = check(
+      source,
+      target,
+      createNormalizationSelector(Query.operation, 'client:root', {}),
+      [],
+      null,
+      defaultGetDataID,
+    );
+    expect(status).toEqual({
+      status: 'available',
+      mostRecentlyInvalidatedAt: null,
+    });
+    expect(target.size()).toBe(0);
+  });
+
+  it('reads handle fields in operation and checks missing', () => {
+    const handleKey = getRelayHandleKey('test', null, 'profilePicture');
+    const data = {
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        'profilePicture(size:32)': {__ref: 'client:1'},
+        // missing [handleKey] field
+      },
+      'client:1': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+      },
+      'client:3': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+      },
+    };
+    const source = RelayRecordSource.create(data);
+    const target = RelayRecordSource.create();
+    // LinkedHandle selectors are only generated for a the normalization
+    // code for a query
+    const {Query} = generateAndCompile(`
+      query Query {
+        me {
+          profilePicture(size: 32) @__clientField(handle: "test") {
+            uri
+          }
+        }
+      }
+    `);
+
+    const status = check(
+      source,
+      target,
+      createNormalizationSelector(Query.operation, 'client:root', {}),
+      [],
+      null,
+      defaultGetDataID,
+    );
+    expect(status).toEqual({
+      status: 'missing',
+      mostRecentlyInvalidatedAt: null,
+    });
+    expect(target.size()).toBe(0);
+  });
+
+  it('reads handle fields in operation and checks missing sub field', () => {
+    const handleKey = getRelayHandleKey('test', null, 'profilePicture');
+    const data = {
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        'profilePicture(size:32)': {__ref: 'client:1'},
+        [handleKey]: {__ref: 'client:3'},
+      },
+      'client:1': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+      },
+      'client:3': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        // uri field is missing
+      },
+    };
+    const source = RelayRecordSource.create(data);
+    const target = RelayRecordSource.create();
+    // LinkedHandle selectors are only generated for a the normalization
+    // code for a query
+    const {Query} = generateAndCompile(`
+      query Query {
+        me {
+          profilePicture(size: 32) @__clientField(handle: "test") {
+            uri
+          }
+        }
+      }
+    `);
+
+    const status = check(
+      source,
+      target,
+      createNormalizationSelector(Query.operation, 'client:root', {}),
+      [],
+      null,
+      defaultGetDataID,
+    );
+    expect(status).toEqual({
+      status: 'missing',
+      mostRecentlyInvalidatedAt: null,
+    });
+    expect(target.size()).toBe(0);
+  });
+
+  it('reads scalar handle fields in operation and checks presence', () => {
+    const handleKey = getRelayHandleKey('test', null, 'uri');
+    const data = {
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        'profilePicture(size:32)': {__ref: 'client:1'},
+      },
+      'client:1': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+        [handleKey]: 'https://...',
+      },
+    };
+    const source = RelayRecordSource.create(data);
+    const target = RelayRecordSource.create();
+    // ScalarHandle selectors are only generated for a the normalization
+    // code for a query
+    const {Query} = generateAndCompile(`
+      query Query {
+        me {
+          profilePicture(size: 32) {
+            uri @__clientField(handle: "test")
+          }
+        }
+      }
+    `);
+
+    const status = check(
+      source,
+      target,
+      createNormalizationSelector(Query.operation, 'client:root', {}),
+      [],
+      null,
+      defaultGetDataID,
+    );
+    expect(status).toEqual({
+      status: 'available',
+      mostRecentlyInvalidatedAt: null,
+    });
+    expect(target.size()).toBe(0);
+  });
+
+  it('reads scalar handle fields in operation and checks missing', () => {
+    const handleKey = getRelayHandleKey('test', null, 'uri');
+    const data = {
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        'profilePicture(size:32)': {__ref: 'client:1'},
+      },
+      'client:1': {
+        __id: 'client:2',
+        __typename: 'Photo',
+        uri: 'https://...',
+        // [handleKey] field is missing
+      },
+    };
+    const source = RelayRecordSource.create(data);
+    const target = RelayRecordSource.create();
+    // ScalarHandle selectors are only generated for a the normalization
+    // code for a query
+    const {Query} = generateAndCompile(`
+      query Query {
+        me {
+          profilePicture(size: 32) {
+            uri @__clientField(handle: "test")
+          }
+        }
+      }
+    `);
+    const status = check(
+      source,
+      target,
+      createNormalizationSelector(Query.operation, 'client:root', {}),
+      [],
+      null,
+      defaultGetDataID,
+    );
+    expect(status).toEqual({
+      status: 'missing',
       mostRecentlyInvalidatedAt: null,
     });
     expect(target.size()).toBe(0);

--- a/packages/relay-runtime/store/__tests__/cloneRelayHandleSourceField-test.js
+++ b/packages/relay-runtime/store/__tests__/cloneRelayHandleSourceField-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @emails oncall+relay
+ * @flow strict-local
  * @format
  */
 
@@ -36,7 +37,7 @@ describe('cloneRelayHandleSourceField()', () => {
   it('returns a clone of the source, with the same name as the handle', () => {
     const handleField = selections.find(node => node.kind === LINKED_HANDLE);
     const sourceField = selections.find(node => node.kind === LINKED_FIELD);
-    const clone = cloneRelayHandleSourceField(handleField, selections);
+    const clone = cloneRelayHandleSourceField(handleField, selections, {});
 
     expect(clone.kind).toBe(LINKED_FIELD);
     expect(clone.name).toBe(getRelayHandleKey('test', null, 'address'));
@@ -48,7 +49,7 @@ describe('cloneRelayHandleSourceField()', () => {
     selections = selections.filter(node => node.kind === LINKED_HANDLE);
 
     expect(() =>
-      cloneRelayHandleSourceField(handleField, selections),
+      cloneRelayHandleSourceField(handleField, selections, {}),
     ).toThrowError(
       'cloneRelayHandleSourceField: Expected a corresponding source field ' +
         'for handle `test`.',

--- a/packages/relay-runtime/store/__tests__/cloneRelayScalarHandleSourceField-test.js
+++ b/packages/relay-runtime/store/__tests__/cloneRelayScalarHandleSourceField-test.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+relay
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const cloneRelayScalarHandleSourceField = require('../cloneRelayScalarHandleSourceField');
+const getRelayHandleKey = require('../../util/getRelayHandleKey');
+
+const {SCALAR_FIELD, SCALAR_HANDLE} = require('../../util/RelayConcreteNode');
+const {generateWithTransforms} = require('relay-test-utils-internal');
+
+describe('cloneRelayScalarHandleSourceField()', () => {
+  let selections;
+
+  beforeEach(() => {
+    const {TestQuery} = generateWithTransforms(`
+      query TestQuery {
+        me {
+          address {
+            street @__clientField(handle: "test")
+          }
+        }
+      }
+    `);
+    // Get the selections on `me.addresss`.
+    selections = TestQuery.operation.selections[0].selections[0].selections;
+  });
+
+  it('returns a clone of the source, with the same name as the handle', () => {
+    const handleField = selections.find(node => node.kind === SCALAR_HANDLE);
+    const clone = cloneRelayScalarHandleSourceField(
+      handleField,
+      selections,
+      {},
+    );
+
+    expect(clone.kind).toBe(SCALAR_FIELD);
+    expect(clone.name).toBe(getRelayHandleKey('test', null, 'street'));
+    expect(clone.storageKey).toBe(getRelayHandleKey('test', null, 'street'));
+  });
+
+  it('throws if the source field is not present', () => {
+    const handleField = selections.find(node => node.kind === SCALAR_HANDLE);
+    selections = selections.filter(node => node.kind === SCALAR_HANDLE);
+
+    expect(() =>
+      cloneRelayScalarHandleSourceField(handleField, selections, {}),
+    ).toThrowError(
+      'cloneRelayScalarHandleSourceField: Expected a corresponding source field ' +
+        'for handle `test`.',
+    );
+  });
+});

--- a/packages/relay-runtime/store/cloneRelayScalarHandleSourceField.js
+++ b/packages/relay-runtime/store/cloneRelayScalarHandleSourceField.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// flowlint ambiguous-object-type:error
+
+'use strict';
+
+const areEqual = require('areEqual');
+const invariant = require('invariant');
+
+const {SCALAR_FIELD} = require('../util/RelayConcreteNode');
+const {getHandleStorageKey} = require('./RelayStoreUtils');
+
+import type {
+  NormalizationScalarField,
+  NormalizationSelection,
+} from '../util/NormalizationNode';
+import type {NormalizationScalarHandle} from '../util/NormalizationNode';
+import type {Variables} from '../util/RelayRuntimeTypes';
+
+/**
+ * @private
+ *
+ * Creates a clone of the supplied `handleField` by finding the original scalar
+ * field (on which the handle was declared) among the sibling `selections`.
+ */
+function cloneRelayScalarHandleSourceField(
+  handleField: NormalizationScalarHandle,
+  selections: $ReadOnlyArray<NormalizationSelection>,
+  variables: Variables,
+): NormalizationScalarField {
+  const sourceField = selections.find(
+    source =>
+      source.kind === SCALAR_FIELD &&
+      source.name === handleField.name &&
+      source.alias === handleField.alias &&
+      areEqual(source.args, handleField.args),
+  );
+  invariant(
+    sourceField && sourceField.kind === SCALAR_FIELD,
+    'cloneRelayScalarHandleSourceField: Expected a corresponding source field for ' +
+      'handle `%s`.',
+    handleField.handle,
+  );
+  const handleKey = getHandleStorageKey(handleField, variables);
+  return {
+    kind: 'ScalarField',
+    alias: sourceField.alias,
+    name: handleKey,
+    storageKey: handleKey,
+    args: null,
+  };
+}
+
+module.exports = cloneRelayScalarHandleSourceField;


### PR DESCRIPTION
If we have a fragment that makes use of a handler in a scalar field, `DataChecker` will throw an error because the `SCALAR_HANDLE` kind of selection is not supported. Talking with the team we agreed this was a case that should be supported.

I did this by replicating the logic for LINKED_HANDLE, only that in this case we don't need to copy inner selections since this is a scalar field. I created a `cloneRelayScalarHandleSourceField` module similar to its linked handle counterpart. Also while at it, I added some tests to support this functionality and that of LINKED_HANDLE, since it was previously not covered.

### **Wrong assumptions based on @kassens's [comment below,](https://github.com/facebook/relay/pull/3100#issuecomment-647920623) leaving this for posterity:**

~~When figuring out the logic around a handle when checking if the data is complete, given that a handle field lives alongside the original one (which contains the data that came back from the response), it turned out that it would be enough to just skip this selection, as the logic for the original field would be enough to test that the data is complete.~~

~~I went a bit further with this reasoning and did the same with a `LINKED_HANDLE`. The logic here was even creating a clone of the original field and assigning the sub selections, traversing that in the same way we do for linked fields. But if the original linked field is always present next to a handler, then this is already being done when traversing the original field, so there should be no need to do this.~~

~~Probably I'm missing something in the assumptions for the latter case, but figured I would just send a PR and explaining the rationale to start the discussion. However, worth noting that all tests still pass even when skipping a LINKED_HANDLE field. So if this is not the right thing to do, we should at least add a test that validates this is indeed used.~~