### PR TITLE
[Rust] log error when compiler fails

### DIFF
--- a/compiler/crates/relay-compiler/src/main.rs
+++ b/compiler/crates/relay-compiler/src/main.rs
@@ -51,7 +51,8 @@ async fn main() {
             Ok(_compiler_state) => {
                 info!("Done");
             }
-            Err(_) => {
+            Err(err) => {
+                error!("{}", err);
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
I was trying to get the Rust compiler working in a test project, and having this would've saved me a while 😄 