### PR TITLE
Plural support for @deleteRecord directive

### DIFF
--- a/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
+++ b/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
@@ -66,11 +66,7 @@ function visitScalarField(field: ScalarField): ScalarField {
   }
   const schema = this.getContext().getSchema();
 
-  if (
-    ['ID', 'ID!', '[ID]', '[ID!]', '[ID!]!'].includes(
-      schema.getTypeString(field.type),
-    ) === false
-  ) {
+  if (!schema.isId(schema.getRawType(field.type))) {
     throw createUserError(
       `Invalid use of @${DELETE_RECORD} on field '${
         field.name

--- a/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
+++ b/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
@@ -70,7 +70,7 @@ function visitScalarField(field: ScalarField): ScalarField {
     throw createUserError(
       `Invalid use of @${DELETE_RECORD} on field '${
         field.name
-      }'. Expected field type to be a single or list of ID, got ${schema.getTypeString(
+      }'. Expected field to return an ID or list of ID values, got ${schema.getTypeString(
         field.type,
       )}.`,
       [deleteDirective.loc],

--- a/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
+++ b/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
@@ -67,14 +67,14 @@ function visitScalarField(field: ScalarField): ScalarField {
   const schema = this.getContext().getSchema();
 
   if (
-    !schema.isId(field.type) &&
-    (!schema.isList(field.type) ||
-      (schema.isList(field.type) && !schema.isId(field.type.ofType)))
+    ['ID', 'ID!', '[ID]', '[ID!]', '[ID!]!'].includes(
+      schema.getTypeString(field.type),
+    ) === false
   ) {
     throw createUserError(
       `Invalid use of @${DELETE_RECORD} on field '${
         field.name
-      }'. Expected field type ID or [ID], got ${schema.getTypeString(
+      }'. Expected field type to be a single or list of ID, got ${schema.getTypeString(
         field.type,
       )}.`,
       [deleteDirective.loc],

--- a/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
+++ b/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
@@ -65,11 +65,18 @@ function visitScalarField(field: ScalarField): ScalarField {
     return field;
   }
   const schema = this.getContext().getSchema();
-  if (!schema.isId(field.type)) {
+
+  if (
+    !schema.isId(field.type) &&
+    (!schema.isList(field.type) ||
+      (schema.isList(field.type) && !schema.isId(field.type.ofType)))
+  ) {
     throw createUserError(
       `Invalid use of @${DELETE_RECORD} on field '${
         field.name
-      }'. Expected field type ID, got ${schema.getTypeString(field.type)}.`,
+      }'. Expected field type ID or [ID], got ${schema.getTypeString(
+        field.type,
+      )}.`,
       [deleteDirective.loc],
     );
   }

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
@@ -79,6 +79,25 @@ mutation CommentDeleteMutation(
 
 `;
 
