### PR TITLE
Rust: js config loader crate

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1042,6 +1042,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "js-config-loader"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,7 +1957,6 @@ dependencies = [
  "common",
  "fnv",
  "graphql-syntax",
- "graphql-test-helpers",
  "interner",
  "lazy_static",
  "schema",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/graphql-test-helpers",
     "crates/graphql-text-printer",
     "crates/interner",
+    "crates/js-config-loader",
     "crates/persist-query",
     "crates/relay-codegen",
     "crates/relay-compiler-neon/native",

--- a/compiler/crates/js-config-loader/Cargo.toml
+++ b/compiler/crates/js-config-loader/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "js-config-loader"
+edition = "2018"
+version = "0.0.0"
+authors = ['Facebook']
+license = "MIT"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive", "rc"] }
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
+thiserror = "1.0"
+
+[dev-dependencies]
+tempfile = "3.1.0"

--- a/compiler/crates/js-config-loader/src/error.rs
+++ b/compiler/crates/js-config-loader/src/error.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+use std::process::Output;
+
+use thiserror::Error;
+
+/// Fixed set of validation errors with custom display messages
+#[derive(Debug)]
+pub struct ConfigError {
+    pub path: PathBuf,
+    pub code: ErrorCode,
+}
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Invalid config file: {:?}: {}", &self.path, &self.code)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ErrorCode {
+    #[error("Error parsing package.json: {error}")]
+    PackageJsonParseError { error: serde_json::Error },
+
+    #[error("Found key `{key}` in package.json, but failed incorrect value: {error}")]
+    PackageJsonInvalidValue {
+        key: String,
+        error: serde_json::Error,
+    },
+
+    #[error("Error parsing JSON: {error}")]
+    JsonParseError {
+        #[from]
+        error: serde_json::Error,
+    },
+
+    #[error("YAML file parsing not supported")]
+    YamlFileUnsupported,
+
+    #[error("Error running node: {}", String::from_utf8_lossy(&output.stderr))]
+    NodeExecuteError { output: Output },
+}

--- a/compiler/crates/js-config-loader/src/lib.rs
+++ b/compiler/crates/js-config-loader/src/lib.rs
@@ -1,0 +1,58 @@
+mod error;
+mod loader;
+
+pub use error::{ConfigError, ErrorCode};
+use loader::{JsLoader, JsonLoader, Loader, PackageJsonLoader, YamlLoader};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct Config<T> {
+    pub path: PathBuf,
+    pub value: T,
+}
+
+pub fn search<T>(name: &str, dir: &Path) -> Result<Option<Config<T>>, ConfigError>
+where
+    T: for<'de> Deserialize<'de> + 'static,
+{
+    let loaders: Vec<(String, Box<dyn Loader<T>>)> = vec![
+        (
+            String::from("package.json"),
+            Box::new(PackageJsonLoader { key: name }),
+        ),
+        (format!(".{}rc", name), Box::new(JsonLoader)),
+        (format!(".{}rc.json", name), Box::new(JsonLoader)),
+        (format!(".{}rc.yaml", name), Box::new(YamlLoader)),
+        (format!(".{}rc.yml", name), Box::new(YamlLoader)),
+        (format!(".{}rc.js", name), Box::new(JsLoader)),
+        (format!(".{}rc.cjs", name), Box::new(JsLoader)),
+        (format!("{}.config.js", name), Box::new(JsLoader)),
+        (format!("{}.config.cjs", name), Box::new(JsLoader)),
+    ];
+
+    for search_dir in dir.ancestors() {
+        for (file_name, loader) in &loaders {
+            let file_path = search_dir.join(file_name);
+            if file_path.exists() {
+                match loader.load(&file_path) {
+                    Ok(None) => {}
+                    Ok(Some(value)) => {
+                        return Ok(Some(Config {
+                            path: file_path,
+                            value,
+                        }));
+                    }
+                    Err(code) => {
+                        return Err(ConfigError {
+                            path: file_path,
+                            code,
+                        });
+                    }
+                };
+            }
+        }
+    }
+
+    Ok(None)
+}

