### PR TITLE
Add --config option to specify relay config file for relay-compiler

### DIFF
--- a/packages/relay-compiler/bin/RelayCompilerBin.js
+++ b/packages/relay-compiler/bin/RelayCompilerBin.js
@@ -140,6 +140,13 @@ const options = {
     type: 'boolean',
     default: false,
   },
+  config: {
+    describe: 'Path to relay config',
+    type: 'string',
+    array: false,
+    default: './relay.config.js',
+    config: true,
+  },
 };
 
 // Parse CLI args
@@ -151,17 +158,7 @@ let yargs = _yargs
   .options(options)
   .strict();
 
-// Load external config
-const config = RelayConfig && RelayConfig.loadConfig();
-if (config) {
-  // Apply externally loaded config through the yargs API so that we can leverage yargs' defaults and have them show up
-  // in the help banner. We add it conditionally otherwise yargs would add new option `--config` which is confusing for
-  // Relay users (it's not Relay Config file).
-  yargs = yargs.config(config);
-}
-
 const argv: Config = (yargs.help().argv: $FlowFixMe);
-
 // Start the application
 main(argv).catch(error => {
   console.error(String(error.stack || error));

--- a/packages/relay-compiler/bin/RelayCompilerMain.js
+++ b/packages/relay-compiler/bin/RelayCompilerMain.js
@@ -64,6 +64,7 @@ export type Config = {|
   repersist: boolean,
   artifactDirectory?: ?string,
   customScalars?: ScalarTypeMapping,
+  config: string,
 |};
 
 function buildWatchExpression(config: {


### PR DESCRIPTION
You can use few different graphql schemas for your projects, and there is no possibility to manage them via config files. This PR adds this possibility with using yargs config option. Just specify path to relay config file with --config cli option

Some discussions in #3030 