### PR TITLE
Compiler: refactor type generation API

### DIFF
--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -7,10 +7,15 @@
 
 use crate::writer::{Prop, Writer, AST, SPREAD_KEY};
 use interner::{Intern, StringKey};
+use lazy_static::lazy_static;
 use std::fmt::{Result, Write};
 
 pub struct FlowPrinter {
     indentation: usize,
+}
+
+lazy_static! {
+    static ref FRAGMENT_REFERENCE: StringKey = "FragmentReference".intern();
 }
 
 impl Writer for FlowPrinter {
@@ -35,7 +40,7 @@ impl Writer for FlowPrinter {
             AST::DefineType(name, value) => self.write_type_definition(writer, name, value),
             AST::ImportType(types, from) => self.write_import_type(writer, types, from),
             AST::DeclareExportFragment(alias, value) => {
-                let default_value = "FragmentReference".intern();
+                let default_value = *FRAGMENT_REFERENCE;
                 self.write_declare_export_opaque_type(
                     writer,
                     alias,
@@ -59,6 +64,10 @@ impl Writer for FlowPrinter {
                     .as_slice(),
             ),
         }
+    }
+
+    fn get_runtime_fragment_import(&self) -> StringKey {
+        *FRAGMENT_REFERENCE
     }
 }
 

--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -54,7 +54,6 @@ impl Writer for FlowPrinter {
                 )
             }
             AST::ExportFragmentList(names) => self.write_export_list(names),
-            AST::ImportFragmentType(types, from) => self.write_import_type(types, *from),
             AST::FragmentReference(fragments) => self.write_intersection(
                 fragments
                     .iter()
@@ -86,6 +85,10 @@ impl Writer for FlowPrinter {
                 .join(", "),
             from
         )
+    }
+
+    fn write_import_fragment_type(&mut self, types: &[StringKey], from: StringKey) -> Result {
+        self.write_import_type(types, from)
     }
 }
 

--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -42,7 +42,6 @@ impl Writer for FlowPrinter {
             AST::Local3DPayload(document_name, selections) => {
                 self.write_local_3d_payload(*document_name, selections)
             }
-            AST::DefineType(name, value) => self.write_type_definition(name, value),
             AST::FragmentReference(fragments) => self.write_intersection(
                 fragments
                     .iter()
@@ -100,6 +99,10 @@ declare export opaque type {new_name}: {old_name};",
             "export type {{ {}, {} }};",
             old_fragment_type_name, new_fragment_type_name
         )
+    }
+
+    fn write_any_type_definition(&mut self, name: StringKey) -> Result {
+        writeln!(&mut self.result, "type {} = any;", name)
     }
 }
 
@@ -233,12 +236,6 @@ impl FlowPrinter {
         self.write(selections)?;
         write!(&mut self.result, ">")?;
         Ok(())
-    }
-
-    fn write_type_definition(&mut self, name: &StringKey, value: &AST) -> Result {
-        write!(&mut self.result, "type {} = ", name)?;
-        self.write(value)?;
-        writeln!(&mut self.result, ";")
     }
 }
 

--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -43,7 +43,6 @@ impl Writer for FlowPrinter {
                 self.write_local_3d_payload(*document_name, selections)
             }
             AST::DefineType(name, value) => self.write_type_definition(name, value),
-            AST::ExportFragmentList(names) => self.write_export_list(names),
             AST::FragmentReference(fragments) => self.write_intersection(
                 fragments
                     .iter()
@@ -88,6 +87,18 @@ impl Writer for FlowPrinter {
 declare export opaque type {new_name}: {old_name};",
             old_name = old_name,
             new_name = new_name
+        )
+    }
+
+    fn write_export_fragment_types(
+        &mut self,
+        old_fragment_type_name: StringKey,
+        new_fragment_type_name: StringKey,
+    ) -> Result {
+        writeln!(
+            &mut self.result,
+            "export type {{ {}, {} }};",
+            old_fragment_type_name, new_fragment_type_name
         )
     }
 }
@@ -228,18 +239,6 @@ impl FlowPrinter {
         write!(&mut self.result, "type {} = ", name)?;
         self.write(value)?;
         writeln!(&mut self.result, ";")
-    }
-
-    fn write_export_list(&mut self, names: &[StringKey]) -> Result {
-        writeln!(
-            &mut self.result,
-            "export type {{ {} }};",
-            names
-                .iter()
-                .map(|t| format!("{}", t))
-                .collect::<Vec<_>>()
-                .join(", "),
-        )
     }
 }
 

--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -54,7 +54,6 @@ impl Writer for FlowPrinter {
                     },
                 )
             }
