### PR TITLE
Fix loadQuery export

### DIFF
--- a/packages/react-relay/hooks.js
+++ b/packages/react-relay/hooks.js
@@ -16,7 +16,7 @@ const ProfilerContext = require('./relay-experimental/ProfilerContext');
 const RelayEnvironmentProvider = require('./relay-experimental/RelayEnvironmentProvider');
 
 const fetchQuery = require('./relay-experimental/fetchQuery');
-const loadQuery = require('./relay-experimental/loadQuery');
+const {loadQuery} = require('./relay-experimental/loadQuery');
 
 const loadEntryPoint = require('./relay-experimental/loadEntryPoint');
 

--- a/packages/react-relay/hooks.js
+++ b/packages/react-relay/hooks.js
@@ -30,7 +30,7 @@ const usePreloadedQuery = require('./relay-experimental/usePreloadedQuery');
 const useQueryLoader = require('./relay-experimental/useQueryLoader');
 const useRefetchableFragment = require('./relay-experimental/useRefetchableFragment');
 const useRelayEnvironment = require('./relay-experimental/useRelayEnvironment');
-const useSubscribeToInvalidationState = require('./relay-experimental/useSubscribeToInvalidationState')
+const useSubscribeToInvalidationState = require('./relay-experimental/useSubscribeToInvalidationState');
 const useSubscription = require('./relay-experimental/useSubscription');
 
 const {graphql} = require('relay-runtime');
@@ -41,10 +41,7 @@ export type {
   RefetchFnDynamic,
 } from './relay-experimental';
 
-export type {
-  FetchPolicy,
-  RenderPolicy,
-} from 'relay-runtime';
+export type {FetchPolicy, RenderPolicy} from 'relay-runtime';
 
 /**
  * The public interface for Relay Hooks


### PR DESCRIPTION
**Expected**:
```js
import { loadQuery } from 'react-relay/hooks';

loadQuery(/* ... */);
```

**Results in error:**
```
TypeError: Object(…) is not a function
```

**See:**
https://github.com/facebook/relay/blob/relay-experimental-release/packages/relay-experimental/loadQuery.js#L219
https://github.com/facebook/relay/blob/relay-experimental-release/packages/relay-experimental/index.js#L38

---

Fixes the error by importing the named `loadQuery` export from `./relay-experimental/loadQuery` for re-exporting.