--- a/compiler/crates/js-config-loader/src/loader.rs
+++ b/compiler/crates/js-config-loader/src/loader.rs
@@ -1,0 +1,74 @@
+use crate::ErrorCode;
+use serde::Deserialize;
+use serde_json::Value;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+use std::process::Command;
+
+pub trait Loader<T> {
+    fn load(&self, path: &Path) -> Result<Option<T>, ErrorCode>;
+}
+
+pub struct PackageJsonLoader<'a> {
+    pub key: &'a str,
+}
+impl<'a, T: for<'de> Deserialize<'de>> Loader<T> for PackageJsonLoader<'a> {
+    fn load(&self, path: &Path) -> Result<Option<T>, ErrorCode> {
+        let file = File::open(&path).unwrap();
+        let reader = BufReader::new(file);
+        let mut package_json: Value = serde_json::from_reader(reader)
+            .map_err(|error| ErrorCode::PackageJsonParseError { error })?;
+        if let Some(config_value) = package_json.get_mut(self.key).take() {
+            match serde_json::from_value::<T>(config_value.clone()) {
+                Ok(config) => {
+                    return Ok(Some(config));
+                }
+                Err(error) => {
+                    return Err(ErrorCode::PackageJsonInvalidValue {
+                        key: self.key.into(),
+                        error,
+                    });
+                }
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub struct YamlLoader;
+impl<T> Loader<T> for YamlLoader {
+    fn load(&self, _path: &Path) -> Result<Option<T>, ErrorCode> {
+        Err(ErrorCode::YamlFileUnsupported)
+    }
+}
+
+pub struct JsonLoader;
+impl<T: for<'de> Deserialize<'de> + 'static> Loader<T> for JsonLoader {
+    fn load(&self, path: &Path) -> Result<Option<T>, ErrorCode> {
+        let file = File::open(&path).unwrap();
+        let reader = BufReader::new(file);
+        let config = serde_json::from_reader(reader)?;
+        Ok(Some(config))
+    }
+}
+
+pub struct JsLoader;
+impl<T: for<'de> Deserialize<'de> + 'static> Loader<T> for JsLoader {
+    fn load(&self, path: &Path) -> Result<Option<T>, ErrorCode> {
+        let output = Command::new("node")
+            .arg("-e")
+            .arg(r#"process.stdout.write(JSON.stringify(require(process.argv[1])))"#)
+            .arg(&path)
+            .output()
+            .expect("failed to execute process");
+
+        if output.status.success() {
+            let value = serde_json::from_slice::<T>(&output.stdout);
+            Ok(Some(value.unwrap()))
+        } else {
+            Err(ErrorCode::NodeExecuteError { output })
+        }
+    }
+}

--- a/compiler/crates/js-config-loader/tests/test.rs
+++ b/compiler/crates/js-config-loader/tests/test.rs
@@ -1,0 +1,184 @@
+use js_config_loader::{search, ConfigError, ErrorCode};
+use serde::Deserialize;
+use std::fs::create_dir_all;
+use tempfile::tempdir;
+
+#[derive(Debug, Deserialize)]
+struct TestConfig {
+    name: String,
+}
+
+#[test]
+fn package_json_and_rc_same_dir() {
+    let dir = tempdir().unwrap();
+    let dir_d = dir.path().join("a/b/c/d");
+    let dir_f = dir.path().join("a/b/c/d/e/f");
+    create_dir_all(&dir_f).unwrap();
+
+    std::fs::write(dir_d.join("package.json"), r#"{ "false": "hope" }"#).unwrap();
+    std::fs::write(dir_d.join(".foorc"), r#"{ "name": "correct" }"#).unwrap();
+
+    let config = search::<TestConfig>("foo", &dir_f).unwrap().unwrap();
+    assert_eq!(config.value.name, "correct");
+}
+
+#[test]
+fn rc_json_invalid_syntax() {
+    let dir = tempdir().unwrap();
+    let dir_d = dir.path().join("a/b/c/d");
+    let dir_f = dir.path().join("a/b/c/d/e/f");
+    create_dir_all(&dir_f).unwrap();
+
+    std::fs::write(dir_d.join(".foorc"), "invalid").unwrap();
+
+    match search::<TestConfig>("foo", &dir_f) {
+        Err(ConfigError {
+            code: ErrorCode::JsonParseError { error },
+            path,
+        }) => {
+            assert!(error.is_syntax());
+            assert_eq!(path.file_name().unwrap(), ".foorc");
+        }
+        other => {
+            panic!("unexpected value: {:?}", other);
+        }
+    }
+}
+
+#[test]
+fn package_json() {
+    let dir = tempdir().unwrap();
+    let dir_d = dir.path().join("a/b/c/d");
+    let dir_f = dir.path().join("a/b/c/d/e/f");
+    create_dir_all(&dir_f).unwrap();
+
+    std::fs::write(
+        dir_d.join("package.json"),
+        r#"
+            {
+                "foo": { "name": "correct" }
+            }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(dir_d.join(".foorc"), r#"{ "name": "wrong" }"#).unwrap();
+
+    let config = search::<TestConfig>("foo", &dir_f).unwrap().unwrap();
+    assert_eq!(config.value.name, "correct");
+}
+
+#[test]
+fn package_json_invalid_syntax() {
+    let dir = tempdir().unwrap();
+    let dir_d = dir.path().join("a/b/c/d");
+    let dir_f = dir.path().join("a/b/c/d/e/f");
+    create_dir_all(&dir_f).unwrap();
+
+    std::fs::write(dir_d.join("package.json"), "invalid").unwrap();
+    std::fs::write(dir_d.join(".foorc"), r#"{ "name": "wrong" }"#).unwrap();
+
+    match search::<TestConfig>("foo", &dir_f).unwrap_err() {
+        ConfigError {
+            path: _,
+            code: ErrorCode::PackageJsonParseError { error },
+        } => {
+            assert!(error.is_syntax());
+        }
+        other => panic!("incorrect error: {:?}", other),
+    }
+}
+
+#[test]
+fn package_json_invalid_format() {
+    let dir = tempdir().unwrap();
+    let dir_d = dir.path().join("a/b/c/d");
+    let dir_f = dir.path().join("a/b/c/d/e/f");
+    create_dir_all(&dir_f).unwrap();
+
+    std::fs::write(
+        dir_d.join("package.json"),
+        r#"
+            {
+                "foo": { "incorrect": 1 }
+            }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(dir_d.join(".foorc"), r#"{ "name": "wrong" }"#).unwrap();
+
+    match search::<TestConfig>("foo", &dir_f).unwrap_err() {
+        ConfigError {
+            path: _,
+            code: ErrorCode::PackageJsonInvalidValue { key, error },
+        } => {
+            assert_eq!(key, "foo");
+            assert!(error.is_data());
+        }
+        other => panic!("incorrect error: {:?}", other),
+    }
+}
+
+#[test]
+fn config_js() {
+    let dir = tempdir().unwrap();
+    let dir_d = dir.path().join("a/b/c/d");
+    let dir_f = dir.path().join("a/b/c/d/e/f");
+    create_dir_all(&dir_f).unwrap();
+
+    std::fs::write(
+        dir_d.join("foo.config.js"),
+        r#"
+        module.exports = { name: "correct" };
+        "#,
+    )
+    .unwrap();
+
+    let config = search::<TestConfig>("foo", &dir_f).unwrap().unwrap();
+    assert_eq!(config.value.name, "correct");
+}
+
+#[test]
+fn config_js_invalid_js() {
+    let dir = tempdir().unwrap();
+    let dir_d = dir.path().join("a/b/c/d");
+    let dir_f = dir.path().join("a/b/c/d/e/f");
+    create_dir_all(&dir_f).unwrap();
+
+    std::fs::write(
+        dir_d.join("foo.config.js"),
+        r#"
+        module.exports = foo();
+        "#,
+    )
+    .unwrap();
+
+    match search::<TestConfig>("foo", &dir_f).unwrap_err() {
+        ConfigError {
+            code: ErrorCode::NodeExecuteError { output: _ },
+            path,
+        } => {
+            assert_eq!(path.file_name().unwrap(), "foo.config.js");
+        }
+        other => panic!("incorrect error: {:?}", other),
+    }
+}
+
+#[test]
+fn unsupported_file() {
+    let dir = tempdir().unwrap();
+    let dir_d = dir.path().join("a/b/c/d");
+    let dir_f = dir.path().join("a/b/c/d/e/f");
+    create_dir_all(&dir_f).unwrap();
+
+    std::fs::write(dir_d.join(".foorc.yaml"), "name: correct").unwrap();
+
+    match search::<TestConfig>("foo", &dir_f).unwrap_err() {
+        ConfigError {
+            code: ErrorCode::YamlFileUnsupported,
+            path,
+        } => {
+            assert_eq!(path.file_name().unwrap(), ".foorc.yaml");
+        }
+        other => panic!("incorrect error: {:?}", other),
+    }
+}


### PR DESCRIPTION
This crate implements a similar config resolution mechanism as [cosmiconfig](https://www.npmjs.com/package/cosmiconfig). This could be used for the Rust based compiler to find the Relay compiler config.