### PR TITLE
[docs] fix typos in loading-states.md

### DIFF
--- a/website/docs/guided-tour/rendering/loading-states.md
+++ b/website/docs/guided-tour/rendering/loading-states.md
@@ -78,7 +78,7 @@ const {Suspense} = require('React');
 
 function App() {
   return (
-    // LoadingSpinner is rendered via the Suspense fallback
+    // LoadingGlimmer is rendered via the Suspense fallback
     <Suspense fallback={<LoadingGlimmer />}>
       <MainContent /> {/* MainContent may suspend */}
     </Suspense>
@@ -107,10 +107,10 @@ const {Suspense} = require('React');
 
 function App() {
   return (
-    // A LoadingSpinner for *_all_* content is rendered via the Suspense fallback
+    // A LoadingGlimmer for *_all_* content is rendered via the Suspense fallback
     <Suspense fallback={<LoadingGlimmer />}>
       <MainContent />
-      <SecondaryContent />  *{**/* SecondaryContent can also suspend */**}*
+      <SecondaryContent /> {/* SecondaryContent can also suspend */}
     </Suspense>
   );
 }
@@ -211,7 +211,7 @@ const {Suspense} = require('React');
 
 function App() {
   return (
-    // LoadingSpinner is rendered via the Suspense fallback
+    // LoadingGlimmer is rendered via the Suspense fallback
     <Suspense fallback={<LoadingGlimmer />}>
       <MainContent /> {/* MainContent may suspend */}
     </Suspense>
@@ -224,7 +224,7 @@ function App() {
 Let's distill what's going on here:
 
 * We have a `MainContent` component, which is a query renderer that fetches and renders a query. `MainContent` will *suspend* rendering when it attempts to fetch the query, indicating that it isn't ready to be rendered yet, and it will resolve when the query is fetched.
-* The `Suspense `component that wraps `MainContent` will detect that `MainContent` suspended, and will render the `fallback` element (i.e. the `LoadingSpinner` in this case) up until `MainContent` is ready to be rendered; that is, up until the query is fetched.
+* The `Suspense `component that wraps `MainContent` will detect that `MainContent` suspended, and will render the `fallback` element (i.e. the `LoadingGlimmer` in this case) up until `MainContent` is ready to be rendered; that is, up until the query is fetched.
 
 
 ### Fragments

--- a/website/versioned_docs/version-v11.0.0/guided-tour/rendering/loading-states.md
+++ b/website/versioned_docs/version-v11.0.0/guided-tour/rendering/loading-states.md
@@ -78,7 +78,7 @@ const {Suspense} = require('React');
 
 function App() {
   return (
-    // LoadingSpinner is rendered via the Suspense fallback
+    // LoadingGlimmer is rendered via the Suspense fallback
     <Suspense fallback={<LoadingGlimmer />}>
       <MainContent /> {/* MainContent may suspend */}
     </Suspense>
@@ -107,10 +107,10 @@ const {Suspense} = require('React');
 
 function App() {
   return (
-    // A LoadingSpinner for *_all_* content is rendered via the Suspense fallback
+    // A LoadingGlimmer for *_all_* content is rendered via the Suspense fallback
     <Suspense fallback={<LoadingGlimmer />}>
       <MainContent />
-      <SecondaryContent />  *{**/* SecondaryContent can also suspend */**}*
+      <SecondaryContent /> {/* SecondaryContent can also suspend */}
     </Suspense>
   );
 }
@@ -211,7 +211,7 @@ const {Suspense} = require('React');
 
 function App() {
   return (
-    // LoadingSpinner is rendered via the Suspense fallback
+    // LoadingGlimmer is rendered via the Suspense fallback
     <Suspense fallback={<LoadingGlimmer />}>
       <MainContent /> {/* MainContent may suspend */}
     </Suspense>
@@ -224,7 +224,7 @@ function App() {
 Let's distill what's going on here:
 
 * We have a `MainContent` component, which is a query renderer that fetches and renders a query. `MainContent` will *suspend* rendering when it attempts to fetch the query, indicating that it isn't ready to be rendered yet, and it will resolve when the query is fetched.
-* The `Suspense `component that wraps `MainContent` will detect that `MainContent` suspended, and will render the `fallback` element (i.e. the `LoadingSpinner` in this case) up until `MainContent` is ready to be rendered; that is, up until the query is fetched.
+* The `Suspense `component that wraps `MainContent` will detect that `MainContent` suspended, and will render the `fallback` element (i.e. the `LoadingGlimmer` in this case) up until `MainContent` is ready to be rendered; that is, up until the query is fetched.
 
 
 ### Fragments


### PR DESCRIPTION
hi,

I noticed a variable name mismatch between the comment (`LoadingSpinner`) and the jsx (`LoadingGlimmer`), so I took the liberty of replacing `LoadingSpinner` with the more commonly used `LoadingGlimmer`, but I can revert those changes if `LoadingSpinner` is preferred.

Also fixed a comment inside of jsx.
<img width="697" alt="Screen Shot 2021-03-15 at 9 10 23 AM" src="https://user-images.githubusercontent.com/30640930/111091562-4ecebb00-856e-11eb-8038-7fa83caae6b6.png">
