### PR TITLE
Add scalar type name to object output

### DIFF
--- a/compiler/crates/relay-codegen/src/build_ast.rs
+++ b/compiler/crates/relay-codegen/src/build_ast.rs
@@ -503,6 +503,10 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
             ),
             (CODEGEN_CONSTANTS.name, Primitive::String(name)),
             (
+                CODEGEN_CONSTANTS.type_,
+                Primitive::String(self.schema.get_type_name(schema_field.type_.inner())),
+            ),
+            (
                 CODEGEN_CONSTANTS.storage_key,
                 match args {
                     None => Primitive::Null,

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fields-of-client-type.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fields-of-client-type.expected
@@ -32,6 +32,7 @@ type Foo {
       "args": null,
       "kind": "ScalarField",
       "name": "id",
+      "type": "ID",
       "storageKey": null
     },
     {
@@ -50,6 +51,7 @@ type Foo {
               "args": null,
               "kind": "ScalarField",
               "name": "client_name",
+              "type": "string",
               "storageKey": null
             },
             {
@@ -71,6 +73,7 @@ type Foo {
                   "args": null,
                   "kind": "ScalarField",
                   "name": "uri",
+                  "type": "string",
                   "storageKey": null
                 }
               ],


### PR DESCRIPTION
I've been working on introspecting the output of the Relay object artifacts (using it to inform client side outputs)
and I'd noticed that the Scalar name was not in the output. So I've poked at the compiler and hacked this in.

This PR is by no means finished, but I'm putting it up as a POC and wonder if it was up to scratch if it is something that would be merged in.

TBH, I'm not even sure if the rust compiler is the compiler that's being used, if not I'd obviously have to do the same thing in the shipped compiler.

Before shipping this, it would at the very least require nullability information to be added to the output.

Would love comments/feedback/information about getting this in the codebase.