### PR TITLE
[docs] use updated Flow object syntax

### DIFF
--- a/website-v2/docs/current/api-reference/entrypoint-apis/entrypoint-container.md
+++ b/website-v2/docs/current/api-reference/entrypoint-apis/entrypoint-container.md
@@ -19,10 +19,10 @@ For more information, see the [Defining EntryPoints](../../guides/entrypoints/us
 function EntryPointContainer({
   entryPointReference,
   props,
-}: {|
+}: {
   +entryPointReference: PreloadedEntryPoint<TEntryPointComponent>,
   +props: TRuntimeProps,
-|}): ReactElement
+}): ReactElement
 ```
 
 A React component that renders a preloaded EntryPoint.

--- a/website-v2/docs/current/api-reference/hooks/use-fragment.md
+++ b/website-v2/docs/current/api-reference/hooks/use-fragment.md
@@ -15,9 +15,9 @@ const React = require('React');
 
 const {graphql, useFragment} = require('react-relay');
 
-type Props = {|
+type Props = {
   user: UserComponent_user$key,
-|};
+};
 
 function UserComponent(props: Props) {
   const data = useFragment(
@@ -52,7 +52,7 @@ function UserComponent(props: Props) {
 ### Return Value
 
 * `data`: Object that contains data which has been read out from the Relay store; the object matches the shape of specified fragment.
-    * The Flow type for data will also match this shape, and contain types derived from the GraphQL Schema. For example, the type of `data` above is: `{| name: ?string, profile_picture: ?{| uri: ?string |} |}`.
+    * The Flow type for data will also match this shape, and contain types derived from the GraphQL Schema. For example, the type of `data` above is: `{ name: ?string, profile_picture: ?{ uri: ?string } }`.
 
 ### Behavior
 

--- a/website-v2/docs/current/api-reference/hooks/use-lazy-load-query.md
+++ b/website-v2/docs/current/api-reference/hooks/use-lazy-load-query.md
@@ -54,7 +54,7 @@ function App() {
 ### Return Value
 
 * `data`: Object that contains data which has been read out from the Relay store; the object matches the shape of specified query.
-    * The Flow type for data will also match this shape, and contain types derived from the GraphQL Schema. For example, the type of `data` above is: `{| user: ?{| name: ?string |} |}`.
+    * The Flow type for data will also match this shape, and contain types derived from the GraphQL Schema. For example, the type of `data` above is: `{ user: ?{ name: ?string } }`.
 
 ### Behavior
 

--- a/website-v2/docs/current/api-reference/hooks/use-pagination-fragment.md
+++ b/website-v2/docs/current/api-reference/hooks/use-pagination-fragment.md
@@ -20,9 +20,9 @@ const React = require('React');
 
 const {graphql, usePaginationFragment} = require('react-relay');
 
-type Props = {|
+type Props = {
   user: FriendsList_user$key,
-|};
+};
 
 function FriendsList(props: Props) {
   const {

--- a/website-v2/docs/current/api-reference/hooks/use-preloaded-query.md
+++ b/website-v2/docs/current/api-reference/hooks/use-preloaded-query.md
@@ -66,7 +66,7 @@ function NameDisplay({ queryReference }) {
 ### Return Value
 
 * `data`: Object that contains data which has been read out from the Relay store; the object matches the shape of specified query.
-    * The Flow type for data will also match this shape, and contain types derived from the GraphQL Schema. For example, the type of `data` above is: `{| user: ?{| name: ?string |} |}`.
+    * The Flow type for data will also match this shape, and contain types derived from the GraphQL Schema. For example, the type of `data` above is: `{ user: ?{ name: ?string } }`.
 
 
 

--- a/website-v2/docs/current/api-reference/hooks/use-refetchable-fragment.md
+++ b/website-v2/docs/current/api-reference/hooks/use-refetchable-fragment.md
@@ -28,9 +28,9 @@ const React = require('React');
 const {graphql, useRefetchableFragment} = require('react-relay');
 
 
-type Props = {|
+type Props = {
   comment: CommentBody_comment$key,
-|};
+};
 
 function CommentBody(props: Props) {
   const [data, refetch] = useRefetchableFragment<CommentBodyRefetchQuery, _>(


### PR DESCRIPTION
Flow standard is now to use `{ }` for strict objects and `{ key: value, ... }` for open objects. This removes the old syntax from the docs.