### PR TITLE
ignore Rust compiler in OSS flow check

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 <PROJECT_ROOT>/dist/.*
+<PROJECT_ROOT>/compiler/.*
 
 [options]
 module.system=haste


### PR DESCRIPTION
The Rust compiler contains some generated test project files that we don't need to check as part of the Relay runtime.

Test Plan:
GitHub Actions flow check passes again.