### PR TITLE
Remove unused fetchGraphQL import in App.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -279,11 +279,20 @@ const copyRelayExperimental = [
       .src(INCLUDE_GLOBS, {
         cwd: path.join(PACKAGES, 'relay-experimental'),
       })
-      .pipe(once())
       .pipe(babel(babelOptions))
-      .pipe(gulp.dest(path.join(DIST, 'react-relay', 'lib', 'relay-experimental')));
-  }
-]
+      .pipe(
+        gulp.dest(path.join(DIST, 'react-relay', 'lib', 'relay-experimental')),
+      );
+  },
+  function modulesTask() {
+    return gulp
+      .src(INCLUDE_GLOBS, {
+        cwd: path.join(PACKAGES, 'relay-experimental'),
+      })
+      .pipe(rename({extname: '.js.flow'}))
+      .pipe(gulp.dest(path.join(DIST, 'react-relay', 'relay-experimental')));
+  },
+];
 
 const copyFilesTasks = [];
 builds.forEach(build => {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react": "16.13.1",
     "react-refresh": "^0.4.0",
     "react-test-renderer": "16.13.1",
+    "scheduler": "^0.19.1",
     "signedsource": "^1.0.0",
     "webpack": "^4.30.0",
     "webpack-stream": "^5.1.1",

--- a/packages/react-relay/hooks.js
+++ b/packages/react-relay/hooks.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+const EntryPointContainer = require('./relay-experimental/EntryPointContainer.react');
+const MatchContainer = require('./relay-experimental/MatchContainer');
+const ProfilerContext = require('./relay-experimental/ProfilerContext');
+const RelayEnvironmentProvider = require('./relay-experimental/RelayEnvironmentProvider');
+
+const fetchQuery = require('./relay-experimental/fetchQuery');
+const loadQuery = require('./relay-experimental/loadQuery');
+
+const loadEntryPoint = require('./relay-experimental/loadEntryPoint');
+
+const useBlockingPaginationFragment = require('./relay-experimental/useBlockingPaginationFragment');
+const useEntryPointLoader = require('./relay-experimental/useEntryPointLoader');
+const useFragment = require('./relay-experimental/useFragment');
+const useLazyLoadQuery = require('./relay-experimental/useLazyLoadQuery');
+const useMutation = require('./relay-experimental/useMutation');
+const usePaginationFragment = require('./relay-experimental/usePaginationFragment');
+const usePreloadedQuery = require('./relay-experimental/usePreloadedQuery');
+const useQueryLoader = require('./relay-experimental/useQueryLoader');
+const useRefetchableFragment = require('./relay-experimental/useRefetchableFragment');
+const useRelayEnvironment = require('./relay-experimental/useRelayEnvironment');
+const useSubscribeToInvalidationState = require('./relay-experimental/useSubscribeToInvalidationState')
+const useSubscription = require('./relay-experimental/useSubscription');
+
+const {graphql} = require('relay-runtime');
+
+export type {
+  LoadMoreFn,
+  RefetchFn,
+  RefetchFnDynamic,
+} from 'relay-experimental';
+
+export type {
+  FetchPolicy,
+  RenderPolicy,
+} from 'relay-runtime';
+
+/**
+ * The public interface for Relay Hooks
+ */
+module.exports = {
+  EntryPointContainer: EntryPointContainer,
+  MatchContainer: MatchContainer,
+  ProfilerContext: ProfilerContext,
+  RelayEnvironmentProvider: RelayEnvironmentProvider,
+
+  fetchQuery: fetchQuery,
+  loadEntryPoint: loadEntryPoint,
+  loadQuery: loadQuery,
+
+  graphql: graphql,
+  useBlockingPaginationFragment: useBlockingPaginationFragment,
+  useEntryPointLoader: useEntryPointLoader,
+  useFragment: useFragment,
+  useLazyLoadQuery: useLazyLoadQuery,
+  useMutation: useMutation,
+  usePaginationFragment: usePaginationFragment,
+  usePreloadedQuery: usePreloadedQuery,
+  useQueryLoader: useQueryLoader,
+  useRefetchableFragment: useRefetchableFragment,
+  useRelayEnvironment: useRelayEnvironment,
+  useSubscribeToInvalidationState: useSubscribeToInvalidationState,
+  useSubscription: useSubscription,
+};

--- a/packages/react-relay/hooks.js
+++ b/packages/react-relay/hooks.js
@@ -39,7 +39,7 @@ export type {
   LoadMoreFn,
   RefetchFn,
   RefetchFnDynamic,
-} from 'relay-experimental';
+} from './relay-experimental';
 
 export type {
   FetchPolicy,

--- a/packages/react-relay/package.json
+++ b/packages/react-relay/package.json
@@ -15,7 +15,8 @@
     "@babel/runtime": "^7.0.0",
     "fbjs": "^1.0.0",
     "nullthrows": "^1.1.1",
-    "relay-runtime": "10.0.1"
+    "relay-runtime": "10.0.1",
+    "scheduler": "^0.19.1"
   },
   "peerDependencies": {
     "react": "^16.9.0"

--- a/website/versioned_docs/version-experimental/RelayHooks-StepByStep.md
+++ b/website/versioned_docs/version-experimental/RelayHooks-StepByStep.md
@@ -227,7 +227,6 @@ Now that Relay is installed and configured we can change `App.js` to use it inst
 ```javascript
 import React from 'react';
 import './App.css';
-import fetchGraphQL from './fetchGraphQL';
 import graphql from 'babel-plugin-relay/macro';
 import {
   RelayEnvironmentProvider,


### PR DESCRIPTION
We no longer need `fetchGraphQL` in `App.js` (abstracted in `RelayEnvironment.js`)