### PR TITLE
[rust] compiler config for Jest tests

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1764,6 +1764,7 @@ version = "0.0.0"
 dependencies = [
  "common",
  "fixture-tests",
+ "graphql-test-helpers",
  "interner",
  "thiserror",
 ]

--- a/scripts/compile-tests.sh
+++ b/scripts/compile-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+GITHUB_ROOT=$(dirname $(dirname $(realpath "$0")))
+
+cd "$GITHUB_ROOT"/compiler
+cargo run --bin relay --release -- "$GITHUB_ROOT"/scripts/config.tests.json

--- a/scripts/config.tests.json
+++ b/scripts/config.tests.json
@@ -1,0 +1,22 @@
+{
+    "root": "..",
+    "name": "tests",
+    "sources": {
+        "packages": "tests"
+    },
+    "excludes": [
+        "**/__flowtests__/**"
+    ],
+    "header": [
+        "Copyright (c) Facebook, Inc. and its affiliates.",
+        "",
+        "This source code is licensed under the MIT license found in the",
+        "LICENSE file in the root directory of this source tree."
+    ],
+    "projects": {
+        "tests": {
+            "enumModuleSuffix": ".tests",
+            "schema": "packages/relay-test-utils-internal/testschema.graphql"
+        }
+    }
+}


### PR DESCRIPTION
This didn't get synced out of the internal repo and requires slightly different paths externally.

For now, this just creates an OSS only version of the tests compiler config. We might want to iterate a bit more here.

Test Plan:
Ran the added script from the GitHub checkout:

  scripts/compile-tests.sh