### PR TITLE
Use getRawType to unwrap any wrappers around edge type before getting fields

### DIFF
--- a/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
+++ b/packages/relay-compiler/transforms/DeclarativeConnectionMutationTransform.js
@@ -164,9 +164,7 @@ function visitLinkedField(field: LinkedField): LinkedField {
   }
   const schema = this.getContext().getSchema();
   if (edgeDirective) {
-    const fieldType = schema.isList(transformedField.type)
-      ? transformedField.type.ofType
-      : transformedField.type;
+    const fieldType = schema.getRawType(transformedField.type);
     const fields = schema.getFields(fieldType);
     let cursorFieldID;
     let nodeFieldID;


### PR DESCRIPTION
Currently, if you try to use `@prependEdge` or `@appendEdge` on a field whose type is non-null, you get this error when running the compiler:

```
ERROR:
Internal Error: _getFieldsMap: Type 'undefined' should have fields.
```

This happens because the type is wrapped. There was already unwrapping logic for handling lists of edges, but replacing that with `getRawType` should handle any amount of list and non-null wrapping.