+exports[`matches expected output: delete-from-store-plural.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+mutation CommentsDeleteMutation($input: CommentsDeleteInput) {
+  commentsDelete(input: $input) {
+    deletedCommentIds @deleteRecord
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+mutation CommentsDeleteMutation(
+  $input: CommentsDeleteInput
+) {
+  commentsDelete(input: $input) {
+    deletedCommentIds @__clientField(handle: "deleteRecord")
+  }
+}
+
+`;
+
 exports[`matches expected output: delete-on-unspported-type.invalid.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 # expected-to-throw

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
@@ -110,7 +110,7 @@ mutation CommentDeleteMutation($input: CommentDeleteInput) {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 THROWN EXCEPTION:
 
-Invalid use of @deleteRecord on field '__typename'. Expected field type to be a single or list of ID, got String!.
+Invalid use of @deleteRecord on field '__typename'. Expected field to return an ID or list of ID values, got String!.
 
 Source: GraphQL request (4:16)
 3:   commentDelete(input: $input) {

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
@@ -110,7 +110,7 @@ mutation CommentDeleteMutation($input: CommentDeleteInput) {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 THROWN EXCEPTION:
 
-Invalid use of @deleteRecord on field '__typename'. Expected field type ID or [ID], got String!.
+Invalid use of @deleteRecord on field '__typename'. Expected field type to be a single or list of ID, got String!.
 
 Source: GraphQL request (4:16)
 3:   commentDelete(input: $input) {

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
@@ -110,7 +110,7 @@ mutation CommentDeleteMutation($input: CommentDeleteInput) {
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 THROWN EXCEPTION:
 
-Invalid use of @deleteRecord on field '__typename'. Expected field type ID, got String!.
+Invalid use of @deleteRecord on field '__typename'. Expected field type ID or [ID], got String!.
 
 Source: GraphQL request (4:16)
 3:   commentDelete(input: $input) {

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-from-store-plural.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-from-store-plural.graphql
@@ -1,0 +1,5 @@
+mutation CommentsDeleteMutation($input: CommentsDeleteInput) {
+  commentsDelete(input: $input) {
+    deletedCommentIds @deleteRecord
+  }
+}

--- a/packages/relay-runtime/handlers/connection/MutationHandlers.js
+++ b/packages/relay-runtime/handlers/connection/MutationHandlers.js
@@ -27,10 +27,18 @@ import type {
 const DeleteRecordHandler = {
   update: (store: RecordSourceProxy, payload: HandleFieldPayload) => {
     const record = store.get(payload.dataID);
+
     if (record != null) {
-      const id = record.getValue(payload.fieldKey);
-      if (typeof id === 'string') {
-        store.delete(id);
+      const idOrIds = record.getValue(payload.fieldKey);
+
+      if (typeof idOrIds === 'string') {
+        store.delete(idOrIds);
+      } else if (Array.isArray(idOrIds)) {
+        idOrIds.forEach(id => {
+          if (typeof id === 'string') {
+            store.delete(id);
+          }
+        });
       }
     }
   },

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
@@ -25,28 +25,29 @@ const {
 const {generateAndCompile} = require('relay-test-utils-internal');
 
 describe('deleteFromStore', () => {
-  let callbacks;
-  let commentId;
-  let CommentQuery;
-  let DeleteCommentMutation;
-  let complete;
-  let environment;
-  let error;
-  let fetch;
-  let next;
-  let operation;
-  let queryOperation;
-  let source;
-  let store;
-  let subject;
-  let variables;
-  let queryVariables;
+  describe('single ids', () => {
+    let callbacks;
+    let commentId;
+    let CommentQuery;
+    let DeleteCommentMutation;
+    let complete;
+    let environment;
+    let error;
+    let fetch;
+    let next;
+    let operation;
+    let queryOperation;
+    let source;
+    let store;
+    let subject;
+    let variables;
+    let queryVariables;
 
-  beforeEach(() => {
-    jest.resetModules();
-    commentId = 'comment-id';
+    beforeEach(() => {
+      jest.resetModules();
+      commentId = 'comment-id';
 
-    ({DeleteCommentMutation, CommentQuery} = generateAndCompile(`
+      ({DeleteCommentMutation, CommentQuery} = generateAndCompile(`
         mutation DeleteCommentMutation($input: CommentDeleteInput) {
           commentDelete(input: $input) {
             deletedCommentId @deleteRecord
@@ -62,201 +63,503 @@ describe('deleteFromStore', () => {
           }
         }
       `));
-    variables = {
-      input: {
-        clientMutationId: '0',
-        commentId,
-      },
-    };
-    queryVariables = {
-      id: commentId,
-    };
-    operation = createOperationDescriptor(DeleteCommentMutation, variables);
-    queryOperation = createOperationDescriptor(CommentQuery, queryVariables);
+      variables = {
+        input: {
+          clientMutationId: '0',
+          commentId,
+        },
+      };
+      queryVariables = {
+        id: commentId,
+      };
+      operation = createOperationDescriptor(DeleteCommentMutation, variables);
+      queryOperation = createOperationDescriptor(CommentQuery, queryVariables);
 
-    fetch = jest.fn((_query, _variables, _cacheConfig) =>
-      RelayObservable.create(sink => {
-        subject = sink;
-      }),
-    );
-    source = RelayRecordSource.create();
-    store = new RelayModernStore(source);
-    environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(fetch),
-      store,
+      fetch = jest.fn((_query, _variables, _cacheConfig) =>
+        RelayObservable.create(sink => {
+          subject = sink;
+        }),
+      );
+      source = RelayRecordSource.create();
+      store = new RelayModernStore(source);
+      environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(fetch),
+        store,
+      });
+      complete = jest.fn();
+      error = jest.fn();
+      next = jest.fn();
+      callbacks = {complete, error, next};
+
+      environment.execute({operation: queryOperation}).subscribe({});
+      subject.next({
+        data: {
+          node: {
+            __typename: 'Comment',
+            id: commentId,
+            body: {
+              text: 'Comment',
+            },
+          },
+        },
+      });
+      jest.runAllTimers();
     });