-            AST::ExportTypeEquals(name, value) => self.write_export_type_equals(name, value),
             AST::ExportFragmentList(names) => self.write_export_list(names),
             AST::ImportFragmentType(types, from) => self.write_import_type(types, from),
             AST::FragmentReference(fragments) => self.write_intersection(
@@ -69,6 +68,12 @@ impl Writer for FlowPrinter {
 
     fn get_runtime_fragment_import(&self) -> StringKey {
         *FRAGMENT_REFERENCE
+    }
+
+    fn write_export_type(&mut self, name: StringKey, value: &AST) -> Result {
+        write!(&mut self.result, "export type {} = ", name)?;
+        self.write(value)?;
+        writeln!(&mut self.result, ";")
     }
 }
 
@@ -223,12 +228,6 @@ impl FlowPrinter {
             "declare export opaque type {}: {};",
             alias, value
         )
-    }
-
-    fn write_export_type_equals(&mut self, name: &StringKey, value: &AST) -> Result {
-        write!(&mut self.result, "export type {} = ", name)?;
-        self.write(value)?;
-        writeln!(&mut self.result, ";")
     }
 
     fn write_type_definition(&mut self, name: &StringKey, value: &AST) -> Result {

--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -11,6 +11,7 @@ use lazy_static::lazy_static;
 use std::fmt::{Result, Write};
 
 pub struct FlowPrinter {
+    result: String,
     indentation: usize,
 }
 
@@ -19,30 +20,33 @@ lazy_static! {
 }
 
 impl Writer for FlowPrinter {
-    fn write(&mut self, writer: &mut dyn Write, ast: &AST) -> Result {
+    fn into_string(self: Box<Self>) -> String {
+        self.result
+    }
+
+    fn write(&mut self, ast: &AST) -> Result {
         match ast {
-            AST::Any => write!(writer, "any"),
-            AST::String => write!(writer, "string"),
-            AST::StringLiteral(literal) => self.write_string_literal(writer, *literal),
-            AST::OtherTypename => self.write_other_string(writer),
-            AST::Number => write!(writer, "number"),
-            AST::Boolean => write!(writer, "boolean"),
-            AST::Identifier(identifier) => write!(writer, "{}", identifier),
-            AST::RawType(raw) => write!(writer, "{}", raw),
-            AST::Union(members) => self.write_union(writer, members),
-            AST::ReadOnlyArray(of_type) => self.write_read_only_array(writer, of_type),
-            AST::Nullable(of_type) => self.write_nullable(writer, of_type),
-            AST::ExactObject(props) => self.write_object(writer, props, true),
-            AST::InexactObject(props) => self.write_object(writer, props, false),
+            AST::Any => write!(&mut self.result, "any"),
+            AST::String => write!(&mut self.result, "string"),
+            AST::StringLiteral(literal) => self.write_string_literal(*literal),
+            AST::OtherTypename => self.write_other_string(),
+            AST::Number => write!(&mut self.result, "number"),
+            AST::Boolean => write!(&mut self.result, "boolean"),
+            AST::Identifier(identifier) => write!(&mut self.result, "{}", identifier),
+            AST::RawType(raw) => write!(&mut self.result, "{}", raw),
+            AST::Union(members) => self.write_union(members),
+            AST::ReadOnlyArray(of_type) => self.write_read_only_array(of_type),
+            AST::Nullable(of_type) => self.write_nullable(of_type),
+            AST::ExactObject(props) => self.write_object(props, true),
+            AST::InexactObject(props) => self.write_object(props, false),
             AST::Local3DPayload(document_name, selections) => {
-                self.write_local_3d_payload(writer, *document_name, selections)
+                self.write_local_3d_payload(*document_name, selections)
             }
-            AST::DefineType(name, value) => self.write_type_definition(writer, name, value),
-            AST::ImportType(types, from) => self.write_import_type(writer, types, from),
+            AST::DefineType(name, value) => self.write_type_definition(name, value),
+            AST::ImportType(types, from) => self.write_import_type(types, from),
             AST::DeclareExportFragment(alias, value) => {
                 let default_value = *FRAGMENT_REFERENCE;
                 self.write_declare_export_opaque_type(
-                    writer,
                     alias,
                     match value {
                         Some(type_name) => type_name,
@@ -50,13 +54,10 @@ impl Writer for FlowPrinter {
                     },
                 )
             }
-            AST::ExportTypeEquals(name, value) => {
-                self.write_export_type_equals(writer, name, value)
-            }
-            AST::ExportFragmentList(names) => self.write_export_list(writer, names),
-            AST::ImportFragmentType(types, from) => self.write_import_type(writer, types, from),
+            AST::ExportTypeEquals(name, value) => self.write_export_type_equals(name, value),
+            AST::ExportFragmentList(names) => self.write_export_list(names),
+            AST::ImportFragmentType(types, from) => self.write_import_type(types, from),
             AST::FragmentReference(fragments) => self.write_intersection(
-                writer,
                 fragments
                     .iter()
                     .map(|fragment| AST::Identifier(format!("{}$ref", fragment).intern()))
@@ -73,143 +74,139 @@ impl Writer for FlowPrinter {
 
 impl FlowPrinter {
     pub fn new() -> Self {
-        Self { indentation: 0 }
+        Self {
+            result: String::new(),
+            indentation: 0,
+        }
     }
 
-    fn write_indentation(&mut self, writer: &mut dyn Write) -> Result {
-        writer.write_str(&"  ".repeat(self.indentation))
+    fn write_indentation(&mut self) -> Result {
+        self.result.write_str(&"  ".repeat(self.indentation))
     }
 
-    fn write_string_literal(&mut self, writer: &mut dyn Write, literal: StringKey) -> Result {
-        write!(writer, "\"{}\"", literal)
+    fn write_string_literal(&mut self, literal: StringKey) -> Result {
+        write!(&mut self.result, "\"{}\"", literal)
     }
 
-    fn write_other_string(&mut self, writer: &mut dyn Write) -> Result {
-        write!(writer, r#""%other""#)
+    fn write_other_string(&mut self) -> Result {
+        write!(&mut self.result, r#""%other""#)
     }
 
-    fn write_union(&mut self, writer: &mut dyn Write, members: &[AST]) -> Result {
+    fn write_union(&mut self, members: &[AST]) -> Result {
         let mut first = true;
         for member in members {
             if first {
                 first = false;
             } else {
-                write!(writer, " | ")?;
+                write!(&mut self.result, " | ")?;
             }
-            self.write(writer, member)?;
+            self.write(member)?;
         }
         Ok(())
     }
 
-    fn write_intersection(&mut self, writer: &mut dyn Write, members: &[AST]) -> Result {
+    fn write_intersection(&mut self, members: &[AST]) -> Result {
         let mut first = true;
         for member in members {
             if first {
                 first = false;
             } else {
-                write!(writer, " & ")?;
+                write!(&mut self.result, " & ")?;
             }
-            self.write(writer, member)?;
+            self.write(member)?;
         }
         Ok(())
     }
 
-    fn write_read_only_array(&mut self, writer: &mut dyn Write, of_type: &AST) -> Result {
-        write!(writer, "$ReadOnlyArray<")?;
-        self.write(writer, of_type)?;
-        write!(writer, ">")
+    fn write_read_only_array(&mut self, of_type: &AST) -> Result {
+        write!(&mut self.result, "$ReadOnlyArray<")?;
+        self.write(of_type)?;
+        write!(&mut self.result, ">")
     }
 
-    fn write_nullable(&mut self, writer: &mut dyn Write, of_type: &AST) -> Result {
-        write!(writer, "?")?;
+    fn write_nullable(&mut self, of_type: &AST) -> Result {
+        write!(&mut self.result, "?")?;
         match of_type {
             AST::Union(members) if members.len() > 1 => {
-                write!(writer, "(")?;
-                self.write(writer, of_type)?;
-                write!(writer, ")")?;
+                write!(&mut self.result, "(")?;
+                self.write(of_type)?;
+                write!(&mut self.result, ")")?;
             }
             _ => {
-                self.write(writer, of_type)?;
+                self.write(of_type)?;
             }
         }
         Ok(())
     }
 
-    fn write_object(&mut self, writer: &mut dyn Write, props: &[Prop], exact: bool) -> Result {
+    fn write_object(&mut self, props: &[Prop], exact: bool) -> Result {
         if props.is_empty() && exact {
-            write!(writer, "{{||}}")?;
+            write!(&mut self.result, "{{||}}")?;
             return Ok(());
         }
 
         if exact {
-            writeln!(writer, "{{|")?;
+            writeln!(&mut self.result, "{{|")?;
         } else {
-            writeln!(writer, "{{")?;
+            writeln!(&mut self.result, "{{")?;
         }
         self.indentation += 1;
 
         for prop in props {
-            self.write_indentation(writer)?;
+            self.write_indentation()?;
             if prop.key == *SPREAD_KEY {
-                write!(writer, "...")?;
-                self.write(writer, &prop.value)?;
-                writeln!(writer, ",")?;
+                write!(&mut self.result, "...")?;
+                self.write(&prop.value)?;
+                writeln!(&mut self.result, ",")?;
                 continue;
             }
             if let AST::OtherTypename = prop.value {
-                writeln!(writer, "// This will never be '%other', but we need some")?;
-                self.write_indentation(writer)?;
                 writeln!(
-                    writer,
+                    &mut self.result,
+                    "// This will never be '%other', but we need some"
+                )?;
+                self.write_indentation()?;
+                writeln!(
+                    &mut self.result,
                     "// value in case none of the concrete values match."
                 )?;
-                self.write_indentation(writer)?;
+                self.write_indentation()?;
             }
             if prop.read_only {
-                write!(writer, "+")?;
+                write!(&mut self.result, "+")?;
             }
-            write!(writer, "{}", prop.key)?;
+            write!(&mut self.result, "{}", prop.key)?;
             if prop.optional {
-                write!(writer, "?")?;
+                write!(&mut self.result, "?")?;
             }
-            write!(writer, ": ")?;
-            self.write(writer, &prop.value)?;
-            writeln!(writer, ",")?;
+            write!(&mut self.result, ": ")?;
+            self.write(&prop.value)?;
+            writeln!(&mut self.result, ",")?;
         }
         if !exact {
-            self.write_indentation(writer)?;
-            writeln!(writer, "...")?;
+            self.write_indentation()?;
+            writeln!(&mut self.result, "...")?;
         }
         self.indentation -= 1;
-        self.write_indentation(writer)?;
+        self.write_indentation()?;
         if exact {
-            write!(writer, "|}}")?;
+            write!(&mut self.result, "|}}")?;
         } else {
-            write!(writer, "}}")?;
+            write!(&mut self.result, "}}")?;
         }
         Ok(())
     }
 
-    fn write_local_3d_payload(
-        &mut self,
-        writer: &mut dyn Write,
-        document_name: StringKey,
-        selections: &AST,
-    ) -> Result {
-        write!(writer, "Local3DPayload<\"{}\", ", document_name)?;
-        self.write(writer, selections)?;
-        write!(writer, ">")?;
+    fn write_local_3d_payload(&mut self, document_name: StringKey, selections: &AST) -> Result {
+        write!(&mut self.result, "Local3DPayload<\"{}\", ", document_name)?;
+        self.write(selections)?;
+        write!(&mut self.result, ">")?;
         Ok(())
     }
 
-    fn write_import_type(
-        &mut self,
-        writer: &mut dyn Write,
-        types: &[StringKey],
-        from: &StringKey,
-    ) -> Result {
+    fn write_import_type(&mut self, types: &[StringKey], from: &StringKey) -> Result {
         writeln!(
-            writer,
+            &mut self.result,
             "import type {{ {} }} from \"{}\";",
             types
                 .iter()
@@ -220,40 +217,29 @@ impl FlowPrinter {
         )
     }
 
-    fn write_declare_export_opaque_type(
-        &mut self,
-        writer: &mut dyn Write,
-        alias: &StringKey,
-        value: &StringKey,
-    ) -> Result {
-        writeln!(writer, "declare export opaque type {}: {};", alias, value)
-    }
-
-    fn write_export_type_equals(
-        &mut self,
-        writer: &mut dyn Write,
-        name: &StringKey,
-        value: &AST,
-    ) -> Result {
-        write!(writer, "export type {} = ", name)?;
-        self.write(writer, value)?;
-        writeln!(writer, ";")
-    }
-
-    fn write_type_definition(
-        &mut self,
-        writer: &mut dyn Write,
-        name: &StringKey,
-        value: &AST,
-    ) -> Result {
-        write!(writer, "type {} = ", name)?;
-        self.write(writer, value)?;
-        writeln!(writer, ";")
-    }
-
-    fn write_export_list(&mut self, writer: &mut dyn Write, names: &[StringKey]) -> Result {
+    fn write_declare_export_opaque_type(&mut self, alias: &StringKey, value: &StringKey) -> Result {
         writeln!(
-            writer,
+            &mut self.result,
+            "declare export opaque type {}: {};",
+            alias, value
+        )
+    }
+
+    fn write_export_type_equals(&mut self, name: &StringKey, value: &AST) -> Result {
+        write!(&mut self.result, "export type {} = ", name)?;
+        self.write(value)?;
+        writeln!(&mut self.result, ";")
+    }
+
+    fn write_type_definition(&mut self, name: &StringKey, value: &AST) -> Result {
+        write!(&mut self.result, "type {} = ", name)?;
+        self.write(value)?;
+        writeln!(&mut self.result, ";")
+    }
+
+    fn write_export_list(&mut self, names: &[StringKey]) -> Result {
+        writeln!(
+            &mut self.result,
             "export type {{ {} }};",
             names
                 .iter()
@@ -270,9 +256,9 @@ mod tests {
     use interner::Intern;
 
     fn print_type(ast: &AST) -> String {
-        let mut result = String::new();
-        FlowPrinter::new().write(&mut result, ast).unwrap();
-        result
+        let mut printer = Box::new(FlowPrinter::new());
+        printer.write(ast).unwrap();
+        printer.into_string()
     }
 
     #[test]

--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -357,14 +357,8 @@ impl<'a> TypeGenerator<'a> {
                 AST::ExportFragmentList(vec![old_fragment_type_name, new_fragment_type_name,])
             )?;
         } else {
-            write_ast!(
-                self,
-                AST::DeclareExportFragment(old_fragment_type_name, None)
-            )?;
-            write_ast!(
-                self,
-                AST::DeclareExportFragment(new_fragment_type_name, Some(old_fragment_type_name))
-            )?;
+            self.writer
+                .write_export_fragment_type(old_fragment_type_name, new_fragment_type_name)?;
         }
         self.writer.write_export_type(node.name.item, &type_)?;
         self.writer
@@ -1077,15 +1071,8 @@ impl<'a> TypeGenerator<'a> {
     ) -> Result {
         let old_fragment_type_name = format!("{}$ref", refetchable_fragment_name).intern();
         let new_fragment_type_name = format!("{}$fragmentType", refetchable_fragment_name).intern();
-        write_ast!(
-            self,
-            AST::DeclareExportFragment(old_fragment_type_name, None)
-        )?;
-        write_ast!(
-            self,
-            AST::DeclareExportFragment(new_fragment_type_name, Some(old_fragment_type_name))
-        )?;
-        Ok(())
+        self.writer
+            .write_export_fragment_type(old_fragment_type_name, new_fragment_type_name)
     }
 
     fn write_enum_definitions(&mut self) -> Result {

--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -59,7 +59,9 @@ lazy_static! {
 }
 
 macro_rules! write_ast {
-    ($self:ident, $ast:expr) => {{ $self.writer.write(&mut $self.result, &$ast) }};
+    ($self:ident, $ast:expr) => {{
+        $self.writer.write(&$ast)
+    }};
 }
 
 pub fn generate_fragment_type(
@@ -69,7 +71,7 @@ pub fn generate_fragment_type(
 ) -> String {
     let mut generator = TypeGenerator::new(schema, typegen_config);
     generator.generate_fragment_type(fragment).unwrap();
-    generator.result
+    generator.writer.into_string()
 }
 
 pub fn generate_operation_type(
@@ -110,7 +112,6 @@ struct RuntimeImports {
 }
 
 struct TypeGenerator<'a> {
-    result: String,
     schema: &'a SDLSchema,
     generated_fragments: FnvHashSet<StringKey>,
     generated_input_object_types: IndexMap<StringKey, GeneratedInputObject>,
@@ -125,7 +126,6 @@ struct TypeGenerator<'a> {
 impl<'a> TypeGenerator<'a> {
     fn new(schema: &'a SDLSchema, typegen_config: &'a TypegenConfig) -> Self {
         Self {
-            result: String::new(),
             schema,
             generated_fragments: Default::default(),
             generated_input_object_types: Default::default(),

--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -48,6 +48,8 @@ lazy_static! {
     pub(crate) static ref KEY_DATA: StringKey = "$data".intern();
     pub(crate) static ref KEY_REF_TYPE: StringKey = "$refType".intern();
     pub(crate) static ref KEY_FRAGMENT_REFS: StringKey = "$fragmentRefs".intern();
+    static ref RELAY_RUNTIME: StringKey = "relay-runtime".intern();
+    static ref LOCAL_3D_PAYLOAD: StringKey = "Local3DPayload".intern();
     static ref KEY_TYPENAME: StringKey = "__typename".intern();
     static ref TYPE_ID: StringKey = "ID".intern();
     static ref TYPE_STRING: StringKey = "String".intern();
@@ -1001,33 +1003,22 @@ impl<'a> TypeGenerator<'a> {
             RuntimeImports {
                 local_3d_payload: true,
                 fragment_reference: true,
-            } => write_ast!(
-                self,
-                AST::ImportType(
-                    vec![
-                        self.writer.get_runtime_fragment_import(),
-                        "Local3DPayload".intern()
-                    ],
-                    "relay-runtime".intern(),
-                )
+            } => self.writer.write_import_type(
+                &vec![self.writer.get_runtime_fragment_import(), *LOCAL_3D_PAYLOAD],
+                *RELAY_RUNTIME,
             ),
             RuntimeImports {
                 local_3d_payload: true,
                 fragment_reference: false,
-            } => write_ast!(
-                self,
-                AST::ImportType(vec!["Local3DPayload".intern()], "relay-runtime".intern(),)
-            ),
+            } => self
+                .writer
+                .write_import_type(&[*LOCAL_3D_PAYLOAD], *RELAY_RUNTIME),
             RuntimeImports {
                 local_3d_payload: false,
                 fragment_reference: true,
-            } => write_ast!(
-                self,
-                AST::ImportType(
-                    vec![self.writer.get_runtime_fragment_import()],
-                    "relay-runtime".intern(),
-                )
-            ),
+            } => self
+                .writer
+                .write_import_type(&[self.writer.get_runtime_fragment_import()], *RELAY_RUNTIME),
             RuntimeImports {
                 local_3d_payload: false,
                 fragment_reference: false,
@@ -1112,12 +1103,9 @@ impl<'a> TypeGenerator<'a> {
         for enum_id in enum_ids {
             let enum_type = self.schema.enum_(enum_id);
             if let Some(enum_module_suffix) = &self.typegen_config.enum_module_suffix {
-                write_ast!(
-                    self,
-                    AST::ImportType(
-                        vec![enum_type.name],
-                        format!("{}{}", enum_type.name, enum_module_suffix).intern()
-                    )
+                self.writer.write_import_type(
+                    &[enum_type.name],
+                    format!("{}{}", enum_type.name, enum_module_suffix).intern(),
                 )?;
             } else {
                 let mut members: Vec<AST> = enum_type

--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -352,10 +352,8 @@ impl<'a> TypeGenerator<'a> {
                 )?;
             }
 
-            write_ast!(
-                self,
-                AST::ExportFragmentList(vec![old_fragment_type_name, new_fragment_type_name,])
-            )?;
+            self.writer
+                .write_export_fragment_types(old_fragment_type_name, new_fragment_type_name)?;
         } else {
             self.writer
                 .write_export_fragment_type(old_fragment_type_name, new_fragment_type_name)?;

--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -71,7 +71,7 @@ pub fn generate_fragment_type(
 ) -> String {
     let mut generator = TypeGenerator::new(schema, typegen_config);
     generator.generate_fragment_type(fragment).unwrap();
-    generator.writer.into_string()
+    generator.into_string()
 }
 
 pub fn generate_operation_type(
@@ -84,7 +84,7 @@ pub fn generate_operation_type(
     generator
         .generate_operation_type(typegen_operation, normalization_operation)
         .unwrap();
-    generator.result
+    generator.into_string()
 }
 
 pub fn generate_split_operation_type(
@@ -97,7 +97,7 @@ pub fn generate_split_operation_type(
     generator
         .generate_split_operation_type(typegen_operation, normalization_operation)
         .unwrap();
-    generator.result
+    generator.into_string()
 }
 
 enum GeneratedInputObject {
@@ -137,6 +137,10 @@ impl<'a> TypeGenerator<'a> {
             runtime_imports: RuntimeImports::default(),
             writer: Self::create_writer(typegen_config),
         }
+    }
+
+    fn into_string(self) -> String {
+        self.writer.into_string()
     }
 
     fn create_writer(typegen_config: &TypegenConfig) -> Box<dyn Writer> {

--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -337,12 +337,9 @@ impl<'a> TypeGenerator<'a> {
             if self.typegen_config.haste {
                 // TODO(T22653277) support non-haste environments when importing
                 // fragments
-                write_ast!(
-                    self,
-                    AST::ImportFragmentType(
-                        vec![old_fragment_type_name, new_fragment_type_name],
-                        format!("{}.graphql", refetchable_metadata.operation_name).intern()
-                    )
+                self.writer.write_import_fragment_type(
+                    &[old_fragment_type_name, new_fragment_type_name],
+                    format!("{}.graphql", refetchable_metadata.operation_name).intern(),
                 )?;
             } else {
                 write_ast!(
@@ -1033,12 +1030,9 @@ impl<'a> TypeGenerator<'a> {
                 if self.typegen_config.haste {
                     // TODO(T22653277) support non-haste environments when importing
                     // fragments
-                    write_ast!(
-                        self,
-                        AST::ImportFragmentType(
-                            vec![fragment_type_name],
-                            format!("{}.graphql", used_fragment).intern()
-                        )
+                    self.writer.write_import_fragment_type(
+                        &[fragment_type_name],
+                        format!("{}.graphql", used_fragment).intern(),
                     )?;
                 // } else if (state.useSingleArtifactDirectory) {
                 //   imports.push(
@@ -1062,12 +1056,9 @@ impl<'a> TypeGenerator<'a> {
 
         for &imported_raw_response_type in self.imported_raw_response_types.iter().sorted() {
             if self.typegen_config.haste {
-                write_ast!(
-                    self,
-                    AST::ImportFragmentType(
-                        vec![imported_raw_response_type],
-                        format!("{}.graphql", imported_raw_response_type).intern()
-                    )
+                self.writer.write_import_fragment_type(
+                    &[imported_raw_response_type],
+                    format!("{}.graphql", imported_raw_response_type).intern(),
                 )?;
             } else {
                 write_ast!(

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -50,7 +50,6 @@ impl Writer for TypeScriptPrinter {
             // In Typescript, we don't export & import fragments. We just use the generic FragmentRefs type instead.
             AST::ExportFragmentList(_) => Ok(()),
             AST::DeclareExportFragment(_, _) => Ok(()),
-            AST::ImportFragmentType(_, _) => Ok(()),
         }
     }
 
@@ -76,6 +75,10 @@ impl Writer for TypeScriptPrinter {
                 .join(", "),
             from
         )
+    }
+
+    fn write_import_fragment_type(&mut self, _types: &[StringKey], _from: StringKey) -> Result {
+        Ok(())
     }
 }
 

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -49,7 +49,6 @@ impl Writer for TypeScriptPrinter {
 
             // In Typescript, we don't export & import fragments. We just use the generic FragmentRefs type instead.
             AST::ExportFragmentList(_) => Ok(()),
-            AST::DeclareExportFragment(_, _) => Ok(()),
         }
     }
 
@@ -78,6 +77,10 @@ impl Writer for TypeScriptPrinter {
     }
 
     fn write_import_fragment_type(&mut self, _types: &[StringKey], _from: StringKey) -> Result {
+        Ok(())
+    }
+
+    fn write_export_fragment_type(&mut self, _old_name: StringKey, _new_name: StringKey) -> Result {
         Ok(())
     }
 }

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -46,9 +46,6 @@ impl Writer for TypeScriptPrinter {
             }
             AST::DefineType(name, value) => self.write_type_definition(name, value),
             AST::FragmentReference(fragments) => self.write_fragment_references(fragments),
-
-            // In Typescript, we don't export & import fragments. We just use the generic FragmentRefs type instead.
-            AST::ExportFragmentList(_) => Ok(()),
         }
     }
 
@@ -76,11 +73,18 @@ impl Writer for TypeScriptPrinter {
         )
     }
 
+    // In Typescript, we don't export & import fragments. We just use the generic FragmentRefs type instead.
     fn write_import_fragment_type(&mut self, _types: &[StringKey], _from: StringKey) -> Result {
         Ok(())
     }
-
     fn write_export_fragment_type(&mut self, _old_name: StringKey, _new_name: StringKey) -> Result {
+        Ok(())
+    }
+    fn write_export_fragment_types(
+        &mut self,
+        _old_fragment_type_name: StringKey,
+        _new_fragment_type_name: StringKey,
+    ) -> Result {
         Ok(())
     }
 }

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -46,7 +46,6 @@ impl Writer for TypeScriptPrinter {
             }
             AST::DefineType(name, value) => self.write_type_definition(name, value),
             AST::ImportType(types, from) => self.write_import_type(types, from),
-            AST::ExportTypeEquals(name, value) => self.write_export_type_equals(name, value),
             AST::FragmentReference(fragments) => self.write_fragment_references(fragments),
 
             // In Typescript, we don't export & import fragments. We just use the generic FragmentRefs type instead.
@@ -54,6 +53,12 @@ impl Writer for TypeScriptPrinter {
             AST::DeclareExportFragment(_, _) => Ok(()),
             AST::ImportFragmentType(_, _) => Ok(()),
         }
+    }
+
+    fn write_export_type(&mut self, name: StringKey, value: &AST) -> Result {
+        write!(&mut self.result, "export type {} = ", name)?;
+        self.write(value)?;
+        writeln!(&mut self.result, ";")
     }
 }
 
@@ -217,12 +222,6 @@ impl TypeScriptPrinter {
 
     fn write_type_definition(&mut self, name: &StringKey, value: &AST) -> Result {
         write!(&mut self.result, "type {} = ", name)?;
-        self.write(value)?;
-        writeln!(&mut self.result, ";")
-    }
-
-    fn write_export_type_equals(&mut self, name: &StringKey, value: &AST) -> Result {
-        write!(&mut self.result, "export type {} = ", name)?;
         self.write(value)?;
         writeln!(&mut self.result, ";")
     }

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -44,7 +44,6 @@ impl Writer for TypeScriptPrinter {
             AST::Local3DPayload(document_name, selections) => {
                 self.write_local_3d_payload(*document_name, selections)
             }
-            AST::DefineType(name, value) => self.write_type_definition(name, value),
             AST::FragmentReference(fragments) => self.write_fragment_references(fragments),
         }
     }
@@ -71,6 +70,10 @@ impl Writer for TypeScriptPrinter {
                 .join(", "),
             from
         )
+    }
+
+    fn write_any_type_definition(&mut self, name: StringKey) -> Result {
+        writeln!(&mut self.result, "type {} = any;", name)
     }
 
     // In Typescript, we don't export & import fragments. We just use the generic FragmentRefs type instead.
@@ -227,12 +230,6 @@ impl TypeScriptPrinter {
                 .collect(),
         ))?;
         write!(&mut self.result, ">")
-    }
-
-    fn write_type_definition(&mut self, name: &StringKey, value: &AST) -> Result {
-        write!(&mut self.result, "type {} = ", name)?;
-        self.write(value)?;
-        writeln!(&mut self.result, ";")
     }
 }
 

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -29,7 +29,6 @@ pub enum AST {
     Any,
     DefineType(StringKey, Box<AST>),
     FragmentReference(Vec<StringKey>),
-    ExportFragmentList(Vec<StringKey>),
 }
 
 #[derive(Debug, Clone)]
@@ -59,4 +58,10 @@ pub trait Writer {
     fn write_import_fragment_type(&mut self, types: &[StringKey], from: StringKey) -> Result;
 
     fn write_export_fragment_type(&mut self, old_name: StringKey, new_name: StringKey) -> Result;
+
+    fn write_export_fragment_types(
+        &mut self,
+        old_fragment_type_name: StringKey,
+        new_fragment_type_name: StringKey,
+    ) -> Result;
 }

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -29,7 +29,6 @@ pub enum AST {
     Any,
     DefineType(StringKey, Box<AST>),
     FragmentReference(Vec<StringKey>),
-    ImportType(Vec<StringKey>, StringKey),
     ImportFragmentType(Vec<StringKey>, StringKey),
     DeclareExportFragment(StringKey, Option<StringKey>),
     ExportFragmentList(Vec<StringKey>),
@@ -56,4 +55,6 @@ pub trait Writer {
     fn write(&mut self, ast: &AST) -> Result;
 
     fn write_export_type(&mut self, name: StringKey, ast: &AST) -> Result;
+
+    fn write_import_type(&mut self, types: &[StringKey], from: StringKey) -> Result;
 }

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -7,7 +7,7 @@
 
 use interner::{Intern, StringKey};
 use lazy_static::lazy_static;
-use std::fmt::{Result, Write};
+use std::fmt::Result;
 
 #[derive(Debug, Clone)]
 pub enum AST {
@@ -50,9 +50,9 @@ lazy_static! {
 }
 
 pub trait Writer {
-    fn into_string(self) -> String;
+    fn into_string(self: Box<Self>) -> String;
 
     fn get_runtime_fragment_import(&self) -> StringKey;
 
-    fn write(&mut self, writer: &mut dyn Write, ast: &AST) -> Result;
+    fn write(&mut self, ast: &AST) -> Result;
 }

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -29,7 +29,6 @@ pub enum AST {
     Any,
     DefineType(StringKey, Box<AST>),
     FragmentReference(Vec<StringKey>),
-    ImportFragmentType(Vec<StringKey>, StringKey),
     DeclareExportFragment(StringKey, Option<StringKey>),
     ExportFragmentList(Vec<StringKey>),
 }
@@ -57,4 +56,6 @@ pub trait Writer {
     fn write_export_type(&mut self, name: StringKey, ast: &AST) -> Result;
 
     fn write_import_type(&mut self, types: &[StringKey], from: StringKey) -> Result;
+
+    fn write_import_fragment_type(&mut self, types: &[StringKey], from: StringKey) -> Result;
 }

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -50,9 +50,7 @@ lazy_static! {
 }
 
 pub trait Writer {
-    fn get_runtime_fragment_import(&self) -> StringKey {
-        "FragmentReference".intern()
-    }
+    fn get_runtime_fragment_import(&self) -> StringKey;
 
     fn write(&mut self, writer: &mut dyn Write, ast: &AST) -> Result;
 }

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -33,7 +33,6 @@ pub enum AST {
     ImportFragmentType(Vec<StringKey>, StringKey),
     DeclareExportFragment(StringKey, Option<StringKey>),
     ExportFragmentList(Vec<StringKey>),
-    ExportTypeEquals(StringKey, Box<AST>),
 }
 
 #[derive(Debug, Clone)]
@@ -55,4 +54,6 @@ pub trait Writer {
     fn get_runtime_fragment_import(&self) -> StringKey;
 
     fn write(&mut self, ast: &AST) -> Result;
+
+    fn write_export_type(&mut self, name: StringKey, ast: &AST) -> Result;
 }

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -29,7 +29,6 @@ pub enum AST {
     Any,
     DefineType(StringKey, Box<AST>),
     FragmentReference(Vec<StringKey>),
-    DeclareExportFragment(StringKey, Option<StringKey>),
     ExportFragmentList(Vec<StringKey>),
 }
 
@@ -58,4 +57,6 @@ pub trait Writer {
     fn write_import_type(&mut self, types: &[StringKey], from: StringKey) -> Result;
 
     fn write_import_fragment_type(&mut self, types: &[StringKey], from: StringKey) -> Result;
+
+    fn write_export_fragment_type(&mut self, old_name: StringKey, new_name: StringKey) -> Result;
 }

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -27,7 +27,6 @@ pub enum AST {
     Number,
     Boolean,
     Any,
-    DefineType(StringKey, Box<AST>),
     FragmentReference(Vec<StringKey>),
 }
 
@@ -64,4 +63,6 @@ pub trait Writer {
         old_fragment_type_name: StringKey,
         new_fragment_type_name: StringKey,
     ) -> Result;
+
+    fn write_any_type_definition(&mut self, name: StringKey) -> Result;
 }

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -50,6 +50,8 @@ lazy_static! {
 }
 
 pub trait Writer {
+    fn into_string(self) -> String;
+
     fn get_runtime_fragment_import(&self) -> StringKey;
 
     fn write(&mut self, writer: &mut dyn Write, ast: &AST) -> Result;


### PR DESCRIPTION
Moves a couple "AST" types that were used only on the top level to be dedicated functions:
- reduces the enum size
- removes a bit of indirections