### PR TITLE
feat: adds more meta to execute logs

### DIFF
--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -532,6 +532,8 @@ class RelayModernEnvironment implements IEnvironment {
           name: 'execute.next',
           transactionID,
           response,
+          params,
+          variables
         });
       },
       error: error => {
@@ -539,18 +541,24 @@ class RelayModernEnvironment implements IEnvironment {
           name: 'execute.error',
           transactionID,
           error,
+          params,
+          variables
         });
       },
       complete: () => {
         log({
           name: 'execute.complete',
           transactionID,
+          params,
+          variables
         });
       },
       unsubscribe: () => {
         log({
           name: 'execute.unsubscribe',
           transactionID,
+          params,
+          variables
         });
       },
     };
@@ -559,6 +567,8 @@ class RelayModernEnvironment implements IEnvironment {
         name: 'execute.info',
         transactionID,
         info,
+        params,
+        variables
       });
     };
     return [logObserver, logRequestInfo];

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -433,6 +433,8 @@ export type LogEvent =
       +name: 'execute.info',
       +transactionID: number,
       +info: mixed,
+      +params: RequestParameters,
+      +variables: Variables,
     |}
   | {|
       +name: 'execute.start',
@@ -444,19 +446,27 @@ export type LogEvent =
       +name: 'execute.next',
       +transactionID: number,
       +response: GraphQLResponse,
+      +params: RequestParameters,
+      +variables: Variables,
     |}
   | {|
       +name: 'execute.error',
       +transactionID: number,
       +error: Error,
+      +params: RequestParameters,
+      +variables: Variables,
     |}
   | {|
       +name: 'execute.complete',
       +transactionID: number,
+      +params: RequestParameters,
+      +variables: Variables,
     |}
   | {|
       +name: 'execute.unsubscribe',
       +transactionID: number,
+      +params: RequestParameters,
+      +variables: Variables,
     |}
   | {|
       +name: 'store.publish',


### PR DESCRIPTION
With this PR I aim to add the params + variables what ordinarily get sent into `execute.start`, to also be sent into the rest of the `execute.*` entries.

This is primarily done to enhance exceptions that get monitored in tooling like Sentry. To enhance the stack traces with "which query", "what variables" and so on. Stitching in that world around the `transactionID` is hard as their transaction pattern would involve having a single context that a "transaction" would flow in see https://docs.sentry.io/platforms/javascript/performance/capturing/manual/.

This I believe is a more general approach as the information is there, may as well pass it on.

further this, and i think it was a little out of my depth. But being able to stitch the queryResrouce stuff to an execute, to capture that span also.

---

I could be going about this the wrong way. And really what im after is the Profiler—but afaik that isn't "instrumented" in the execution stuff?
