### PR TITLE
refactors to use `hasOwnProperty` on Object prototype

### DIFF
--- a/packages/relay-runtime/handlers/connection/ConnectionInterface.js
+++ b/packages/relay-runtime/handlers/connection/ConnectionInterface.js
@@ -14,6 +14,8 @@
 
 import type {Record} from '../../store/RelayStoreTypes';
 
+const hasOwnProperty = require('../../util/hasOwnProperty');
+
 type Call = {name: string, ...};
 
 export type EdgeRecord = Record & {
@@ -85,7 +87,7 @@ const ConnectionInterface = {
    * same identity.
    */
   isConnectionCall(call: Call): boolean {
-    return CONNECTION_CALLS.hasOwnProperty(call.name);
+    return hasOwnProperty(CONNECTION_CALLS, call.name);
   },
 };
 

--- a/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
@@ -16,6 +16,7 @@ const RelayModernRecord = require('../store/RelayModernRecord');
 const RelayRecordProxy = require('./RelayRecordProxy');
 
 const invariant = require('invariant');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 const {EXISTENT, NONEXISTENT} = require('../store/RelayRecordState');
 const {ROOT_ID, ROOT_TYPE} = require('../store/RelayStoreUtils');
@@ -113,7 +114,7 @@ class RelayRecordSourceProxy implements RecordSourceProxy {
   }
 
   get(dataID: DataID): ?RecordProxy {
-    if (!this._proxies.hasOwnProperty(dataID)) {
+    if (!hasOwnProperty(this._proxies, dataID)) {
       const status = this.__mutator.getStatus(dataID);
       if (status === EXISTENT) {
         this._proxies[dataID] = new RelayRecordProxy(

--- a/packages/relay-runtime/mutations/validateMutation.js
+++ b/packages/relay-runtime/mutations/validateMutation.js
@@ -28,6 +28,7 @@ type ValidationContext = {
   ...
 };
 const warning = require('warning');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 let validateMutation = () => {};
 if (__DEV__) {
@@ -140,7 +141,7 @@ if (__DEV__) {
     context.visitedPaths.add(path);
     switch (field.kind) {
       case 'ScalarField':
-        if (optimisticResponse.hasOwnProperty(fieldName) === false) {
+        if (hasOwnProperty(optimisticResponse, fieldName) === false) {
           addFieldToDiff(path, context.missingDiff, true);
         }
         return;

--- a/packages/relay-runtime/store/DataChecker.js
+++ b/packages/relay-runtime/store/DataChecker.js
@@ -24,6 +24,7 @@ const RelayStoreUtils = require('./RelayStoreUtils');
 const cloneRelayHandleSourceField = require('./cloneRelayHandleSourceField');
 const cloneRelayScalarHandleSourceField = require('./cloneRelayScalarHandleSourceField');
 const getOperation = require('../util/getOperation');
+const hasOwnProperty = require('../util/hasOwnProperty');
 const invariant = require('invariant');
 
 const {isClientID} = require('./ClientID');
@@ -157,7 +158,7 @@ class DataChecker {
 
   _getVariableValue(name: string): mixed {
     invariant(
-      this._variables.hasOwnProperty(name),
+      hasOwnProperty(this._variables, name),
       'RelayAsyncLoader(): Undefined variable `%s`.',
       name,
     );

--- a/packages/relay-runtime/store/RelayConcreteVariables.js
+++ b/packages/relay-runtime/store/RelayConcreteVariables.js
@@ -18,6 +18,8 @@ import type {NormalizationOperation} from '../util/NormalizationNode';
 import type {ReaderFragment} from '../util/ReaderNode';
 import type {Variables} from '../util/RelayRuntimeTypes';
 
+const hasOwnProperty = require('../util/hasOwnProperty');
+
 /**
  * Determines the variables that are in scope for a fragment given the variables
  * in scope at the root query as well as any arguments applied at the fragment
@@ -32,7 +34,7 @@ function getFragmentVariables(
 ): Variables {
   let variables;
   fragment.argumentDefinitions.forEach(definition => {
-    if (argumentVariables.hasOwnProperty(definition.name)) {
+    if (hasOwnProperty(argumentVariables, definition.name)) {
       return;
     }
     variables = variables || {...argumentVariables};
@@ -41,7 +43,7 @@ function getFragmentVariables(
         variables[definition.name] = definition.defaultValue;
         break;
       case 'RootArgument':
-        if (!rootVariables.hasOwnProperty(definition.name)) {
+        if (!hasOwnProperty(rootVariables, definition.name)) {
           /*
            * Global variables passed as values of @arguments are not required to
            * be declared unless they are used by the callee fragment or a

--- a/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
+++ b/packages/relay-runtime/store/RelayModernFragmentSpecResolver.js
@@ -19,6 +19,7 @@ const invariant = require('invariant');
 const isScalarAndEqual = require('../util/isScalarAndEqual');
 const reportMissingRequiredFields = require('../util/reportMissingRequiredFields');
 const warning = require('warning');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 const {getPromiseForActiveRequest} = require('../query/fetchQueryInternal');
 const {createRequestDescriptor} = require('./RelayModernOperationDescriptor');
@@ -96,7 +97,7 @@ class RelayModernFragmentSpecResolver implements FragmentSpecResolver {
 
   dispose(): void {
     for (const key in this._resolvers) {
-      if (this._resolvers.hasOwnProperty(key)) {
+      if (hasOwnProperty(this._resolvers, key)) {
         disposeCallback(this._resolvers[key]);
       }
     }
@@ -109,7 +110,7 @@ class RelayModernFragmentSpecResolver implements FragmentSpecResolver {
       const prevData = this._data;
       let nextData;
       for (const key in this._resolvers) {
-        if (this._resolvers.hasOwnProperty(key)) {
+        if (hasOwnProperty(this._resolvers, key)) {
           const resolver = this._resolvers[key];
           const prevItem = prevData[key];
           if (resolver) {
@@ -143,7 +144,7 @@ class RelayModernFragmentSpecResolver implements FragmentSpecResolver {
     this._props = {};
 
     for (const key in ownedSelectors) {
-      if (ownedSelectors.hasOwnProperty(key)) {
+      if (hasOwnProperty(ownedSelectors, key)) {
         const ownedSelector = ownedSelectors[key];
         let resolver = this._resolvers[key];
         if (ownedSelector == null) {
@@ -191,7 +192,7 @@ class RelayModernFragmentSpecResolver implements FragmentSpecResolver {
 
   setVariables(variables: Variables, request: ConcreteRequest): void {
     for (const key in this._resolvers) {
-      if (this._resolvers.hasOwnProperty(key)) {
+      if (hasOwnProperty(this._resolvers, key)) {
         const resolver = this._resolvers[key];
         if (resolver) {
           resolver.setVariables(variables, request);

--- a/packages/relay-runtime/store/RelayModernQueryExecutor.js
+++ b/packages/relay-runtime/store/RelayModernQueryExecutor.js
@@ -23,6 +23,7 @@ const getOperation = require('../util/getOperation');
 const invariant = require('invariant');
 const stableCopy = require('../util/stableCopy');
 const warning = require('warning');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 const {generateClientID} = require('./ClientID');
 const {createNormalizationSelector} = require('./RelayModernSelector');
@@ -326,7 +327,7 @@ class Executor {
       if (
         response.data === null &&
         response.extensions != null &&
-        !response.hasOwnProperty('errors')
+        !hasOwnProperty(response, 'errors')
       ) {
         // Skip extensions-only payloads
         return;
@@ -334,7 +335,7 @@ class Executor {
         // Error if any other payload in the batch is missing data, regardless of whether
         // it had `errors` or not.
         const errors =
-          response.hasOwnProperty('errors') && response.errors != null
+          hasOwnProperty(response, 'errors') && response.errors != null
             ? response.errors
             : null;
         const messages = errors

--- a/packages/relay-runtime/store/RelayModernRecord.js
+++ b/packages/relay-runtime/store/RelayModernRecord.js
@@ -16,6 +16,7 @@ const areEqual = require('areEqual');
 const deepFreeze = require('../util/deepFreeze');
 const invariant = require('invariant');
 const warning = require('warning');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 const {isClientID} = require('./ClientID');
 const {
@@ -97,7 +98,7 @@ function clone(record: Record): Record {
  */
 function copyFields(source: Record, sink: Record): void {
   for (const key in source) {
-    if (source.hasOwnProperty(key)) {
+    if (hasOwnProperty(source, key)) {
       if (key !== ID_KEY && key !== TYPENAME_KEY) {
         sink[key] = source[key];
       }
@@ -145,12 +146,12 @@ function getValue(record: Record, storageKey: string): mixed {
   const value = record[storageKey];
   if (value && typeof value === 'object') {
     invariant(
-      !value.hasOwnProperty(REF_KEY) && !value.hasOwnProperty(REFS_KEY),
+      !hasOwnProperty(value, REF_KEY) && !hasOwnProperty(value, REFS_KEY),
       'RelayModernRecord.getValue(): Expected a scalar (non-link) value for `%s.%s` ' +
         'but found %s.',
       record[ID_KEY],
       storageKey,
-      value.hasOwnProperty(REF_KEY)
+      hasOwnProperty(value, REF_KEY)
         ? 'a linked record'
         : 'plural linked records',
     );

--- a/packages/relay-runtime/store/RelayModernSelector.js
+++ b/packages/relay-runtime/store/RelayModernSelector.js
@@ -15,6 +15,7 @@
 const areEqual = require('areEqual');
 const invariant = require('invariant');
 const warning = require('warning');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 const {getFragmentVariables} = require('./RelayConcreteVariables');
 const {
@@ -201,7 +202,7 @@ function getSelectorsFromObject(
 ): {[key: string]: ?ReaderSelector, ...} {
   const selectors = {};
   for (const key in fragments) {
-    if (fragments.hasOwnProperty(key)) {
+    if (hasOwnProperty(fragments, key)) {
       const fragment = fragments[key];
       const item = object[key];
       selectors[key] = getSelector(fragment, item);
@@ -225,7 +226,7 @@ function getDataIDsFromObject(
 ): {[key: string]: ?(DataID | Array<DataID>), ...} {
   const ids = {};
   for (const key in fragments) {
-    if (fragments.hasOwnProperty(key)) {
+    if (hasOwnProperty(fragments, key)) {
       const fragment = fragments[key];
       const item = object[key];
       ids[key] = getDataIDsFromFragment(fragment, item);
@@ -326,7 +327,7 @@ function getVariablesFromObject(
 ): Variables {
   const variables = {};
   for (const key in fragments) {
-    if (fragments.hasOwnProperty(key)) {
+    if (hasOwnProperty(fragments, key)) {
       const fragment = fragments[key];
       const item = object[key];
       const itemVariables = getVariablesFromFragment(fragment, item);

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -16,6 +16,7 @@ const RelayFeatureFlags = require('../util/RelayFeatureFlags');
 const RelayModernRecord = require('./RelayModernRecord');
 
 const invariant = require('invariant');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 const {
   CLIENT_EXTENSION,
@@ -187,7 +188,7 @@ class RelayReader {
 
   _getVariableValue(name: string): mixed {
     invariant(
-      this._variables.hasOwnProperty(name),
+      hasOwnProperty(this._variables, name),
       'RelayReader(): Undefined variable `%s`.',
       name,
     );

--- a/packages/relay-runtime/store/RelayReferenceMarker.js
+++ b/packages/relay-runtime/store/RelayReferenceMarker.js
@@ -21,6 +21,7 @@ const RelayStoreUtils = require('./RelayStoreUtils');
 const cloneRelayHandleSourceField = require('./cloneRelayHandleSourceField');
 const getOperation = require('../util/getOperation');
 const invariant = require('invariant');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 const {generateTypeID} = require('./TypeID');
 
@@ -114,7 +115,7 @@ class RelayReferenceMarker {
 
   _getVariableValue(name: string): mixed {
     invariant(
-      this._variables.hasOwnProperty(name),
+      hasOwnProperty(this._variables, name),
       'RelayReferenceMarker(): Undefined variable `%s`.',
       name,
     );

--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -15,6 +15,7 @@
 const RelayFeatureFlags = require('../util/RelayFeatureFlags');
 const RelayModernRecord = require('./RelayModernRecord');
 const RelayProfiler = require('../util/RelayProfiler');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 const areEqual = require('areEqual');
 const invariant = require('invariant');
@@ -169,7 +170,7 @@ class RelayResponseNormalizer {
 
   _getVariableValue(name: string): mixed {
     invariant(
-      this._variables.hasOwnProperty(name),
+      hasOwnProperty(this._variables, name),
       'RelayResponseNormalizer(): Undefined variable `%s`.',
       name,
     );
@@ -212,7 +213,7 @@ class RelayResponseNormalizer {
               this._traverseSelections(selection, record, data);
             }
           } else if (RelayFeatureFlags.ENABLE_PRECISE_TYPE_REFINEMENT) {
-            const implementsInterface = data.hasOwnProperty(abstractKey);
+            const implementsInterface = hasOwnProperty(data, abstractKey);
             const typeName = RelayModernRecord.getType(record);
             const typeID = generateTypeID(typeName);
             let typeRecord = this._recordSource.get(typeID);
@@ -232,7 +233,7 @@ class RelayResponseNormalizer {
             // legacy behavior for abstract refinements: always normalize even
             // if the type doesn't conform, but track if the type matches or not
             // for determining whether response fields are expected to be present
-            const implementsInterface = data.hasOwnProperty(abstractKey);
+            const implementsInterface = hasOwnProperty(data, abstractKey);
             const parentIsUnmatchedAbstractType = this._isUnmatchedAbstractType;
             this._isUnmatchedAbstractType =
               this._isUnmatchedAbstractType || !implementsInterface;
@@ -244,7 +245,7 @@ class RelayResponseNormalizer {
         case TYPE_DISCRIMINATOR: {
           if (RelayFeatureFlags.ENABLE_PRECISE_TYPE_REFINEMENT) {
             const {abstractKey} = selection;
-            const implementsInterface = data.hasOwnProperty(abstractKey);
+            const implementsInterface = hasOwnProperty(data, abstractKey);
             const typeName = RelayModernRecord.getType(record);
             const typeID = generateTypeID(typeName);
             let typeRecord = this._recordSource.get(typeID);

--- a/packages/relay-runtime/store/RelayStoreUtils.js
+++ b/packages/relay-runtime/store/RelayStoreUtils.js
@@ -17,6 +17,7 @@ const RelayConcreteNode = require('../util/RelayConcreteNode');
 const getRelayHandleKey = require('../util/getRelayHandleKey');
 const invariant = require('invariant');
 const stableCopy = require('../util/stableCopy');
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 import type {ReactFlightPayloadData} from '../network/RelayNetworkTypes';
 import type {
@@ -160,7 +161,7 @@ function formatStorageKey(name: string, argValues: ?Arguments): string {
   }
   const values = [];
   for (const argName in argValues) {
-    if (argValues.hasOwnProperty(argName)) {
+    if (hasOwnProperty(argValues, argName)) {
       const value = argValues[argName];
       if (value != null) {
         values.push(argName + ':' + (JSON.stringify(value) ?? 'undefined'));
@@ -176,7 +177,7 @@ function formatStorageKey(name: string, argValues: ?Arguments): string {
  */
 function getStableVariableValue(name: string, variables: Variables): mixed {
   invariant(
-    variables.hasOwnProperty(name),
+    hasOwnProperty(variables, name),
     'getVariableValue(): Undefined variable `%s`.',
     name,
   );

--- a/packages/relay-runtime/store/hasOverlappingIDs.js
+++ b/packages/relay-runtime/store/hasOverlappingIDs.js
@@ -13,8 +13,7 @@
 'use strict';
 
 import type {RecordMap, UpdatedRecords} from './RelayStoreTypes';
-
-const hasOwnProperty = Object.prototype.hasOwnProperty;
+const hasOwnProperty = require('../util/hasOwnProperty');
 
 function hasOverlappingIDs(
   seenRecords: RecordMap,
@@ -22,8 +21,8 @@ function hasOverlappingIDs(
 ): boolean {
   for (const key in seenRecords) {
     if (
-      hasOwnProperty.call(seenRecords, key) &&
-      hasOwnProperty.call(updatedRecordIDs, key)
+      hasOwnProperty(seenRecords, key) &&
+      hasOwnProperty(updatedRecordIDs, key)
     ) {
       return true;
     }

--- a/packages/relay-runtime/util/RelayProfiler.js
+++ b/packages/relay-runtime/util/RelayProfiler.js
@@ -15,6 +15,8 @@
 type Handler = (name: string, callback: () => void) => void;
 type ProfileHandler = (name: string, state?: any) => (error?: Error) => void;
 
+const hasOwnProperty = require('../util/hasOwnProperty');
+
 function emptyFunction() {}
 
 const aggregateHandlersByName: {[name: string]: Array<Handler>, ...} = {
@@ -86,7 +88,7 @@ const RelayProfiler = {
     names: {[key: string]: string, ...},
   ): void {
     for (const key in names) {
-      if (names.hasOwnProperty(key)) {
+      if (hasOwnProperty(names, key)) {
         if (typeof object[key] === 'function') {
           object[key] = RelayProfiler.instrument(names[key], object[key]);
         }
@@ -112,7 +114,7 @@ const RelayProfiler = {
       originalFunction.detachHandler = emptyFunction;
       return originalFunction;
     }
-    if (!aggregateHandlersByName.hasOwnProperty(name)) {
+    if (!hasOwnProperty(aggregateHandlersByName, name)) {
       aggregateHandlersByName[name] = [];
     }
     const catchallHandlers = aggregateHandlersByName['*'];
@@ -190,7 +192,7 @@ const RelayProfiler = {
    */
   attachAggregateHandler(name: string, handler: Handler): void {
     if (shouldInstrument(name)) {
-      if (!aggregateHandlersByName.hasOwnProperty(name)) {
+      if (!hasOwnProperty(aggregateHandlersByName, name)) {
         aggregateHandlersByName[name] = [];
       }
       aggregateHandlersByName[name].push(handler);
@@ -202,7 +204,7 @@ const RelayProfiler = {
    */
   detachAggregateHandler(name: string, handler: Handler): void {
     if (shouldInstrument(name)) {
-      if (aggregateHandlersByName.hasOwnProperty(name)) {
+      if (hasOwnProperty(aggregateHandlersByName, name)) {
         removeFromArray(aggregateHandlersByName[name], handler);
       }
     }
@@ -223,7 +225,7 @@ const RelayProfiler = {
    */
   profile(name: string, state?: any): {stop: (error?: Error) => void, ...} {
     const hasCatchAllHandlers = profileHandlersByName['*'].length > 0;
-    const hasNamedHandlers = profileHandlersByName.hasOwnProperty(name);
+    const hasNamedHandlers = hasOwnProperty(profileHandlersByName, name);
     if (hasNamedHandlers || hasCatchAllHandlers) {
       const profileHandlers =
         hasNamedHandlers && hasCatchAllHandlers
@@ -255,7 +257,7 @@ const RelayProfiler = {
    */
   attachProfileHandler(name: string, handler: ProfileHandler): void {
     if (shouldInstrument(name)) {
-      if (!profileHandlersByName.hasOwnProperty(name)) {
+      if (!hasOwnProperty(profileHandlersByName, name)) {
         profileHandlersByName[name] = [];
       }
       profileHandlersByName[name].push(handler);
@@ -267,7 +269,7 @@ const RelayProfiler = {
    */
   detachProfileHandler(name: string, handler: ProfileHandler): void {
     if (shouldInstrument(name)) {
-      if (profileHandlersByName.hasOwnProperty(name)) {
+      if (hasOwnProperty(profileHandlersByName, name)) {
         removeFromArray(profileHandlersByName[name], handler);
       }
     }

--- a/packages/relay-runtime/util/hasOwnProperty.js
+++ b/packages/relay-runtime/util/hasOwnProperty.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+function hasOwnProperty(obj: {+[key: string]: mixed}, key: string) {
+  return (Object.prototype.hasOwnProperty.call(obj, key): boolean);
+}
+
+module.exports = hasOwnProperty;

--- a/packages/relay-runtime/util/hasOwnProperty.js
+++ b/packages/relay-runtime/util/hasOwnProperty.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-function hasOwnProperty(obj: {+[key: string]: mixed}, key: string) {
+function hasOwnProperty(obj: {+[key: string]: mixed}, key: string): boolean {
   return (Object.prototype.hasOwnProperty.call(obj, key): boolean);
 }
 

--- a/packages/relay-runtime/util/isEmptyObject.js
+++ b/packages/relay-runtime/util/isEmptyObject.js
@@ -10,12 +10,11 @@
  */
 
 'use strict';
-
-const hasOwnProperty = Object.prototype.hasOwnProperty;
+const hasOwnProperty = require('./hasOwnProperty');
 
 function isEmptyObject(obj: {+[key: string]: mixed}): boolean {
   for (const key in obj) {
-    if (hasOwnProperty.call(obj, key)) {
+    if (hasOwnProperty(obj, key)) {
       return false;
     }
   }


### PR DESCRIPTION
This PR aims to resolve issues where resolver data that has the Object prototype removed can cause `relay-runtime` to throw errors.

An example of where this error occurs:

> **RelayResponseNormalizer line 236:**
> https://github.com/facebook/relay/blob/master/packages/relay-runtime/store/RelayResponseNormalizer.js#L235

Refactoring to use Object's `hasOwnProperty` directly to provide safer abstraction to avoid these issues.