### PR TITLE
Rust: add --locked flag to GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --manifest-path=compiler/Cargo.toml
+          args: --manifest-path=compiler/Cargo.toml --locked
 
   test-rust:
     name: Test Rust
@@ -78,7 +78,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=compiler/Cargo.toml
+          args: --manifest-path=compiler/Cargo.toml --locked
 
   test-relay-compiler-neon:
     name: Test Relay Compiler (Neon)


### PR DESCRIPTION
This verifies that the `Cargo.lock` is up to date with the `Cargo.toml` file.

Currently this should fail. After #3230 is merged, I expect this to succeed.