### PR TITLE
Allow array of Uploadable in UploadableMap

### DIFF
--- a/packages/relay-runtime/network/RelayNetworkTypes.js
+++ b/packages/relay-runtime/network/RelayNetworkTypes.js
@@ -120,7 +120,10 @@ export type SubscribeFunction = (
 ) => RelayObservable<GraphQLResponse>;
 
 export type Uploadable = File | Blob;
-export type UploadableMap = {[key: string]: Uploadable, ...};
+export type UploadableMap = {
+  [key: string]: Uploadable | Array<Uploadable>,
+  ...,
+};
 
 /**
  * React Flight tree created on the server.


### PR DESCRIPTION
The current types of `UploadableMap` define a strict single-value pairing on `FormData`, despite the fact that with vanilla javascript, `FormData` values can be arrays:
```
const formData = new FormData();
formData.append('myKey', 1);
formData.append('myKey', 2);
formData.append('myKey', 3);
```
in this case, `myKey` is `[1, 2, 3]`

The example comes up primarily when using `multiple` file input tags -- the value of that tag is a `FileList`, which is often then converted to an array with `Array.from`. I'm looking for any good solution to multiple uploadables on the same `FormData` key; this just seems the easiest but I'm not tied to it. I'd appreciate any guidance as to the "correct" way to tackle this kind of problem!

Some libraries alternatively work by also appending a key which represents a mapping from form data key to pathname, enabling the backend to know which keys to look at. This works, but it's quite ugly/opaque, 
 and it pushes an implicit requirement on the consumer to generate such a mapping.

It's also worth noting that `react-relay-network-modern` (which is referenced by Relay, but not directly endorsed) allows a `FileList` or array of files via `extract-files`: https://github.com/relay-tools/react-relay-network-modern/blob/master/src/middlewares/upload.js#L19 and https://github.com/jaydenseric/extract-files/blob/master/src/public/extractFiles.js#L98