### PR TITLE
Support defer/stream spec proposal

### DIFF
--- a/compiler/crates/relay-codegen/src/printer.rs
+++ b/compiler/crates/relay-codegen/src/printer.rs
@@ -31,7 +31,12 @@ pub fn print_operation(
     project_config: &ProjectConfig,
     top_level_statements: &mut TopLevelStatements,
 ) -> String {
-    Printer::without_dedupe(project_config).print_operation(schema, operation, top_level_statements)
+    Printer::without_dedupe(project_config).print_operation(
+        schema,
+        operation,
+        top_level_statements,
+        project_config,
+    )
 }
 
 pub fn print_fragment(
@@ -40,7 +45,12 @@ pub fn print_fragment(
     project_config: &ProjectConfig,
     top_level_statements: &mut TopLevelStatements,
 ) -> String {
-    Printer::without_dedupe(project_config).print_fragment(schema, fragment, top_level_statements)
+    Printer::without_dedupe(project_config).print_fragment(
+        schema,
+        fragment,
+        top_level_statements,
+        project_config,
+    )
 }
 
 pub fn print_request(
@@ -57,6 +67,7 @@ pub fn print_request(
         fragment,
         request_parameters,
         top_level_statements,
+        project_config,
     )
 }
 
@@ -77,6 +88,7 @@ pub fn print_request_params(
         &mut builder,
         operation,
         top_level_statements,
+        &project_config.schema_config.defer_stream_interface,
     );
     let printer = JSONPrinter::new(&builder, project_config, top_level_statements);
     printer.print(request_parameters_ast_key, false)
@@ -110,8 +122,14 @@ impl<'p> Printer<'p> {
         schema: &SDLSchema,
         operation: &OperationDefinition,
         top_level_statements: &mut TopLevelStatements,
+        project_config: &ProjectConfig,
     ) -> Option<String> {
-        let key = build_provided_variables(schema, &mut self.builder, operation)?;
+        let key = build_provided_variables(
+            schema,
+            &mut self.builder,
+            operation,
+            &project_config.schema_config.defer_stream_interface,
+        )?;
         let printer = JSONPrinter::new(&self.builder, self.project_config, top_level_statements);
         Some(printer.print(key, self.dedupe))
     }
@@ -123,6 +141,7 @@ impl<'p> Printer<'p> {
         fragment: &FragmentDefinition,
         request_parameters: RequestParameters<'_>,
         top_level_statements: &mut TopLevelStatements,
+        project_config: &ProjectConfig,
     ) -> String {
         let request_parameters = build_request_params_ast_key(
             schema,
@@ -130,6 +149,7 @@ impl<'p> Printer<'p> {
             &mut self.builder,
             operation,
             top_level_statements,
+            &project_config.schema_config.defer_stream_interface,
         );
         let key = build_request(
             schema,
@@ -137,6 +157,7 @@ impl<'p> Printer<'p> {
             operation,
             fragment,
             request_parameters,
+            &project_config.schema_config.defer_stream_interface,
         );
         let printer = JSONPrinter::new(&self.builder, self.project_config, top_level_statements);
         printer.print(key, self.dedupe)
@@ -147,8 +168,14 @@ impl<'p> Printer<'p> {
         schema: &SDLSchema,
         operation: &OperationDefinition,
         top_level_statements: &mut TopLevelStatements,
+        project_config: &ProjectConfig,
     ) -> String {
-        let key = build_operation(schema, &mut self.builder, operation);
+        let key = build_operation(
+            schema,
+            &mut self.builder,
+            operation,
+            &project_config.schema_config.defer_stream_interface,
+        );
         let printer = JSONPrinter::new(&self.builder, self.project_config, top_level_statements);
         printer.print(key, self.dedupe)
     }
@@ -158,8 +185,14 @@ impl<'p> Printer<'p> {
         schema: &SDLSchema,
         fragment: &FragmentDefinition,
         top_level_statements: &mut TopLevelStatements,
+        project_config: &ProjectConfig,
     ) -> String {
-        let key = build_fragment(schema, &mut self.builder, fragment);
+        let key = build_fragment(
+            schema,
+            &mut self.builder,
+            fragment,
+            &project_config.schema_config.defer_stream_interface,
+        );
         let printer = JSONPrinter::new(&self.builder, self.project_config, top_level_statements);
         printer.print(key, self.dedupe)
     }
@@ -170,6 +203,7 @@ impl<'p> Printer<'p> {
         request_parameters: RequestParameters<'_>,
         operation: &OperationDefinition,
         top_level_statements: &mut TopLevelStatements,
+        project_config: &ProjectConfig,
     ) -> String {
         let key = build_request_params_ast_key(
             schema,
@@ -177,6 +211,7 @@ impl<'p> Printer<'p> {
             &mut self.builder,
             operation,
             top_level_statements,
+            &project_config.schema_config.defer_stream_interface,
         );
         let printer = JSONPrinter::new(&self.builder, self.project_config, top_level_statements);
         printer.print(key, self.dedupe)

--- a/compiler/crates/relay-codegen/tests/connections/mod.rs
+++ b/compiler/crates/relay-codegen/tests/connections/mod.rs
@@ -37,7 +37,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     validate_connections(&program, &connection_interface)
         .map_err(|diagnostics| diagnostics_to_sorted_string(fixture.content, &diagnostics))?;
 
-    let next_program = transform_connections(&program, &connection_interface);
+    let next_program = transform_connections(&program, &project_config.schema_config);
 
     let mut printed = next_program
         .operations()
@@ -58,13 +58,14 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
                 &operation_fragment,
                 request_parameters,
                 &mut import_statements,
+                &project_config,
             );
             format!("{}{}", import_statements, request)
         })
         .collect::<Vec<_>>();
     let mut import_statements = Default::default();
     for def in next_program.fragments() {
-        printed.push(printer.print_fragment(&schema, def, &mut import_statements));
+        printed.push(printer.print_fragment(&schema, def, &mut import_statements, &project_config));
     }
     if !import_statements.is_empty() {
         printed.push(import_statements.to_string())

--- a/compiler/crates/relay-codegen/tests/deduped_json_codegen/mod.rs
+++ b/compiler/crates/relay-codegen/tests/deduped_json_codegen/mod.rs
@@ -35,13 +35,18 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
                             &TEST_SCHEMA,
                             operation,
                             &mut import_statements,
+                            &project_config,
                         );
                         format!("Operation:\n{}{}\n", import_statements, operation,)
                     }
                     graphql_ir::ExecutableDefinition::Fragment(fragment) => {
                         let mut import_statements = Default::default();
-                        let fragment =
-                            printer.print_fragment(&TEST_SCHEMA, fragment, &mut import_statements);
+                        let fragment = printer.print_fragment(
+                            &TEST_SCHEMA,
+                            fragment,
+                            &mut import_statements,
+                            &project_config,
+                        );
                         format!("Fragment:\n{}{}\n", import_statements, fragment)
                     }
                 })

