### PR TITLE
avoid an unnecessary rerender in useFragmentNode 

### DIFF
--- a/packages/relay-experimental/__tests__/useFragmentNode-test.js
+++ b/packages/relay-experimental/__tests__/useFragmentNode-test.js
@@ -501,10 +501,7 @@ it('should re-read and resubscribe to fragment when environment changes', () => 
     profile_picture: null,
     ...createFragmentRef('1', singularQuery),
   };
-  assertFragmentResults([
-    {data: expectedUser, shouldUpdate: true},
-    {data: expectedUser, shouldUpdate: false},
-  ]);
+  assertFragmentResults([{data: expectedUser, shouldUpdate: true}]);
 
   TestRenderer.act(() => {
     newEnvironment.commitPayload(singularQuery, {
@@ -568,10 +565,7 @@ it('should re-read and resubscribe to fragment when fragment pointers change', (
     // Assert that ref now points to newQuery owner
     ...createFragmentRef('200', newQuery),
   };
-  assertFragmentResults([
-    {data: expectedUser, shouldUpdate: true},
-    {data: expectedUser, shouldUpdate: false},
-  ]);
+  assertFragmentResults([{data: expectedUser, shouldUpdate: true}]);
 
   TestRenderer.act(() => {
     environment.commitPayload(newQuery, {
@@ -637,10 +631,7 @@ it('should render correct data when changing fragment refs multiple times', () =
     // Assert that ref now points to newQuery owner
     ...createFragmentRef('200', newQuery),
   };
-  assertFragmentResults([
-    {data: expectedUser, shouldUpdate: true},
-    {data: expectedUser, shouldUpdate: false},
-  ]);
+  assertFragmentResults([{data: expectedUser, shouldUpdate: true}]);
 
   // Udpate data for ID 1
   environment.commitPayload(singularQuery, {
@@ -666,10 +657,7 @@ it('should render correct data when changing fragment refs multiple times', () =
     // Assert that ref points to original singularQuery owner
     ...createFragmentRef('1', singularQuery),
   };
-  assertFragmentResults([
-    {data: expectedUser, shouldUpdate: true},
-    {data: expectedUser, shouldUpdate: false},
-  ]);
+  assertFragmentResults([{data: expectedUser, shouldUpdate: true}]);
 
   // Assert it correctly subscribes to new data
   TestRenderer.act(() => {
@@ -858,10 +846,7 @@ it('should re-read and resubscribe to fragment when variables change', () => {
     // Assert that ref now points to newQuery owner
     ...createFragmentRef('1', newQuery),
   };
-  assertFragmentResults([
-    {data: expectedUser, shouldUpdate: true},
-    {data: expectedUser, shouldUpdate: false},
-  ]);
+  assertFragmentResults([{data: expectedUser, shouldUpdate: true}]);
 
   TestRenderer.act(() => {
     environment.commitPayload(newQuery, {

--- a/packages/relay-experimental/__tests__/useRefetchableFragmentNode-test.js
+++ b/packages/relay-experimental/__tests__/useRefetchableFragmentNode-test.js
@@ -3760,9 +3760,6 @@ describe('useRefetchableFragmentNode', () => {
           {
             data: refetchedUser,
           },
-          {
-            data: refetchedUser,
-          },
         ]);
 
         // Refetch on another enironment afterwards should work

--- a/packages/relay-experimental/useFragmentNode.js
+++ b/packages/relay-experimental/useFragmentNode.js
@@ -168,11 +168,9 @@ function useFragmentNode<TFragmentData: mixed>(
 }
 
 function useHasChanged(value: mixed): boolean {
-  const [mirroredValue, setMirroredValue] = useState(value);
-  const valueChanged = mirroredValue !== value;
-  if (valueChanged) {
-    setMirroredValue(value);
-  }
+  const prev = useRef<mixed>();
+  const valueChanged = prev.current !== value;
+  prev.current = value;
   return valueChanged;
 }
 


### PR DESCRIPTION
With this PR I changed the useHasChange by using useRef instead of useState. In this way, when the stored value changes, no unnecessary rerender is performed