### PR TITLE
Rust Compiler: use config loader

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1789,6 +1789,7 @@ dependencies = [
  "graphql-text-printer",
  "hex",
  "interner",
+ "js-config-loader",
  "lazy_static",
  "log",
  "md-5",

--- a/compiler/crates/relay-codegen/src/js_module_format.rs
+++ b/compiler/crates/relay-codegen/src/js_module_format.rs
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum JsModuleFormat {
     CommonJS,

--- a/compiler/crates/relay-compiler/Cargo.toml
+++ b/compiler/crates/relay-compiler/Cargo.toml
@@ -18,6 +18,7 @@ path = "tests/compile_relay_artifacts_test.rs"
 async-trait = "0.1.45"
 bincode = "1.2"
 common = { path = "../common" }
+js-config-loader = { path = "../js-config-loader" }
 dependency-analyzer = { path = "../dependency-analyzer" }
 env_logger = "0.7"
 errors = { path = "../errors" }

--- a/compiler/crates/relay-compiler/src/compiler_state.rs
+++ b/compiler/crates/relay-compiler/src/compiler_state.rs
@@ -60,7 +60,7 @@ impl ProjectSet {
 }
 
 /// Represents the name of the source set, or list of source sets
-#[derive(Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(untagged)]
 pub enum SourceSet {
     SourceSetName(SourceSetName),

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -25,13 +25,11 @@ use regex::Regex;
 use relay_codegen::JsModuleFormat;
 use relay_transforms::{ConnectionInterface, FeatureFlags};
 use relay_typegen::TypegenConfig;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    path::PathBuf,
-};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::path::{Path, PathBuf};
 use watchman_client::pdu::ScmAwareClockData;
 
 type PostArtifactsWriter = Box<
@@ -90,19 +88,12 @@ pub struct Config {
 }
 
 impl Config {
-    /// Iterator over projects that are enabled.
-    pub fn enabled_projects(&self) -> impl Iterator<Item = &ProjectConfig> {
-        self.projects
-            .values()
-            .filter(|project_config| project_config.enabled)
-    }
-
-    /// Rayon parallel iterator over projects that are enabled.
-    pub fn par_enabled_projects(&self) -> impl ParallelIterator<Item = &ProjectConfig> {
-        self.projects
-            .par_iter()
-            .map(|(_project_name, project_config)| project_config)
-            .filter(|project_config| project_config.enabled)
+    pub fn search(start_dir: &Path) -> Result<Self> {
+        match js_config_loader::search("relay", start_dir) {
+            Ok(Some(config)) => Self::from_struct(config.path, config.value, true),
+            Ok(None) => Err(Error::ConfigNotFound),
+            Err(error) => Err(Error::ConfigSearchError { error }),
+        }
     }
 
     pub fn load(config_path: PathBuf) -> Result<Self> {
@@ -131,6 +122,18 @@ impl Config {
                 config_path: config_path.clone(),
                 source: err,
             })?;
+        Self::from_struct(config_path, config_file, validate_fs)
+    }
+
+    /// `validate_fs` disables all filesystem checks for existence of files
+    fn from_struct(
+        config_path: PathBuf,
+        config_file: ConfigFile,
+        validate_fs: bool,
+    ) -> Result<Self> {
+        let mut hash = Sha1::new();
+        serde_json::to_writer(&mut hash, &config_file).unwrap();
+
         let projects = config_file
             .projects
             .into_iter()
@@ -197,9 +200,6 @@ impl Config {
             config_file_dir.to_owned()
         };
 
-        let mut hash = Sha1::new();
-        hash.input(&config_string);
-
         let config = Self {
             name: config_file.name,
             artifact_writer: Box::new(ArtifactFileWriter::new(None, root_dir.clone())),
@@ -237,6 +237,21 @@ impl Config {
                 validation_errors,
             })
         }
+    }
+
+    /// Iterator over projects that are enabled.
+    pub fn enabled_projects(&self) -> impl Iterator<Item = &ProjectConfig> {
+        self.projects
+            .values()
+            .filter(|project_config| project_config.enabled)
+    }
+
+    /// Rayon parallel iterator over projects that are enabled.
+    pub fn par_enabled_projects(&self) -> impl ParallelIterator<Item = &ProjectConfig> {
+        self.projects
+            .par_iter()
+            .map(|(_project_name, project_config)| project_config)
+            .filter(|project_config| project_config.enabled)
     }
 
     /// Validated internal consistency of the config.
@@ -358,7 +373,11 @@ impl fmt::Debug for Config {
         } = self;
 
         fn option_fn_to_string<T>(option: &Option<T>) -> &'static str {
-            if option.is_some() { "Some(Fn)" } else { "None" }
+            if option.is_some() {
+                "Some(Fn)"
+            } else {
+                "None"
+            }
         }
 
         f.debug_struct("Config")
@@ -487,7 +506,7 @@ pub enum SchemaLocation {
 }
 
 /// Schema of the compiler configuration JSON file.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct ConfigFile {
     /// Optional name for this config, might be used for logging or custom extra
@@ -528,7 +547,7 @@ struct ConfigFile {
     saved_state_config: Option<ScmAwareClockData>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct ConfigFileProject {
     /// If a base project is set, the documents of that project can be
@@ -601,7 +620,7 @@ struct ConfigFileProject {
     js_module_format: JsModuleFormat,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PersistConfig {
     /// URL to send a POST request to to persist.

--- a/compiler/crates/relay-compiler/src/errors.rs
+++ b/compiler/crates/relay-compiler/src/errors.rs
@@ -22,6 +22,14 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[error("No config found.")]
+    ConfigNotFound,
+
+    #[error("Error searching config: {error}")]
+    ConfigSearchError {
+        error: js_config_loader::ConfigError,
+    },
+
     #[error("Failed to parse config file `{config_path}`: {source}")]
     ConfigFileParse {
         config_path: PathBuf,
@@ -85,7 +93,7 @@ pub enum Error {
         source: std::io::Error,
     },
 
-    #[error("Watchman error: {source}.")]
+    #[error("Watchman error: {source}")]
     Watchman {
         #[from]
         source: watchman_client::Error,

--- a/compiler/crates/relay-compiler/src/rollout.rs
+++ b/compiler/crates/relay-compiler/src/rollout.rs
@@ -6,12 +6,12 @@
  */
 
 use md5::{Digest, Md5};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A utility to enable gradual rollout of large codegen changes.
 /// Can be constructed as the Default which passes or a percentage between 0 and
 /// 100.
-#[derive(Default, Debug, Deserialize, Clone, Copy)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct Rollout(Option<u8>);
 
 impl Rollout {

--- a/compiler/crates/relay-transforms/src/connections/connection_interface.rs
+++ b/compiler/crates/relay-transforms/src/connections/connection_interface.rs
@@ -7,10 +7,10 @@
 
 use interner::{Intern, StringKey};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Configuration where Relay should expect some fields in the schema.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ConnectionInterface {
     pub cursor: StringKey,

--- a/compiler/crates/relay-transforms/src/feature_flags.rs
+++ b/compiler/crates/relay-transforms/src/feature_flags.rs
@@ -7,10 +7,10 @@
 
 use indexmap::IndexSet;
 use interner::StringKey;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct FeatureFlags {
     #[serde(default)]
@@ -36,7 +36,7 @@ impl Default for FeatureFlags {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum NoInlineFeature {
     /// Fully disabled: developers may not use @no_inline

--- a/compiler/crates/relay-typegen/src/config.rs
+++ b/compiler/crates/relay-typegen/src/config.rs
@@ -7,9 +7,9 @@
 
 use fnv::FnvHashMap;
 use interner::StringKey;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum TypegenLanguage {
     Flow,
@@ -22,7 +22,7 @@ impl Default for TypegenLanguage {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct TypegenConfig {
     /// The desired output language, "flow" or "typescript".


### PR DESCRIPTION
This uses the `js-config-loader` crate to find a `relay` config either in a `relay.json` file or `relay` key in the `package.json`.

Tested this on the todo example app and after adding a config to the package.json, it worked there!