### PR TITLE
[CI] remove --locked argument from cargo for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --manifest-path=compiler/Cargo.toml --locked
+          # add --locked back when we have a better way to ensure it's up to
+          # date
+          args: --manifest-path=compiler/Cargo.toml
 
   test-rust:
     name: Test Rust
@@ -78,7 +80,9 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path=compiler/Cargo.toml --locked
+          # add --locked back when we have a better way to ensure it's up to
+          # date
+          args: --manifest-path=compiler/Cargo.toml
 
   master-release:
     name: Publish master tag to npm


### PR DESCRIPTION
Since we don't have internal validation that the lock file is up to date, I think these breakages are diluting the CI signal. Removing the `--locked` flag might end us up with an outdated lockfile in OSS, but we at least notice test breakages there without noise.

I'd suggest we add this back later when we have some internal validation for this?

Test Plan:
passed on my fork with outdated lockfile.