### PR TITLE
implement deleteEdge store updater directive

### DIFF
--- a/packages/relay-compiler/codegen/NormalizationCodeGenerator.js
+++ b/packages/relay-compiler/codegen/NormalizationCodeGenerator.js
@@ -384,13 +384,7 @@ function generateScalarField(node): Array<NormalizationSelection> {
   const handles =
     (node.handles &&
       node.handles.map(handle => {
-        if (handle.dynamicKey != null) {
-          throw createUserError(
-            'Dynamic key values are not supported on scalar fields.',
-            [handle.dynamicKey.loc],
-          );
-        }
-        return {
+        let handleNode = {
           alias: node.alias === node.name ? null : node.alias,
           args: generateArgs(node.args),
           filters: handle.filters,
@@ -399,6 +393,23 @@ function generateScalarField(node): Array<NormalizationSelection> {
           kind: 'ScalarHandle',
           name: node.name,
         };
+
+        if (handle.dynamicKey != null) {
+          throw createUserError(
+            'Dynamic key values are not supported on scalar fields.',
+            [handle.dynamicKey.loc],
+          );
+        }
+        if (handle.handleArgs != null) {
+          const handleArgs = generateArgs(handle.handleArgs);
+          if (handleArgs != null) {
+            handleNode = {
+              ...handleNode,
+              handleArgs,
+            };
+          }
+        }
+        return handleNode;
       })) ||
     [];
   let field = {

--- a/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
+++ b/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
@@ -6098,6 +6098,230 @@ Fragment {
 }
 `;
 
+exports[`compileRelayArtifacts matches expected output: delete-edge.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+mutation CommentDeleteMutation($input: CommentDeleteInput, $connections: [String!]!) {
+  commentDelete(input: $input) {
+    deletedCommentId @deleteEdge(connections: $connections)
+  }
+}
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+Request {
+  fragment: Fragment {
+    argumentDefinitions: [
+      LocalArgument {
+        defaultValue: null,
+        name: "connections",
+      },
+      LocalArgument {
+        defaultValue: null,
+        name: "input",
+      },
+    ],
+    metadata: null,
+    name: "CommentDeleteMutation",
+    selections: [
+      LinkedField {
+        alias: null,
+        args: [
+          Variable {
+            name: "input",
+            variableName: "input",
+          },
+        ],
+        concreteType: "CommentDeleteResponsePayload",
+        name: "commentDelete",
+        plural: false,
+        selections: [
+          ScalarField {
+            alias: null,
+            args: null,
+            name: "deletedCommentId",
+            storageKey: null,
+          },
+        ],
+        storageKey: null,
+      },
+    ],
+    type: "Mutation",
+    abstractKey: null,
+  },
+  operation: Operation {
+    argumentDefinitions: [
+      LocalArgument {
+        defaultValue: null,
+        name: "input",
+      },
+      LocalArgument {
+        defaultValue: null,
+        name: "connections",
+      },
+    ],
+    name: "CommentDeleteMutation",
+    selections: [
+      LinkedField {
+        alias: null,
+        args: [
+          Variable {
+            name: "input",
+            variableName: "input",
+          },
+        ],
+        concreteType: "CommentDeleteResponsePayload",
+        name: "commentDelete",
+        plural: false,
+        selections: [
+          ScalarField {
+            alias: null,
+            args: null,
+            name: "deletedCommentId",
+            storageKey: null,
+          },
+          ScalarHandle {
+            alias: null,
+            args: null,
+            filters: null,
+            handle: "deleteEdge",
+            key: "",
+            name: "deletedCommentId",
+            handleArgs: [
+              Variable {
+                name: "connections",
+                variableName: "connections",
+              },
+            ],
+          },
+        ],
+        storageKey: null,
+      },
+    ],
+  },
+}
+
+QUERY:
+
+mutation CommentDeleteMutation(
+  $input: CommentDeleteInput
+) {
+  commentDelete(input: $input) {
+    deletedCommentId
+  }
+}
+
+`;
+
+exports[`compileRelayArtifacts matches expected output: delete-edge-plural.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+mutation CommentsDeleteMutation($input: CommentsDeleteInput, $connections: [String!]!) {
+  commentsDelete(input: $input) {
+    deletedCommentIds @deleteEdge(connections: $connections)
+  }
+}
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+Request {
+  fragment: Fragment {
+    argumentDefinitions: [
+      LocalArgument {
+        defaultValue: null,
+        name: "connections",
+      },
+      LocalArgument {
+        defaultValue: null,
+        name: "input",
+      },
+    ],
+    metadata: null,
+    name: "CommentsDeleteMutation",
+    selections: [
+      LinkedField {
+        alias: null,
+        args: [
+          Variable {
+            name: "input",
+            variableName: "input",
+          },
+        ],
+        concreteType: "CommentsDeleteResponsePayload",
+        name: "commentsDelete",
+        plural: false,
+        selections: [
+          ScalarField {
+            alias: null,
+            args: null,
+            name: "deletedCommentIds",
+            storageKey: null,
+          },
+        ],
+        storageKey: null,
+      },
+    ],
+    type: "Mutation",
+    abstractKey: null,
+  },
+  operation: Operation {
+    argumentDefinitions: [
+      LocalArgument {
+        defaultValue: null,
+        name: "input",
+      },
+      LocalArgument {
+        defaultValue: null,
+        name: "connections",
+      },
+    ],
+    name: "CommentsDeleteMutation",
+    selections: [
+      LinkedField {
+        alias: null,
+        args: [
+          Variable {
+            name: "input",
+            variableName: "input",
+          },
+        ],
+        concreteType: "CommentsDeleteResponsePayload",
+        name: "commentsDelete",
+        plural: false,
+        selections: [
+          ScalarField {
+            alias: null,
+            args: null,
+            name: "deletedCommentIds",
+            storageKey: null,
+          },
+          ScalarHandle {
+            alias: null,
+            args: null,
+            filters: null,
+            handle: "deleteEdge",
+            key: "",
+            name: "deletedCommentIds",
+            handleArgs: [
+              Variable {
+                name: "connections",
+                variableName: "connections",
+              },
+            ],
+          },
+        ],
+        storageKey: null,
+      },
+    ],
+  },
+}
+
+QUERY:
+
+mutation CommentsDeleteMutation(
+  $input: CommentsDeleteInput
+) {
+  commentsDelete(input: $input) {
+    deletedCommentIds
+  }
+}
+
+`;
+
 exports[`compileRelayArtifacts matches expected output: explicit-null-argument.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 query Test {

--- a/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/delete-edge-plural.graphql
+++ b/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/delete-edge-plural.graphql
@@ -1,0 +1,5 @@
+mutation CommentsDeleteMutation($input: CommentsDeleteInput, $connections: [String!]!) {
+  commentsDelete(input: $input) {
+    deletedCommentIds @deleteEdge(connections: $connections)
+  }
+}

--- a/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/delete-edge.graphql
+++ b/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/delete-edge.graphql
@@ -1,0 +1,5 @@
+mutation CommentDeleteMutation($input: CommentDeleteInput, $connections: [String!]!) {
+  commentDelete(input: $input) {
+    deletedCommentId @deleteEdge(connections: $connections)
+  }
+}

--- a/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
+++ b/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
@@ -18,12 +18,14 @@ const {createUserError} = require('../core/CompilerError');
 const {ConnectionInterface} = require('relay-runtime');
 
 const DELETE_RECORD = 'deleteRecord';
+const DELETE_EDGE = 'deleteEdge';
 const APPEND_EDGE = 'appendEdge';
 const PREPEND_EDGE = 'prependEdge';
 const APPEND_NODE = 'appendNode';
 const PREPEND_NODE = 'prependNode';
 const EDGE_LINKED_FIELD_DIRECTIVES = [APPEND_EDGE, PREPEND_EDGE];
 const NODE_LINKED_FIELD_DIRECTIVES = [APPEND_NODE, PREPEND_NODE];
+const SCALAR_FIELD_DIRECTIVES = [DELETE_RECORD, DELETE_EDGE];
 const LINKED_FIELD_DIRECTIVES = [
   ...EDGE_LINKED_FIELD_DIRECTIVES,
   ...NODE_LINKED_FIELD_DIRECTIVES,
@@ -31,6 +33,9 @@ const LINKED_FIELD_DIRECTIVES = [
 
 const SCHEMA_EXTENSION = `
   directive @${DELETE_RECORD} on FIELD
+  directive @${DELETE_EDGE}(
+    connections: [String!]!
+  ) on FIELD
   directive @${APPEND_EDGE}(
     connections: [String!]!
   ) on FIELD
@@ -73,34 +78,43 @@ function visitScalarField(field: ScalarField): ScalarField {
       [linkedFieldDirective.loc],
     );
   }
-  const deleteDirective = field.directives.find(
+  const deleteNodeDirective = field.directives.find(
     directive => directive.name === DELETE_RECORD,
   );
-  if (deleteDirective == null) {
+  const deleteEdgeDirective = field.directives.find(
+    directive => directive.name === DELETE_EDGE,
+  );
+  const targetDirective = deleteNodeDirective ?? deleteEdgeDirective;
+  if (targetDirective == null) {
     return field;
   }
+
   const schema = this.getContext().getSchema();
 
   if (!schema.isId(schema.getRawType(field.type))) {
     throw createUserError(
-      `Invalid use of @${DELETE_RECORD} on field '${
+      `Invalid use of @${targetDirective.name} on field '${
         field.name
       }'. Expected field to return an ID or list of ID values, got ${schema.getTypeString(
         field.type,
       )}.`,
-      [deleteDirective.loc],
+      [targetDirective.loc],
     );
   }
+  const connectionsArg = targetDirective.args.find(
+    arg => arg.name === 'connections',
+  );
   const handle: Handle = {
-    name: DELETE_RECORD,
+    name: targetDirective.name,
     key: '',
     dynamicKey: null,
     filters: null,
+    handleArgs: connectionsArg ? [connectionsArg] : undefined,
   };
   return {
     ...field,
     directives: field.directives.filter(
-      directive => directive !== deleteDirective,
+      directive => directive !== targetDirective,
     ),
     handles: field.handles ? [...field.handles, handle] : [handle],
   };

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
@@ -147,6 +147,68 @@ Source: GraphQL request (10:9)
 
 `;
 
+exports[`matches expected output: delete-edge-from-connection.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+mutation CommentDeleteMutation($input: CommentDeleteInput, $connections: [String!]!) {
+  commentDelete(input: $input) {
+    deletedCommentId @deleteEdge(connections: $connections)
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+mutation CommentDeleteMutation(
+  $input: CommentDeleteInput
+  $connections: [String!]!
+) {
+  commentDelete(input: $input) {
+    deletedCommentId @__clientField(handle: "deleteEdge", handleArgs: (connections: $connections))
+  }
+}
+
+`;
+
+exports[`matches expected output: delete-edge-from-connection-on-unspported-type.invalid.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+# expected-to-throw
+mutation CommentDeleteMutation($input: CommentDeleteInput, $connections: [String!]!) {
+  commentDelete(input: $input) {
+    __typename @deleteEdge(connections: $connections)
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+THROWN EXCEPTION:
+
+Invalid use of @deleteEdge on field '__typename'. Expected field to return an ID or list of ID values, got String!.
+
+Source: GraphQL request (4:16)
+3:   commentDelete(input: $input) {
+4:     __typename @deleteEdge(connections: $connections)
+                  ^
+5:   }
+
+`;
+
+exports[`matches expected output: delete-edge-from-connection-plural.graphql 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+mutation CommentsDeleteMutation($input: CommentsDeleteInput, $connections: [String!]!) {
+  commentsDelete(input: $input) {
+    deletedCommentIds @deleteEdge(connections: $connections)
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+mutation CommentsDeleteMutation(
+  $input: CommentsDeleteInput
+  $connections: [String!]!
+) {
+  commentsDelete(input: $input) {
+    deletedCommentIds @__clientField(handle: "deleteEdge", handleArgs: (connections: $connections))
+  }
+}
+
+`;
+
 exports[`matches expected output: delete-from-store.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentDeleteMutation($input: CommentDeleteInput) {

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection-on-unspported-type.invalid.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection-on-unspported-type.invalid.graphql
@@ -1,0 +1,6 @@
+# expected-to-throw
+mutation CommentDeleteMutation($input: CommentDeleteInput, $connections: [String!]!) {
+  commentDelete(input: $input) {
+    __typename @deleteEdge(connections: $connections)
+  }
+}

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection-plural.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection-plural.graphql
@@ -1,0 +1,5 @@
+mutation CommentsDeleteMutation($input: CommentsDeleteInput, $connections: [String!]!) {
+  commentsDelete(input: $input) {
+    deletedCommentIds @deleteEdge(connections: $connections)
+  }
+}

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection.graphql
@@ -1,0 +1,5 @@
+mutation CommentDeleteMutation($input: CommentDeleteInput, $connections: [String!]!) {
+  commentDelete(input: $input) {
+    deletedCommentId @deleteEdge(connections: $connections)
+  }
+}

--- a/packages/relay-runtime/handlers/RelayDefaultHandlerProvider.js
+++ b/packages/relay-runtime/handlers/RelayDefaultHandlerProvider.js
@@ -26,6 +26,8 @@ function RelayDefaultHandlerProvider(handle: string): Handler {
       return ConnectionHandler;
     case 'deleteRecord':
       return MutationHandlers.DeleteRecordHandler;
+    case 'deleteEdge':
+      return MutationHandlers.DeleteEdgeHandler;
     case 'appendEdge':
       return MutationHandlers.AppendEdgeHandler;
     case 'prependEdge':

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
@@ -577,8 +577,12 @@ describe('connection edge mutations', () => {
   let store;
   let AppendCommentMutation;
   let PrependCommentMutation;
+  let DeleteCommentMutation;
+  let DeleteCommentsMutation;
   let appendOperation;
   let prependOperation;
+  let deleteOperation;
+  let deletePluralOperation;
   const clientID =
     'client:<feedbackid>:__FeedbackFragment_comments_connection(orderby:"date")';
 
@@ -591,6 +595,8 @@ describe('connection edge mutations', () => {
       FeedbackQuery: query,
       AppendCommentMutation,
       PrependCommentMutation,
+      DeleteCommentMutation,
+      DeleteCommentsMutation,
     } = generateAndCompile(`
       query FeedbackQuery($id: ID!) {
         node(id: $id) {
@@ -635,6 +641,24 @@ describe('connection edge mutations', () => {
           }
         }
       }
+
+      mutation DeleteCommentMutation(
+        $connections: [String!]!
+        $input: CommentDeleteInput
+      ) {
+        commentDelete(input: $input) {
+          deletedCommentId @deleteEdge(connections: $connections)
+        }
+      }
+
+      mutation DeleteCommentsMutation(
+        $connections: [String!]!
+        $input: CommentsDeleteInput
+      ) {
+        commentsDelete(input: $input) {
+          deletedCommentIds @deleteEdge(connections: $connections)
+        }
+      }
     `));
     const variables = {
       id: '<feedbackid>',
@@ -645,6 +669,14 @@ describe('connection edge mutations', () => {
       input: {},
     });
     prependOperation = createOperationDescriptor(PrependCommentMutation, {
+      connections: [clientID],
+      input: {},
+    });
+    deleteOperation = createOperationDescriptor(DeleteCommentMutation, {
+      connections: [clientID],
+      input: {},
+    });
+    deletePluralOperation = createOperationDescriptor(DeleteCommentsMutation, {
       connections: [clientID],
       input: {},
     });
@@ -729,207 +761,275 @@ describe('connection edge mutations', () => {
     error.mockClear();
   });
 
-  it('commits the mutation and inserts comment edges into the connection', () => {
-    const snapshot = environment.lookup(operation.fragment);
-    const callback = jest.fn();
-    environment.subscribe(snapshot, callback);
+  describe('append and prepend edges', () => {
+    it('commits the mutation and inserts comment edges into the connection', () => {
+      const snapshot = environment.lookup(operation.fragment);
+      const callback = jest.fn();
+      environment.subscribe(snapshot, callback);
 
-    environment
-      .executeMutation({
-        operation: appendOperation,
-      })
-      .subscribe(callbacks);
+      environment
+        .executeMutation({
+          operation: appendOperation,
+        })
+        .subscribe(callbacks);
 
-    callback.mockClear();
-    subject.next({
-      data: {
-        commentCreate: {
-          feedbackCommentEdge: {
-            cursor: 'cursor-append',
-            node: {
-              __typename: 'Comment',
-              id: 'node-append',
-            },
-          },
-        },
-      },
-    });
-    subject.complete();
-
-    expect(complete).toBeCalled();
-    expect(error).not.toBeCalled();
-    expect(callback.mock.calls.length).toBe(1);
-    // $FlowExpectedError[incompatible-use]
-    expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
-      {
-        cursor: 'cursor-1',
-        node: {
-          __typename: 'Comment',
-          id: 'node-1',
-        },
-      },
-      {
-        cursor: 'cursor-2',
-        node: {
-          __typename: 'Comment',
-          id: 'node-2',
-        },
-      },
-      {
-        cursor: 'cursor-append',
-        node: {
-          __typename: 'Comment',
-          id: 'node-append',
-        },
-      },
-    ]);
-
-    environment
-      .executeMutation({
-        operation: prependOperation,
-      })
-      .subscribe(callbacks);
-
-    callback.mockClear();
-    subject.next({
-      data: {
-        commentCreate: {
-          feedbackCommentEdge: {
-            cursor: 'cursor-prepend',
-            node: {
-              __typename: 'Comment',
-              id: 'node-prepend',
-            },
-          },
-        },
-      },
-    });
-    subject.complete();
-    expect(callback.mock.calls.length).toBe(1);
-    // $FlowExpectedError[incompatible-use]
-    expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
-      {
-        cursor: 'cursor-prepend',
-        node: {
-          __typename: 'Comment',
-          id: 'node-prepend',
-        },
-      },
-      {
-        cursor: 'cursor-1',
-        node: {
-          __typename: 'Comment',
-          id: 'node-1',
-        },
-      },
-      {
-        cursor: 'cursor-2',
-        node: {
-          __typename: 'Comment',
-          id: 'node-2',
-        },
-      },
-      {
-        cursor: 'cursor-append',
-        node: {
-          __typename: 'Comment',
-          id: 'node-append',
-        },
-      },
-    ]);
-  });
-
-  it('inserts an comment edge during optmistic update, and reverts and inserts new edge when server payload resolves', () => {
-    const snapshot = environment.lookup(operation.fragment);
-    const callback = jest.fn();
-    environment.subscribe(snapshot, callback);
-
-    environment
-      .executeMutation({
-        operation: appendOperation,
-        optimisticResponse: {
+      callback.mockClear();
+      subject.next({
+        data: {
           commentCreate: {
             feedbackCommentEdge: {
-              cursor: 'cursor-optimistic-append',
+              cursor: 'cursor-append',
               node: {
                 __typename: 'Comment',
-                id: 'node-optimistic-append',
+                id: 'node-append',
               },
             },
           },
         },
-      })
-      .subscribe(callbacks);
+      });
+      subject.complete();
 
-    expect(callback.mock.calls.length).toBe(1);
-    // $FlowExpectedError[incompatible-use]
-    expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
-      {
-        cursor: 'cursor-1',
-        node: {
-          __typename: 'Comment',
-          id: 'node-1',
+      expect(complete).toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(callback.mock.calls.length).toBe(1);
+      // $FlowExpectedError[incompatible-use]
+      expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
+        {
+          cursor: 'cursor-1',
+          node: {
+            __typename: 'Comment',
+            id: 'node-1',
+          },
         },
-      },
-      {
-        cursor: 'cursor-2',
-        node: {
-          __typename: 'Comment',
-          id: 'node-2',
+        {
+          cursor: 'cursor-2',
+          node: {
+            __typename: 'Comment',
+            id: 'node-2',
+          },
         },
-      },
-      {
-        cursor: 'cursor-optimistic-append',
-        node: {
-          __typename: 'Comment',
-          id: 'node-optimistic-append',
+        {
+          cursor: 'cursor-append',
+          node: {
+            __typename: 'Comment',
+            id: 'node-append',
+          },
         },
-      },
-    ]);
+      ]);
 
-    callback.mockClear();
-    subject.next({
-      data: {
-        commentCreate: {
-          feedbackCommentEdge: {
-            cursor: 'cursor-append',
-            node: {
-              __typename: 'Comment',
-              id: 'node-append',
+      environment
+        .executeMutation({
+          operation: prependOperation,
+        })
+        .subscribe(callbacks);
+
+      callback.mockClear();
+      subject.next({
+        data: {
+          commentCreate: {
+            feedbackCommentEdge: {
+              cursor: 'cursor-prepend',
+              node: {
+                __typename: 'Comment',
+                id: 'node-prepend',
+              },
             },
           },
         },
-      },
+      });
+      subject.complete();
+      expect(callback.mock.calls.length).toBe(1);
+      // $FlowExpectedError[incompatible-use]
+      expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
+        {
+          cursor: 'cursor-prepend',
+          node: {
+            __typename: 'Comment',
+            id: 'node-prepend',
+          },
+        },
+        {
+          cursor: 'cursor-1',
+          node: {
+            __typename: 'Comment',
+            id: 'node-1',
+          },
+        },
+        {
+          cursor: 'cursor-2',
+          node: {
+            __typename: 'Comment',
+            id: 'node-2',
+          },
+        },
+        {
+          cursor: 'cursor-append',
+          node: {
+            __typename: 'Comment',
+            id: 'node-append',
+          },
+        },
+      ]);
     });
-    subject.complete();
 
-    expect(complete).toBeCalled();
-    expect(error).not.toBeCalled();
-    expect(callback.mock.calls.length).toBe(1);
-    // $FlowExpectedError[incompatible-use]
-    expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
-      {
-        cursor: 'cursor-1',
-        node: {
-          __typename: 'Comment',
-          id: 'node-1',
+    it('inserts an comment edge during optmistic update, and reverts and inserts new edge when server payload resolves', () => {
+      const snapshot = environment.lookup(operation.fragment);
+      const callback = jest.fn();
+      environment.subscribe(snapshot, callback);
+
+      environment
+        .executeMutation({
+          operation: appendOperation,
+          optimisticResponse: {
+            commentCreate: {
+              feedbackCommentEdge: {
+                cursor: 'cursor-optimistic-append',
+                node: {
+                  __typename: 'Comment',
+                  id: 'node-optimistic-append',
+                },
+              },
+            },
+          },
+        })
+        .subscribe(callbacks);
+
+      expect(callback.mock.calls.length).toBe(1);
+      // $FlowExpectedError[incompatible-use]
+      expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
+        {
+          cursor: 'cursor-1',
+          node: {
+            __typename: 'Comment',
+            id: 'node-1',
+          },
         },
-      },
-      {
-        cursor: 'cursor-2',
-        node: {
-          __typename: 'Comment',
-          id: 'node-2',
+        {
+          cursor: 'cursor-2',
+          node: {
+            __typename: 'Comment',
+            id: 'node-2',
+          },
         },
-      },
-      {
-        cursor: 'cursor-append',
-        node: {
-          __typename: 'Comment',
-          id: 'node-append',
+        {
+          cursor: 'cursor-optimistic-append',
+          node: {
+            __typename: 'Comment',
+            id: 'node-optimistic-append',
+          },
         },
-      },
-    ]);
+      ]);
+
+      callback.mockClear();
+      subject.next({
+        data: {
+          commentCreate: {
+            feedbackCommentEdge: {
+              cursor: 'cursor-append',
+              node: {
+                __typename: 'Comment',
+                id: 'node-append',
+              },
+            },
+          },
+        },
+      });
+      subject.complete();
+
+      expect(complete).toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(callback.mock.calls.length).toBe(1);
+      // $FlowExpectedError[incompatible-use]
+      expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
+        {
+          cursor: 'cursor-1',
+          node: {
+            __typename: 'Comment',
+            id: 'node-1',
+          },
+        },
+        {
+          cursor: 'cursor-2',
+          node: {
+            __typename: 'Comment',
+            id: 'node-2',
+          },
+        },
+        {
+          cursor: 'cursor-append',
+          node: {
+            __typename: 'Comment',
+            id: 'node-append',
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('delete edges', () => {
+    it('commits the mutation and deletes comment edges from the connection from a single id', () => {
+      const snapshot = environment.lookup(operation.fragment);
+      const callback = jest.fn();
+      environment.subscribe(snapshot, callback);
+
+      environment
+        .executeMutation({
+          operation: deleteOperation,
+        })
+        .subscribe(callbacks);
+
+      callback.mockClear();
+      subject.next({
+        data: {
+          commentDelete: {
+            deletedCommentId: 'node-1',
+          },
+        },
+      });
+      subject.complete();
+
+      expect(complete).toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(callback.mock.calls.length).toBe(1);
+      // $FlowExpectedError[incompatible-use]
+      expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
+        {
+          cursor: 'cursor-2',
+          node: {
+            __typename: 'Comment',
+            id: 'node-2',
+          },
+        },
+      ]);
+    });
+
+    it('commits the mutation and deletes comment edges from the connection from a list of ids', () => {
+      const snapshot = environment.lookup(operation.fragment);
+      const callback = jest.fn();
+      environment.subscribe(snapshot, callback);
+
+      environment
+        .executeMutation({
+          operation: deletePluralOperation,
+        })
+        .subscribe(callbacks);
+
+      callback.mockClear();
+      subject.next({
+        data: {
+          commentsDelete: {
+            deletedCommentIds: ['node-1', 'node-2'],
+          },
+        },
+      });
+      subject.complete();
+
+      expect(complete).toBeCalled();
+      expect(error).not.toBeCalled();
+      expect(callback.mock.calls.length).toBe(1);
+      // $FlowExpectedError[incompatible-use]
+      expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([]);
+    });
   });
 });
 

--- a/packages/relay-runtime/util/NormalizationNode.js
+++ b/packages/relay-runtime/util/NormalizationNode.js
@@ -52,6 +52,7 @@ export type NormalizationScalarHandle = {|
   // NOTE: this property is optional because it's expected to be rarely used
   +dynamicKey?: ?NormalizationArgument,
   +filters: ?$ReadOnlyArray<string>,
+  +handleArgs?: $ReadOnlyArray<NormalizationArgument>,
 |};
 
 export type NormalizationArgument =


### PR DESCRIPTION
_This supersedes https://github.com/facebook/relay/pull/3148 which I've now closed._

This implements a new declarative for updating the store declaratively after mutations called `@deleteEdge`. As the name hints at, this particular directive allows you to remove a node's edge from the provided connections. Please note that this directive does not _delete the node_, only edge(s) for the node. There's `@deleteRecord` already for deleting a record, which can be combined with this directive.

It's intended to be used like this:

```
mutation DeleteComment($input: DeleteCommentInput!, $connections: [String!]!) {
  deleteComment(input: $input) {
    deletedCommentId @deleteEdge(connections: $connections)
    # This will delete any edge for the node with id `deletedCommentId` from the 
    # connections provided through `$connections`
  }
}
```

It works for single IDs (as demonstrated above) as well as a list of IDs.
