### PR TITLE
Bump immutable from 3.7.6 to 3.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "gulp-once": "2.0.3",
     "gulp-rename": "^2.0.0",
     "gulp-util": "3.0.8",
-    "immutable": "~3.7.6",
+    "immutable": "3.8.2",
     "jest": "^24.8.0",
     "nullthrows": "^1.1.1",
     "prettier": "1.19.1",

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -26,7 +26,7 @@
     "fb-watchman": "^2.0.0",
     "fbjs": "^1.0.0",
     "glob": "^7.1.1",
-    "immutable": "~3.7.6",
+    "immutable": "3.8.2",
     "nullthrows": "^1.1.1",
     "relay-runtime": "10.0.0",
     "signedsource": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3528,10 +3528,10 @@ ignore@^4.0.2:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-immutable@~3.7.6:
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
-  integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
+immutable@3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This changes the license of immutable to MIT. This is the changelog

- [3.8.0](https://github.com/immutable-js/immutable-js/releases/tag/3.8.0)
- [3.8.1](https://github.com/immutable-js/immutable-js/releases/tag/3.8.1)
- [3.8.2](https://github.com/immutable-js/immutable-js/releases/tag/3.8.2)