### PR TITLE
feat - Added the TTL configuration for single query

### DIFF
--- a/packages/relay-runtime/store/RelayModernStore.js
+++ b/packages/relay-runtime/store/RelayModernStore.js
@@ -202,7 +202,7 @@ class RelayModernStore implements Store {
       operationAvailability,
       operationLastWrittenAt,
       rootEntry?.fetchTime,
-      this._queryCacheExpirationTime,
+      operation.request?.cacheConfig?.ttl ?? this._queryCacheExpirationTime,
     );
   }
 
@@ -225,11 +225,12 @@ class RelayModernStore implements Store {
       rootEntry.refCount--;
 
       if (rootEntry.refCount === 0) {
-        const {_queryCacheExpirationTime} = this;
+        const ttl =
+          operation.request?.cacheConfig?.ttl ?? this._queryCacheExpirationTime;
         const rootEntryIsStale =
           rootEntry.fetchTime != null &&
-          _queryCacheExpirationTime != null &&
-          rootEntry.fetchTime <= Date.now() - _queryCacheExpirationTime;
+          ttl != null &&
+          rootEntry.fetchTime <= Date.now() - ttl;
 
         if (rootEntryIsStale) {
           this._roots.delete(id);

--- a/packages/relay-runtime/util/RelayRuntimeTypes.js
+++ b/packages/relay-runtime/util/RelayRuntimeTypes.js
@@ -59,6 +59,7 @@ export type CacheConfig = {|
   liveConfigId?: ?string,
   metadata?: {[key: string]: mixed, ...},
   transactionId?: ?string,
+  ttl?: number,
 |};
 
 /**


### PR DESCRIPTION
With this PR it is possible to configure a TTL different from the queryCacheExpirationTime configured in the Store for each query.

To do this, simply add the new ttl property to the cacheConfig property of the QueryRenderer