### PR TITLE
change the ID type for directives handling connection IDs

### DIFF
--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-edge-unspported.invalid.expected
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-edge-unspported.invalid.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 # expected-to-throw
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-edge-unspported.invalid.graphql
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-edge-unspported.invalid.graphql
@@ -1,6 +1,6 @@
 # expected-to-throw
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-edge.expected
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-edge.expected
@@ -1,6 +1,6 @@
 ==================================== INPUT ====================================
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {
@@ -14,7 +14,7 @@ mutation CommentCreateMutation(
 }
 ==================================== OUTPUT ===================================
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-edge.graphql
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-edge.graphql
@@ -1,5 +1,5 @@
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node-edge-literal.expected
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node-edge-literal.expected
@@ -1,6 +1,6 @@
 ==================================== INPUT ====================================
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {
@@ -12,7 +12,7 @@ mutation CommentCreateMutation(
 }
 ==================================== OUTPUT ===================================
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node-edge-literal.graphql
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node-edge-literal.graphql
@@ -1,5 +1,5 @@
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node-unsupported.invalid.expected
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node-unsupported.invalid.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 # expected-to-throw
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node-unsupported.invalid.graphql
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node-unsupported.invalid.graphql
@@ -1,6 +1,6 @@
 # expected-to-throw
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node.expected
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node.expected
@@ -1,6 +1,6 @@
 ==================================== INPUT ====================================
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {
@@ -13,7 +13,7 @@ mutation CommentCreateMutation(
 }
 ==================================== OUTPUT ===================================
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node.graphql
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/append-node.graphql
@@ -1,5 +1,5 @@
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection-on-unsupported-type.invalid.expected
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection-on-unsupported-type.invalid.expected
@@ -2,7 +2,7 @@
 # expected-to-throw
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     __typename @deleteEdge(connections: $connections)

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection-on-unsupported-type.invalid.graphql
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection-on-unsupported-type.invalid.graphql
@@ -1,7 +1,7 @@
 # expected-to-throw
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     __typename @deleteEdge(connections: $connections)

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection-plural.expected
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection-plural.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 mutation CommentsDeleteMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @deleteEdge(connections: $connections)
@@ -10,7 +10,7 @@ mutation CommentsDeleteMutation(
 ==================================== OUTPUT ===================================
 mutation CommentsDeleteMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @deleteEdge(connections: $connections) @__clientField(key: "", handle: "deleteEdge", handleArgs: {connections: $connections})

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection-plural.graphql
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection-plural.graphql
@@ -1,6 +1,6 @@
 mutation CommentsDeleteMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @deleteEdge(connections: $connections)

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection.expected
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @deleteEdge(connections: $connections)
@@ -10,7 +10,7 @@ mutation CommentDeleteMutation(
 ==================================== OUTPUT ===================================
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @deleteEdge(connections: $connections) @__clientField(key: "", handle: "deleteEdge", handleArgs: {connections: $connections})

--- a/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection.graphql
+++ b/compiler/crates/graphql-transforms/tests/declarative_connection/fixtures/delete-edge-from-connection.graphql
@@ -1,6 +1,6 @@
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @deleteEdge(connections: $connections)

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-edge.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-edge.expected
@@ -1,6 +1,6 @@
 ==================================== INPUT ====================================
 mutation appendEdge_CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-edge.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-edge.graphql
@@ -1,5 +1,5 @@
 mutation appendEdge_CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.expected
@@ -1,6 +1,6 @@
 ==================================== INPUT ====================================
 mutation appendNodeLiteralEdgeTypeNameCommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.graphql
@@ -1,5 +1,5 @@
 mutation appendNodeLiteralEdgeTypeNameCommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node.expected
@@ -1,6 +1,6 @@
 ==================================== INPUT ====================================
 mutation appendNodeCommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node.graphql
@@ -1,5 +1,5 @@
 mutation appendNodeCommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/delete-edge-plural.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/delete-edge-plural.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 mutation deleteEdgePluralMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @deleteEdge(connections: $connections)

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/delete-edge-plural.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/delete-edge-plural.graphql
@@ -1,6 +1,6 @@
 mutation deleteEdgePluralMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @deleteEdge(connections: $connections)

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/delete-edge.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/delete-edge.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 mutation deleteEdgeMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @deleteEdge(connections: $connections)

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/delete-edge.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/delete-edge.graphql
@@ -1,6 +1,6 @@
 mutation deleteEdgeMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @deleteEdge(connections: $connections)

--- a/compiler/crates/schema/src/relay-extensions.graphql
+++ b/compiler/crates/schema/src/relay-extensions.graphql
@@ -58,8 +58,8 @@ directive @required(action: RequiredFieldAction!) on FIELD
 
 # DeclarativeConnection
 directive @deleteRecord on FIELD
-directive @deleteEdge(connections: [String!]!) on FIELD
-directive @appendEdge(connections: [String!]!) on FIELD
-directive @prependEdge(connections: [String!]!) on FIELD
-directive @appendNode(connections: [String!]!, edgeTypeName: String!) on FIELD
-directive @prependNode(connections: [String!]!, edgeTypeName: String!) on FIELD
+directive @deleteEdge(connections: [ID!]!) on FIELD
+directive @appendEdge(connections: [ID!]!) on FIELD
+directive @prependEdge(connections: [ID!]!) on FIELD
+directive @appendNode(connections: [ID!]!, edgeTypeName: String!) on FIELD
+directive @prependNode(connections: [ID!]!, edgeTypeName: String!) on FIELD

--- a/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
+++ b/packages/relay-compiler/codegen/__tests__/__snapshots__/compileRelayArtifacts-test.js.snap
@@ -1910,7 +1910,7 @@ mutation ChangeNameMutation(
 exports[`compileRelayArtifacts matches expected output: append-edge.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {
@@ -2088,7 +2088,7 @@ mutation CommentCreateMutation(
 exports[`compileRelayArtifacts matches expected output: append-node.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {
@@ -6102,7 +6102,7 @@ exports[`compileRelayArtifacts matches expected output: delete-edge.graphql 1`] 
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @deleteEdge(connections: $connections)
@@ -6218,7 +6218,7 @@ exports[`compileRelayArtifacts matches expected output: delete-edge-plural.graph
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentsDeleteMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @deleteEdge(connections: $connections)

--- a/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/append-edge.graphql
+++ b/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/append-edge.graphql
@@ -1,5 +1,5 @@
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/append-node.graphql
+++ b/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/append-node.graphql
@@ -1,5 +1,5 @@
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {

--- a/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/delete-edge-plural.graphql
+++ b/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/delete-edge-plural.graphql
@@ -1,6 +1,6 @@
 mutation CommentsDeleteMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @deleteEdge(connections: $connections)

--- a/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/delete-edge.graphql
+++ b/packages/relay-compiler/codegen/__tests__/fixtures/compileRelayArtifacts/delete-edge.graphql
@@ -1,6 +1,6 @@
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @deleteEdge(connections: $connections)

--- a/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
+++ b/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
@@ -33,20 +33,20 @@ const LINKED_FIELD_DIRECTIVES = [
 const SCHEMA_EXTENSION = `
   directive @${DELETE_RECORD} on FIELD
   directive @${DELETE_EDGE}(
-    connections: [String!]!
+    connections: [ID!]!
   ) on FIELD
   directive @${APPEND_EDGE}(
-    connections: [String!]!
+    connections: [ID!]!
   ) on FIELD
   directive @${PREPEND_EDGE}(
-    connections: [String!]!
+    connections: [ID!]!
   ) on FIELD
   directive @${APPEND_NODE}(
-    connections: [String!]!
+    connections: [ID!]!
     edgeTypeName: String!
   ) on FIELD
   directive @${PREPEND_NODE}(
-    connections: [String!]!
+    connections: [ID!]!
     edgeTypeName: String!
   ) on FIELD
 `;

--- a/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
+++ b/packages/relay-compiler/transforms/__tests__/__snapshots__/DeclarativeConnectionMutationTransform-test.js.snap
@@ -3,7 +3,7 @@
 exports[`matches expected output: append-edge.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {
@@ -18,7 +18,7 @@ mutation CommentCreateMutation(
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {
@@ -37,7 +37,7 @@ exports[`matches expected output: append-edge-unspported.invalid.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 # expected-to-throw
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {
@@ -63,7 +63,7 @@ Source: GraphQL request (7:12)
 exports[`matches expected output: append-node.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {
@@ -77,7 +77,7 @@ mutation CommentCreateMutation(
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {
@@ -93,7 +93,7 @@ mutation CommentCreateMutation(
 exports[`matches expected output: append-node-edge-literal.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {
@@ -106,7 +106,7 @@ mutation CommentCreateMutation(
 
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {
@@ -122,7 +122,7 @@ exports[`matches expected output: append-node-unsupported.invalid.graphql 1`] = 
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 # expected-to-throw
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {
@@ -151,7 +151,7 @@ exports[`matches expected output: delete-edge-from-connection.graphql 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @deleteEdge(connections: $connections)
@@ -161,7 +161,7 @@ mutation CommentDeleteMutation(
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @__clientField(handle: "deleteEdge", handleArgs: (connections: $connections))
@@ -175,7 +175,7 @@ exports[`matches expected output: delete-edge-from-connection-on-unspported-type
 # expected-to-throw
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     __typename @deleteEdge(connections: $connections)
@@ -199,7 +199,7 @@ exports[`matches expected output: delete-edge-from-connection-plural.graphql 1`]
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 mutation CommentsDeleteMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @deleteEdge(connections: $connections)
@@ -209,7 +209,7 @@ mutation CommentsDeleteMutation(
 ~~~~~~~~~~ OUTPUT ~~~~~~~~~~
 mutation CommentsDeleteMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @__clientField(handle: "deleteEdge", handleArgs: (connections: $connections))

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-edge-unspported.invalid.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-edge-unspported.invalid.graphql
@@ -1,6 +1,6 @@
 # expected-to-throw
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-edge.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-edge.graphql
@@ -1,5 +1,5 @@
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-node-edge-literal.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-node-edge-literal.graphql
@@ -1,5 +1,5 @@
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-node-unsupported.invalid.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-node-unsupported.invalid.graphql
@@ -1,6 +1,6 @@
 # expected-to-throw
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-node.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/append-node.graphql
@@ -1,5 +1,5 @@
 mutation CommentCreateMutation(
-  $connections: [String!]!
+  $connections: [ID!]!
   $edgeTypeName: String!
   $input: CommentCreateInput
 ) {

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection-on-unspported-type.invalid.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection-on-unspported-type.invalid.graphql
@@ -1,7 +1,7 @@
 # expected-to-throw
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     __typename @deleteEdge(connections: $connections)

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection-plural.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection-plural.graphql
@@ -1,6 +1,6 @@
 mutation CommentsDeleteMutation(
   $input: CommentsDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentsDelete(input: $input) {
     deletedCommentIds @deleteEdge(connections: $connections)

--- a/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection.graphql
+++ b/packages/relay-compiler/transforms/__tests__/fixtures/declarative-connection-mutation-transform/delete-edge-from-connection.graphql
@@ -1,6 +1,6 @@
 mutation CommentDeleteMutation(
   $input: CommentDeleteInput
-  $connections: [String!]!
+  $connections: [ID!]!
 ) {
   commentDelete(input: $input) {
     deletedCommentId @deleteEdge(connections: $connections)

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
@@ -615,7 +615,7 @@ describe('connection edge mutations', () => {
       }
 
       mutation AppendCommentMutation(
-        $connections: [String!]!
+        $connections: [ID!]!
         $input: CommentCreateInput
       ) {
         commentCreate(input: $input) {
@@ -629,7 +629,7 @@ describe('connection edge mutations', () => {
       }
 
       mutation PrependCommentMutation(
-        $connections: [String!]!
+        $connections: [ID!]!
         $input: CommentCreateInput
       ) {
         commentCreate(input: $input) {
@@ -643,7 +643,7 @@ describe('connection edge mutations', () => {
       }
 
       mutation DeleteCommentMutation(
-        $connections: [String!]!
+        $connections: [ID!]!
         $input: CommentDeleteInput
       ) {
         commentDelete(input: $input) {
@@ -652,7 +652,7 @@ describe('connection edge mutations', () => {
       }
 
       mutation DeleteCommentsMutation(
-        $connections: [String!]!
+        $connections: [ID!]!
         $input: CommentsDeleteInput
       ) {
         commentsDelete(input: $input) {
@@ -1090,7 +1090,7 @@ describe('connection node mutations', () => {
       }
 
       mutation AppendCommentMutation(
-        $connections: [String!]!
+        $connections: [ID!]!
         $edgeTypeName: String!
         $input: CommentCreateInput
       ) {
@@ -1105,7 +1105,7 @@ describe('connection node mutations', () => {
       }
 
       mutation AppendCommentWithLiteralEdgeMutation(
-        $connections: [String!]!
+        $connections: [ID!]!
         $input: CommentCreateInput
       ) {
         commentCreate(input: $input) {
@@ -1119,7 +1119,7 @@ describe('connection node mutations', () => {
       }
 
       mutation AppendCommentsMutation(
-        $connections: [String!]!
+        $connections: [ID!]!
         $edgeTypeName: String!
         $input: CommentsCreateInput
       ) {
@@ -1134,7 +1134,7 @@ describe('connection node mutations', () => {
       }
 
       mutation PrependCommentMutation(
-        $connections: [String!]!
+        $connections: [ID!]!
         $edgeTypeName: String!
         $input: CommentCreateInput
       ) {
@@ -1149,7 +1149,7 @@ describe('connection node mutations', () => {
       }
 
       mutation PrependCommentsMutation(
-        $connections: [String!]!
+        $connections: [ID!]!
         $edgeTypeName: String!
         $input: CommentsCreateInput
       ) {


### PR DESCRIPTION
This changes the type of the `connections: [String]` arguments to the new store updater directives handling connections from `String` to `ID`. This is to make it match better type-wise and semantically to what it actually is (an ID coming from the store), but since both `String` and `ID` normally serialize to `string`, it won't change the behavior of any product code.

It is however a breaking change in the sense that all operations that use the new store directives with `connections` will need to change from `String` to `ID` in the definition itself.