### PR TITLE
Remove unused promise-polyfill dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "jest": "^24.8.0",
     "nullthrows": "^1.1.1",
     "prettier": "1.19.1",
-    "promise-polyfill": "6.1.0",
     "react": "16.13.1",
     "react-refresh": "^0.4.0",
     "react-test-renderer": "16.13.1",

--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -29,7 +29,6 @@ module.exports = function(options) {
     {
       map: {
         ErrorUtils: 'fbjs/lib/ErrorUtils',
-        Promise: 'promise-polyfill',
         areEqual: 'fbjs/lib/areEqual',
         invariant: 'fbjs/lib/invariant',
         mapObject: 'fbjs/lib/mapObject',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5636,11 +5636,6 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise-polyfill@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
-  integrity sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=
-
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"


### PR DESCRIPTION
I think we used to auto-require `Promise` when `Promise` was used in the
code and that would then be rewritten to `require('promise-polyfill')`.
We no longer ship a Promise implementation, so I think this can go now.

Test Plan:
yarn, then grep over `dist/`.