### PR TITLE
Realign top graphic element inside "Ahead-of-time" section

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -202,7 +202,7 @@
   background-repeat: no-repeat;
   content: '';
   display: block;
-  width: 369px;
+  width: 329px;
   height: 128px;
   position: absolute;
   top: 0;


### PR DESCRIPTION
In viewports larger than 1500px in width the top-right graphic inside "Ahead-of-time Safety" section (the downgoing grey line
breaking to the right) is misaligned with the rightmost vertical white line inside "Flexible mutations":
>> ![image](https://user-images.githubusercontent.com/229435/102723520-84993600-42d6-11eb-8d2d-6950d40f0aaa.png)

### What changed
The 40px shift in width on the default CSS style fixes this issue:
>> ![image](https://user-images.githubusercontent.com/229435/102723530-9549ac00-42d6-11eb-8d8b-3a53a03fad1f.png)

cc @luansantosti @josephsavona