### PR TITLE
Documentation fixes and improvements

### DIFF
--- a/docs/Modern-Debugging.md
+++ b/docs/Modern-Debugging.md
@@ -22,9 +22,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 ## Tools
 
-Relay DevTools is tool designed to help developers inspect their Relay state and understand how store changes overtime. Relay DevTools ships in two ways:
-
-- [Chrome Extension][extension] creates a Relay tab in the developer tools interface for debugging apps in Chrome
+Relay DevTools is a tool designed to help developers inspect their Relay state and understand how the store changes overtime. Relay DevTools ships as a [Chrome Extension][extension] which creates a Relay tab in the developer tools interface for debugging apps in Chrome.
 
 ![Store Explorer](/img/docs/store-explorer-updated.png)
 ![Mutations View](/img/docs/mutations-view-updated.png)

--- a/docs/Modern-Mutations.md
+++ b/docs/Modern-Mutations.md
@@ -161,7 +161,7 @@ const configs = [{
 ```
 
 ### RANGE_ADD
-Given a parent, information about the connection, and the name of the newly created edge in the response payload Relay will add the node to the store and attach it to the connection according to the range behavior(s) specified in the connectionInfo.
+Given a parent, information about the connection, and the name of the newly created edge in the response payload Relay will add the node to the store and attach it to the connection according to the range behavior(s) specified in the `connectionInfo`.
 
 #### Arguments
 * `parentID: string`: The DataID of the parent node that contains the
@@ -262,7 +262,7 @@ When you provide these functions, this is roughly what happens during the mutati
 - Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 - If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here's a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js

--- a/docs/Modern-PersistedQueries.md
+++ b/docs/Modern-PersistedQueries.md
@@ -22,7 +22,7 @@ In your `npm` script in `package.json`, run the relay compiler using the `--pers
 }
 ```
 
-The `--persist-ouput` flag does 3 things:
+The `--persist-ouput` flag does 2 things:
 
 1. It converts all query and mutation operation texts to md5 hashes.
 

--- a/docs/Modern-RelayStore.md
+++ b/docs/Modern-RelayStore.md
@@ -157,7 +157,7 @@ interface RecordProxy {
 
 ### `getDataID(): string`
 
-Returns the dataID of the current record.
+Returns the `dataID` of the current record.
 
 #### Example
 ```javascript
@@ -287,12 +287,12 @@ rootField {
 Usage:
 ```javascript
 const rootField = store.getRootField('rootField');
-const viewer = rootField.getLinkedRecord('viewer', {count: 10});
+const nodes = rootField.getLinkedRecords('nodes', {count: 10});
 ```
 
 ### `getOrCreateLinkedRecord(name: string, typeName: string, arguments?: ?Object)`
 
-Retrieves the a record associated with the current record given the field name, as defined by the GraphQL document. If the linked record does not exist, it will be created given the type name. Returns a `RecordProxy`.
+Retrieves a record associated with the current record given the field name, as defined by the GraphQL document. If the linked record does not exist, it will be created given the type name. Returns a `RecordProxy`.
 
 #### Example
 
@@ -349,7 +349,7 @@ record.copyFieldsFrom(otherRecord); // Mutates `record`
 
 ### `setLinkedRecord(record: RecordProxy, name: string, arguments?: ?Object)`
 
-Mutates the current record by setting a new linked record on the given the field name.
+Mutates the current record by setting a new linked record on the given field name.
 
 #### Example
 
@@ -365,15 +365,15 @@ rootField {
 Usage:
 ```javascript
 const rootField = store.getRootField('rootField');
-const newViewer = store.create(/* ... */)''
-rootField.setLinkedRecord(newViewer, 'viewer'); //
+const newViewer = store.create(/* ... */);
+rootField.setLinkedRecord(newViewer, 'viewer');
 ```
 
 Optionally, if the linked record takes arguments, you can pass a bag of `variables` as well.
 
 ### `setLinkedRecords(records: Array<RecordProxy>, name: string, variables?: ?Object)`
 
-Mutates the current record by setting a new set of linked records on the given the field name.
+Mutates the current record by setting a new set of linked records on the given field name.
 
 #### Example
 
@@ -391,7 +391,7 @@ Usage:
 const rootField = store.getRootField('rootField');
 const newNode = store.create(/* ... */);
 const newNodes = [...rootField.getLinkedRecords('nodes'), newNode];
-rootField.setLinkedRecords(newNodes, 'nodes'); //
+rootField.setLinkedRecords(newNodes, 'nodes');
 ```
 
 Optionally, if the linked record takes arguments, you can pass a bag of `variables` as well.
@@ -462,7 +462,7 @@ fragment FriendsFragment on User {
 }
 ```
 
-Accessing a plain connection field like this is the same as other regular field:
+Accessing a plain connection field like this is the same as other regular fields:
 ```javascript
 // The `friends` connection record can be accessed with:
 const user = store.get(userID);
@@ -495,7 +495,7 @@ import {ConnectionHandler} from 'relay-runtime';
 const user = store.get(userID);
 const friends = ConnectionHandler.getConnection(
  user,                        // parent record
- 'FriendsFragment_friends'    // connection key
+ 'FriendsFragment_friends',   // connection key
  {orderby: 'firstname'}       // 'filters' that is used to identify the connection
 );
 // Access fields on the connection:
@@ -506,7 +506,7 @@ const edges = friends.getLinkedRecords('edges');
 
 #### `createEdge(store: RecordSourceProxy, connection: RecordProxy, node: RecordProxy, edgeType: string)`
 
-Creates an edge given a [`store`](#recordsourceselectorproxy), a connection, the edge type, and a record that holds that connection.
+Creates an edge given a [`store`](#recordsourceselectorproxy), a connection, the edge node, and the edge type.
 
 #### `insertEdgeBefore(connection: RecordProxy, newEdge: RecordProxy, cursor?: ?string)`
 
@@ -520,24 +520,25 @@ Given a connection, inserts the edge at the end of the connection, or after the 
 
 ```
 const user = store.get(userID);
-const friends = ConnectionHandler.getConnection(user, 'friends');
-const edge = ConnectionHandler.createEdge(store, friends, user, 'UserEdge');
+const friends = ConnectionHandler.getConnection(user, 'FriendsFragment_friends');
+const newFriend = store.get(newFriendId);
+const edge = ConnectionHandler.createEdge(store, friends, newFriend, 'UserEdge');
 
 // No cursor provided, append the edge at the end.
 ConnectionHandler.insertEdgeAfter(friends, edge);
 
-// No cursor provided, Insert the edge at the front:
+// No cursor provided, insert the edge at the front:
 ConnectionHandler.insertEdgeBefore(friends, edge);
 ```
 
 ### `deleteNode(connection: RecordProxy, nodeID: string): void`
 
-Given a connection, deletes any edges whose id matches the given id.
+Given a connection, deletes any edges whose node id matches the given id.
 
 #### Example
 
 ```
 const user = store.get(userID);
-const friends = ConnectionHandler.getConnection(user, 'friends');
+const friends = ConnectionHandler.getConnection(user, 'FriendsFragment_friends');
 ConnectionHandler.deleteNode(friends, idToDelete);
 ```


### PR DESCRIPTION
- Improve paragraph about Relay DevTools in the Debugging docs, no longer mentioning that it ships in two ways, since it ships only as a Chrome extension.
- Fix some `ConnectionHandler` utility descriptions.
- Fix some code examples.
- Fix some typos.
- Add some missing backticks.