### PR TITLE
feat: added id & dispose function in RelayModernEnvironment

### DIFF
--- a/packages/relay-experimental/EntryPointContainer.react.js
+++ b/packages/relay-experimental/EntryPointContainer.react.js
@@ -67,7 +67,7 @@ function EntryPointContainer<
       profilerContext,
       rootModuleID,
     });
-  }, [environment, profilerContext, rootModuleID]);
+  }, [environment.id, profilerContext, rootModuleID]);
   return (
     <Component
       entryPoints={entryPoints}

--- a/packages/relay-experimental/LazyLoadEntryPointContainer_DEPRECATED.react.js
+++ b/packages/relay-experimental/LazyLoadEntryPointContainer_DEPRECATED.react.js
@@ -196,7 +196,7 @@ function LazyLoadEntryPointContainer_DEPRECATED<
     );
     // NOTE: stableParams encodes the information from params
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [environment, environmentProvider, getPreloadProps, entryPointParamsHash]);
+  }, [environment.id, environmentProvider, getPreloadProps, entryPointParamsHash]);
   const Component = useMemo(() => {
     return getComponent();
   }, [getComponent]);
@@ -208,7 +208,7 @@ function LazyLoadEntryPointContainer_DEPRECATED<
       profilerContext,
       rootModuleID,
     });
