### PR TITLE
Add support for input object extensions

### DIFF
--- a/compiler/crates/schema/tests/build_schema/fixtures/kitchen-sink.expected
+++ b/compiler/crates/schema/tests/build_schema/fixtures/kitchen-sink.expected
@@ -39,6 +39,9 @@ extend type User {
   nickname: String
   client: ClientType
 }
+input ClientInput {
+  clientName: String
+}
 ==================================== OUTPUT ===================================
 Schema {
  query_type: Some(
@@ -93,6 +96,7 @@ Schema {
  type_map: {
     "Actor": Union(0),
     "Boolean": Scalar(3),
+    "ClientInput": InputObject(0),
     "ClientType": Object(3),
     "Float": Scalar(1),
     "ID": Scalar(4),
@@ -323,7 +327,21 @@ Schema {
         parent_type: None,
     },
 ]
- input_objects: []
+ input_objects: [
+    InputObject {
+        name: "ClientInput",
+        fields: [
+            Argument {
+                name: "clientName",
+                type_: Named(
+                    Scalar(2),
+                ),
+                default_value: None,
+            },
+        ],
+        directives: [],
+    },
+]
  interfaces: [
     Interface {
         name: "Node",

--- a/compiler/crates/schema/tests/build_schema/fixtures/kitchen-sink.graphql
+++ b/compiler/crates/schema/tests/build_schema/fixtures/kitchen-sink.graphql
@@ -38,3 +38,6 @@ extend type User {
   nickname: String
   client: ClientType
 }
+input ClientInput {
+  clientName: String
+}

--- a/packages/relay-compiler/core/Schema.js
+++ b/packages/relay-compiler/core/Schema.js
@@ -1839,6 +1839,8 @@ class TypeMap {
         this._parseObjectTypeNode(definition, true);
       } else if (definition.kind === 'InterfaceTypeDefinition') {
         this._parseInterfaceNode(definition, true);
+      } else if (definition.kind === 'InputObjectTypeDefinition') {
+        this._parseInputObjectTypeNode(definition, true);
       } else if (definition.kind === 'ScalarTypeDefinition') {
         this._parseScalarNode(definition, true);
       } else if (definition.kind === 'EnumTypeDefinition') {

--- a/packages/relay-compiler/core/__tests__/Schema-test.js
+++ b/packages/relay-compiler/core/__tests__/Schema-test.js
@@ -1108,7 +1108,12 @@ describe('Schema: RelayCompiler Internal GraphQL Schema Interface', () => {
         input I {value: String}
     `),
       [],
-      ['type ClientUser { client_id: ID }'],
+      [
+        `
+        type ClientUser { client_id: ID }
+        input ClientInput { client_id: ID }
+      `,
+      ],
     );
 
     test('assert scalar type', () => {
@@ -1148,6 +1153,7 @@ describe('Schema: RelayCompiler Internal GraphQL Schema Interface', () => {
         '[String]',
         'I',
         'E',
+        'ClientInput',
       ]);
       testInvalidTypeNames('assertInputType', [
         'A',


### PR DESCRIPTION
I would like to be able to add input types on the client. I am building client side mutations using the missingFields handler but can't create the new input object.