### PR TITLE
Fix broken link to `Relay Babel plugin` anchor in "GraphQL in Relay" docs

### DIFF
--- a/docs/Modern-GraphQLInRelay.md
+++ b/docs/Modern-GraphQLInRelay.md
@@ -324,7 +324,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup.html#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup.html#set-up-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 


### PR DESCRIPTION
Noticed this anchor link was broken in the "GraphQL in Relay" docs.