### PR TITLE
Easy: Add shebang to relay-compiler-experimental

### DIFF
--- a/packages/relay-compiler-experimental/cli.js
+++ b/packages/relay-compiler-experimental/cli.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *


### PR DESCRIPTION
Somehow this got lost during rebases, but is required to actually run this script using `yarn run relay-compiler-experimental`.

Test Plan:
added the line to the file in `node_modules` and was able to run the script.