### PR TITLE
Update example for QueryRenderer in `ThinkingInRelay` docs page.

### DIFF
--- a/docs/PrinciplesAndArchitecture-ThinkingInRelay.md
+++ b/docs/PrinciplesAndArchitecture-ThinkingInRelay.md
@@ -73,7 +73,7 @@ ReactDOM.render(
     variables={{
       storyID: '123',
     }}
-    render={(props, error) => {
+    render={({ props, error }) => {
       if (error) {
         return <ErrorView />;
       } else if (props) {


### PR DESCRIPTION
While trying the example above. I found the arguments for render props are incorrect. In the example, it is shown the render prop callback has 2 arguments.
1. For props passed after resolving the `graphql` query.
2. boolean value for error argument.
But when queried the 2nd argument value is undefined.
And the first argument's value structure is as follows:
```
{error: null, props: Object, retry: null}
```
And according to `typescript` typing on `@types/react-relay` as well. The render props contain only a single argument.