### PR TITLE
feat(rust-compiler): Build FB as a feature flag at compile-time

### DIFF
--- a/compiler/crates/graphql-transforms/src/connections/connection_interface.rs
+++ b/compiler/crates/graphql-transforms/src/connections/connection_interface.rs
@@ -22,27 +22,32 @@ pub struct ConnectionInterface {
     pub start_cursor_selection_name: StringKey,
 }
 
-lazy_static! {
-    pub static ref OSS_CONNECTION_INTERFACE: Arc<ConnectionInterface> =
-        Arc::new(ConnectionInterface {
-            cursor_selection_name: "cursor".intern(),
-            edges_selection_name: "edges".intern(),
-            end_cursor_selection_name: "endCursor".intern(),
-            has_next_page_selection_name: "hasNextPage".intern(),
-            has_prev_page_selection_name: "hasPreviousPage".intern(),
-            node_selection_name: "node".intern(),
-            page_info_selection_name: "pageInfo".intern(),
-            start_cursor_selection_name: "startCursor".intern(),
-        });
-    pub static ref FB_CONNECTION_INTERFACE: Arc<ConnectionInterface> =
-        Arc::new(ConnectionInterface {
-            cursor_selection_name: "cursor".intern(),
-            edges_selection_name: "edges".intern(),
-            end_cursor_selection_name: "end_cursor".intern(),
-            has_next_page_selection_name: "has_next_page".intern(),
-            has_prev_page_selection_name: "has_previous_page".intern(),
-            node_selection_name: "node".intern(),
-            page_info_selection_name: "page_info".intern(),
-            start_cursor_selection_name: "start_cursor".intern(),
-        });
-}
+#[cfg(feature = "is_FB")]
+    lazy_static! {
+        pub static ref CONNECTION_INTERFACE: Arc<ConnectionInterface> =
+            Arc::new(ConnectionInterface {
+                cursor_selection_name: "cursor".intern(),
+                edges_selection_name: "edges".intern(),
+                end_cursor_selection_name: "end_cursor".intern(),
+                has_next_page_selection_name: "has_next_page".intern(),
+                has_prev_page_selection_name: "has_previous_page".intern(),
+                node_selection_name: "node".intern(),
+                page_info_selection_name: "page_info".intern(),
+                start_cursor_selection_name: "start_cursor".intern(),
+            });
+    }
+
+#[cfg(not(feature = "is_FB"))]
+    lazy_static! {
+       pub static ref CONNECTION_INTERFACE: Arc<ConnectionInterface> =
+            Arc::new(ConnectionInterface {
+                cursor_selection_name: "cursor".intern(),
+                edges_selection_name: "edges".intern(),
+                end_cursor_selection_name: "endCursor".intern(),
+                has_next_page_selection_name: "hasNextPage".intern(),
+                has_prev_page_selection_name: "hasPreviousPage".intern(),
+                node_selection_name: "node".intern(),
+                page_info_selection_name: "pageInfo".intern(),
+                start_cursor_selection_name: "startCursor".intern(),
+            });
+    }

