### PR TITLE
Rust: break cycling dependency tripping up rust-analyzer

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -811,7 +811,7 @@ version = "0.0.0"
 dependencies = [
  "common",
  "fixture-tests",
- "graphql-test-helpers",
+ "graphql-cli",
  "interner",
  "logos",
  "lsp-types",

--- a/compiler/crates/graphql-syntax/Cargo.toml
+++ b/compiler/crates/graphql-syntax/Cargo.toml
@@ -40,4 +40,4 @@ thiserror = "1.0"
 
 [dev-dependencies]
 fixture-tests = { path = "../fixture-tests" }
-graphql-test-helpers = { path = "../graphql-test-helpers" }
+graphql-cli = { path = "../graphql-cli" }

--- a/compiler/crates/graphql-syntax/tests/parse_document/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_document/mod.rs
@@ -5,10 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use common::SourceLocationKey;
+use common::{Diagnostic, SourceLocationKey};
 use fixture_tests::Fixture;
+use graphql_cli::DiagnosticPrinter;
 use graphql_syntax::parse_document;
-use graphql_test_helpers::diagnostics_to_sorted_string;
+
+// NOTE: copied from graphql-test-helpers to avoid cyclic dependency breaking Rust Analyzer
+fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
+    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let mut printed = diagnostics
+        .iter()
+        .map(|diagnostic| printer.diagnostic_to_string(diagnostic))
+        .collect::<Vec<_>>();
+    printed.sort();
+    printed.join("\n\n")
+}
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_document(

--- a/compiler/crates/graphql-syntax/tests/parse_executable_document/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_executable_document/mod.rs
@@ -5,10 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use common::SourceLocationKey;
+use common::{Diagnostic, SourceLocationKey};
 use fixture_tests::Fixture;
+use graphql_cli::DiagnosticPrinter;
 use graphql_syntax::parse_executable;
-use graphql_test_helpers::diagnostics_to_sorted_string;
+
+// NOTE: copied from graphql-test-helpers to avoid cyclic dependency breaking Rust Analyzer
+fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
+    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let mut printed = diagnostics
+        .iter()
+        .map(|diagnostic| printer.diagnostic_to_string(diagnostic))
+        .collect::<Vec<_>>();
+    printed.sort();
+    printed.join("\n\n")
+}
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_executable(

--- a/compiler/crates/graphql-syntax/tests/parse_executable_document_with_error_recovery/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_executable_document_with_error_recovery/mod.rs
@@ -5,10 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use common::SourceLocationKey;
+use common::{Diagnostic, SourceLocationKey};
 use fixture_tests::Fixture;
+use graphql_cli::DiagnosticPrinter;
 use graphql_syntax::parse_executable_with_error_recovery;
-use graphql_test_helpers::diagnostics_to_sorted_string;
+
+// NOTE: copied from graphql-test-helpers to avoid cyclic dependency breaking Rust Analyzer
+fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
+    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let mut printed = diagnostics
+        .iter()
+        .map(|diagnostic| printer.diagnostic_to_string(diagnostic))
+        .collect::<Vec<_>>();
+    printed.sort();
+    printed.join("\n\n")
+}
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let result = parse_executable_with_error_recovery(

--- a/compiler/crates/graphql-syntax/tests/parse_schema_document/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_schema_document/mod.rs
@@ -5,10 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use common::SourceLocationKey;
+use common::{Diagnostic, SourceLocationKey};
 use fixture_tests::Fixture;
+use graphql_cli::DiagnosticPrinter;
 use graphql_syntax::parse_schema_document;
-use graphql_test_helpers::diagnostics_to_sorted_string;
+
+// NOTE: copied from graphql-test-helpers to avoid cyclic dependency breaking Rust Analyzer
+fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
+    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let mut printed = diagnostics
+        .iter()
+        .map(|diagnostic| printer.diagnostic_to_string(diagnostic))
+        .collect::<Vec<_>>();
+    printed.sort();
+    printed.join("\n\n")
+}
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_schema_document(


### PR DESCRIPTION
There was a cyclic dependency here (involving dev-dependencies). This seems okay with `cargo` and rust builds, but was tripping up `rust-analyzer` failing to find the `graphql-syntax` crate.

This fixes the cycle by some small copy-pasta for a test utility. I used this instead of pulling this one small function out into yet another crate.

Test Plan:
Open `schema/src/definitions.rs` and see that Rust Analyzer in VS Code now resolves `use graphql_syntax::*` correctly.