### PR TITLE
Fix wrong function name in "Mutations" docs

### DIFF
--- a/docs/Modern-RelayEnvironment.md
+++ b/docs/Modern-RelayEnvironment.md
@@ -34,7 +34,7 @@ const environment = new Environment({
 
 For more details on creating a Network, see the [NetworkLayer guide](./network-layer.html).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer.html) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations.html)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer.html) instance, or into mutations via the `commitMutation` function (see "[Mutations](./mutations.html)").
 
 ## Adding a `handlerProvider`
 


### PR DESCRIPTION
Only the "commitMutation" function and "commitLocalUpdate", not the "commitUpdate" function, can be seen in ["Relay Environment" docs](https://relay.dev/docs/en/relay-environment#a-simple-example).

https://relay.dev/docs/en/mutations

If you meant "commitUpdate" by combining "commitMutation" and "commitLocalUpdate", i'm sorry about this PR and will close it.