--- a/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-default-label.expected
+++ b/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-default-label.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1) {
+  actors @stream(initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-default-label.graphql
+++ b/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-default-label.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1) {
+  actors @stream(initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-codegen/tests/defer_stream/mod.rs
+++ b/compiler/crates/relay-codegen/tests/defer_stream/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use graphql_ir::{build, Program};
 use graphql_syntax::parse_executable;
 use relay_codegen::{print_fragment, print_operation, JsModuleFormat};
-use relay_config::ProjectConfig;
+use relay_config::{DeferStreamInterface, ProjectConfig};
 use relay_test_schema::get_test_schema;
 use relay_transforms::{sort_selections, transform_defer_stream};
 use std::sync::Arc;
@@ -24,7 +24,9 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let schema = get_test_schema();
     let ir = build(&schema, &ast.definitions).unwrap();
     let program = Program::from_definitions(Arc::clone(&schema), ir);
-    let next_program = sort_selections(&transform_defer_stream(&program).unwrap());
+    let defer_stream_interface = DeferStreamInterface::default();
+    let next_program =
+        sort_selections(&transform_defer_stream(&program, &defer_stream_interface).unwrap());
     let mut result = next_program
         .fragments()
         .map(|def| {

--- a/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
+++ b/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
@@ -274,9 +274,12 @@ fn generate_operation(
         TypegenLanguage::TypeScript => writeln!(content)?,
     }
     let mut top_level_statements = Default::default();
-    if let Some(provided_variables) =
-        printer.print_provided_variables(schema, normalization_operation, &mut top_level_statements)
-    {
+    if let Some(provided_variables) = printer.print_provided_variables(
+        schema,
+        normalization_operation,
+        &mut top_level_statements,
+        project_config,
+    ) {
         let mut provided_variable_text = String::new();
         write_variable_value_with_type(
             &project_config.typegen_config.language,
@@ -298,6 +301,7 @@ fn generate_operation(
         &operation_fragment,
         request_parameters,
         &mut top_level_statements,
+        project_config,
     );
 
     write!(content, "{}", &top_level_statements)?;
@@ -399,8 +403,12 @@ fn generate_split_operation(
     }
 
     let mut top_level_statements = Default::default();
-    let operation =
-        printer.print_operation(schema, normalization_operation, &mut top_level_statements);
+    let operation = printer.print_operation(
+        schema,
+        normalization_operation,
+        &mut top_level_statements,
+        project_config,
+    );
 
     write!(content, "{}", &top_level_statements)?;
 
@@ -527,7 +535,12 @@ fn generate_read_only_fragment(
         TypegenLanguage::TypeScript => writeln!(content)?,
     }
     let mut top_level_statements = Default::default();
-    let fragment = printer.print_fragment(schema, reader_fragment, &mut top_level_statements);
+    let fragment = printer.print_fragment(
+        schema,
+        reader_fragment,
+        &mut top_level_statements,
+        project_config,
+    );
 
     write!(content, "{}", &top_level_statements)?;
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected
@@ -8,7 +8,7 @@ query fragmentWithDeferInStream_QueryWithFragmentWithStreamQuery($id: ID!) {
 
 fragment fragmentWithDeferInStream_FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     ...fragmentWithDeferInStream_ActorFragment @defer
   }
 }
@@ -193,7 +193,7 @@ fragment fragmentWithDeferInStream_ActorFragment on Actor {
 
 fragment fragmentWithDeferInStream_FeedbackFragment on Feedback {
   id
-  actors @stream(label: "fragmentWithDeferInStream_FeedbackFragment$stream$StreamedActorsLabel", initial_count: 1) {
+  actors @stream(label: "fragmentWithDeferInStream_FeedbackFragment$stream$StreamedActorsLabel", initialCount: 1) {
     __typename
     ...fragmentWithDeferInStream_ActorFragment @defer(label: "fragmentWithDeferInStream_FeedbackFragment$defer$fragmentWithDeferInStream_ActorFragment")
     id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.graphql
@@ -7,7 +7,7 @@ query fragmentWithDeferInStream_QueryWithFragmentWithStreamQuery($id: ID!) {
 
 fragment fragmentWithDeferInStream_FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     ...fragmentWithDeferInStream_ActorFragment @defer
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.expected
@@ -8,7 +8,7 @@ query fragmentWithStream_QueryWithFragmentWithStreamQuery($id: ID!) {
 
 fragment fragmentWithStream_FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     name
   }
 }
@@ -173,7 +173,7 @@ query fragmentWithStream_QueryWithFragmentWithStreamQuery(
 
 fragment fragmentWithStream_FeedbackFragment on Feedback {
   id
-  actors @stream(label: "fragmentWithStream_FeedbackFragment$stream$StreamedActorsLabel", initial_count: 1) {
+  actors @stream(label: "fragmentWithStream_FeedbackFragment$stream$StreamedActorsLabel", initialCount: 1) {
     __typename
     name
     id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.graphql
@@ -7,7 +7,7 @@ query fragmentWithStream_QueryWithFragmentWithStreamQuery($id: ID!) {
 
 fragment fragmentWithStream_FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     name
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.expected
@@ -9,7 +9,7 @@ fragment refetchableFragmentWithConnectionWithStream_PaginationFragment on Node
   ... on User {
     name
     friends(after: $cursor, first: $count)
-      @stream_connection(key: "PaginationFragment_friends", initial_count: 1) {
+      @stream_connection(key: "PaginationFragment_friends", initialCount: 1) {
       edges {
         node {
           id
@@ -305,7 +305,7 @@ fragment refetchableFragmentWithConnectionWithStream_PaginationFragment_1G22uz o
   ... on User {
     name
     friends(after: $cursor, first: $count) {
-      edges @stream(label: "refetchableFragmentWithConnectionWithStream_PaginationFragment$stream$PaginationFragment_friends", initial_count: 1) {
+      edges @stream(label: "refetchableFragmentWithConnectionWithStream_PaginationFragment$stream$PaginationFragment_friends", initialCount: 1) {
         node {
           id
           __typename

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.graphql
@@ -8,7 +8,7 @@ fragment refetchableFragmentWithConnectionWithStream_PaginationFragment on Node
   ... on User {
     name
     friends(after: $cursor, first: $count)
-      @stream_connection(key: "PaginationFragment_friends", initial_count: 1) {
+      @stream_connection(key: "PaginationFragment_friends", initialCount: 1) {
       edges {
         node {
           id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.expected
@@ -5,7 +5,7 @@ query selectionSetConflictInconsistentStreamUsage1Query {
     ... on User {
       friends {
         ... on FriendsConnection {
-          edges @stream(label: "hdijf", initial_count: 1) {
+          edges @stream(label: "hdijf", initialCount: 1) {
             node {
               name
             }
@@ -25,7 +25,7 @@ query selectionSetConflictInconsistentStreamUsage1Query {
 
   selection_set_conflict_inconsistent_stream_usage_1.graphql:7:11
     6 │         ... on FriendsConnection {
-    7 │           edges @stream(label: "hdijf", initial_count: 1) {
+    7 │           edges @stream(label: "hdijf", initialCount: 1) {
       │           ^^^^^
     8 │             node {
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.graphql
@@ -4,7 +4,7 @@ query selectionSetConflictInconsistentStreamUsage1Query {
     ... on User {
       friends {
         ... on FriendsConnection {
-          edges @stream(label: "hdijf", initial_count: 1) {
+          edges @stream(label: "hdijf", initialCount: 1) {
             node {
               name
             }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.expected
@@ -5,13 +5,13 @@ query selectionSetConflictInconsistentStreamUsage2Query {
     ... on User {
       friends {
         ... on FriendsConnection {
-          edges @stream(label: "hdijf", initial_count: 1) {
+          edges @stream(label: "hdijf", initialCount: 1) {
             node {
               name
             }
           }
         }
-        edges @stream(label: "hkjdf", initial_count: 2) {
+        edges @stream(label: "hkjdf", initialCount: 2) {
           node {
             id
           }
@@ -25,7 +25,7 @@ query selectionSetConflictInconsistentStreamUsage2Query {
 
   selection_set_conflict_inconsistent_stream_usage_2.graphql:7:11
     6 │         ... on FriendsConnection {
-    7 │           edges @stream(label: "hdijf", initial_count: 1) {
+    7 │           edges @stream(label: "hdijf", initialCount: 1) {
       │           ^^^^^
     8 │             node {
 
@@ -33,6 +33,6 @@ query selectionSetConflictInconsistentStreamUsage2Query {
 
   selection_set_conflict_inconsistent_stream_usage_2.graphql:13:9
    12 │         }
-   13 │         edges @stream(label: "hkjdf", initial_count: 2) {
+   13 │         edges @stream(label: "hkjdf", initialCount: 2) {
       │         ^^^^^
    14 │           node {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.graphql
@@ -4,13 +4,13 @@ query selectionSetConflictInconsistentStreamUsage2Query {
     ... on User {
       friends {
         ... on FriendsConnection {
-          edges @stream(label: "hdijf", initial_count: 1) {
+          edges @stream(label: "hdijf", initialCount: 1) {
             node {
               name
             }
           }
         }
-        edges @stream(label: "hkjdf", initial_count: 2) {
+        edges @stream(label: "hkjdf", initialCount: 2) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.expected
@@ -3,7 +3,7 @@ query selectionSetConflictStreamOnNodesOrEdgesQuery {
   me {
     ... on User {
       friends {
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }
@@ -167,7 +167,7 @@ QUERY:
 query selectionSetConflictStreamOnNodesOrEdgesQuery {
   me {
     friends {
-      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesQuery$stream$b", initial_count: 1) {
+      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesQuery$stream$b", initialCount: 1) {
         node {
           id
         }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.graphql
@@ -2,7 +2,7 @@ query selectionSetConflictStreamOnNodesOrEdgesQuery {
   me {
     ... on User {
       friends {
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.expected
@@ -9,7 +9,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery {
             hasNextPage
           }
         }
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }
@@ -212,7 +212,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery {
       pageInfo {
         hasNextPage
       }
-      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery$stream$b", initial_count: 1) {
+      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery$stream$b", initialCount: 1) {
         node {
           id
         }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.graphql
@@ -8,7 +8,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery {
             hasNextPage
           }
         }
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.expected
@@ -9,7 +9,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoA
             hasNextPage
           }
         }
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }
@@ -212,7 +212,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoA
       pagination: pageInfo {
         hasNextPage
       }
-      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoAliasQuery$stream$b", initial_count: 1) {
+      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoAliasQuery$stream$b", initialCount: 1) {
         node {
           id
         }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.graphql
@@ -8,7 +8,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoA
             hasNextPage
           }
         }
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.expected
@@ -3,7 +3,7 @@ query selectionSetConflictValidStreamQuery {
   me {
     ... on User {
       friends {
-        edges @stream(label: "jkdhg", initial_count: 0) {
+        edges @stream(label: "jkdhg", initialCount: 0) {
           node {
             id
           }
@@ -167,7 +167,7 @@ QUERY:
 query selectionSetConflictValidStreamQuery {
   me {
     friends {
-      edges @stream(label: "selectionSetConflictValidStreamQuery$stream$jkdhg", initial_count: 0) {
+      edges @stream(label: "selectionSetConflictValidStreamQuery$stream$jkdhg", initialCount: 0) {
         node {
           id
         }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.graphql
@@ -2,7 +2,7 @@ query selectionSetConflictValidStreamQuery {
   me {
     ... on User {
       friends {
-        edges @stream(label: "jkdhg", initial_count: 0) {
+        edges @stream(label: "jkdhg", initialCount: 0) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.expected
@@ -7,7 +7,7 @@ query streamAndHandleQuery {
 
 fragment streamAndHandleFragment on Feedback {
   actors
-    @stream(label: "actors", if: true, initial_count: 0)
+    @stream(label: "actors", if: true, initialCount: 0)
     @__clientField(handle: "actors_handler") {
     name @__clientField(handle: "name_handler")
   }
@@ -169,7 +169,7 @@ query streamAndHandleQuery {
 }
 
 fragment streamAndHandleFragment on Feedback {
-  actors @stream(label: "streamAndHandleFragment$stream$actors", if: true, initial_count: 0) {
+  actors @stream(label: "streamAndHandleFragment$stream$actors", if: true, initialCount: 0) {
     __typename
     name
     id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.graphql
@@ -6,7 +6,7 @@ query streamAndHandleQuery {
 
 fragment streamAndHandleFragment on Feedback {
   actors
-    @stream(label: "actors", if: true, initial_count: 0)
+    @stream(label: "actors", if: true, initialCount: 0)
     @__clientField(handle: "actors_handler") {
     name @__clientField(handle: "name_handler")
   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection-conditional.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection-conditional.expected
@@ -5,9 +5,9 @@ query streamConnectionConditionalQuery($id: ID!, $cond: Boolean!) {
     ... on Story {
       comments(first: 10)
       @stream_connection(
-        use_customized_batch: $cond
+        useCustomizedBatch: $cond
         if: $cond
-        initial_count: 0
+        initialCount: 0
         key: "NodeQuery_comments"
       ) {
         edges {
@@ -359,7 +359,7 @@ query streamConnectionConditionalQuery(
     id
     ... on Story {
       comments(first: 10) {
-        edges @stream(label: "streamConnectionConditionalQuery$stream$NodeQuery_comments", if: $cond, initial_count: 0, use_customized_batch: $cond) {
+        edges @stream(label: "streamConnectionConditionalQuery$stream$NodeQuery_comments", if: $cond, initialCount: 0, useCustomizedBatch: $cond) {
           node {
             __typename
             id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection-conditional.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection-conditional.graphql
@@ -4,9 +4,9 @@ query streamConnectionConditionalQuery($id: ID!, $cond: Boolean!) {
     ... on Story {
       comments(first: 10)
       @stream_connection(
-        use_customized_batch: $cond
+        useCustomizedBatch: $cond
         if: $cond
-        initial_count: 0
+        initialCount: 0
         key: "NodeQuery_comments"
       ) {
         edges {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection.expected
@@ -4,7 +4,7 @@ query streamConnection_NodeQuery($id: ID!) {
     id
     ... on Story {
       comments(first: 10)
-        @stream_connection(key: "NodeQuery_comments", initial_count: 0) {
+        @stream_connection(key: "NodeQuery_comments", initialCount: 0) {
         edges {
           node {
             actor {
@@ -399,7 +399,7 @@ query streamConnection_NodeQuery(
     id
     ... on Story {
       comments(first: 10) {
-        edges @stream(label: "streamConnection_NodeQuery$stream$NodeQuery_comments", initial_count: 0) {
+        edges @stream(label: "streamConnection_NodeQuery$stream$NodeQuery_comments", initialCount: 0) {
           node {
             actor {
               __typename

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection.graphql
@@ -3,7 +3,7 @@ query streamConnection_NodeQuery($id: ID!) {
     id
     ... on Story {
       comments(first: 10)
-        @stream_connection(key: "NodeQuery_comments", initial_count: 0) {
+        @stream_connection(key: "NodeQuery_comments", initialCount: 0) {
         edges {
           node {
             actor {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream_if_arguments.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream_if_arguments.expected
@@ -19,27 +19,27 @@ fragment streamIfArgumentsFragment on User
   setToFalse: { type: "Boolean", defaultValue: false }
 ) {
   withDefaultTrue: tasks
-    @stream(initial_count: 1, if: $defaultsToTrue, label: "defaultTrue") {
+    @stream(initialCount: 1, if: $defaultsToTrue, label: "defaultTrue") {
     __typename
   }
   withDefaultFalse: tasks
-    @stream(initial_count: 1, if: $defaultsToFalse, label: "defaultFalse") {
+    @stream(initialCount: 1, if: $defaultsToFalse, label: "defaultFalse") {
     __typename
   }
   setToTrue: tasks
-    @stream(initial_count: 1, if: $setToTrue, label: "setToTrue") {
+    @stream(initialCount: 1, if: $setToTrue, label: "setToTrue") {
     __typename
   }
   setToFalse: tasks
-    @stream(initial_count: 1, if: $setToFalse, label: "setToFalse") {
+    @stream(initialCount: 1, if: $setToFalse, label: "setToFalse") {
     __typename
   }
   withValueFromQueryDirectly: tasks
-    @stream(initial_count: 1, if: $valueFromQuery, label: "fromQueryDirectly") {
+    @stream(initialCount: 1, if: $valueFromQuery, label: "fromQueryDirectly") {
     __typename
   }
   withValueFromQueryViaArgDef: tasks
-    @stream(initial_count: 1, if: $setToValue, label: "fromQueryViaArg") {
+    @stream(initialCount: 1, if: $setToValue, label: "fromQueryViaArg") {
     __typename
   }
 }
@@ -282,22 +282,22 @@ query streamIfArgumentsQuery(
 }
 
 fragment streamIfArgumentsFragment_39RTKZ on User {
-  withDefaultTrue: tasks @stream(label: "streamIfArgumentsFragment$stream$defaultTrue", if: true, initial_count: 1) {
+  withDefaultTrue: tasks @stream(label: "streamIfArgumentsFragment$stream$defaultTrue", if: true, initialCount: 1) {
     __typename
   }
   withDefaultFalse: tasks {
     __typename
   }
-  setToTrue: tasks @stream(label: "streamIfArgumentsFragment$stream$setToTrue", if: true, initial_count: 1) {
+  setToTrue: tasks @stream(label: "streamIfArgumentsFragment$stream$setToTrue", if: true, initialCount: 1) {
     __typename
   }
   setToFalse: tasks {
     __typename
   }
-  withValueFromQueryDirectly: tasks @stream(label: "streamIfArgumentsFragment$stream$fromQueryDirectly", if: $valueFromQuery, initial_count: 1) {
+  withValueFromQueryDirectly: tasks @stream(label: "streamIfArgumentsFragment$stream$fromQueryDirectly", if: $valueFromQuery, initialCount: 1) {
     __typename
   }
-  withValueFromQueryViaArgDef: tasks @stream(label: "streamIfArgumentsFragment$stream$fromQueryViaArg", if: $valueFromQuery, initial_count: 1) {
+  withValueFromQueryViaArgDef: tasks @stream(label: "streamIfArgumentsFragment$stream$fromQueryViaArg", if: $valueFromQuery, initialCount: 1) {
     __typename
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream_if_arguments.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream_if_arguments.graphql
@@ -18,27 +18,27 @@ fragment streamIfArgumentsFragment on User
   setToFalse: { type: "Boolean", defaultValue: false }
 ) {
   withDefaultTrue: tasks
-    @stream(initial_count: 1, if: $defaultsToTrue, label: "defaultTrue") {
+    @stream(initialCount: 1, if: $defaultsToTrue, label: "defaultTrue") {
     __typename
   }
   withDefaultFalse: tasks
-    @stream(initial_count: 1, if: $defaultsToFalse, label: "defaultFalse") {
+    @stream(initialCount: 1, if: $defaultsToFalse, label: "defaultFalse") {
     __typename
   }
   setToTrue: tasks
-    @stream(initial_count: 1, if: $setToTrue, label: "setToTrue") {
+    @stream(initialCount: 1, if: $setToTrue, label: "setToTrue") {
     __typename
   }
   setToFalse: tasks
-    @stream(initial_count: 1, if: $setToFalse, label: "setToFalse") {
+    @stream(initialCount: 1, if: $setToFalse, label: "setToFalse") {
     __typename
   }
   withValueFromQueryDirectly: tasks
-    @stream(initial_count: 1, if: $valueFromQuery, label: "fromQueryDirectly") {
+    @stream(initialCount: 1, if: $valueFromQuery, label: "fromQueryDirectly") {
     __typename
   }
   withValueFromQueryViaArgDef: tasks
-    @stream(initial_count: 1, if: $setToValue, label: "fromQueryViaArg") {
+    @stream(initialCount: 1, if: $setToValue, label: "fromQueryViaArg") {
     __typename
   }
 }

--- a/compiler/crates/relay-config/src/defer_stream_interface.rs
+++ b/compiler/crates/relay-config/src/defer_stream_interface.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use intern::string_key::{Intern, StringKey};
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration where Relay should expect some fields in the schema.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DeferStreamInterface {
+    pub defer_name: StringKey,
+    pub stream_name: StringKey,
+    pub if_arg: StringKey,
+    pub label_arg: StringKey,
+    pub initial_count_arg: StringKey,
+    pub use_customized_batch_arg: StringKey,
+}
+
+impl Default for DeferStreamInterface {
+    fn default() -> Self {
+        DeferStreamInterface {
+            defer_name: "defer".intern(),
+            stream_name: "stream".intern(),
+            if_arg: "if".intern(),
+            label_arg: "label".intern(),
+            initial_count_arg: "initialCount".intern(),
+            use_customized_batch_arg: "useCustomizedBatch".intern(),
+        }
+    }
+}

--- a/compiler/crates/relay-config/src/lib.rs
+++ b/compiler/crates/relay-config/src/lib.rs
@@ -10,11 +10,13 @@
 #![deny(clippy::all)]
 
 mod connection_interface;
+mod defer_stream_interface;
 mod js_module_format;
 mod project_config;
 mod typegen_config;
 
 pub use connection_interface::ConnectionInterface;
+pub use defer_stream_interface::DeferStreamInterface;
 pub use js_module_format::JsModuleFormat;
 pub use project_config::{PersistConfig, ProjectConfig, ProjectName, SchemaConfig, SchemaLocation};
 pub use typegen_config::{FlowTypegenConfig, FlowTypegenPhase, TypegenConfig, TypegenLanguage};

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -16,7 +16,9 @@ use regex::Regex;
 use serde::{de::Error, Deserialize, Deserializer, Serialize};
 use tokio::sync::Semaphore;
 
-use crate::{connection_interface::ConnectionInterface, JsModuleFormat, TypegenConfig};
+use crate::{
+    connection_interface::ConnectionInterface, DeferStreamInterface, JsModuleFormat, TypegenConfig,
+};
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
@@ -69,6 +71,9 @@ pub struct SchemaConfig {
     /// The name of the `id` field that exists on the `Node` interface.
     #[serde(default = "default_node_interface_id_field")]
     pub node_interface_id_field: StringKey,
+
+    #[serde(default)]
+    pub defer_stream_interface: DeferStreamInterface,
 }
 
 fn default_node_interface_id_field() -> StringKey {
@@ -80,6 +85,7 @@ impl Default for SchemaConfig {
         Self {
             connection_interface: ConnectionInterface::default(),
             node_interface_id_field: default_node_interface_id_field(),
+            defer_stream_interface: DeferStreamInterface::default(),
         }
     }
 }

--- a/compiler/crates/relay-lsp/src/completion/test.rs
+++ b/compiler/crates/relay-lsp/src/completion/test.rs
@@ -249,7 +249,7 @@ fn empty_argument_list() {
     );
     assert_labels(
         items.unwrap(),
-        vec!["label", "initial_count", "if", "use_customized_batch"],
+        vec!["label", "initialCount", "if", "useCustomizedBatch"],
     );
 }
 
@@ -267,7 +267,7 @@ fn argument_name_without_value() {
     );
     assert_labels(
         items.unwrap(),
-        vec!["label", "initial_count", "if", "use_customized_batch"],
+        vec!["label", "initialCount", "if", "useCustomizedBatch"],
     );
 }
 
@@ -288,7 +288,7 @@ fn argument_name_with_existing_name() {
     );
     assert_labels(
         items.unwrap(),
-        vec!["label", "initial_count", "use_customized_batch"],
+        vec!["label", "initialCount", "useCustomizedBatch"],
     );
 }
 

--- a/compiler/crates/relay-schema/src/relay-extensions.graphql
+++ b/compiler/crates/relay-schema/src/relay-extensions.graphql
@@ -128,9 +128,9 @@ directive @stream_connection(
   filters: [String]
   handler: String
   label: String
-  initial_count: Int!
+  initialCount: Int!
   if: Boolean = true
-  use_customized_batch: Boolean = false
+  useCustomizedBatch: Boolean = false
   dynamicKey_UNSTABLE: String
 ) on FIELD
 

--- a/compiler/crates/relay-test-schema/src/testschema.graphql
+++ b/compiler/crates/relay-test-schema/src/testschema.graphql
@@ -25,9 +25,9 @@ directive @defer(
 
 directive @stream(
   label: String!
-  initial_count: Int!
+  initialCount: Int!
   if: Boolean = true
-  use_customized_batch: Boolean = false
+  useCustomizedBatch: Boolean = false
 ) on FIELD
 
 directive @fetchable(field_name: String!) on OBJECT

--- a/compiler/crates/relay-transforms/src/defer_stream/directives.rs
+++ b/compiler/crates/relay-transforms/src/defer_stream/directives.rs
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use super::DEFER_STREAM_CONSTANTS;
 use graphql_ir::{Argument, Directive};
+use relay_config::DeferStreamInterface;
 
 /// Utility to access the arguments of the @defer directive.
 pub struct DeferDirective<'a> {
@@ -18,13 +18,13 @@ impl<'a> DeferDirective<'a> {
     /// Extracts the arguments from the given directive assumed to be a @defer
     /// directive.
     /// Panics on any unexpected arguments.
-    pub fn from(directive: &'a Directive) -> Self {
+    pub fn from(directive: &'a Directive, defer_stream_interface: &DeferStreamInterface) -> Self {
         let mut if_arg = None;
         let mut label_arg = None;
         for arg in &directive.arguments {
-            if arg.name.item == DEFER_STREAM_CONSTANTS.if_arg {
+            if arg.name.item == defer_stream_interface.if_arg {
                 if_arg = Some(arg);
-            } else if arg.name.item == DEFER_STREAM_CONSTANTS.label_arg {
+            } else if arg.name.item == defer_stream_interface.label_arg {
                 label_arg = Some(arg);
             } else {
                 panic!("Unexpected argument to @defer: {}", arg.name.item);
@@ -46,19 +46,19 @@ impl<'a> StreamDirective<'a> {
     /// Extracts the arguments from the given directive assumed to be a @stream
     /// directive.
     /// Panics on any unexpected arguments.
-    pub fn from(directive: &'a Directive) -> Self {
+    pub fn from(directive: &'a Directive, defer_stream_interface: &DeferStreamInterface) -> Self {
         let mut if_arg = None;
         let mut label_arg = None;
         let mut initial_count_arg = None;
         let mut use_customized_batch_arg = None;
         for arg in &directive.arguments {
-            if arg.name.item == DEFER_STREAM_CONSTANTS.if_arg {
+            if arg.name.item == defer_stream_interface.if_arg {
                 if_arg = Some(arg);
-            } else if arg.name.item == DEFER_STREAM_CONSTANTS.label_arg {
+            } else if arg.name.item == defer_stream_interface.label_arg {
                 label_arg = Some(arg);
-            } else if arg.name.item == DEFER_STREAM_CONSTANTS.initial_count_arg {
+            } else if arg.name.item == defer_stream_interface.initial_count_arg {
                 initial_count_arg = Some(arg);
-            } else if arg.name.item == DEFER_STREAM_CONSTANTS.use_customized_batch_arg {
+            } else if arg.name.item == defer_stream_interface.use_customized_batch_arg {
                 use_customized_batch_arg = Some(arg);
             } else {
                 panic!("Unexpected argument to @stream: {}", arg.name.item);

--- a/compiler/crates/relay-transforms/src/defer_stream/mod.rs
+++ b/compiler/crates/relay-transforms/src/defer_stream/mod.rs
@@ -17,43 +17,21 @@ use graphql_ir::{
     Value,
 };
 use intern::string_key::{Intern, StringKey};
-use lazy_static::lazy_static;
+use relay_config::DeferStreamInterface;
 use schema::Schema;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 
-pub struct DeferStreamConstants {
-    pub defer_name: StringKey,
-    pub stream_name: StringKey,
-    pub if_arg: StringKey,
-    pub label_arg: StringKey,
-    pub initial_count_arg: StringKey,
-    pub use_customized_batch_arg: StringKey,
-}
-
-impl Default for DeferStreamConstants {
-    fn default() -> Self {
-        Self {
-            defer_name: "defer".intern(),
-            stream_name: "stream".intern(),
-            if_arg: "if".intern(),
-            label_arg: "label".intern(),
-            initial_count_arg: "initial_count".intern(),
-            use_customized_batch_arg: "use_customized_batch".intern(),
-        }
-    }
-}
-
-lazy_static! {
-    pub static ref DEFER_STREAM_CONSTANTS: DeferStreamConstants = Default::default();
-}
-
-pub fn transform_defer_stream(program: &Program) -> DiagnosticsResult<Program> {
+pub fn transform_defer_stream(
+    program: &Program,
+    defer_stream_interface: &DeferStreamInterface,
+) -> DiagnosticsResult<Program> {
     let mut transformer = DeferStreamTransform {
         program,
         current_document_name: None,
         labels: Default::default(),
         errors: Default::default(),
+        defer_stream_interface,
     };
     let next_program = transformer.transform_program(program);
 
@@ -69,6 +47,7 @@ struct DeferStreamTransform<'s> {
     current_document_name: Option<StringKey>,
     labels: HashMap<StringKey, Directive>,
     errors: Vec<Diagnostic>,
+    defer_stream_interface: &'s DeferStreamInterface,
 }
 
 impl DeferStreamTransform<'_> {
@@ -83,7 +62,7 @@ impl DeferStreamTransform<'_> {
                 self.errors.push(
                     Diagnostic::error(
                         ValidationMessage::LabelNotUniqueForDeferStream {
-                            directive_name: DEFER_STREAM_CONSTANTS.defer_name,
+                            directive_name: self.defer_stream_interface.defer_name,
                         },
                         prev.name.location,
                     )
@@ -101,7 +80,8 @@ impl DeferStreamTransform<'_> {
         spread: &FragmentSpread,
         defer: &Directive,
     ) -> Result<Transformed<Selection>, Diagnostic> {
-        let DeferDirective { if_arg, label_arg } = DeferDirective::from(defer);
+        let DeferDirective { if_arg, label_arg } =
+            DeferDirective::from(defer, self.defer_stream_interface);
 
         if is_literal_false_arg(if_arg) {
             return Ok(Transformed::Replace(Selection::FragmentSpread(Arc::new(
@@ -118,14 +98,14 @@ impl DeferStreamTransform<'_> {
         let transformed_label = transform_label(
             self.current_document_name
                 .expect("We expect the parent name to be defined here."),
-            DEFER_STREAM_CONSTANTS.defer_name,
+            self.defer_stream_interface.defer_name,
             label,
         );
         self.record_label(transformed_label, defer);
         let next_label_value = Value::Constant(ConstantValue::String(transformed_label));
         let next_label_arg = Argument {
             name: WithLocation {
-                item: DEFER_STREAM_CONSTANTS.label_arg,
+                item: self.defer_stream_interface.label_arg,
                 location: label_arg.map_or(defer.name.location, |arg| arg.name.location),
             },
             value: WithLocation {
@@ -178,7 +158,7 @@ impl DeferStreamTransform<'_> {
             label_arg,
             initial_count_arg,
             use_customized_batch_arg,
-        } = StreamDirective::from(stream);
+        } = StreamDirective::from(stream, self.defer_stream_interface);
 
         let transformed_linked_field = self.default_transform_linked_field(linked_field);
         let get_next_selection = |directives| match transformed_linked_field {
@@ -218,14 +198,14 @@ impl DeferStreamTransform<'_> {
         let transformed_label = transform_label(
             self.current_document_name
                 .expect("We expect the parent name to be defined here."),
-            DEFER_STREAM_CONSTANTS.stream_name,
+            self.defer_stream_interface.stream_name,
             label,
         );
         self.record_label(transformed_label, stream);
         let next_label_value = Value::Constant(ConstantValue::String(transformed_label));
         let next_label_arg = Argument {
             name: WithLocation {
-                item: DEFER_STREAM_CONSTANTS.label_arg,
+                item: self.defer_stream_interface.label_arg,
                 location: label_arg.map_or(stream.name.location, |arg| arg.name.location),
             },
             value: WithLocation {
@@ -287,10 +267,13 @@ impl<'s> Transformer for DeferStreamTransform<'s> {
     ) -> Transformed<Selection> {
         let defer_directive = inline_fragment
             .directives
-            .named(DEFER_STREAM_CONSTANTS.defer_name);
+            .named(self.defer_stream_interface.defer_name);
         if let Some(directive) = defer_directive {
             // Special case for @defer generated by transform_connection
-            if let Some(label) = directive.arguments.named(DEFER_STREAM_CONSTANTS.label_arg) {
+            if let Some(label) = directive
+                .arguments
+                .named(self.defer_stream_interface.label_arg)
+            {
                 if let Some(label) = label.value.item.get_string_literal() {
                     if label.lookup().contains("$defer$") {
                         return self.default_transform_inline_fragment(inline_fragment);
@@ -308,7 +291,9 @@ impl<'s> Transformer for DeferStreamTransform<'s> {
 
     /// Transform of fragment spread with @defer is delegated to `transform_defer`.
     fn transform_fragment_spread(&mut self, spread: &FragmentSpread) -> Transformed<Selection> {
-        let defer_directive = spread.directives.named(DEFER_STREAM_CONSTANTS.defer_name);
+        let defer_directive = spread
+            .directives
+            .named(self.defer_stream_interface.defer_name);
         if let Some(defer) = defer_directive {
             match self.transform_defer(spread, defer) {
                 Ok(transformed) => transformed,
@@ -326,7 +311,7 @@ impl<'s> Transformer for DeferStreamTransform<'s> {
     fn transform_scalar_field(&mut self, scalar_field: &ScalarField) -> Transformed<Selection> {
         let stream_directive = &scalar_field
             .directives
-            .named(DEFER_STREAM_CONSTANTS.stream_name);
+            .named(self.defer_stream_interface.stream_name);
         if let Some(directive) = stream_directive {
             self.errors.push(Diagnostic::error(
                 ValidationMessage::InvalidStreamOnScalarField {
@@ -342,7 +327,7 @@ impl<'s> Transformer for DeferStreamTransform<'s> {
     fn transform_linked_field(&mut self, linked_field: &LinkedField) -> Transformed<Selection> {
         let stream_directive = linked_field
             .directives
-            .named(DEFER_STREAM_CONSTANTS.stream_name);
+            .named(self.defer_stream_interface.stream_name);
         if let Some(stream) = stream_directive {
             match self.transform_stream(linked_field, stream) {
                 Ok(transformed) => transformed,

--- a/compiler/crates/relay-transforms/src/lib.rs
+++ b/compiler/crates/relay-transforms/src/lib.rs
@@ -101,9 +101,7 @@ pub use connections::{
     ConnectionMetadata,
 };
 pub use declarative_connection::transform_declarative_connection;
-pub use defer_stream::{
-    transform_defer_stream, DeferDirective, StreamDirective, DEFER_STREAM_CONSTANTS,
-};
+pub use defer_stream::{transform_defer_stream, DeferDirective, StreamDirective};
 pub use directive_finder::DirectiveFinder;
 pub use flatten::flatten;
 pub use generate_data_driven_dependency_metadata::{

--- a/compiler/crates/relay-transforms/src/skip_redundant_nodes.rs
+++ b/compiler/crates/relay-transforms/src/skip_redundant_nodes.rs
@@ -8,7 +8,6 @@
 use crate::{
     node_identifier::NodeIdentifier,
     util::{is_relay_custom_inline_fragment_directive, PointerAddress},
-    DEFER_STREAM_CONSTANTS,
 };
 
 use common::{sync::*, NamedItem};
@@ -17,6 +16,7 @@ use graphql_ir::{
     Condition, FragmentDefinition, InlineFragment, LinkedField, OperationDefinition, Program,
     Selection, Transformed, TransformedValue,
 };
+use relay_config::DeferStreamInterface;
 use schema::SDLSchema;
 use std::sync::Arc;
 
@@ -111,8 +111,11 @@ use std::sync::Arc;
  *
  * 1 can be skipped because it is already fetched at the outer level.
  */
-pub fn skip_redundant_nodes(program: &Program) -> Program {
-    let transform = SkipRedundantNodesTransform::new(program);
+pub fn skip_redundant_nodes(
+    program: &Program,
+    defer_stream_interface: &DeferStreamInterface,
+) -> Program {
+    let transform = SkipRedundantNodesTransform::new(program, defer_stream_interface);
     transform
         .transform_program(program)
         .replace_or_else(|| program.clone())
@@ -123,16 +126,18 @@ struct SelectionMap(VecMap<NodeIdentifier, Option<SelectionMap>>);
 
 type Cache = DashMap<PointerAddress, (Transformed<Selection>, SelectionMap)>;
 
-struct SkipRedundantNodesTransform {
+struct SkipRedundantNodesTransform<'a> {
     schema: Arc<SDLSchema>,
     cache: Cache,
+    defer_stream_interface: &'a DeferStreamInterface,
 }
 
-impl<'s> SkipRedundantNodesTransform {
-    fn new(program: &'_ Program) -> Self {
+impl<'s> SkipRedundantNodesTransform<'s> {
+    fn new(program: &'_ Program, defer_stream_interface: &'s DeferStreamInterface) -> Self {
         Self {
             schema: Arc::clone(&program.schema),
             cache: DashMap::new(),
+            defer_stream_interface,
         }
     }
 
@@ -331,7 +336,7 @@ impl<'s> SkipRedundantNodesTransform {
         }
         let mut result: Vec<Selection> = Vec::new();
         let mut has_changes = false;
-        let selections = get_partitioned_selections(selections);
+        let selections = get_partitioned_selections(selections, self.defer_stream_interface);
 
         for (index, prev_item) in selections.iter().enumerate() {
             let next_item = self.transform_selection(prev_item, selection_map);
@@ -427,18 +432,19 @@ impl<'s> SkipRedundantNodesTransform {
  * guaranteed to be fetched are encountered prior to any duplicates that may be
  * fetched within a conditional.
  */
-fn get_partitioned_selections(selections: &[Selection]) -> Vec<&Selection> {
+fn get_partitioned_selections<'a>(
+    selections: &'a [Selection],
+    defer_stream_interface: &'a DeferStreamInterface,
+) -> Vec<&'a Selection> {
     let mut result = Vec::with_capacity(selections.len());
-    unsafe {
-        result.set_len(selections.len())
-    };
+    unsafe { result.set_len(selections.len()) };
     let mut non_field_index = selections
         .iter()
-        .filter(|sel| is_selection_linked_or_scalar(sel))
+        .filter(|sel| is_selection_linked_or_scalar(sel, defer_stream_interface))
         .count();
     let mut field_index = 0;
     for sel in selections.iter() {
-        if is_selection_linked_or_scalar(sel) {
+        if is_selection_linked_or_scalar(sel, defer_stream_interface) {
             result[field_index] = sel;
             field_index += 1;
         } else {
@@ -449,11 +455,14 @@ fn get_partitioned_selections(selections: &[Selection]) -> Vec<&Selection> {
     result
 }
 
-fn is_selection_linked_or_scalar(selection: &Selection) -> bool {
+fn is_selection_linked_or_scalar(
+    selection: &Selection,
+    defer_stream_interface: &DeferStreamInterface,
+) -> bool {
     match selection {
         Selection::LinkedField(field) => field
             .directives
-            .named(DEFER_STREAM_CONSTANTS.stream_name)
+            .named(defer_stream_interface.stream_name)
             .is_none(),
         Selection::ScalarField(_) => true,
         _ => false,

--- a/compiler/crates/relay-transforms/src/unwrap_custom_directive_selection.rs
+++ b/compiler/crates/relay-transforms/src/unwrap_custom_directive_selection.rs
@@ -5,23 +5,36 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use crate::DEFER_STREAM_CONSTANTS;
 use common::NamedItem;
 use graphql_ir::{FragmentSpread, InlineFragment, Program, Selection, Transformed, Transformer};
+use relay_config::DeferStreamInterface;
 use std::{iter, sync::Arc};
 
 /// Transform to unwrap selections wrapped in a InlineFragment with custom
 /// directive for printing
-pub fn unwrap_custom_directive_selection(program: &Program) -> Program {
-    let mut transform = UnwrapCustomDirectiveSelection;
+pub fn unwrap_custom_directive_selection(
+    program: &Program,
+    defer_stream_interface: &DeferStreamInterface,
+) -> Program {
+    let mut transform = UnwrapCustomDirectiveSelection::new(defer_stream_interface);
     transform
         .transform_program(program)
         .replace_or_else(|| program.clone())
 }
 
-struct UnwrapCustomDirectiveSelection;
+struct UnwrapCustomDirectiveSelection<'s> {
+    defer_stream_interface: &'s DeferStreamInterface,
+}
 
-impl Transformer for UnwrapCustomDirectiveSelection {
+impl<'s> UnwrapCustomDirectiveSelection<'s> {
+    fn new(defer_stream_interface: &'s DeferStreamInterface) -> Self {
+        Self {
+            defer_stream_interface,
+        }
+    }
+}
+
+impl Transformer for UnwrapCustomDirectiveSelection<'_> {
     const NAME: &'static str = "UnwrapCustomDirectiveSelection";
     const VISIT_ARGUMENTS: bool = false;
     const VISIT_DIRECTIVES: bool = false;
@@ -29,7 +42,9 @@ impl Transformer for UnwrapCustomDirectiveSelection {
     fn transform_inline_fragment(&mut self, fragment: &InlineFragment) -> Transformed<Selection> {
         if fragment.type_condition.is_none() {
             // Remove the wrapping `... @defer` for `@defer` on fragment spreads.
-            let defer = fragment.directives.named(DEFER_STREAM_CONSTANTS.defer_name);
+            let defer = fragment
+                .directives
+                .named(self.defer_stream_interface.defer_name);
             if let Some(defer) = defer {
                 if let Selection::FragmentSpread(frag_spread) = &fragment.selections[0] {
                     return Transformed::Replace(Selection::FragmentSpread(Arc::new(

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-default-label.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-default-label.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1) {
+  actors @stream(initialCount: 1) {
     name
   }
 }
@@ -24,7 +24,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$actors", initial_count: 1) {
+  actors @stream(label: "FeedbackFragment$stream$actors", initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-default-label.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-default-label.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1) {
+  actors @stream(initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.expected
@@ -9,10 +9,10 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "actors") {
+  actors @stream(initialCount: 1, label: "actors") {
     name
   }
-  otherActors: actors @stream(initial_count: 1, label: "actors") {
+  otherActors: actors @stream(initialCount: 1, label: "actors") {
     # invalid: duplicate label
     name
   }
@@ -22,7 +22,7 @@ fragment FeedbackFragment on Feedback {
 
   fragment-with-stream-duplicate-label.invalid.graphql:11:10
    10 │   id
-   11 │   actors @stream(initial_count: 1, label: "actors") {
+   11 │   actors @stream(initialCount: 1, label: "actors") {
       │          ^^^^^^^
    12 │     name
 
@@ -30,6 +30,6 @@ fragment FeedbackFragment on Feedback {
 
   fragment-with-stream-duplicate-label.invalid.graphql:14:23
    13 │   }
-   14 │   otherActors: actors @stream(initial_count: 1, label: "actors") {
+   14 │   otherActors: actors @stream(initialCount: 1, label: "actors") {
       │                       ^^^^^^^
    15 │     # invalid: duplicate label

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.graphql
@@ -8,10 +8,10 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "actors") {
+  actors @stream(initialCount: 1, label: "actors") {
     name
   }
-  otherActors: actors @stream(initial_count: 1, label: "actors") {
+  otherActors: actors @stream(initialCount: 1, label: "actors") {
     # invalid: duplicate label
     name
   }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-if-arg.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-if-arg.expected
@@ -9,7 +9,7 @@ query QueryWithFragmentWithStream($id: ID!, $enableStream: Boolean) {
 fragment FeedbackFragment on Feedback {
   id
   actors
-    @stream(initial_count: 1, label: "StreamedActorsLabel", if: $enableStream) {
+    @stream(initialCount: 1, label: "StreamedActorsLabel", if: $enableStream) {
     name
   }
 }
@@ -26,7 +26,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", if: $enableStream, initial_count: 1) {
+  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", if: $enableStream, initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-if-arg.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-if-arg.graphql
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!, $enableStream: Boolean) {
 fragment FeedbackFragment on Feedback {
   id
   actors
-    @stream(initial_count: 1, label: "StreamedActorsLabel", if: $enableStream) {
+    @stream(initialCount: 1, label: "StreamedActorsLabel", if: $enableStream) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-initial-count-arg.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-initial-count-arg.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!, $initialCount: Int) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: $initialCount, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: $initialCount, label: "StreamedActorsLabel") {
     name
   }
 }
@@ -25,7 +25,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", initial_count: $initialCount) {
+  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", initialCount: $initialCount) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-initial-count-arg.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-initial-count-arg.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!, $initialCount: Int) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: $initialCount, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: $initialCount, label: "StreamedActorsLabel") {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.expected
@@ -15,7 +15,7 @@ fragment FeedbackFragment on Feedback {
   }
 }
 ==================================== ERROR ====================================
-✖︎ Missing required argument: `initial_count`
+✖︎ Missing required argument: `initialCount`
 
   fragment-with-stream-missing-initial-count-arg.invalid.graphql:11:11
    10 │   id

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected
@@ -9,13 +9,13 @@ query QueryWithFragmentWithStream($id: ID!, $label: String!) {
 
 fragment UserFragment on User {
   id
-  name @stream(initial_count: 1, label: $label)
+  name @stream(initialCount: 1, label: $label)
 }
 ==================================== ERROR ====================================
 ✖︎ Invalid use of @stream on scalar field 'name'
 
   fragment-with-stream-on-scalar-field.invalid.graphql:11:8
    10 │   id
-   11 │   name @stream(initial_count: 1, label: $label)
+   11 │   name @stream(initialCount: 1, label: $label)
       │        ^^^^^^^
    12 │ }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.graphql
@@ -8,5 +8,5 @@ query QueryWithFragmentWithStream($id: ID!, $label: String!) {
 
 fragment UserFragment on User {
   id
-  name @stream(initial_count: 1, label: $label)
+  name @stream(initialCount: 1, label: $label)
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-statically-disabled.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-statically-disabled.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel", if: false) {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel", if: false) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-statically-disabled.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-statically-disabled.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel", if: false) {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel", if: false) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.expected
@@ -11,9 +11,9 @@ fragment FeedbackFragment on Feedback {
   actors
     @stream(
       if: true
-      initial_count: 1
+      initialCount: 1
       label: "StreamedActorsLabel"
-      use_customized_batch: $useCustomizedBatch
+      useCustomizedBatch: $useCustomizedBatch
     ) {
     name
   }
@@ -31,7 +31,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", if: true, initial_count: 1, use_customized_batch: $useCustomizedBatch) {
+  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", if: true, initialCount: 1, useCustomizedBatch: $useCustomizedBatch) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.graphql
@@ -10,9 +10,9 @@ fragment FeedbackFragment on Feedback {
   actors
     @stream(
       if: true
-      initial_count: 1
+      initialCount: 1
       label: "StreamedActorsLabel"
-      use_customized_batch: $useCustomizedBatch
+      useCustomizedBatch: $useCustomizedBatch
     ) {
     name
   }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-variable-label.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-variable-label.invalid.expected
@@ -9,7 +9,7 @@ query QueryWithFragmentWithStream($id: ID!, $label: String!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: $label) {
+  actors @stream(initialCount: 1, label: $label) {
     name
   }
 }
@@ -18,6 +18,6 @@ fragment FeedbackFragment on Feedback {
 
   fragment-with-stream-variable-label.invalid.graphql:11:10
    10 │   id
-   11 │   actors @stream(initial_count: 1, label: $label) {
+   11 │   actors @stream(initialCount: 1, label: $label) {
       │          ^^^^^^^
    12 │     name

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-variable-label.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-variable-label.invalid.graphql
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!, $label: String!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: $label) {
+  actors @stream(initialCount: 1, label: $label) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     name
   }
 }
@@ -24,7 +24,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", initial_count: 1) {
+  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/query-with-stream.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/query-with-stream.expected
@@ -2,7 +2,7 @@
 query QueryWithStream($id: ID!) {
   node(id: $id) {
     ... on Feedback {
-      actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+      actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
         name
       }
     }
@@ -14,7 +14,7 @@ query QueryWithStream(
 ) {
   node(id: $id) {
     ... on Feedback {
-      actors @stream(label: "QueryWithStream$stream$StreamedActorsLabel", initial_count: 1) {
+      actors @stream(label: "QueryWithStream$stream$StreamedActorsLabel", initialCount: 1) {
         name
       }
     }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/query-with-stream.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/query-with-stream.graphql
@@ -1,7 +1,7 @@
 query QueryWithStream($id: ID!) {
   node(id: $id) {
     ... on Feedback {
-      actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+      actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
         name
       }
     }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/stream.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/stream.invalid.expected
@@ -3,7 +3,7 @@
 
 fragment FeedbackFragment on Feedback {
   id
-  actor @stream(initial_count: 1) {
+  actor @stream(initialCount: 1) {
     name
   }
 }
@@ -12,6 +12,6 @@ fragment FeedbackFragment on Feedback {
 
   stream.invalid.graphql:5:9
     4 │   id
-    5 │   actor @stream(initial_count: 1) {
+    5 │   actor @stream(initialCount: 1) {
       │         ^^^^^^^
     6 │     name

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/stream.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/stream.invalid.graphql
@@ -2,7 +2,7 @@
 
 fragment FeedbackFragment on Feedback {
   id
-  actor @stream(initial_count: 1) {
+  actor @stream(initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/mod.rs
+++ b/compiler/crates/relay-transforms/tests/defer_stream/mod.rs
@@ -7,12 +7,14 @@
 
 use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
+use relay_config::DeferStreamInterface;
 use relay_transforms::{transform_defer_stream, unwrap_custom_directive_selection};
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
-        let program = transform_defer_stream(program)?;
-        let program = unwrap_custom_directive_selection(&program);
+        let defer_stream_interface = DeferStreamInterface::default();
+        let program = transform_defer_stream(program, &defer_stream_interface)?;
+        let program = unwrap_custom_directive_selection(&program, &defer_stream_interface);
         Ok(program)
     })
 }

--- a/compiler/crates/relay-transforms/tests/generate_data_driven_dependency_metadata/mod.rs
+++ b/compiler/crates/relay-transforms/tests/generate_data_driven_dependency_metadata/mod.rs
@@ -8,12 +8,14 @@
 use common::FeatureFlags;
 use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
+use relay_config::DeferStreamInterface;
 use relay_transforms::{generate_data_driven_dependency_metadata, transform_match};
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         let flags = FeatureFlags::default();
-        let program = transform_match(program, &flags)?;
+        let defer_stream_interface = DeferStreamInterface::default();
+        let program = transform_match(program, &flags, &defer_stream_interface)?;
         let program = generate_data_driven_dependency_metadata(&program);
         Ok(program)
     })

--- a/compiler/crates/relay-transforms/tests/match_transform/mod.rs
+++ b/compiler/crates/relay-transforms/tests/match_transform/mod.rs
@@ -8,9 +8,13 @@
 use common::FeatureFlags;
 use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
+use relay_config::DeferStreamInterface;
 use relay_transforms::transform_match;
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let flags = FeatureFlags::default();
-    apply_transform_for_test(fixture, |program| transform_match(program, &flags))
+    let defer_stream_interface = DeferStreamInterface::default();
+    apply_transform_for_test(fixture, |program| {
+        transform_match(program, &flags, &defer_stream_interface)
+    })
 }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.expected
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.expected
@@ -9,7 +9,7 @@ fragment PaginationFragment on Node
   ... on User {
     name
     friends(after: $cursor, first: $count)
-      @stream_connection(key: "PaginationFragment_friends", initial_count: 1) {
+      @stream_connection(key: "PaginationFragment_friends", initialCount: 1) {
       edges {
         node {
           id
@@ -73,7 +73,7 @@ fragment PaginationFragment on Node @refetchable(queryName: "RefetchableFragment
   ... on User {
     name
     friends(after: $cursor, first: $count) @__clientField(key: "PaginationFragment_friends", handle: "connection", filters: null, dynamicKey_UNSTABLE: null) {
-      edges @stream(label: "PaginationFragment_friends", initial_count: 1) {
+      edges @stream(label: "PaginationFragment_friends", initialCount: 1) {
         node {
           id
         }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.graphql
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.graphql
@@ -8,7 +8,7 @@ fragment PaginationFragment on Node
   ... on User {
     name
     friends(after: $cursor, first: $count)
-      @stream_connection(key: "PaginationFragment_friends", initial_count: 1) {
+      @stream_connection(key: "PaginationFragment_friends", initialCount: 1) {
       edges {
         node {
           id

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/mod.rs
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/mod.rs
@@ -6,15 +6,14 @@
  */
 
 use fixture_tests::Fixture;
-use relay_transforms::{
-    transform_connections, transform_refetchable_fragment, ConnectionInterface,
-};
+use relay_config::SchemaConfig;
+use relay_transforms::{transform_connections, transform_refetchable_fragment};
 
 use graphql_test_helpers::apply_transform_for_test;
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
-        let program = transform_connections(program, &ConnectionInterface::default());
+        let program = transform_connections(program, &SchemaConfig::default());
         let base_fragments = Default::default();
         transform_refetchable_fragment(&program, &Default::default(), &base_fragments, false)
     })

--- a/compiler/crates/relay-transforms/tests/skip_redundant_nodes/mod.rs
+++ b/compiler/crates/relay-transforms/tests/skip_redundant_nodes/mod.rs
@@ -10,6 +10,7 @@ use fixture_tests::Fixture;
 use graphql_ir::{build, Program};
 use graphql_syntax::parse_executable;
 use graphql_text_printer::{print_operation, PrinterOptions};
+use relay_config::DeferStreamInterface;
 use relay_test_schema::{get_test_schema, get_test_schema_with_extensions};
 use relay_transforms::{inline_fragments, skip_redundant_nodes};
 use std::sync::Arc;
@@ -21,12 +22,14 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         debug_directive_data: true,
         ..Default::default()
     };
+    let defer_stream_interface = DeferStreamInterface::default();
     let mut printed = if let [base, extensions] = parts.as_slice() {
         let ast = parse_executable(base, source_location).unwrap();
         let schema = get_test_schema_with_extensions(extensions);
         let ir = build(&schema, &ast.definitions).unwrap();
         let program = Program::from_definitions(Arc::clone(&schema), ir);
-        let next_program = skip_redundant_nodes(&inline_fragments(&program));
+        let next_program =
+            skip_redundant_nodes(&inline_fragments(&program), &defer_stream_interface);
         next_program
             .operations()
             .map(|def| print_operation(&schema, def, printer_options.clone()))
@@ -36,7 +39,8 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         let ast = parse_executable(fixture.content, source_location).unwrap();
         let ir = build(&schema, &ast.definitions).unwrap();
         let program = Program::from_definitions(Arc::clone(&schema), ir);
-        let next_program = skip_redundant_nodes(&inline_fragments(&program));
+        let next_program =
+            skip_redundant_nodes(&inline_fragments(&program), &defer_stream_interface);
         next_program
             .operations()
             .map(|def| print_operation(&schema, def, printer_options.clone()))

--- a/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/mod.rs
+++ b/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/mod.rs
@@ -7,8 +7,12 @@
 
 use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
+use relay_config::DeferStreamInterface;
 use relay_transforms::skip_unreachable_node;
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
-    apply_transform_for_test(fixture, skip_unreachable_node)
+    let defer_stream_interface = DeferStreamInterface::default();
+    apply_transform_for_test(fixture, |program| {
+        skip_unreachable_node(program, &defer_stream_interface)
+    })
 }

--- a/compiler/crates/relay-transforms/tests/skip_unused_variables/fixtures/kitchen-sink.expected
+++ b/compiler/crates/relay-transforms/tests/skip_unused_variables/fixtures/kitchen-sink.expected
@@ -54,7 +54,7 @@ query StreamQuerry($RELAY_INCREMENTAL_DELIVERY: Boolean!) {
   node(id: 4) {
     id
     ... on Feedback {
-      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initial_count: 3) {
+      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initialCount: 3) {
         name
       }
     }
@@ -78,7 +78,7 @@ query StreamQuerry(
   node(id: 4) {
     id
     ... on Feedback {
-      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initial_count: 3) {
+      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initialCount: 3) {
         name
       }
     }

--- a/compiler/crates/relay-transforms/tests/skip_unused_variables/fixtures/kitchen-sink.graphql
+++ b/compiler/crates/relay-transforms/tests/skip_unused_variables/fixtures/kitchen-sink.graphql
@@ -53,7 +53,7 @@ query StreamQuerry($RELAY_INCREMENTAL_DELIVERY: Boolean!) {
   node(id: 4) {
     id
     ... on Feedback {
-      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initial_count: 3) {
+      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initialCount: 3) {
         name
       }
     }

--- a/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection-no-label.expected
+++ b/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection-no-label.expected
@@ -4,7 +4,7 @@ query NodeQuery($id: ID!) {
     id
     ... on Story {
       comments(first: 10)
-        @stream_connection(key: "NodeQuery_comments", initial_count: 0) {
+        @stream_connection(key: "NodeQuery_comments", initialCount: 0) {
         edges {
           node {
             actor {
@@ -47,7 +47,7 @@ query NodeQuery(
     id
     ... on Story {
       comments(first: 10) @__clientField(key: "NodeQuery_comments", handle: "connection", filters: null, dynamicKey_UNSTABLE: null) {
-        edges @stream(label: "NodeQuery_comments", initial_count: 0) {
+        edges @stream(label: "NodeQuery_comments", initialCount: 0) {
           node {
             actor {
               name

--- a/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection-no-label.graphql
+++ b/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection-no-label.graphql
@@ -3,7 +3,7 @@ query NodeQuery($id: ID!) {
     id
     ... on Story {
       comments(first: 10)
-        @stream_connection(key: "NodeQuery_comments", initial_count: 0) {
+        @stream_connection(key: "NodeQuery_comments", initialCount: 0) {
         edges {
           node {
             actor {

--- a/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection.expected
+++ b/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection.expected
@@ -6,7 +6,7 @@ query NodeQuery($id: ID!) {
       comments(first: 10)
         @stream_connection(
           key: "NodeQuery_comments"
-          initial_count: 0
+          initialCount: 0
           label: "comments"
         ) {
         edges {
@@ -51,7 +51,7 @@ query NodeQuery(
     id
     ... on Story {
       comments(first: 10) @__clientField(key: "NodeQuery_comments", handle: "connection", filters: null, dynamicKey_UNSTABLE: null) {
-        edges @stream(label: "NodeQuery_comments", initial_count: 0) {
+        edges @stream(label: "NodeQuery_comments", initialCount: 0) {
           node {
             actor {
               name

--- a/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection.graphql
+++ b/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection.graphql
@@ -5,7 +5,7 @@ query NodeQuery($id: ID!) {
       comments(first: 10)
         @stream_connection(
           key: "NodeQuery_comments"
-          initial_count: 0
+          initialCount: 0
           label: "comments"
         ) {
         edges {

--- a/compiler/crates/relay-transforms/tests/transform_connections/mod.rs
+++ b/compiler/crates/relay-transforms/tests/transform_connections/mod.rs
@@ -11,8 +11,9 @@ use graphql_ir::{build, Program};
 use graphql_syntax::parse_executable;
 use graphql_test_helpers::diagnostics_to_sorted_string;
 use graphql_text_printer::{print_fragment, print_operation, PrinterOptions};
+use relay_config::SchemaConfig;
 use relay_test_schema::get_test_schema;
-use relay_transforms::{transform_connections, validate_connections, ConnectionInterface};
+use relay_transforms::{transform_connections, validate_connections};
 use std::sync::Arc;
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
@@ -26,12 +27,12 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
 
     let program = Program::from_definitions(Arc::clone(&schema), ir);
 
-    let connection_interface = ConnectionInterface::default();
+    let schema_config = SchemaConfig::default();
 
-    validate_connections(&program, &connection_interface)
+    validate_connections(&program, &schema_config.connection_interface)
         .map_err(|diagnostics| diagnostics_to_sorted_string(fixture.content, &diagnostics))?;
 
-    let next_program = transform_connections(&program, &connection_interface);
+    let next_program = transform_connections(&program, &schema_config);
 
     let printer_options = PrinterOptions {
         debug_directive_data: true,

--- a/compiler/crates/relay-transforms/tests/validate_connections/fixtures/stream-connection-with-aliased-edges.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_connections/fixtures/stream-connection-with-aliased-edges.invalid.expected
@@ -5,7 +5,7 @@ query NodeQuery($id: ID!) {
     id
     ... on Story {
       comments(first: 10)
-        @stream_connection(key: "NodeQuery_comments", initial_count: 0) {
+        @stream_connection(key: "NodeQuery_comments", initialCount: 0) {
         commentEdges: edges {
           node {
             actor {
@@ -24,7 +24,7 @@ query NodeQuery($id: ID!) {
 ✖︎ @stream_connection does not support aliasing the 'edges' field.
 
   stream-connection-with-aliased-edges.invalid.graphql:8:23
-    7 │         @stream_connection(key: "NodeQuery_comments", initial_count: 0) {
+    7 │         @stream_connection(key: "NodeQuery_comments", initialCount: 0) {
     8 │         commentEdges: edges {
       │                       ^^^^^
     9 │           node {

--- a/compiler/crates/relay-transforms/tests/validate_connections/fixtures/stream-connection-with-aliased-edges.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_connections/fixtures/stream-connection-with-aliased-edges.invalid.graphql
@@ -4,7 +4,7 @@ query NodeQuery($id: ID!) {
     id
     ... on Story {
       comments(first: 10)
-        @stream_connection(key: "NodeQuery_comments", initial_count: 0) {
+        @stream_connection(key: "NodeQuery_comments", initialCount: 0) {
         commentEdges: edges {
           node {
             actor {

--- a/compiler/crates/relay-transforms/tests/validate_connections/fixtures/stream-connection-with-aliased-page-info.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_connections/fixtures/stream-connection-with-aliased-page-info.invalid.expected
@@ -5,7 +5,7 @@ query NodeQuery($id: ID!) {
     id
     ... on Story {
       comments(first: 10)
-        @stream_connection(key: "NodeQuery_comments", initial_count: 0) {
+        @stream_connection(key: "NodeQuery_comments", initialCount: 0) {
         edges {
           node {
             actor {

--- a/compiler/crates/relay-transforms/tests/validate_connections/fixtures/stream-connection-with-aliased-page-info.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_connections/fixtures/stream-connection-with-aliased-page-info.invalid.graphql
@@ -4,7 +4,7 @@ query NodeQuery($id: ID!) {
     id
     ... on Story {
       comments(first: 10)
-        @stream_connection(key: "NodeQuery_comments", initial_count: 0) {
+        @stream_connection(key: "NodeQuery_comments", initialCount: 0) {
         edges {
           node {
             actor {

--- a/compiler/crates/relay-transforms/tests/validate_selection_conflict/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_selection_conflict/mod.rs
@@ -11,6 +11,7 @@ use graphql_cli::DiagnosticPrinter;
 use graphql_ir::{build, Program};
 use graphql_syntax::{parse_executable, GraphQLSource};
 use graphql_test_helpers::diagnostics_to_sorted_string;
+use relay_config::DeferStreamInterface;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_selection_conflict;
 use std::sync::Arc;
@@ -40,7 +41,8 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     };
 
     let program = Program::from_definitions(Arc::clone(&TEST_SCHEMA), ir);
-    validate_selection_conflict(&program)
+    let defer_stream_interface = DeferStreamInterface::default();
+    validate_selection_conflict(&program, &defer_stream_interface)
         .map_err(|diagnostics| diagnostics_to_sorted_string(fixture.content, &diagnostics))?;
 
     Ok("OK".to_owned())

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.expected
@@ -11,7 +11,7 @@ fragment FeedbackFragment on Feedback {
   id
   foo {
     bar {
-      users @stream(initial_count: 1, label: "StreamedActorsLabel") {
+      users @stream(initialCount: 1, label: "StreamedActorsLabel") {
         id
         name
       }
@@ -36,7 +36,7 @@ type Bar {
 
   fragment-with-stream-child-of-client.invalid.graphql:13:13
    12 │     bar {
-   13 │       users @stream(initial_count: 1, label: "StreamedActorsLabel") {
+   13 │       users @stream(initialCount: 1, label: "StreamedActorsLabel") {
       │             ^^^^^^^
    14 │         id
 

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.graphql
@@ -10,7 +10,7 @@ fragment FeedbackFragment on Feedback {
   id
   foo {
     bar {
-      users @stream(initial_count: 1, label: "StreamedActorsLabel") {
+      users @stream(initialCount: 1, label: "StreamedActorsLabel") {
         id
         name
       }

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.expected
@@ -9,7 +9,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  foos @stream(initialCount: 1, label: "StreamedActorsLabel") {
     bar
   }
 }
@@ -28,7 +28,7 @@ type Foo {
 
   fragment-with-stream-on-client.invalid.graphql:11:8
    10 │   id
-   11 │   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+   11 │   foos @stream(initialCount: 1, label: "StreamedActorsLabel") {
       │        ^^^^^^^
    12 │     bar
 
@@ -36,6 +36,6 @@ type Foo {
 
   fragment-with-stream-on-client.invalid.graphql:11:3
    10 │   id
-   11 │   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+   11 │   foos @stream(initialCount: 1, label: "StreamedActorsLabel") {
       │   ^^^^
    12 │     bar

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.graphql
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  foos @stream(initialCount: 1, label: "StreamedActorsLabel") {
     bar
   }
 }

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/stream-connection-on-client.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/stream-connection-on-client.invalid.expected
@@ -7,7 +7,7 @@ query NodeQuery($id: ID!) {
       clientComments(first: 10)
         @stream_connection(
           key: "NodeQuery_clientComments"
-          initial_count: 0
+          initialCount: 0
           label: "comments"
         ) {
         edges {

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/stream-connection-on-client.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/stream-connection-on-client.invalid.graphql
@@ -6,7 +6,7 @@ query NodeQuery($id: ID!) {
       clientComments(first: 10)
         @stream_connection(
           key: "NodeQuery_clientComments"
-          initial_count: 0
+          initialCount: 0
           label: "comments"
         ) {
         edges {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream-connection.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream-connection.expected
@@ -4,7 +4,7 @@ query TestDefer @raw_response_type {
     ... on User {
       name
       friends(first: 10)
-        @stream_connection(key: "TestDefer_friends", initial_count: 0) {
+        @stream_connection(key: "TestDefer_friends", initialCount: 0) {
         edges {
           node {
             actor {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream-connection.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream-connection.graphql
@@ -3,7 +3,7 @@ query TestDefer @raw_response_type {
     ... on User {
       name
       friends(first: 10)
-        @stream_connection(key: "TestDefer_friends", initial_count: 0) {
+        @stream_connection(key: "TestDefer_friends", initialCount: 0) {
         edges {
           node {
             actor {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream.expected
@@ -6,7 +6,7 @@ query TestStream @raw_response_type {
       friends(first: 10)
         @stream_connection(
           key: "PaginationFragment_friends"
-          initial_count: 1
+          initialCount: 1
         ) {
         edges {
           node {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream.graphql
@@ -5,7 +5,7 @@ query TestStream @raw_response_type {
       friends(first: 10)
         @stream_connection(
           key: "PaginationFragment_friends"
-          initial_count: 1
+          initialCount: 1
         ) {
         edges {
           node {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.expected
@@ -4,7 +4,7 @@ query TestDefer @raw_response_type {
     ... on User {
       name
       friends(first: 10)
-        @stream_connection(key: "TestDefer_friends", initial_count: 0) {
+        @stream_connection(key: "TestDefer_friends", initialCount: 0) {
         edges {
           node {
             actor {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.graphql
@@ -3,7 +3,7 @@ query TestDefer @raw_response_type {
     ... on User {
       name
       friends(first: 10)
-        @stream_connection(key: "TestDefer_friends", initial_count: 0) {
+        @stream_connection(key: "TestDefer_friends", initialCount: 0) {
         edges {
           node {
             actor {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.expected
@@ -6,7 +6,7 @@ query TestStream @raw_response_type {
       friends(first: 10)
         @stream_connection(
           key: "PaginationFragment_friends"
-          initial_count: 1
+          initialCount: 1
         ) {
         edges {
           node {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.graphql
@@ -5,7 +5,7 @@ query TestStream @raw_response_type {
       friends(first: 10)
         @stream_connection(
           key: "PaginationFragment_friends"
-          initial_count: 1
+          initialCount: 1
         ) {
         edges {
           node {

--- a/packages/relay-runtime/network/RelayNetworkTypes.js
+++ b/packages/relay-runtime/network/RelayNetworkTypes.js
@@ -51,6 +51,7 @@ export type GraphQLResponseWithData = {|
   +extensions?: PayloadExtensions,
   +label?: string,
   +path?: Array<string | number>,
+  +hasNext?: boolean,
 |};
 
 export type GraphQLResponseWithoutData = {|
@@ -59,6 +60,7 @@ export type GraphQLResponseWithoutData = {|
   +extensions?: PayloadExtensions,
   +label?: string,
   +path?: Array<string | number>,
+  +hasNext?: boolean,
 |};
 
 export type GraphQLResponseWithExtensionsOnly = {|
@@ -72,6 +74,7 @@ export type GraphQLResponseWithExtensionsOnly = {|
   // does not necessarily indicate that there was an error.
   +data: null,
   +extensions: PayloadExtensions,
+  +hasNext?: boolean,
 |};
 
 export type GraphQLSingularResponse =

--- a/packages/relay-runtime/query/__tests__/fetchQueryInternal-test.js
+++ b/packages/relay-runtime/query/__tests__/fetchQueryInternal-test.js
@@ -976,6 +976,30 @@ describe('getObservableForActiveRequest', () => {
     expect(events).toEqual(['next']);
   });
 
+  it('calls next asynchronously with subsequent non-final payloads (OSS)', () => {
+    fetchQuery(environment, query).subscribe({});
+    const observable = getObservableForActiveRequest(
+      environment,
+      query.request,
+    );
+    expect(observable).not.toEqual(null);
+    if (!observable) {
+      return;
+    }
+
+    response = {
+      ...response,
+      extensions: {},
+      hasNext: true,
+    };
+
+    observable.subscribe(observer);
+    expect(events).toEqual([]);
+
+    environment.mock.nextValue(gqlQuery, response);
+    expect(events).toEqual(['next']);
+  });
+
   it('calls complete asynchronously with subsequent final payload', () => {
     fetchQuery(environment, query).subscribe({});
     const observable = getObservableForActiveRequest(
@@ -986,6 +1010,30 @@ describe('getObservableForActiveRequest', () => {
     if (!observable) {
       return;
     }
+
+    observable.subscribe(observer);
+    expect(events).toEqual([]);
+
+    environment.mock.nextValue(gqlQuery, response);
+    expect(events).toEqual(['complete']);
+  });
+
+  it('calls complete asynchronously with subsequent final payload (OSS)', () => {
+    fetchQuery(environment, query).subscribe({});
+    const observable = getObservableForActiveRequest(
+      environment,
+      query.request,
+    );
+    expect(observable).not.toEqual(null);
+    if (!observable) {
+      return;
+    }
+
+    response = {
+      ...response,
+      extensions: {},
+      hasNext: false,
+    };
 
     observable.subscribe(observer);
     expect(events).toEqual([]);

--- a/packages/relay-runtime/store/OperationExecutor.js
+++ b/packages/relay-runtime/store/OperationExecutor.js
@@ -508,7 +508,7 @@ class Executor<TMutation: MutationParameters> {
     if (responsesWithData.length === 0) {
       // no results with data, nothing to process
       // this can occur with extensions-only payloads
-      const isFinal = responses.some(x => x.extensions?.is_final === true);
+      const isFinal = responses.some((x) => responseIsFinal(x));
       if (isFinal) {
         this._state = 'loading_final';
         this._updateActiveState();
@@ -1302,7 +1302,7 @@ class Executor<TMutation: MutationParameters> {
         incrementalPlaceholders: null,
         followupPayloads: null,
         source: RelayRecordSource.create(),
-        isFinal: response.extensions?.is_final === true,
+        isFinal: responseIsFinal(response),
       };
       this._getPublishQueueAndSaveActor().commitPayload(
         this._operation,
@@ -1661,7 +1661,7 @@ function normalizeResponse(
   return {
     ...relayPayload,
     errors,
-    isFinal: response.extensions?.is_final === true,
+    isFinal: responseIsFinal(response),
   };
 }
 
@@ -1681,6 +1681,19 @@ function validateOptimisticResponsePayload(
         '@stream, and @stream_connection).',
     );
   }
+}
+
+/**
+ * Check for both FB specific (extensions?.is_final)
+ * and spec-complaint (hasNext) properties.
+ */
+function responseIsFinal(response: GraphQLSingularResponse): boolean {
+  if (response.extensions?.is_final === true) {
+    return true;
+  } else if (response.hasNext === false) {
+    return true;
+  }
+  return false;
 }
 
 module.exports = {


### PR DESCRIPTION
This change will allow Relay to support `@defer`/`@stream` in the form that is currently being proposed to the GraphQL WG:

Draft Spec: https://github.com/graphql/graphql-spec/pull/742
GraphQL-js: https://github.com/graphql/graphql-js/pull/2319

This works by allowing either `initial_count` or `initialCount` as an argument for `@stream`. Whichever one is passed will be forwarded to the GraphQL server.

Additionally, either `extensions.is_final: true` or `hasNext: false` will be used to track final payloads.