### PR TITLE
chore: Re-export graphql for the hooks

### DIFF
--- a/packages/relay-experimental/index.js
+++ b/packages/relay-experimental/index.js
@@ -35,6 +35,8 @@ const useRelayEnvironment = require('./useRelayEnvironment');
 const useSubscribeToInvalidationState = require('./useSubscribeToInvalidationState');
 const useSubscription = require('./useSubscription');
 
+const graphql = require('relay-runtime');
+
 const {loadQuery} = require('./loadQuery');
 
 export type * from './EntryPointTypes.flow';
@@ -59,6 +61,7 @@ module.exports = {
 
   loadQuery: loadQuery,
   loadEntryPoint: loadEntryPoint,
+  graphql: graphql,
 
   prepareEntryPoint_DEPRECATED: prepareEntryPoint_DEPRECATED,
 


### PR DESCRIPTION
From what I can see the "internally" released, relay experimental releases with a re-export of graphql, can we also articulate this in the OSS version?

https://unpkg.com/browse/react-relay@0.0.0-experimental-183bdd28/lib/hooks.js

Really tripped me up when I got the types aligned in the new DT types (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48638/files#diff-cf027a09fee4ac3fe3dddd1ca1649cccR1)