-    complete = jest.fn();
-    error = jest.fn();
-    next = jest.fn();
-    callbacks = {complete, error, next};
 
-    environment.execute({operation: queryOperation}).subscribe({});
-    subject.next({
-      data: {
+    it('commit the mutation, and remove the given id from the store', () => {
+      const snapshot = environment.lookup(queryOperation.fragment);
+      expect(snapshot.data).toEqual({
         node: {
-          __typename: 'Comment',
           id: commentId,
           body: {
             text: 'Comment',
           },
         },
-      },
-    });
-    jest.runAllTimers();
-  });
+      });
+      const callback = jest.fn();
+      environment.subscribe(snapshot, callback);
 
-  it('commit the mutation, and remove the given id from the store', () => {
-    const snapshot = environment.lookup(queryOperation.fragment);
-    expect(snapshot.data).toEqual({
-      node: {
-        id: commentId,
-        body: {
-          text: 'Comment',
-        },
-      },
-    });
-    const callback = jest.fn();
-    environment.subscribe(snapshot, callback);
+      environment
+        .executeMutation({
+          operation,
+        })
+        .subscribe(callbacks);
 
-    environment
-      .executeMutation({
-        operation,
-      })
-      .subscribe(callbacks);
-
-    callback.mockClear();
-    subject.next({
-      data: {
-        commentDelete: {
-          deletedCommentId: commentId,
-        },
-      },
-    });
-    subject.complete();
-
-    expect(complete).toBeCalled();
-    expect(error).not.toBeCalled();
-    expect(callback.mock.calls.length).toBe(1);
-    expect(callback.mock.calls[0][0].data).toEqual({node: null});
-  });
-
-  it('executes the optimist response, and remove the given id from the store', () => {
-    const snapshot = environment.lookup(queryOperation.fragment);
-    expect(snapshot.data).toEqual({
-      node: {
-        id: commentId,
-        body: {
-          text: 'Comment',
-        },
-      },
-    });
-    const callback = jest.fn();
-    environment.subscribe(snapshot, callback);
-
-    environment
-      .executeMutation({
-        operation,
-        optimisticResponse: {
+      callback.mockClear();
+      subject.next({
+        data: {
           commentDelete: {
             deletedCommentId: commentId,
           },
         },
-      })
-      .subscribe(callbacks);
+      });
+      subject.complete();
 
-    expect(complete).not.toBeCalled();
-    expect(error).not.toBeCalled();
-    expect(callback.mock.calls.length).toBe(1);
-    expect(callback.mock.calls[0][0].data).toEqual({node: null});
-  });
-
-  it('removes different `id`s in optimistic update and the server response', () => {
-    const anotherCommentId = 'serverCommentId';
-    const anotherQueryOperation = createOperationDescriptor(CommentQuery, {
-      id: anotherCommentId,
+      expect(complete).toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(callback.mock.calls.length).toBe(1);
+      expect(callback.mock.calls[0][0].data).toEqual({node: null});
     });
-    environment.execute({operation: anotherQueryOperation}).subscribe({});
-    subject.next({
-      data: {
+
+    it('executes the optimist response, and remove the given id from the store', () => {
+      const snapshot = environment.lookup(queryOperation.fragment);
+      expect(snapshot.data).toEqual({
         node: {
-          __typename: 'Comment',
+          id: commentId,
+          body: {
+            text: 'Comment',
+          },
+        },
+      });
+      const callback = jest.fn();
+      environment.subscribe(snapshot, callback);
+
+      environment
+        .executeMutation({
+          operation,
+          optimisticResponse: {
+            commentDelete: {
+              deletedCommentId: commentId,
+            },
+          },
+        })
+        .subscribe(callbacks);
+
+      expect(complete).not.toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(callback.mock.calls.length).toBe(1);
+      expect(callback.mock.calls[0][0].data).toEqual({node: null});
+    });
+
+    it('removes different `id`s in optimistic update and the server response', () => {
+      const anotherCommentId = 'serverCommentId';
+      const anotherQueryOperation = createOperationDescriptor(CommentQuery, {
+        id: anotherCommentId,
+      });
+      environment.execute({operation: anotherQueryOperation}).subscribe({});
+      subject.next({
+        data: {
+          node: {
+            __typename: 'Comment',
+            id: anotherCommentId,
+            body: {
+              text: 'Comment 2',
+            },
+          },
+        },
+      });
+      jest.runAllTimers();
+
+      const serverSnapshot = environment.lookup(anotherQueryOperation.fragment);
+      const clientSnapshot = environment.lookup(queryOperation.fragment);
+
+      expect(serverSnapshot.data).toEqual({
+        node: {
           id: anotherCommentId,
           body: {
             text: 'Comment 2',
           },
         },
-      },
-    });
-    jest.runAllTimers();
+      });
+      const serverCallback = jest.fn();
+      const clientCallback = jest.fn();
+      environment.subscribe(serverSnapshot, serverCallback);
+      environment.subscribe(clientSnapshot, clientCallback);
 
-    const serverSnapshot = environment.lookup(anotherQueryOperation.fragment);
-    const clientSnapshot = environment.lookup(queryOperation.fragment);
+      environment
+        .executeMutation({
+          operation,
+          optimisticResponse: {
+            commentDelete: {
+              deletedCommentId: commentId,
+            },
+          },
+        })
+        .subscribe(callbacks);
 
-    expect(serverSnapshot.data).toEqual({
-      node: {
-        id: anotherCommentId,
-        body: {
-          text: 'Comment 2',
-        },
-      },
-    });
-    const serverCallback = jest.fn();
-    const clientCallback = jest.fn();
-    environment.subscribe(serverSnapshot, serverCallback);
-    environment.subscribe(clientSnapshot, clientCallback);
-
-    environment
-      .executeMutation({
-        operation,
-        optimisticResponse: {
-          commentDelete: {
-            deletedCommentId: commentId,
+      expect(complete).not.toBeCalled();
+      expect(error).not.toBeCalled();
+      // Removes `commentId`
+      expect(clientCallback.mock.calls.length).toBe(1);
+      expect(environment.lookup(queryOperation.fragment).data).toEqual({
+        node: null,
+      });
+      // Doesn't remove `serverCommentId`
+      expect(serverCallback.mock.calls.length).toBe(0);
+      expect(environment.lookup(anotherQueryOperation.fragment).data).toEqual({
+        node: {
+          id: anotherCommentId,
+          body: {
+            text: 'Comment 2',
           },
         },
-      })
-      .subscribe(callbacks);
+      });
 
-    expect(complete).not.toBeCalled();
-    expect(error).not.toBeCalled();
-    // Removes `commentId`
-    expect(clientCallback.mock.calls.length).toBe(1);
-    expect(environment.lookup(queryOperation.fragment).data).toEqual({
-      node: null,
+      clientCallback.mockClear();
+      serverCallback.mockClear();
+      subject.next({
+        data: {
+          commentDelete: {
+            deletedCommentId: anotherCommentId,
+          },
+        },
+      });
+      subject.complete();
+      // Reverts `commentId`
+      expect(clientCallback.mock.calls.length).toBe(1);
+      expect(clientCallback.mock.calls[0][0].data).toEqual({
+        node: {
+          id: commentId,
+          body: {
+            text: 'Comment',
+          },
+        },
+      });
+      // Removes `serverCommentId`
+      expect(serverCallback.mock.calls.length).toBe(1);
+      expect(serverCallback.mock.calls[0][0].data).toEqual({node: null});
     });
-    // Doesn't remove `serverCommentId`
-    expect(serverCallback.mock.calls.length).toBe(0);
-    expect(environment.lookup(anotherQueryOperation.fragment).data).toEqual({
-      node: {
+  });
+
+  describe('list of ids', () => {
+    let callbacks;
+    let commentIds;
+    let firstCommentId;
+    let secondCommentId;
+    let CommentQuery;
+    let DeleteCommentsMutation;
+    let complete;
+    let environment;
+    let error;
+    let fetch;
+    let next;
+    let operation;
+    let queryOperation;
+    let source;
+    let store;
+    let subject;
+    let variables;
+    let queryVariables;
+    let firstCommentQueryOperation;
+    let secondCommentQueryOperation;
+
+    beforeEach(() => {
+      jest.resetModules();
+      firstCommentId = 'comment-id-1';
+      secondCommentId = 'comment-id-2';
+      commentIds = [firstCommentId, secondCommentId];
+
+      ({DeleteCommentsMutation, CommentQuery} = generateAndCompile(`
+        mutation DeleteCommentsMutation($input: CommentsDeleteInput) {
+          commentsDelete(input: $input) {
+            deletedCommentIds @deleteRecord
+          }
+        }
+
+        query CommentQuery($id: ID!) {
+          node(id: $id) {
+            id
+            body {
+              text
+            }
+          }
+        }
+      `));
+      variables = {
+        input: {
+          clientMutationId: '0',
+          commentIds,
+        },
+      };
+      operation = createOperationDescriptor(DeleteCommentsMutation, variables);
+      firstCommentQueryOperation = createOperationDescriptor(CommentQuery, {
+        id: firstCommentId,
+      });
+      secondCommentQueryOperation = createOperationDescriptor(CommentQuery, {
+        id: secondCommentId,
+      });
+
+      fetch = jest.fn((_query, _variables, _cacheConfig) =>
+        RelayObservable.create(sink => {
+          subject = sink;
+        }),
+      );
+      source = RelayRecordSource.create();
+      store = new RelayModernStore(source);
+      environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(fetch),
+        store,
+      });
+      complete = jest.fn();
+      error = jest.fn();
+      next = jest.fn();
+      callbacks = {complete, error, next};
+
+      environment
+        .execute({operation: firstCommentQueryOperation})
+        .subscribe({});
+      subject.next({
+        data: {
+          node: {
+            __typename: 'Comment',
+            id: firstCommentId,
+            body: {
+              text: 'Comment 1',
+            },
+          },
+        },
+      });
+      environment
+        .execute({operation: secondCommentQueryOperation})
+        .subscribe({});
+      subject.next({
+        data: {
+          node: {
+            __typename: 'Comment',
+            id: secondCommentId,
+            body: {
+              text: 'Comment 2',
+            },
+          },
+        },
+      });
+      jest.runAllTimers();
+    });
+
+    it('commit the mutation, and remove the given ids from the store', () => {
+      const firstCommentSnapshot = environment.lookup(
+        firstCommentQueryOperation.fragment,
+      );
+      expect(firstCommentSnapshot.data).toEqual({
+        node: {
+          id: firstCommentId,
+          body: {
+            text: 'Comment 1',
+          },
+        },
+      });
+      const secondCommentSnaphsot = environment.lookup(
+        secondCommentQueryOperation.fragment,
+      );
+      expect(secondCommentSnaphsot.data).toEqual({
+        node: {
+          id: secondCommentId,
+          body: {
+            text: 'Comment 2',
+          },
+        },
+      });
+
+      const firstCallback = jest.fn();
+      const secondCallback = jest.fn();
+      environment.subscribe(firstCommentSnapshot, firstCallback);
+      environment.subscribe(firstCommentSnapshot, secondCallback);
+
+      environment
+        .executeMutation({
+          operation,
+        })
+        .subscribe(callbacks);
+
+      firstCallback.mockClear();
+      secondCallback.mockClear();
+      subject.next({
+        data: {
+          commentsDelete: {
+            deletedCommentIds: commentIds,
+          },
+        },
+      });
+      subject.complete();
+
+      expect(complete).toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(firstCallback.mock.calls.length).toBe(1);
+      expect(secondCallback.mock.calls.length).toBe(1);
+      expect(firstCallback.mock.calls[0][0].data).toEqual({node: null});
+      expect(secondCallback.mock.calls[0][0].data).toEqual({node: null});
+    });
+
+    it('executes the optimist response, and remove the given ids from the store', () => {
+      const firstCommentSnapshot = environment.lookup(
+        firstCommentQueryOperation.fragment,
+      );
+      expect(firstCommentSnapshot.data).toEqual({
+        node: {
+          id: firstCommentId,
+          body: {
+            text: 'Comment 1',
+          },
+        },
+      });
+      const secondCommentSnaphsot = environment.lookup(
+        secondCommentQueryOperation.fragment,
+      );
+      expect(secondCommentSnaphsot.data).toEqual({
+        node: {
+          id: secondCommentId,
+          body: {
+            text: 'Comment 2',
+          },
+        },
+      });
+
+      const firstCallback = jest.fn();
+      const secondCallback = jest.fn();
+      environment.subscribe(firstCommentSnapshot, firstCallback);
+      environment.subscribe(firstCommentSnapshot, secondCallback);
+
+      environment
+        .executeMutation({
+          operation,
+          optimisticResponse: {
+            commentsDelete: {
+              deletedCommentIds: commentIds,
+            },
+          },
+        })
+        .subscribe(callbacks);
+
+      expect(complete).not.toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(firstCallback.mock.calls.length).toBe(1);
+      expect(secondCallback.mock.calls.length).toBe(1);
+      expect(firstCallback.mock.calls[0][0].data).toEqual({node: null});
+      expect(secondCallback.mock.calls[0][0].data).toEqual({node: null});
+    });
+
+    it('removes different `id`s in optimistic update and the server response', () => {
+      const anotherCommentId = 'serverCommentId';
+      const anotherQueryOperation = createOperationDescriptor(CommentQuery, {
         id: anotherCommentId,
-        body: {
-          text: 'Comment 2',
+      });
+      environment.execute({operation: anotherQueryOperation}).subscribe({});
+      subject.next({
+        data: {
+          node: {
+            __typename: 'Comment',
+            id: anotherCommentId,
+            body: {
+              text: 'Comment 2',
+            },
+          },
         },
-      },
-    });
+      });
+      jest.runAllTimers();
 
-    clientCallback.mockClear();
-    serverCallback.mockClear();
-    subject.next({
-      data: {
-        commentDelete: {
-          deletedCommentId: anotherCommentId,
+      const serverSnapshot = environment.lookup(anotherQueryOperation.fragment);
+      const clientSnapshot = environment.lookup(
+        firstCommentQueryOperation.fragment,
+      );
+
+      expect(serverSnapshot.data).toEqual({
+        node: {
+          id: anotherCommentId,
+          body: {
+            text: 'Comment 2',
+          },
         },
-      },
-    });
-    subject.complete();
-    // Reverts `commentId`
-    expect(clientCallback.mock.calls.length).toBe(1);
-    expect(clientCallback.mock.calls[0][0].data).toEqual({
-      node: {
-        id: commentId,
-        body: {
-          text: 'Comment',
+      });
+      const serverCallback = jest.fn();
+      const clientCallback = jest.fn();
+      environment.subscribe(serverSnapshot, serverCallback);
+      environment.subscribe(clientSnapshot, clientCallback);
+
+      environment
+        .executeMutation({
+          operation,
+          optimisticResponse: {
+            commentsDelete: {
+              deletedCommentIds: commentIds,
+            },
+          },
+        })
+        .subscribe(callbacks);
+
+      expect(complete).not.toBeCalled();
+      expect(error).not.toBeCalled();
+      // Removes `commentId`
+      expect(clientCallback.mock.calls.length).toBe(1);
+      expect(
+        environment.lookup(firstCommentQueryOperation.fragment).data,
+      ).toEqual({
+        node: null,
+      });
+      // Doesn't remove `serverCommentId`
+      expect(serverCallback.mock.calls.length).toBe(0);
+      expect(environment.lookup(anotherQueryOperation.fragment).data).toEqual({
+        node: {
+          id: anotherCommentId,
+          body: {
+            text: 'Comment 2',
+          },
         },
-      },
+      });
+
+      clientCallback.mockClear();
+      serverCallback.mockClear();
+      subject.next({
+        data: {
+          commentsDelete: {
+            deletedCommentIds: [anotherCommentId],
+          },
+        },
+      });
+      subject.complete();
+      // Reverts `commentId`
+      expect(clientCallback.mock.calls.length).toBe(1);
+      expect(clientCallback.mock.calls[0][0].data).toEqual({
+        node: {
+          id: firstCommentId,
+          body: {
+            text: 'Comment 1',
+          },
+        },
+      });
+      // Removes `serverCommentId`
+      expect(serverCallback.mock.calls.length).toBe(1);
+      expect(serverCallback.mock.calls[0][0].data).toEqual({node: null});
     });
-    // Removes `serverCommentId`
-    expect(serverCallback.mock.calls.length).toBe(1);
-    expect(serverCallback.mock.calls[0][0].data).toEqual({node: null});
   });
 });
 

--- a/packages/relay-test-utils-internal/testschema.graphql
+++ b/packages/relay-test-utils-internal/testschema.graphql
@@ -107,6 +107,7 @@ type Mutation {
   ): ApplicationRequestDeleteAllResponsePayload
   commentCreate(input: CommentCreateInput): CommentCreateResponsePayload
   commentDelete(input: CommentDeleteInput): CommentDeleteResponsePayload
+  commentsDelete(input: CommentsDeleteInput): CommentsDeleteResponsePayload
   feedbackLike(input: FeedbackLikeInput): FeedbackLikeResponsePayload
   feedbackLikeStrict(
     input: FeedbackLikeInputStrict!
@@ -165,6 +166,11 @@ input CommentCreateSubscriptionInput {
 input CommentDeleteInput {
   clientMutationId: String
   commentId: ID
+}
+
+input CommentsDeleteInput {
+  clientMutationId: String
+  commentIds: [ID]
 }
 
 input FeedbackLikeInput {
@@ -309,6 +315,12 @@ type CommentCreateResponsePayload {
 type CommentDeleteResponsePayload {
   clientMutationId: String
   deletedCommentId: ID
+  feedback: Feedback
+}
+
+type CommentsDeleteResponsePayload {
+  clientMutationId: String
+  deletedCommentIds: [ID]
   feedback: Feedback
 }
 


### PR DESCRIPTION
This adds support for using the new `@deleteRecord` directive on a list of `ID` in addition to a single `ID`.

There's a few things around the implementation I'm looking for guidance on before this is ready for a real review.