### PR TITLE
Fix code example typo in homepage

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -165,7 +165,7 @@ export default function ArtistRenderer({artistID}) {
         if (error) {
           return <div>{error.message}</div>;
         } else if (props) {
-          return <Artist artist={props.artist} />;
+          return <ArtistHeader artist={props.artist} />;
         }
         return <div>Loading</div>;
       }}


### PR DESCRIPTION
Code sample in homepage imports fragment container `ArtistHeader` but returns nonexistent `Artist` component.

Alternatively the intention might have been to show `QueryRenderer` rendering an `Artist` component-that isn't shown in the examples-which presumably renders `ArtistHeader` at some point in its tree. Then the import statement should be changed instead.