-  }, [environment, profilerContext, rootModuleID]);
+  }, [environment.id, profilerContext, rootModuleID]);
   return (
     <Component
       entryPoints={entryPoints}

--- a/packages/relay-experimental/RelayEnvironmentProvider.js
+++ b/packages/relay-experimental/RelayEnvironmentProvider.js
@@ -15,10 +15,12 @@
 
 const React = require('react');
 const ReactRelayContext = require('react-relay/ReactRelayContext');
+const {deleteQueryResourceForEnvironment} = require('./QueryResource');
+const {deleteFragmentResourceForEnvironment} = require('./FragmentResource');
 
 import type {IEnvironment} from 'relay-runtime';
 
-const {useMemo} = React;
+const {useMemo, useEffect} = React;
 
 type Props = $ReadOnly<{|
   children: React.Node,
@@ -27,7 +29,14 @@ type Props = $ReadOnly<{|
 
 function RelayEnvironmentProvider(props: Props): React.Node {
   const {children, environment} = props;
-  const context = useMemo(() => ({environment}), [environment]);
+  const context = useMemo(() => ({environment}), [environment.id]);
+
+  useEffect(() => () => {
+    environment.dispose();
+    deleteFragmentResourceForEnvironment(environment);
+    deleteQueryResourceForEnvironment(environment);
+  }, [environment.id]);
+  
   return (
     <ReactRelayContext.Provider value={context}>
       {children}

--- a/packages/relay-experimental/__tests__/useBlockingPaginationFragment-test.js
+++ b/packages/relay-experimental/__tests__/useBlockingPaginationFragment-test.js
@@ -23,7 +23,7 @@ const TestRenderer = require('react-test-renderer');
 
 const invariant = require('invariant');
 const useBlockingPaginationFragmentOriginal = require('../useBlockingPaginationFragment');
-const ReactRelayContext = require('react-relay/ReactRelayContext');
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const {
   ConnectionHandler,
   FRAGMENT_OWNER_KEY,
@@ -34,6 +34,7 @@ const {
 
 describe('useBlockingPaginationFragment', () => {
   let environment;
+  let newEnvironment;
   let initialUser;
   let gqlQuery;
   let gqlQueryNestedFragment;
@@ -138,6 +139,11 @@ describe('useBlockingPaginationFragment', () => {
 
     // Set up environment and base data
     environment = createMockEnvironment({
+      handlerProvider: () => ConnectionHandler,
+    });
+
+    // Set new environment
+    newEnvironment = createMockEnvironment({
       handlerProvider: () => ConnectionHandler,
     });
     const generated = generateAndCompile(
@@ -389,14 +395,12 @@ describe('useBlockingPaginationFragment', () => {
 
     const ContextProvider = ({children}) => {
       const [env, _setEnv] = useState(environment);
-      const relayContext = useMemo(() => ({environment: env}), [env]);
-
       setEnvironment = _setEnv;
 
       return (
-        <ReactRelayContext.Provider value={relayContext}>
+        <RelayEnvironmentProvider environment={env}>
           {children}
-        </ReactRelayContext.Provider>
+        </RelayEnvironmentProvider>
       );
     };
 
@@ -2788,10 +2792,6 @@ describe('useBlockingPaginationFragment', () => {
           });
           expect(callback).toBeCalledTimes(0);
 
-          // Set new environment
-          const newEnvironment = createMockEnvironment({
-            handlerProvider: () => ConnectionHandler,
-          });
           newEnvironment.commitPayload(query, {
             node: {
               __typename: 'User',

--- a/packages/relay-experimental/__tests__/useBlockingPaginationFragment-with-suspense-transition-test.js
+++ b/packages/relay-experimental/__tests__/useBlockingPaginationFragment-with-suspense-transition-test.js
@@ -23,7 +23,7 @@ const TestRenderer = require('react-test-renderer');
 
 const invariant = require('invariant');
 const useBlockingPaginationFragmentOriginal = require('../useBlockingPaginationFragment');
-const ReactRelayContext = require('react-relay/ReactRelayContext');
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const {
   ConnectionHandler,
   FRAGMENT_OWNER_KEY,
@@ -416,12 +416,10 @@ describe('useBlockingPaginationFragment with useTransition', () => {
         // TODO(T39494051) - We set empty variables in relay context to make
         // Flow happy, but useBlockingPaginationFragment does not use them, instead it uses
         // the variables from the fragment owner.
-        const relayContext = useMemo(() => ({environment}), []);
-
         return (
-          <ReactRelayContext.Provider value={relayContext}>
+          <RelayEnvironmentProvider environment={environment}>
             {children}
-          </ReactRelayContext.Provider>
+          </RelayEnvironmentProvider>
         );
       };
 

--- a/packages/relay-experimental/__tests__/useFragment-test.js
+++ b/packages/relay-experimental/__tests__/useFragment-test.js
@@ -14,7 +14,7 @@
 'use strict';
 
 const React = require('react');
-const ReactRelayContext = require('react-relay/ReactRelayContext');
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const TestRenderer = require('react-test-renderer');
 
 const useFragmentOriginal = require('../useFragment');
@@ -196,12 +196,11 @@ describe('useFragment', () => {
       return <PluralRenderer users={usersData} />;
     };
 
-    const relayContext = {environment};
     ContextProvider = ({children}) => {
       return (
-        <ReactRelayContext.Provider value={relayContext}>
+        <RelayEnvironmentProvider environment={environment}>
           {children}
-        </ReactRelayContext.Provider>
+        </RelayEnvironmentProvider>
       );
     };
 

--- a/packages/relay-experimental/__tests__/useFragmentNode-required-test.js
+++ b/packages/relay-experimental/__tests__/useFragmentNode-required-test.js
@@ -13,7 +13,7 @@
 
 // eslint-disable-next-line no-unused-vars
 const React = require('react');
-const ReactRelayContext = require('react-relay/ReactRelayContext');
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const TestRenderer = require('react-test-renderer');
 
 const useFragmentNodeOriginal = require('../useFragmentNode');
@@ -86,9 +86,9 @@ beforeEach(() => {
 
   const ContextProvider = ({children}) => {
     return (
-      <ReactRelayContext.Provider value={{environment}}>
+      <RelayEnvironmentProvider environment={environment}>
         {children}
-      </ReactRelayContext.Provider>
+      </RelayEnvironmentProvider>
     );
   };
 

--- a/packages/relay-experimental/__tests__/useFragmentNode-test.js
+++ b/packages/relay-experimental/__tests__/useFragmentNode-test.js
@@ -18,7 +18,7 @@ const {useMemo, useState} = React;
 const TestRenderer = require('react-test-renderer');
 
 const useFragmentNodeOriginal = require('../useFragmentNode');
-const ReactRelayContext = require('react-relay/ReactRelayContext');
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const {
   FRAGMENT_OWNER_KEY,
   FRAGMENTS_KEY,
@@ -264,14 +264,11 @@ beforeEach(() => {
 
   const ContextProvider = ({children}) => {
     const [env, _setEnv] = useState(environment);
-    const relayContext = useMemo(() => ({environment: env}), [env]);
-
     setEnvironment = _setEnv;
-
     return (
-      <ReactRelayContext.Provider value={relayContext}>
+      <RelayEnvironmentProvider environment={env}>
         {children}
-      </ReactRelayContext.Provider>
+      </RelayEnvironmentProvider>
     );
   };
 

--- a/packages/relay-experimental/__tests__/usePaginationFragment-test.js
+++ b/packages/relay-experimental/__tests__/usePaginationFragment-test.js
@@ -22,7 +22,7 @@ const TestRenderer = require('react-test-renderer');
 
 const invariant = require('invariant');
 const usePaginationFragmentOriginal = require('../usePaginationFragment');
-const ReactRelayContext = require('react-relay/ReactRelayContext');
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const {
   ConnectionHandler,
   FRAGMENT_OWNER_KEY,
@@ -33,6 +33,7 @@ const {
 
 describe('usePaginationFragment', () => {
   let environment;
+  let newEnvironment;
   let initialUser;
   let gqlQuery;
   let gqlQueryNestedFragment;
@@ -143,6 +144,11 @@ describe('usePaginationFragment', () => {
 
     // Set up environment and base data
     environment = createMockEnvironment({
+      handlerProvider: () => ConnectionHandler,
+    });
+    
+    // Set up new environment
+    newEnvironment = createMockEnvironment({
       handlerProvider: () => ConnectionHandler,
     });
     const generated = generateAndCompile(
@@ -468,15 +474,13 @@ describe('usePaginationFragment', () => {
 
     const ContextProvider = ({children}) => {
       const [env, _setEnv] = useState(environment);
-      const relayContext = useMemo(() => ({environment: env}), [env]);
-
       setEnvironment = _setEnv;
 
       return (
-        <ReactRelayContext.Provider value={relayContext}>
-          {children}
-        </ReactRelayContext.Provider>
-      );
+          <RelayEnvironmentProvider environment={env}>
+            {children}
+          </RelayEnvironmentProvider>
+        );
     };
 
     renderFragment = (args?: {
@@ -2260,10 +2264,6 @@ describe('usePaginationFragment', () => {
           });
           expect(callback).toBeCalledTimes(0);
 
-          // Set new environment
-          const newEnvironment = createMockEnvironment({
-            handlerProvider: () => ConnectionHandler,
-          });
           newEnvironment.commitPayload(query, {
             node: {
               __typename: 'User',

--- a/packages/relay-experimental/__tests__/useRefetchableFragment-test.js
+++ b/packages/relay-experimental/__tests__/useRefetchableFragment-test.js
@@ -19,7 +19,7 @@ const TestRenderer = require('react-test-renderer');
 
 const invariant = require('invariant');
 const useRefetchableFragmentOriginal = require('../useRefetchableFragment');
-const ReactRelayContext = require('react-relay/ReactRelayContext');
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const {
   FRAGMENT_OWNER_KEY,
   FRAGMENTS_KEY,
@@ -163,12 +163,10 @@ describe('useRefetchableFragment', () => {
     };
 
     const ContextProvider = ({children}) => {
-      const relayContext = useMemo(() => ({environment}), []);
-
       return (
-        <ReactRelayContext.Provider value={relayContext}>
+        <RelayEnvironmentProvider environment={environment}>
           {children}
-        </ReactRelayContext.Provider>
+        </RelayEnvironmentProvider>
       );
     };
 

--- a/packages/relay-experimental/__tests__/useRefetchableFragmentNode-with-suspense-transition-test.js
+++ b/packages/relay-experimental/__tests__/useRefetchableFragmentNode-with-suspense-transition-test.js
@@ -22,7 +22,7 @@ const TestRenderer = require('react-test-renderer');
 
 const invariant = require('invariant');
 const useRefetchableFragmentNodeOriginal = require('../useRefetchableFragmentNode');
-const ReactRelayContext = require('react-relay/ReactRelayContext');
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const {
   FRAGMENT_OWNER_KEY,
   FRAGMENTS_KEY,
@@ -301,11 +301,10 @@ describe('useRefetchableFragmentNode with useTransition', () => {
         // TODO(T39494051) - We set empty variables in relay context to make
         // Flow happy, but useRefetchableFragmentNode does not use them, instead it uses
         // the variables from the fragment owner.
-        const relayContext = useMemo(() => ({environment}), []);
         return (
-          <ReactRelayContext.Provider value={relayContext}>
+          <RelayEnvironmentProvider environment={environment}>
             {children}
-          </ReactRelayContext.Provider>
+          </RelayEnvironmentProvider>
         );
       };
 

--- a/packages/relay-experimental/useFragmentNode.js
+++ b/packages/relay-experimental/useFragmentNode.js
@@ -100,7 +100,7 @@ function useFragmentNode<TFragmentData: mixed>(
     // NOTE: We disable react-hooks-deps warning because environment and fragmentIdentifier
     // is capturing all information about whether the effect should be re-ran.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [environment, fragmentIdentifier]);
+  }, [environment.id, fragmentIdentifier]);
 
   if (__DEV__) {
     if (

--- a/packages/relay-experimental/useIsOperationNodeActive.js
+++ b/packages/relay-experimental/useIsOperationNodeActive.js
@@ -40,7 +40,7 @@ function useIsOperationNodeActive(
       'useIsOperationNodeActive: Plural fragments are not supported.',
     );
     return getObservableForActiveRequest(environment, selector.owner);
-  }, [environment, fragmentNode, fragmentRef]);
+  }, [environment.id, fragmentNode, fragmentRef]);
   const [isActive, setIsActive] = useState(observable != null);
 
   useEffect(() => {

--- a/packages/relay-experimental/useLazyLoadQueryNode.js
+++ b/packages/relay-experimental/useLazyLoadQueryNode.js
@@ -118,7 +118,7 @@ function useLazyLoadQueryNode<TQuery: OperationType>({
     // and `cacheIdentifier` identities are capturing all information about whether
     // the effect should be re-executed and the query re-retained.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [environment, cacheIdentifier]);
+  }, [environment.id, cacheIdentifier]);
 
   const {fragmentNode, fragmentRef} = preparedQueryResult;
   const {data} = useFragmentNode(

--- a/packages/relay-experimental/useLoadMoreFunction.js
+++ b/packages/relay-experimental/useLoadMoreFunction.js
@@ -249,7 +249,7 @@ function useLoadMoreFunction<TQuery: OperationType>(
     // inside paginationMetadata are static
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
-      environment,
+      environment.id,
       identifierValue,
       direction,
       cursor,

--- a/packages/relay-experimental/useMutation.js
+++ b/packages/relay-experimental/useMutation.js
@@ -81,7 +81,7 @@ function useMutation<TMutation: MutationParameters>(
         }
       }
     },
-    [environment, isMountedRef, mutation],
+    [environment.id, isMountedRef, mutation],
   );
 
   useEffect(() => {
@@ -96,7 +96,7 @@ function useMutation<TMutation: MutationParameters>(
       environmentRef.current = environment;
       mutationRef.current = mutation;
     }
-  }, [environment, isMountedRef, mutation]);
+  }, [environment.id, isMountedRef, mutation]);
 
   const commit = useCallback(
     (config: UseMutationConfig<TMutation>) => {
@@ -122,7 +122,7 @@ function useMutation<TMutation: MutationParameters>(
       }
       return disposable;
     },
-    [cleanup, commitMutationFn, environment, isMountedRef, mutation],
+    [cleanup, commitMutationFn, environment.id, isMountedRef, mutation],
   );
 
   return [commit, isMutationInFlight];

--- a/packages/relay-experimental/usePreloadedQuery.js
+++ b/packages/relay-experimental/usePreloadedQuery.js
@@ -64,7 +64,7 @@ function usePreloadedQuery<TQuery: OperationType>(
         environment,
         operation.request.identifier,
         () => {
-          if (environment === preloadedQuery.environment && source != null) {
+          if (environment.id === preloadedQuery.environment.id && source != null) {
             return environment.executeWithSource({operation, source});
           } else {
             return environment.execute({operation});
@@ -86,13 +86,13 @@ function usePreloadedQuery<TQuery: OperationType>(
 
     const fallbackFetchObservable = fetchQuery(environment, operation);
     let fetchObservable;
-    if (source != null && environment === preloadedQuery.environment) {
+    if (source != null && environment.id === preloadedQuery.environment.id) {
       // If the source observable exists and the environments match, reuse
       // the source observable.
       // If the source observable happens to be empty, we need to fall back
       // and re-execute and de-dupe the query (at render time).
       fetchObservable = source.ifEmpty(fallbackFetchObservable);
-    } else if (environment !== preloadedQuery.environment) {
+    } else if (environment.id !== preloadedQuery.environment.id) {
       // If a call to loadQuery is made with a particular environment, and that
       // preloaded query is passed to usePreloadedQuery in a different environment
       // context, we cannot re-use the existing preloaded query.

--- a/packages/relay-experimental/useQueryLoader.js
+++ b/packages/relay-experimental/useQueryLoader.js
@@ -141,7 +141,7 @@ function useQueryLoader<TQuery: OperationType>(
         setQueryReference(updatedQueryReference);
       }
     },
-    [environment, preloadableRequest, setQueryReference, isMountedRef],
+    [environment.id, preloadableRequest, setQueryReference, isMountedRef],
   );
 
   const maybeHiddenOrFastRefresh = useRef(false);

--- a/packages/relay-experimental/useRefetchableFragmentNode.js
+++ b/packages/relay-experimental/useRefetchableFragmentNode.js
@@ -213,7 +213,7 @@ function useRefetchableFragmentNode<
   const profilerContext = useContext(ProfilerContext);
 
   const shouldReset =
-    environment !== mirroredEnvironment ||
+    environment.id !== mirroredEnvironment.id ||
     fragmentIdentifier !== mirroredFragmentIdentifier;
   const [queryRef, loadQuery, disposeQuery] = useQueryLoader<TQuery>(
     refetchableRequest,

--- a/packages/relay-experimental/useSubscribeToInvalidationState.js
+++ b/packages/relay-experimental/useSubscribeToInvalidationState.js
@@ -51,7 +51,7 @@ function useSubscribeToInvalidationState(
     // Intentionally excluding dataIDs, since we're using stableDataIDs
     // instead
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stableDataIDs, callback, environment]);
+  }, [stableDataIDs, callback, environment.id]);
 
   return {
     dispose: () => {

--- a/packages/relay-experimental/useSubscription.js
+++ b/packages/relay-experimental/useSubscription.js
@@ -33,7 +33,7 @@ function useSubscription<TSubscriptionPayload>(
   React.useEffect(() => {
     const {dispose} = requestSubscription(environment, config);
     return dispose;
-  }, [environment, config, actualRequestSubscription]);
+  }, [environment.id, config, actualRequestSubscription]);
 }
 
 module.exports = useSubscription;

--- a/packages/relay-runtime/query/fetchQueryInternal.js
+++ b/packages/relay-runtime/query/fetchQueryInternal.js
@@ -33,11 +33,7 @@ type RequestCacheEntry = {|
   +subscription: Subscription,
 |};
 
-const WEAKMAP_SUPPORTED = typeof WeakMap === 'function';
-
-const requestCachesByEnvironment = WEAKMAP_SUPPORTED
-  ? new WeakMap()
-  : new Map();
+const requestCachesByEnvironment = new Map();
 
 /**
  * Fetches the given query and variables on the provided environment,
@@ -311,12 +307,12 @@ function getRequestCache(
   const cached: ?Map<
     RequestIdentifier,
     RequestCacheEntry,
-  > = requestCachesByEnvironment.get(environment);
+  > = requestCachesByEnvironment.get(environment.id);
   if (cached != null) {
     return cached;
   }
   const requestCache: Map<RequestIdentifier, RequestCacheEntry> = new Map();
-  requestCachesByEnvironment.set(environment, requestCache);
+  requestCachesByEnvironment.set(environment.id, requestCache);
   return requestCache;
 }
 
@@ -335,9 +331,16 @@ function getCachedRequest(
   return cached;
 }
 
+function deleteRequestCache(
+  environment: IEnvironment,
+): void {
+  requestCachesByEnvironment.has(environment.id) && requestCachesByEnvironment.delete(environment.id);
+}
+
 module.exports = {
   fetchQuery,
   fetchQueryDeduped,
   getPromiseForActiveRequest,
   getObservableForActiveRequest,
+  deleteRequestCache
 };

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -64,6 +64,7 @@ import type {
   Store,
   StoreUpdater,
 } from './RelayStoreTypes';
+const fetchQueryInternal = require('../query/fetchQueryInternal');
 
 export type EnvironmentConfig = {|
   +configName?: string,
@@ -90,7 +91,10 @@ export type EnvironmentConfig = {|
   +requiredFieldLogger?: ?RequiredFieldLogger,
 |};
 
+let index = 0;
+
 class RelayModernEnvironment implements IEnvironment {
+  id: number;
   __log: LogFunction;
   +_defaultRenderPolicy: RenderPolicy;
   _operationLoader: ?OperationLoader;
@@ -187,6 +191,11 @@ class RelayModernEnvironment implements IEnvironment {
       config.operationTracker ?? new RelayOperationTracker();
     this._reactFlightPayloadDeserializer = reactFlightPayloadDeserializer;
     this._reactFlightServerErrorHandler = reactFlightServerErrorHandler;
+    this.id = index++;
+  }
+
+  dispose(): void {
+    fetchQueryInternal.deleteRequestCache(this);
   }
 
   getStore(): Store {

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -532,6 +532,11 @@ export type LogRequestInfoFunction = mixed => void;
  */
 export interface IEnvironment {
   /**
+   * id of the environment instance
+   */
+  id: number;
+
+  /**
    * Extra information attached to the environment instance
    */
   +options: mixed;
@@ -540,6 +545,8 @@ export interface IEnvironment {
    * **UNSTABLE** Event based logging API thats scoped to the environment.
    */
   __log: LogFunction;
+
+  dispose(): void;
 
   /**
    * Determine if the operation can be resolved with data in the store (i.e. no


### PR DESCRIPTION
Hi to all,
with this PR I added:
 * a unique id to the environment
 * the function dispose to the environment in order to clear the cache of requests associated with the environment
 * deleteQueryResourceForEnvironment in QueryResource in order to delete the query resources associated with the environment from the cache
 * deleteFragmentResourceForEnvironment in FragmentResource in order to delete the fragment resources associated with the environment from the cache
 * useEffect in RelayModernProvider in order to dispose the environment and delete resources when the environment is changed

In this way it is possible to have:
  * a control over the management of the resources used in relay
  * eliminate the need to use weakmap
  * use the id in the useEffect instead of the object
  * evaluate the creation of a public function `getPromiseForAllRequest `in `fetchQueryInternal` in order to be able to use this information during the SSR (you can easily make a first render, perform the await of all promises and perform a new render)

Finally, I made the following changes to the tests:
  * replaced the use of ReactRelayContext in favor of RelayEnvironmentProvider
  * moved the creation of alternative environments to the beginning of the test as the jest resetModule reset the RelayModernEnvironment index and environments with the same identifier were generated