### PR TITLE
Fix neon compiler test

### DIFF
--- a/compiler/crates/relay-compiler-neon/__tests__/compiler-test.js
+++ b/compiler/crates/relay-compiler-neon/__tests__/compiler-test.js
@@ -56,6 +56,6 @@ describe('compiler extensions', () => {
   it('should throw for invalid documents', () => {
     expect(() =>
       compiler.compile('type User { name: String }', ['fragment User ....']),
-    ).toThrow("Expected a non-variable identifier (e.g. 'x' or 'Foo')");
+    ).toThrow("Expected a non-variable identifier");
   });
 });

--- a/compiler/crates/relay-compiler-neon/native/src/lib.rs
+++ b/compiler/crates/relay-compiler-neon/native/src/lib.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 /// Parse JS input to get list of executable definitions (ASTs)
 fn build_definitions_from_js_input(
     input: Vec<Handle<'_, JsValue>>,
-) -> DiagnosticsResult<Vec<ExecutableDefinition>> {
+) -> Result<Vec<ExecutableDefinition>, String> {
     let mut documents: Vec<DiagnosticsResult<ExecutableDocument>> = Vec::with_capacity(input.len());
     let mut errors: Vec<Diagnostic> = vec![];
     for js_value in input {
@@ -42,8 +42,9 @@ fn build_definitions_from_js_input(
             ));
         }
     }
-    if !errors.is_empty() {
-        return Err(errors);
+
+    if let Some(err) = errors.iter().next() {
+        return Err(err.to_string());
     }
 
     let mut definitions: Vec<ExecutableDefinition> = vec![];
@@ -60,10 +61,10 @@ fn build_definitions_from_js_input(
         }
     }
 
-    if errors.is_empty() {
-        Ok(definitions)
+    if let Some(err) = errors.iter().next() {
+        Err(err.to_string())
     } else {
-        Err(errors)
+        Ok(definitions)
     }
 }
 


### PR DESCRIPTION
Something escaping has changed in the compiler test, this shortens the expected substring a bit which should fix the test.

Test Plan:
GitHub CI for the neon test which previously failed