### PR TITLE
Fix typos in the "Introducing Relay Hooks" blog post

### DIFF
--- a/website-v2/blog/2021-03-09-introducing-relay-hooks.md
+++ b/website-v2/blog/2021-03-09-introducing-relay-hooks.md
@@ -22,7 +22,7 @@ Though we still have a ways to go before getting started with Relay is as easy a
 
 ## What was released?
 
-We released Relay Hooks, a set of React Hooks-based APIs for working with GraphQL data. We also took the opportunity to ship other improvements, like a more stable version of <a href={useBaseUrl('/docs/api-reference/fetch-query/')}><code>fetchQuery</code></a> and a the ability to customize object identifiers in the Relay using <code>getDataID</code> (which is useful if your server does not have globally unique IDs.)
+We released Relay Hooks, a set of React Hooks-based APIs for working with GraphQL data. We also took the opportunity to ship other improvements, like a more stable version of <a href={useBaseUrl('/docs/api-reference/fetch-query/')}><code>fetchQuery</code></a> and the ability to customize object identifiers in Relay using <code>getDataID</code> (which is useful if your server does not have globally unique IDs.)
 
  See the [release notes](https://github.com/facebook/relay/releases/tag/v11.0.0) for a complete list of what was released.
 

--- a/website-v2/blog/2021-03-09-introducing-relay-hooks.md
+++ b/website-v2/blog/2021-03-09-introducing-relay-hooks.md
@@ -46,6 +46,7 @@ First, let’s take a look at how we might refetch a fragment with different var
 type Props = {
   comment: CommentBody_comment$key,
 };
+
 function CommentBody(props: Props) {
   const [data, refetch] = useRefetchableFragment<CommentBodyRefetchQuery, _>(
     graphql`
@@ -63,7 +64,7 @@ function CommentBody(props: Props) {
     <CommentText text={data?.text} />
     <Button
       onClick={() =>
-        refetch({ lang: 'SPANISH' }, {fetchPolicy: 'store-or-network'})
+        refetch({ lang: 'SPANISH' }, { fetchPolicy: 'store-or-network' })
       }>
     >
       Translate


### PR DESCRIPTION
- Remove unnecessary determiners.
- Add missing whitespace in the code example about refetching a fragment.