### PR TITLE
Add getConnectionID util to ConnectionHandler

### DIFF
--- a/packages/relay-runtime/handlers/connection/ConnectionHandler.js
+++ b/packages/relay-runtime/handlers/connection/ConnectionHandler.js
@@ -306,10 +306,10 @@ function getConnection(
  * ```
  */
 function getConnectionID(
-  recordID: string,
+  recordID: DataID,
   key: string,
   filters?: ?Variables,
-): string {
+): DataID {
   const handleKey = getRelayHandleKey(CONNECTION, key, null);
   const storageKey = getStableStorageKey(handleKey, filters);
   return generateClientID(recordID, storageKey);

--- a/packages/relay-runtime/handlers/connection/__tests__/ConnectionHandler-test.js
+++ b/packages/relay-runtime/handlers/connection/__tests__/ConnectionHandler-test.js
@@ -110,6 +110,24 @@ describe('ConnectionHandler', () => {
     ));
   });
 
+  describe('getConnectionID()', () => {
+    it('returns the connection ID when no filters are specified', () => {
+      expect(
+        ConnectionHandler.getConnectionID('4', 'ConnectionQuery_friends'),
+      ).toBe('client:4:__ConnectionQuery_friends_connection');
+    });
+
+    it('returns the connection ID when filters are specified', () => {
+      expect(
+        ConnectionHandler.getConnectionID('4', 'ConnectionQuery_friends', {
+          orderby: ['first name'],
+        }),
+      ).toBe(
+        'client:4:__ConnectionQuery_friends_connection(orderby:["first name"])',
+      );
+    });
+  });
+
   describe('insertEdgeAfter()', () => {
     let connection;
     let connectionID;


### PR DESCRIPTION
This PR adds a `getConnectionID` util to `ConnectionHandler` to easily get the connection ID knowing the ID of the record that has the connection field, the connection key, and optionally filters used to identify the connection:

```js
getConnectionID(recordID: string, key: string, filters?: ?Variables): string
```

This util is especially useful when working with the `@appendNode` and `@prependNode` directives, which take connection IDs as argument.

### Usage example with `@appendNode`

This example shows how we could add a comment to a story:

```js
const mutation = graphql`
  mutation AddCommentMutation($input: AddCommentInput!, $connections: [ID!]!) {
    addComment(input: $input) {
      comment @appendNode(connections: $connections, edgeTypeName: "CommentEdge") {
        id
      }
    }
  }
`;

const variables = {
  input: {
    storyID: '<story-id>',
    text: 'Nice story!'
  },
  connections: [
    ConnectionHandler.getConnectionID('<story-id>', 'Story_story_comments')
  ]
};

commitMutation(
  environment,
  {
    mutation,
    variables,
    ...
  }
);
```