### PR TITLE
Add relay-compiler-experimental and publish from master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Tests (Node ${{ matrix.node-version }})
+  js-tests:
+    name: JS Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,8 +24,8 @@ jobs:
       - name: Run tests
         run: yarn run jest
 
-  lint:
-    name: Lint
+  js-lint:
+    name: JS Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -40,7 +40,7 @@ jobs:
         run: yarn run lint
 
   typecheck:
-    name: Typecheck
+    name: Flow Typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -52,8 +52,8 @@ jobs:
       - name: Flow
         run: yarn run typecheck
 
-  test-rust:
-    name: Test Rust (${{ matrix.os }})
+  rust-tests:
+    name: Rust Tests (${{ matrix.os }})
     strategy:
       matrix:
         ## TODO: Windows is currently failing in watchman dependency
@@ -72,16 +72,17 @@ jobs:
           args: --manifest-path=compiler/Cargo.toml
 
   build-compiler:
-    name: Build Compiler (${{ matrix.os }})
+    name: Build Rust Compiler (${{ matrix.target.os }})
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        file-name: [relay]
-        ## TODO: windows is currently failing in watchman dependency
-        # include:
-        # - os: windows-latest
-        #   file-name: relay.exe
-    runs-on: ${{ matrix.os }}
+        target:
+          - os: ubuntu-latest
+            build-name: relay
+            artifact-name: relay-compiler-linux-x64
+          - os: macos-latest
+            build-name: relay
+            artifact-name: relay-compiler-macos-x64
+    runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -95,14 +96,14 @@ jobs:
           args: --manifest-path=compiler/Cargo.toml --release
       - uses: actions/upload-artifact@v2
         with:
-          name: compiler (${{ matrix.os }})
-          path: compiler/target/release/${{ matrix.file-name }}
+          name: ${{ matrix.target.artifact-name }}
+          path: compiler/target/release/${{ matrix.target.build-name }}
 
   master-release:
     name: Publish master tag to npm
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/master'
-    needs: [build, lint, typecheck]
+    needs: [js-tests, js-lint, typecheck, rust-tests, build-compiler]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -111,6 +112,21 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
+      - name: Download artifact relay-compiler-linux-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: relay-compiler-linux-x64
+          path: artifacts/linux-x64
+      - name: Download artifact relay-compiler-macos-x64
+        uses: actions/download-artifact@v2
+        with:
+          name: relay-compiler-macos-x64
+          path: artifacts/macos-x64
+      - name: Mark binaries as executable
+        working-directory: artifacts
+        run: |
+          chmod +x linux-x64/relay
+          chmod +x macos-x64/relay
       - name: Build master version
         run:  RELEASE_COMMIT_SHA=${{github.sha}} yarn gulp masterrelease
       - name: Publish to npm

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -383,6 +383,28 @@ const watch = gulp.series(dist, () =>
   gulp.watch(INCLUDE_GLOBS, {cwd: PACKAGES}, dist),
 );
 
+const experimentalCompiler = gulp.parallel(
+  function copyLicense() {
+    return gulp
+      .src(['LICENSE'])
+      .pipe(gulp.dest(path.join(DIST, 'relay-compiler-experimental')));
+  },
+  function copyPackageFiles() {
+    return gulp
+      .src(['package.json', 'cli.js', 'index.js'], {
+        cwd: path.join(PACKAGES, 'relay-compiler-experimental'),
+      })
+      .pipe(gulp.dest(path.join(DIST, 'relay-compiler-experimental')));
+  },
+  function copyCompilerBins() {
+    return gulp
+      .src('**', {
+        cwd: path.join('artifacts'),
+      })
+      .pipe(gulp.dest(path.join(DIST, 'relay-compiler-experimental')));
+  },
+);
+
 /**
  * Updates the package.json files `/dist/` with a version to release to npm under
  * the master tag.
@@ -392,6 +414,7 @@ const setMasterVersion = async () => {
     throw new Error('Expected the RELEASE_COMMIT_SHA env variable to be set.');
   }
   const packages = builds.map(build => build.package);
+  packages.push('relay-compiler-experimental');
   packages.forEach(pkg => {
     const pkgJsonPath = path.join('.', 'dist', pkg, 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
@@ -421,6 +444,10 @@ const cleanbuild = gulp.series(clean, dist);
 exports.clean = clean;
 exports.dist = dist;
 exports.watch = watch;
-exports.masterrelease = gulp.series(cleanbuild, setMasterVersion);
+exports.masterrelease = gulp.series(
+  cleanbuild,
+  experimentalCompiler,
+  setMasterVersion,
+);
 exports.cleanbuild = cleanbuild;
 exports.default = cleanbuild;

--- a/packages/relay-compiler-experimental/cli.js
+++ b/packages/relay-compiler-experimental/cli.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @noflow
+ * @format
+ */
+
+var spawn = require('child_process').spawn;
+
+var input = process.argv.slice(2);
+var bin = require('./');
+
+if (bin !== null) {
+  spawn(bin, input, {stdio: 'inherit'}).on('exit', process.exit);
+} else {
+  throw new Error('Platform not supported.');
+}

--- a/packages/relay-compiler-experimental/index.js
+++ b/packages/relay-compiler-experimental/index.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @noflow
+ * @format
+ */
+
+'use strict';
+
+const path = require('path');
+
+let binary;
+if (process.platform === 'darwin') {
+  binary = path.join(__dirname, 'macos-x64', 'relay');
+} else if (process.platform === 'linux' && process.arch === 'x64') {
+  binary = path.join(__dirname, 'linux-x64', 'relay');
+} else if (process.platform === 'win32' && process.arch === 'x64') {
+  binary = path.join(__dirname, 'win-x64', 'relay.exe');
+} else {
+  binary = null;
+}
+
+module.exports = binary;

--- a/packages/relay-compiler-experimental/package.json
+++ b/packages/relay-compiler-experimental/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "relay-compiler-experimental",
+  "description": "Experimental version of the Relay Compiler",
+  "version": "0.0.2",
+  "keywords": [
+    "graphql",
+    "relay"
+  ],
+  "license": "MIT",
+  "homepage": "https://relay.dev",
+  "bugs": "https://github.com/facebook/relay/issues",
+  "repository": "facebook/relay",
+  "main": "index.js",
+  "bin": {
+    "relay-compiler-experimental": "cli.js"
+  }
+}


### PR DESCRIPTION
Creates a new package `relay-compiler-experimental` that could be our Rust based compiler. A new package, so we could ship Rust and legacy compiler side by side.

Maybe we could also merge the experimental release into the current JS version, but keeping the new package under its own npm name seemed the least risk for disruption for now.