### PR TITLE
Fix typos in docs

### DIFF
--- a/website/docs/api-reference/hooks/use-preloaded-query.md
+++ b/website/docs/api-reference/hooks/use-preloaded-query.md
@@ -59,7 +59,7 @@ function NameLoader(props) {
 }
 
 function NameDisplay({ queryReference }) {
-  const data = usePreloadedQuery<AppQueryType>(query, queryReference);
+  const data = usePreloadedQuery<AppQueryType>(AppQuery, queryReference);
 
   return <h1>{data.user?.name}</h1>;
 }

--- a/website/docs/api-reference/hooks/use-query-loader.md
+++ b/website/docs/api-reference/hooks/use-query-loader.md
@@ -59,7 +59,7 @@ function QueryFetcherExample(props: Props) {
 }
 
 function NameDisplay({ queryReference }) {
-  const data = usePreloadedQuery<AppQueryType>(query, queryReference);
+  const data = usePreloadedQuery<AppQueryType>(AppQuery, queryReference);
 
   return <h1>{data.user?.name}</h1>;
 }

--- a/website/versioned_docs/version-v11.0.0/api-reference/hooks/use-preloaded-query.md
+++ b/website/versioned_docs/version-v11.0.0/api-reference/hooks/use-preloaded-query.md
@@ -59,7 +59,7 @@ function NameLoader(props) {
 }
 
 function NameDisplay({ queryReference }) {
-  const data = usePreloadedQuery<AppQueryType>(query, queryReference);
+  const data = usePreloadedQuery<AppQueryType>(AppQuery, queryReference);
 
   return <h1>{data.user?.name}</h1>;
 }

--- a/website/versioned_docs/version-v11.0.0/api-reference/hooks/use-query-loader.md
+++ b/website/versioned_docs/version-v11.0.0/api-reference/hooks/use-query-loader.md
@@ -59,7 +59,7 @@ function QueryFetcherExample(props: Props) {
 }
 
 function NameDisplay({ queryReference }) {
-  const data = usePreloadedQuery<AppQueryType>(query, queryReference);
+  const data = usePreloadedQuery<AppQueryType>(AppQuery, queryReference);
 
   return <h1>{data.user?.name}</h1>;
 }


### PR DESCRIPTION
A wrong variable `query` is being used in the code example. The `usePreloadedQuery` should take the `AppQuery`.

Edit: Also fix the same typos in the `useQueryLoader` code example.