### PR TITLE
@append/prependNode - explicitly set cursor to null on created edge

### DIFF
--- a/packages/relay-runtime/handlers/connection/MutationHandlers.js
+++ b/packages/relay-runtime/handlers/connection/MutationHandlers.js
@@ -183,6 +183,7 @@ function nodeUpdater(
           clientEdge != null,
           'MutationHandlers: Failed to build the edge.',
         );
+        clientEdge.setValue(null, 'cursor');
         insertFn(connection, clientEdge);
       }
     }

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
@@ -1329,7 +1329,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-append',
@@ -1360,7 +1360,7 @@ describe('connection node mutations', () => {
     expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-prepend',
@@ -1384,7 +1384,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-append',
@@ -1440,7 +1440,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-append',
@@ -1471,7 +1471,7 @@ describe('connection node mutations', () => {
     expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-prepend',
@@ -1495,7 +1495,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-append',
@@ -1557,7 +1557,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-append-1',
@@ -1565,7 +1565,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-append-2',
@@ -1602,7 +1602,7 @@ describe('connection node mutations', () => {
     expect(callback.mock.calls[0][0].data.node.comments.edges).toEqual([
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-prepend-2',
@@ -1610,7 +1610,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-prepend-1',
@@ -1634,7 +1634,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-append-1',
@@ -1642,7 +1642,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-append-2',
@@ -1691,7 +1691,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-optimistic-append',
@@ -1735,7 +1735,7 @@ describe('connection node mutations', () => {
       },
       {
         __typename: 'CommentsEdge',
-        cursor: undefined,
+        cursor: null,
         node: {
           __typename: 'Comment',
           id: 'node-append',


### PR DESCRIPTION
This PR explicitly sets the `cursor` field to `null` on the edge that's synthetically created by `@appendNode`/`@prependNode`. This is because Relay otherwise yields a warning about missing data (`cursor` being `undefined`). 

My understanding is that this is fine because Relay doesn't look at `cursor` for pagination (just `pageInfo`, right), and it's not realistic that the user can "guess" a correct cursor for an added node anyway. So, better to just null it to get rid of the warning.

Thoughts?