### PR TITLE
Add transformWithOptions export to InlineFragmentsTransform transform

### DIFF
--- a/packages/relay-compiler/transforms/__tests__/InlineFragmentsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/InlineFragmentsTransform-test.js
@@ -36,4 +36,29 @@ describe('InlineFragmentsTransform', () => {
         .join('\n');
     },
   );
+  generateTestsFromFixtures(
+    `${__dirname}/fixtures/inline-fragments-transform`,
+    text => {
+      const {definitions} = parseGraphQLText(TestSchema, text);
+      return new CompilerContext(TestSchema)
+        .addAll(definitions)
+        .applyTransforms([InlineFragmentsTransform.transformWithOptions({includeFragments: true})])
+        .documents()
+        .map(doc => IRPrinter.print(TestSchema, doc))
+        .join('\n');
+    },
+  );
+  generateTestsFromFixtures(
+    `${__dirname}/fixtures/inline-fragments-transform`,
+    text => {
+      const {definitions} = parseGraphQLText(TestSchema, text);
+      return new CompilerContext(TestSchema)
+        .addAll(definitions)
+        .applyTransforms([InlineFragmentsTransform.transformWithOptions({includeFragments: false})])
+        .documents()
+        .map(doc => IRPrinter.print(TestSchema, doc))
+        .join('\n');
+    },
+  );
 });
+

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/InlineFragmentsTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/InlineFragmentsTransform-test.js.snap
@@ -66,3 +66,171 @@ query TestQuery(
 }
 
 `;
+
+exports[`InlineFragmentsTransform matches expected output: inlines-nested-fragments.graphql 2`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query TestQuery($id: ID!) {
+  node(id: $id) {
+    id
+    ...ProfileWithFriends
+  }
+}
+
+fragment ProfileWithFriends on User {
+  id
+  firstName
+  lastName
+  ...ProfileWithoutFriends
+  friends(first: 10) {
+    edges {
+      node {
+        ...ProfileWithoutFriends
+      }
+    }
+  }
+}
+
+fragment ProfileWithoutFriends on User {
+  firstName
+  lastName
+  profilePicture(size: 128) {
+    uri
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+query TestQuery(
+  $id: ID!
+) {
+  node(id: $id) {
+    id
+    ... on User {
+      id
+      firstName
+      lastName
+      ... on User {
+        firstName
+        lastName
+        profilePicture(size: 128) {
+          uri
+        }
+      }
+      friends(first: 10) {
+        edges {
+          node {
+            ... on User {
+              firstName
+              lastName
+              profilePicture(size: 128) {
+                uri
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment ProfileWithFriends on User {
+  id
+  firstName
+  lastName
+  ... on User {
+    firstName
+    lastName
+    profilePicture(size: 128) {
+      uri
+    }
+  }
+  friends(first: 10) {
+    edges {
+      node {
+        ... on User {
+          firstName
+          lastName
+          profilePicture(size: 128) {
+            uri
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment ProfileWithoutFriends on User {
+  firstName
+  lastName
+  profilePicture(size: 128) {
+    uri
+  }
+}
+
+`;
+
+exports[`InlineFragmentsTransform matches expected output: inlines-nested-fragments.graphql 3`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query TestQuery($id: ID!) {
+  node(id: $id) {
+    id
+    ...ProfileWithFriends
+  }
+}
+
+fragment ProfileWithFriends on User {
+  id
+  firstName
+  lastName
+  ...ProfileWithoutFriends
+  friends(first: 10) {
+    edges {
+      node {
+        ...ProfileWithoutFriends
+      }
+    }
+  }
+}
+
+fragment ProfileWithoutFriends on User {
+  firstName
+  lastName
+  profilePicture(size: 128) {
+    uri
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+query TestQuery(
+  $id: ID!
+) {
+  node(id: $id) {
+    id
+    ... on User {
+      id
+      firstName
+      lastName
+      ... on User {
+        firstName
+        lastName
+        profilePicture(size: 128) {
+          uri
+        }
+      }
+      friends(first: 10) {
+        edges {
+          node {
+            ... on User {
+              firstName
+              lastName
+              profilePicture(size: 128) {
+                uri
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+`;


### PR DESCRIPTION
This adds a `transformWithOptions` export to the `InlineFragmentsTransform` which allows passing in an option to includeFragments which keeps fragment definitions in the final output. This is useful for tools that want to generate types from optimized schemas.