### PR TITLE
Display code context for single error, fixes #3318

### DIFF
--- a/packages/relay-compiler/core/CompilerError.js
+++ b/packages/relay-compiler/core/CompilerError.js
@@ -122,7 +122,12 @@ function eachWithCombinedError<T>(iterable: Iterable<T>, fn: T => void): void {
   }
   if (errors.length > 0) {
     if (errors.length === 1) {
-      throw errors[0];
+      throw createUserError(
+        String(errors[0])
+          .split('\n')
+          .map((line, index) => (index === 0 ? `- ${line}` : `  ${line}`))
+          .join('\n'),
+      );
     }
     throw createUserError(
       `Encountered ${errors.length} errors:\n` +


### PR DESCRIPTION
I've fixed issue #3318, where relay-compiler doesn't show the code excerpt and file location when there is only one user error

I have also signed the CLA.