### PR TITLE
CI: revert npm publish step to node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 14.x
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
The experimental publish steps have been failing with an error like this:
```
npm ERR! code 128
npm ERR! command failed
npm ERR! command /usr/bin/git ls-remote ssh://git@github.com/dist/babel-plugin-relay.git
npm ERR! Warning: Permanently added the RSA host key for IP address '140.82.114.4' to the list of known hosts.
npm ERR! git@github.com: Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
npm ERR! 
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.
```

This seems to have started when I upgraded CI to node 15, which I think comes with a new `npm` version as well. Haven't dug into if this is a regression or something we need to update yet.

For now just revert to the stable release.