### PR TITLE
docs(installation): add relay-runtime

### DIFF
--- a/docs/Introduction-InstallationAndSetup.md
+++ b/docs/Introduction-InstallationAndSetup.md
@@ -8,7 +8,7 @@ title: Installation and Setup
 Install React and Relay using `yarn` or `npm`:
 
 ```sh
-yarn add react react-dom react-relay
+yarn add react react-dom react-relay relay-runtime
 ```
 
 ## Set up Relay with a single config file


### PR DESCRIPTION
The environment section of the quick start guide imports from `relay-runtime`: https://relay.dev/docs/en/quick-start-guide#relay-environment
It's not a good idea to rely on transitive package dependencies in your app code, so I am adding `relay-runtime` to the top-level install section.