--- a/compiler/crates/graphql-transforms/src/connections/mod.rs
+++ b/compiler/crates/graphql-transforms/src/connections/mod.rs
@@ -11,7 +11,7 @@ mod connection_util;
 
 pub use connection_constants::ConnectionConstants;
 pub use connection_interface::{
-    ConnectionInterface, FB_CONNECTION_INTERFACE, OSS_CONNECTION_INTERFACE,
+    ConnectionInterface, CONNECTION_INTERFACE,
 };
 pub use connection_util::{
     assert_connection_selections, build_connection_metadata,

--- a/compiler/crates/graphql-transforms/src/lib.rs
+++ b/compiler/crates/graphql-transforms/src/lib.rs
@@ -63,7 +63,7 @@ pub use connections::{
     extract_connection_metadata_from_directive, ConnectionConstants, ConnectionInterface,
     ConnectionMetadata,
 };
-pub use connections::{FB_CONNECTION_INTERFACE, OSS_CONNECTION_INTERFACE};
+pub use connections::{CONNECTION_INTERFACE};
 pub use dedupe_type_discriminator::dedupe_type_discriminator;
 pub use defer_stream::{
     transform_defer_stream, DeferDirective, StreamDirective, DEFER_STREAM_CONSTANTS,

--- a/compiler/crates/graphql-transforms/tests/refetchable_fragment/mod.rs
+++ b/compiler/crates/graphql-transforms/tests/refetchable_fragment/mod.rs
@@ -12,7 +12,7 @@ use graphql_ir::{build, Program};
 use graphql_syntax::parse;
 use graphql_text_printer::{print_fragment, print_operation};
 use graphql_transforms::{
-    transform_connections, transform_refetchable_fragment, OSS_CONNECTION_INTERFACE,
+    transform_connections, transform_refetchable_fragment, CONNECTION_INTERFACE,
 };
 use std::sync::Arc;
 use test_schema::get_test_schema;
@@ -30,7 +30,7 @@ pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
         Err(err) => return Err(format!("{:?}", err)),
     };
     let program = Program::from_definitions(Arc::clone(&schema), ir);
-    let program = transform_connections(&program, Arc::clone(&OSS_CONNECTION_INTERFACE));
+    let program = transform_connections(&program, Arc::clone(&CONNECTION_INTERFACE));
     let base_fragments = Default::default();
     let next_program =
         transform_refetchable_fragment(&program, &base_fragments, false).map_err(|errors| {

--- a/compiler/crates/graphql-transforms/tests/transform_connections/mod.rs
+++ b/compiler/crates/graphql-transforms/tests/transform_connections/mod.rs
@@ -11,7 +11,7 @@ use fnv::FnvHashMap;
 use graphql_ir::{build, Program};
 use graphql_syntax::parse;
 use graphql_text_printer::{print_fragment, print_operation};
-use graphql_transforms::{transform_connections, validate_connections, OSS_CONNECTION_INTERFACE};
+use graphql_transforms::{transform_connections, validate_connections, CONNECTION_INTERFACE};
 use std::sync::Arc;
 use test_schema::get_test_schema;
 
@@ -39,7 +39,7 @@ pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
 
     let program = Program::from_definitions(Arc::clone(&schema), ir);
 
-    let validation_result = validate_connections(&program, &*OSS_CONNECTION_INTERFACE);
+    let validation_result = validate_connections(&program, &*CONNECTION_INTERFACE);
     match validation_result {
         Ok(_) => {}
         Err(errors) => {
@@ -52,7 +52,7 @@ pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
         }
     }
 
-    let next_program = transform_connections(&program, Arc::clone(&OSS_CONNECTION_INTERFACE));
+    let next_program = transform_connections(&program, Arc::clone(&CONNECTION_INTERFACE));
 
     let mut printed = next_program
         .operations()

--- a/compiler/crates/graphql-transforms/tests/validate_connections/mod.rs
+++ b/compiler/crates/graphql-transforms/tests/validate_connections/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use fnv::FnvHashMap;
 use graphql_ir::{build, Program};
 use graphql_syntax::parse;
-use graphql_transforms::{validate_connections, OSS_CONNECTION_INTERFACE};
+use graphql_transforms::{validate_connections, CONNECTION_INTERFACE};
 use std::sync::Arc;
 use test_schema::TEST_SCHEMA;
 
@@ -35,7 +35,7 @@ pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
     };
 
     let program = Program::from_definitions(Arc::clone(&TEST_SCHEMA), ir);
-    let validation_result = validate_connections(&program, &*OSS_CONNECTION_INTERFACE);
+    let validation_result = validate_connections(&program, &*CONNECTION_INTERFACE);
 
     match validation_result {
         Ok(_) => Ok("OK".to_owned()),

--- a/compiler/crates/graphql-transforms/tests/validate_connections_schema/mod.rs
+++ b/compiler/crates/graphql-transforms/tests/validate_connections_schema/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use fnv::FnvHashMap;
 use graphql_ir::{build, Program};
 use graphql_syntax::parse;
-use graphql_transforms::{validate_connections, OSS_CONNECTION_INTERFACE};
+use graphql_transforms::{validate_connections, CONNECTION_INTERFACE};
 use std::sync::Arc;
 use test_schema::get_test_schema_with_extensions;
 
@@ -26,7 +26,7 @@ pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
 
         let ir = build(&schema, &ast.definitions).unwrap();
         let program = Program::from_definitions(Arc::clone(&schema), ir);
-        let result = validate_connections(&program, &*OSS_CONNECTION_INTERFACE);
+        let result = validate_connections(&program, &*CONNECTION_INTERFACE);
 
         match result {
             Ok(_) => Ok("OK".to_owned()),

--- a/compiler/crates/relay-codegen/tests/connections/mod.rs
+++ b/compiler/crates/relay-codegen/tests/connections/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use fnv::FnvHashMap;
 use graphql_ir::{build, FragmentDefinition, Program};
 use graphql_syntax::parse;
-use graphql_transforms::{transform_connections, validate_connections, OSS_CONNECTION_INTERFACE};
+use graphql_transforms::{transform_connections, validate_connections, CONNECTION_INTERFACE};
 use relay_codegen::{build_request_params, Printer};
 use std::sync::Arc;
 use test_schema::get_test_schema;
@@ -40,7 +40,7 @@ pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
 
     let program = Program::from_definitions(Arc::clone(&schema), ir);
 
-    let validation_result = validate_connections(&program, &*OSS_CONNECTION_INTERFACE);
+    let validation_result = validate_connections(&program, &*CONNECTION_INTERFACE);
     match validation_result {
         Ok(_) => {}
         Err(errors) => {
@@ -53,7 +53,7 @@ pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
         }
     }
 
-    let next_program = transform_connections(&program, Arc::clone(&OSS_CONNECTION_INTERFACE));
+    let next_program = transform_connections(&program, Arc::clone(&CONNECTION_INTERFACE));
 
     let mut printed = next_program
         .operations()

--- a/compiler/crates/relay-compiler/Cargo.toml
+++ b/compiler/crates/relay-compiler/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/lib.rs"
 name = "relay_compiler_compile_relay_artifacts_test"
 path = "tests/compile_relay_artifacts_test.rs"
 
+[features]
+default = []
+is_FB = []
+
 [dependencies]
 common = { path = "../common" }
 dependency-analyzer = { path = "../dependency-analyzer" }

--- a/compiler/crates/relay-compiler/src/build_project/mod.rs
+++ b/compiler/crates/relay-compiler/src/build_project/mod.rs
@@ -34,7 +34,7 @@ pub use generate_artifacts::{
 };
 use generate_extra_artifacts::generate_extra_artifacts;
 use graphql_ir::Program;
-use graphql_transforms::FB_CONNECTION_INTERFACE;
+use graphql_transforms::CONNECTION_INTERFACE;
 use log::info;
 use persist_operations::persist_operations;
 use schema::Schema;
@@ -71,7 +71,7 @@ fn build_programs(
     // Call validation rules that go beyond type checking.
     log_event.time("validate_time", || {
         // TODO(T63482263): Pass connection interface from configuration
-        validate(&program, &*FB_CONNECTION_INTERFACE)
+        validate(&program, &*CONNECTION_INTERFACE)
             .map_err(|errors| BuildProjectError::ValidationErrors { errors })
     })?;
 
@@ -81,7 +81,7 @@ fn build_programs(
             project_name,
             Arc::new(program),
             Arc::new(base_fragment_names),
-            Arc::clone(&FB_CONNECTION_INTERFACE),
+            Arc::clone(&CONNECTION_INTERFACE),
             perf_logger,
         )
         .map_err(|errors| BuildProjectError::ValidationErrors { errors })

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
@@ -11,7 +11,7 @@ use fnv::FnvHashMap;
 use graphql_ir::{build, FragmentDefinition, OperationDefinition, Program, ValidationError};
 use graphql_syntax::parse;
 use graphql_text_printer::print_full_operation;
-use graphql_transforms::{MATCH_CONSTANTS, OSS_CONNECTION_INTERFACE};
+use graphql_transforms::{MATCH_CONSTANTS, CONNECTION_INTERFACE};
 use interner::Intern;
 use relay_codegen::{build_request_params, print_fragment, print_operation, print_request};
 use relay_compiler::{apply_transforms, validate};
@@ -51,14 +51,14 @@ pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
     let ir = build(&schema, &ast.definitions).map_err(validation_errors_to_string)?;
     let program = Program::from_definitions(Arc::clone(&schema), ir);
 
-    validate(&program, &*OSS_CONNECTION_INTERFACE).map_err(validation_errors_to_string)?;
+    validate(&program, &*CONNECTION_INTERFACE).map_err(validation_errors_to_string)?;
 
     // TODO pass base fragment names
     let programs = apply_transforms(
         "test".intern(),
         Arc::new(program),
         Default::default(),
-        Arc::clone(&OSS_CONNECTION_INTERFACE),
+        Arc::clone(&CONNECTION_INTERFACE),
         Arc::new(ConsoleLogger),
     )
     .map_err(validation_errors_to_string)?;

--- a/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use fnv::FnvHashMap;
 use graphql_ir::{build, Program};
 use graphql_syntax::parse;
-use graphql_transforms::OSS_CONNECTION_INTERFACE;
+use graphql_transforms::CONNECTION_INTERFACE;
 use interner::Intern;
 use relay_compiler::apply_transforms;
 use relay_typegen::{self, TypegenConfig};
@@ -36,7 +36,7 @@ pub fn transform_fixture(fixture: &Fixture) -> Result<String, String> {
         "test".intern(),
         Arc::new(program),
         Default::default(),
-        Arc::clone(&OSS_CONNECTION_INTERFACE),
+        Arc::clone(&CONNECTION_INTERFACE),
         Arc::new(ConsoleLogger),
     )
     .unwrap();


### PR DESCRIPTION
With this PR I aim to introduce the ability to build the compiler with either Facebook specific things enabled/disabled.

I don't think there are any other specific things at this stage.

The general approach will be to follow the feature spec, which can be done either in code, or as compiler directives.

Facebook will need to apply an extra configuration in Buck to enable this.

- https://doc.rust-lang.org/cargo/reference/features.html
- https://buck.build/rule/rust_library.html#features

---

Might need to investigate an approach here where unit tests could be ran against both versions. Snapshots will obviously fail. But the issue is the feature is defined in the `relay-compiler` crate, but transformers own the reference? So maybe that feature flag _should_ be reiterated per crate that requires that level of context?