### PR TITLE
Update badges on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Relay](https://relay.dev) [![Build Status](https://travis-ci.org/facebook/relay.svg?branch=master)](https://travis-ci.org/facebook/relay) [![npm version](https://badge.fury.io/js/react-relay.svg)](http://badge.fury.io/js/react-relay)
+# [Relay](https://relay.dev) &middot; [![npm version](https://img.shields.io/npm/v/react-relay.svg??style=flat)](https://www.npmjs.com/package/react-relay)
 
 Relay is a JavaScript framework for building data-driven React applications.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Relay](https://relay.dev) &middot; [![npm version](https://img.shields.io/npm/v/react-relay.svg??style=flat)](https://www.npmjs.com/package/react-relay)
+# [Relay](https://relay.dev) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/relay/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/react-relay.svg??style=flat)](https://www.npmjs.com/package/react-relay)
 
 Relay is a JavaScript framework for building data-driven React applications.
 


### PR DESCRIPTION
- Removes the Travis CI badge as we no longer use it.
- Adds a license badge inspired by Reacts badges: https://github.com/facebook/react#readme
- Updates the NPM badge as the current one had problems loading (not sure if permanent). The new badge is coming from the same service that React uses.

Test Plan:
https://github.com/kassens/relay/tree/badge#readme
