### PR TITLE
Include React 17 in peerDependencies

### DIFF
--- a/packages/react-relay/package.json
+++ b/packages/react-relay/package.json
@@ -18,7 +18,7 @@
     "relay-runtime": "10.0.1"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": "^16.9.0 || ^17"
   },
   "directories": {
     "": "./"


### PR DESCRIPTION
This diff is intended to address the incorrect peer dependency warning when React 17 (the latest stable version) is installed