### PR TITLE
Remove link to GraphCool from prerequisites page

### DIFF
--- a/docs/Introduction-Prerequisites.md
+++ b/docs/Introduction-Prerequisites.md
@@ -30,4 +30,3 @@ GraphQL is designed to support a wide range of data access patterns. In order to
 Any server can be taught to load a schema and speak GraphQL. Our [examples](https://github.com/relayjs/relay-examples) use Express.
 
 - **[express-graphql](https://github.com/graphql/express-graphql)** on [npm](https://www.npmjs.com/package/express-graphql)
-- **[Graphcool](https://www.graph.cool/)** ([Quickstart tutorial](https://www.graph.cool/docs/quickstart/))


### PR DESCRIPTION
See GraphCool sunset notice on July 1st, 2020:
https://www.graph.cool/sunset-notice

![image](https://user-images.githubusercontent.com/127199/91453532-b45a9480-e834-11ea-83f9-67a877a53c45.png)
