### PR TITLE
docs: switch comment style to blockstring

### DIFF
--- a/docs/Introduction-QuickStartGuide.md
+++ b/docs/Introduction-QuickStartGuide.md
@@ -30,9 +30,9 @@ Fortunately, we are going to be using this [example todo list app](https://githu
 type Query {
   viewer: User
 
-  # Fetches an object given its ID
+  """Fetches an object given its ID"""
   node(
-    # The ID of an object
+    """The ID of an object"""
     id: ID!
   ): Node
 }


### PR DESCRIPTION
When going through the quick start guide, I noticed this strange comment rendering:

![image](https://user-images.githubusercontent.com/836375/109815174-352f8a00-7be4-11eb-8354-d821b0865acc.png)

This PR switches over the comment format to blockstring, as is currently used in the `schema.graphql` for `relay-examples`. At the very least, the docs are now consistent with the example! 😄 

It renders like this now:

![image](https://user-images.githubusercontent.com/836375/109819926-6068a800-7be9-11eb-8af6-1c126d8279e3.png)

-------

Note: this is not an issue with `website-v2` so the updated docusaurus set up must be working a-ok.

![image](https://user-images.githubusercontent.com/836375/109816759-f13d8480-7be5-11eb-9c31-796368bb33f7.png)



