### PR TITLE
Docs: Fix inter doc links in Relay Classic guides

### DIFF
--- a/website/versioned_docs/version-classic/Classic-APIReference-Container.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-Container.md
@@ -133,7 +133,7 @@ module.exports = Relay.createContainer(StarWarsShip, {
 ```
 In this example, the fields associated with the `ship` fragment will be made available on `this.props.ship`.
 
-See also: [Containers > Relay Containers](guides-containers.html#relay-containers)
+See also: [Containers > Relay Containers](classic-guides-containers.html#relay-containers)
 
 ### initialVariables
 
@@ -229,7 +229,7 @@ if (name === 'SuperAwesomeRoute') {
 }
 ```
 
-See also: [Routes](guides-routes.html)
+See also: [Routes](classic-guides-routes.html)
 
 ### variables
 
@@ -384,7 +384,7 @@ module.exports = Relay.createContainer(Feed, {
 >
 > `setVariables` does not immediately mutate `variables`, but creates a  pending state transition. `variables` will continue returning the previous values until `this.props` has been populated with data that fulfills the new variable values.
 
-See also: [Containers > Requesting Different Data](guides-containers.html#requesting-different-data), [Ready State](guides-ready-state.html)
+See also: [Containers > Requesting Different Data](classic-guides-containers.html#requesting-different-data), [Ready State](classic-guides-ready-state.html)
 
 ### forceFetch
 
@@ -402,7 +402,7 @@ An optional `onReadyStateChange` callback can be supplied to respond to the even
 >
 > `forceFetch` can be called with an empty set of partial variables, meaning it can trigger a refresh of the currently rendered set of data.
 
-See also: [Ready State](guides-ready-state.html)
+See also: [Ready State](classic-guides-ready-state.html)
 
 ### hasOptimisticUpdate
 
@@ -466,7 +466,7 @@ module.exports = Relay.createContainer(Feed, {
 
 ```
 
-See also: [Mutations > Optimistic Updates](guides-mutations.html#optimistic-updates)
+See also: [Mutations > Optimistic Updates](classic-guides-mutations.html#optimistic-updates)
 
 ### getPendingTransactions
 

--- a/website/versioned_docs/version-classic/Classic-APIReference-GraphQLMutation.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-GraphQLMutation.md
@@ -171,7 +171,7 @@ const mutation = new Relay.GraphQLMutation(
 );
 ```
 
-See also: [Relay.Mutation::getCollisionKey()](api-reference-relay-mutation.html#getcollisionkey)
+See also: [Relay.Mutation::getCollisionKey()](classic-api-reference-relay-mutation.html#getcollisionkey)
 
 ### applyOptimistic
 
@@ -217,7 +217,7 @@ const transaction = mutation.applyOptimistic(
 );
 ```
 
-See also: [Relay.Mutation::getConfigs()](api-reference-relay-mutation.html#getconfigs-abstract-method)
+See also: [Relay.Mutation::getConfigs()](classic-api-reference-relay-mutation.html#getconfigs-abstract-method)
 
 ### commit
 
@@ -249,7 +249,7 @@ const configs = [{
 const transaction = mutation.commit(configs);
 ```
 
-See also: [Relay.Mutation::getConfigs()](api-reference-relay-mutation.html#getconfigs-abstract-method)
+See also: [Relay.Mutation::getConfigs()](classic-api-reference-relay-mutation.html#getconfigs-abstract-method)
 
 ### rollback
 

--- a/website/versioned_docs/version-classic/Classic-APIReference-Mutation.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-Mutation.md
@@ -126,8 +126,8 @@ class LikeStoryMutation extends Relay.Mutation {
 ```
 
 See also:
-[Mutations > Fragment variables](guides-mutations.html#fragment-variables) and
-[Mutations > Optimistic updates](guides-mutations.html#optimistic-updates)
+[Mutations > Fragment variables](classic-guides-mutations.html#fragment-variables) and
+[Mutations > Optimistic updates](classic-guides-mutations.html#optimistic-updates)
 
 ### initialVariables (static property)
 
@@ -153,7 +153,7 @@ class ChangeTodoStatusMutation extends Relay.Mutation {
 ```
 
 See also:
-[Mutations > Fragment variables](guides-mutations.html#fragment-variables)
+[Mutations > Fragment variables](classic-guides-mutations.html#fragment-variables)
 
 ### prepareVariables (static property)
 
@@ -189,7 +189,7 @@ class BuySongMutation extends Relay.Mutation {
 ```
 
 See also:
-[Mutations > Fragment variables](guides-mutations.html#fragment-variables)
+[Mutations > Fragment variables](classic-guides-mutations.html#fragment-variables)
 
 ## Methods
 
@@ -227,7 +227,7 @@ class LikeStoryMutation extends Relay.Mutation {
 }
 ```
 
-See also: [Mutations > Mutator configuration](guides-mutations.html#mutator-configuration)
+See also: [Mutations > Mutator configuration](classic-guides-mutations.html#mutator-configuration)
 
 ### getFatQuery (abstract method)
 
@@ -256,7 +256,7 @@ class BuySongMutation extends Relay.Mutation {
 ```
 
 See also:
-[Mutations > The fat query](guides-mutations.html#the-fat-query)
+[Mutations > The fat query](classic-guides-mutations.html#the-fat-query)
 
 ### getMutation (abstract method)
 
@@ -445,4 +445,4 @@ class LikeStoryMutation extends Relay.Mutation {
 }
 ```
 
-See also: [Mutations > Optimistic updates](guides-mutations.html#optimistic-updates)
+See also: [Mutations > Optimistic updates](classic-guides-mutations.html#optimistic-updates)

--- a/website/versioned_docs/version-classic/Classic-APIReference-Relay.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-Relay.md
@@ -92,7 +92,7 @@ See the [Network Layer Guide](guides-network-layer.html).
 
 ### Mutation
 
-See the [Mutations Guide](guides-mutations.html).
+See the [Mutations Guide](classic-guides-mutations.html).
 
 ### QL
 
@@ -104,7 +104,7 @@ See the [PropTypes API reference](api-reference-relay-proptypes.html).
 
 ### RootContainer
 
-See the [RootContainer Guide](guides-root-container.html).
+See the [RootContainer Guide](classic-guides-root-container.html).
 
 ### Route
 
@@ -126,7 +126,7 @@ var Container = Relay.createContainer(Component, {
 });
 ```
 
-Creates a new Relay Container - see the [Container Guide](guides-containers.html) for more details and examples.
+Creates a new Relay Container - see the [Container Guide](classic-guides-containers.html) for more details and examples.
 
 ### injectNetworkLayer (static method)
 

--- a/website/versioned_docs/version-classic/Classic-APIReference-Renderer.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-Renderer.md
@@ -136,4 +136,4 @@ onReadyStateChange(
 
 This callback prop is called as the various events of data resolution occur.
 
-See also: [Ready State](guides-ready-state.html)
+See also: [Ready State](classic-guides-ready-state.html)

--- a/website/versioned_docs/version-classic/Classic-APIReference-RootContainer.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-RootContainer.md
@@ -64,7 +64,7 @@ Component: RelayContainer
 
 Must be a valid `RelayContainer`. Relay will attempt to fulfill its data requirements before rendering it.
 
-See also: [Root Container > Component and Route](guides-root-container.html#component-and-route)
+See also: [Root Container > Component and Route](classic-guides-root-container.html#component-and-route)
 
 ### route
 
@@ -74,7 +74,7 @@ route: RelayRoute
 
 Either an instance of `Relay.Route` or an object with the `name`, `queries`, and optionally the `params` properties.
 
-See also: [Root Container > Component and Route](guides-root-container.html#component-and-route)
+See also: [Root Container > Component and Route](classic-guides-root-container.html#component-and-route)
 
 ### forceFetch
 
@@ -84,7 +84,7 @@ forceFetch: boolean
 
 If supplied and set to true, a request for data will always be made to the server regardless of whether data on the client is available to immediately fulfill the data requirements.
 
-See also: [Root Container > Force Fetching](guides-root-container.html#force-fetching)
+See also: [Root Container > Force Fetching](classic-guides-root-container.html#force-fetching)
 
 ### renderLoading
 
@@ -106,7 +106,7 @@ When data requirements have yet to be fulfilled, `renderLoading` is called to re
 />
 ```
 
-See also: [Root Container > renderLoading](guides-root-container.html#renderloading)
+See also: [Root Container > renderLoading](classic-guides-root-container.html#renderloading)
 
 ### renderFetched
 
@@ -135,7 +135,7 @@ When all data requirements are fulfilled, `renderFetched` is called to render th
 />
 ```
 
-See also: [Root Container > renderFetched](guides-root-container.html#renderfetched)
+See also: [Root Container > renderFetched](classic-guides-root-container.html#renderfetched)
 
 ### renderFailure
 
@@ -162,7 +162,7 @@ When data requirements failed to be fulfilled, `renderFailure` is called to rend
 />
 ```
 
-See also: [Root Container > renderFailure](guides-root-container.html#renderfailure)
+See also: [Root Container > renderFailure](classic-guides-root-container.html#renderfailure)
 
 ### onReadyStateChange
 
@@ -181,4 +181,4 @@ onReadyStateChange(
 
 This callback prop is called as the various events of data resolution occurs.
 
-See also: [Ready State](guides-ready-state.html)
+See also: [Ready State](classic-guides-ready-state.html)

--- a/website/versioned_docs/version-classic/Classic-Guides-Mutations.md
+++ b/website/versioned_docs/version-classic/Classic-Guides-Mutations.md
@@ -138,7 +138,7 @@ class LikeStoryMutation extends Relay.Mutation {
 
 ## Fragment variables
 
-Like it can be done with [Relay containers](guides-containers.html), we can prepare variables for use by our mutation's fragment builders, based on the previous variables and the runtime environment.
+Like it can be done with [Relay containers](classic-guides-containers.html), we can prepare variables for use by our mutation's fragment builders, based on the previous variables and the runtime environment.
 
 ```
 class RentMovieMutation extends Relay.Mutation {

--- a/website/versioned_docs/version-classic/Classic-Guides-NetworkLayer.md
+++ b/website/versioned_docs/version-classic/Classic-Guides-NetworkLayer.md
@@ -59,7 +59,7 @@ Relay.injectNetworkLayer(
 
 Relay also lets us completely replace the default network layer.
 
-Custom network layers must conform to the following [RelayNetworkLayer](interfaces-relay-network-layer.html) interface. Although the default network layer is an instantiable class that accepts some configuration, this is not a requirement of an injected network layer.
+Custom network layers must conform to the following [RelayNetworkLayer](classic-interfaces-relay-network-layer.html) interface. Although the default network layer is an instantiable class that accepts some configuration, this is not a requirement of an injected network layer.
 
 For example, a network layer can be a simple object that conforms to the interface:
 
@@ -79,4 +79,4 @@ var myNetworkLayer = {
 Relay.injectNetworkLayer(myNetworkLayer);
 ```
 
-You can read more about the API [RelayNetworkLayer](interfaces-relay-network-layer.html) interface.
+You can read more about the API [RelayNetworkLayer](classic-interfaces-relay-network-layer.html) interface.

--- a/website/versioned_docs/version-classic/Classic-Guides-RootContainer.md
+++ b/website/versioned_docs/version-classic/Classic-Guides-RootContainer.md
@@ -139,4 +139,4 @@ When `forceFetch` is true and `renderFetched` is called as a result of available
 
 **Relay.RootContainer** also supports the `onReadyStateChange` prop which lets us receive fine-grained events as they occur while fulfilling the data requirements.
 
-Learn how to use `onReadyStateChange` in our next guide, [Ready State](guides-ready-state.html).
+Learn how to use `onReadyStateChange` in our next guide, [Ready State](classic-guides-ready-state.html).

--- a/website/versioned_docs/version-classic/Classic-Interfaces-NetworkLayer.md
+++ b/website/versioned_docs/version-classic/Classic-Interfaces-NetworkLayer.md
@@ -55,7 +55,7 @@ sendMutation(mutationRequest) {
 }
 ```
 
-See [RelayMutationRequest](interfaces-relay-mutation-request.html) for methods available on the argument object.
+See [RelayMutationRequest](classic-interfaces-relay-mutation-request.html) for methods available on the argument object.
 
 ### sendQueries
 
@@ -85,7 +85,7 @@ sendQueries(queryRequests) {
 }
 ```
 
-See [RelayQueryRequest](interfaces-relay-query-request.html) for methods available on the argument objects.
+See [RelayQueryRequest](classic-interfaces-relay-query-request.html) for methods available on the argument objects.
 
 ### supports
 


### PR DESCRIPTION
Hi,

I found many of these guides link URL are missing `classic-` prefix. E.g.

https://relay.dev/docs/en/classic/guides-containers is 404 and the new location is https://relay.dev/docs/en/classic/classic-guides-containers.

