### PR TITLE
remove persisted query id invariant from loadQuery

### DIFF
--- a/packages/relay-experimental/loadQuery.js
+++ b/packages/relay-experimental/loadQuery.js
@@ -194,13 +194,6 @@ function loadQuery<TQuery: OperationType, TEnvironmentProviderOptions>(
     const request = getRequest(graphQlTaggedNode);
     params = request.params;
 
-    ({id: moduleId} = params);
-    invariant(
-      moduleId !== null,
-      'Relay: `loadQuery` requires that preloadable query `%s` has a persisted query id',
-      params.name,
-    );
-
     checkAvailabilityAndExecute(request);
   }
 


### PR DESCRIPTION
This removes the persisted query id invariant, allowing use of `loadQuery` without persisted queries enabled.