### PR TITLE
feat: Support AsyncGenerators as a result from fetchFn

### DIFF
--- a/packages/relay-runtime/network/RelayObservable.js
+++ b/packages/relay-runtime/network/RelayObservable.js
@@ -497,9 +497,9 @@ function fromValue<T>(value: T): RelayObservable<T> {
 function fromAsyncIterator<T>(obj: AsyncIterator<T>): RelayObservable<T> {
   return RelayObservable.create(sink => {
     (async () => {
-      while(true) {
+      while (true) {
         const {value, done} = await obj.next();
-        if (done) break;
+        if (done) {break;}
         sink.next(value);
       }
       sink.complete();

--- a/packages/relay-runtime/network/RelayObservable.js
+++ b/packages/relay-runtime/network/RelayObservable.js
@@ -468,7 +468,10 @@ declare function isAsyncIterator(p: mixed): boolean %checks(p instanceof
   AsyncIterator);
 
 function isAsyncIterator(obj) {
-  return typeof obj === 'object' && typeof obj[Symbol.asyncIterator] < 'u';
+  return typeof val < 'u' &&
+    val !== null &&
+      (val[Symbol.toStringTag] === 'AsyncGenerator' ||
+        (Symbol.asyncIterator && Symbol.asyncIterator in val));
 }
 
 function fromObservable<T>(obj: Subscribable<T>): RelayObservable<T> {

--- a/packages/relay-runtime/network/RelayObservable.js
+++ b/packages/relay-runtime/network/RelayObservable.js
@@ -468,7 +468,7 @@ declare function isAsyncIterator(p: mixed): boolean %checks(p instanceof
   AsyncIterator);
 
 function isAsyncIterator(obj) {
-  return typeof obj[Symbol.asyncIterator] < 'u';
+  return typeof obj === 'object' && typeof obj[Symbol.asyncIterator] < 'u';
 }
 
 function fromObservable<T>(obj: Subscribable<T>): RelayObservable<T> {

--- a/packages/relay-runtime/network/RelayObservable.js
+++ b/packages/relay-runtime/network/RelayObservable.js
@@ -508,7 +508,7 @@ function fromAsyncIterator<T>(obj: AsyncIterator<T>): RelayObservable<T> {
       sink.complete();
     })().catch(sink.error);
 
-    return () => obj.return?.()
+    return () => obj.return?.();
   });
 }
 

--- a/packages/relay-runtime/network/RelayObservable.js
+++ b/packages/relay-runtime/network/RelayObservable.js
@@ -497,8 +497,10 @@ function fromValue<T>(value: T): RelayObservable<T> {
 function fromAsyncIterator<T>(obj: AsyncIterator<T>): RelayObservable<T> {
   return RelayObservable.create(sink => {
     (async () => {
-      for await (const patch of obj) {
-        sink.next(patch);
+      while(true) {
+        const {value, done} = await obj.next();
+        if (done) break;
+        sink.next(value);
       }
       sink.complete();
     })().catch(sink.error);

--- a/packages/relay-runtime/network/RelayObservable.js
+++ b/packages/relay-runtime/network/RelayObservable.js
@@ -505,7 +505,7 @@ function fromAsyncIterator<T>(obj: AsyncIterator<T>): RelayObservable<T> {
     (async () => {
       while (true) {
         const {value, done} = await obj.next();
-        if (done) break;
+        if (done) {break;}
         sink.next(value);
       }
       sink.complete();

--- a/packages/relay-runtime/network/RelayObservable.js
+++ b/packages/relay-runtime/network/RelayObservable.js
@@ -504,6 +504,8 @@ function fromAsyncIterator<T>(obj: AsyncIterator<T>): RelayObservable<T> {
       }
       sink.complete();
     })().catch(sink.error);
+
+    return () => obj.return?.()
   });
 }
 

--- a/packages/relay-runtime/network/__tests__/RelayObservable-test.js
+++ b/packages/relay-runtime/network/__tests__/RelayObservable-test.js
@@ -1577,10 +1577,9 @@ describe('RelayObservable', () => {
         const values = [{key: 'a'}, {key: 'b'}];
         const calls = [];
         const final_call = jest.fn();
-        let resolve; let reject;
 
-        
-let promise = new Promise((rs, rj) => {
+        let resolve; let reject;
+        let promise = new Promise((rs, rj) => {
           resolve = rs;
           reject = rj;
         });

--- a/packages/relay-runtime/network/__tests__/RelayObservable-test.js
+++ b/packages/relay-runtime/network/__tests__/RelayObservable-test.js
@@ -1444,6 +1444,28 @@ describe('RelayObservable', () => {
       expect(list).toEqual(['error', error]);
     });
 
+    it('Converts an AsyncGenerator to an Observable', done => {
+      const value = {key: 'value'};
+
+      async function* generate() {
+        yield value;
+      }
+      const result = generate();
+      const obs = RelayObservable.from(result);
+
+      obs.subscribe({
+        next: val => {
+          expect(val).toEqual(value);
+        },
+        error: err => {
+          done(err);
+        },
+        complete: () => {
+          done();
+        },
+      });
+    });
+
     it('Error in next handler is unhandled', async () => {
       const list = [];
       const error = new Error();

--- a/packages/relay-runtime/network/__tests__/RelayObservable-test.js
+++ b/packages/relay-runtime/network/__tests__/RelayObservable-test.js
@@ -1450,19 +1450,18 @@ describe('RelayObservable', () => {
       async function* generate() {
         yield value;
       }
+
+      // Something else will "run" this before, like the fetchFn
       const result = generate();
       const obs = RelayObservable.from(result);
 
+      expect.assertions(1);
       obs.subscribe({
         next: val => {
           expect(val).toEqual(value);
         },
-        error: err => {
-          done(err);
-        },
-        complete: () => {
-          done();
-        },
+        error: err => done(err),
+        complete: () => done(),
       });
     });
 


### PR DESCRIPTION
This PR aims to allow an async generator be returned from the fetchFn to aid in things like incremental delivery.

Intended usage:

```js
async function* fetchFn(params, variables) {
    const result = await fetch(...).then(myMultipartFnButProbablyMeros);
    for await (const part of result) {
        yield part;
    }
}
```

and being able to feed that directly into Relay's `Observable.from` aka `Network.create`