### PR TITLE
Fixes and improvements to the declarative mutation directives docs

### DIFF
--- a/website/docs/guided-tour/list-data/updating-connections.md
+++ b/website/docs/guided-tour/list-data/updating-connections.md
@@ -68,6 +68,10 @@ function updater(store: RecordSourceSelectorProxy) {
 }
 ```
 
+:::note
+The `__id` field is not something that your GraphQL API needs to expose. Instead, it's an identifier that Relay automatically adds to identify the connection record.
+:::
+
 ### Accessing connections using `ConnectionHandler.getConnectionID`
 
 If we have access to the ID of the parent record that holds the connection, we can access the connection record by using the `ConnectionHandler.getConnectionID` API:
@@ -117,14 +121,16 @@ There are a couple of alternatives for adding edges to a connection:
 
 ### Using declarative directives
 
-Usually, mutation or subscription payloads will expose the new edge that was added on the server as an edge field. If your mutation or subscription exposes an edge field that you can query for in the response, then you can use the `@appendEdge`,  `@prependEdge` , `@prependNode`, `@appendNode` declarative mutation directives on the edge field in order to add the newly created edge to the connection (note that these directives also work on queries).
+Usually, mutation or subscription payloads will expose the new edges that were added on the server as a field with a single edge or list of edges. If your mutation or subscription exposes an edge or edges field that you can query for in the response, then you can use the `@appendEdge` and `@prependEdge` declarative mutation directives on that field in order to add the newly created edges to the specified connections (note that these directives also work on queries).
+
+Alternatively, mutation or subscription payloads might expose the new nodes that were added on the server as a field with a single node or list of nodes. If your mutation or subscription exposes a node or nodes field that you can query for in the response, then you can use the `@appendNode` and `@prependNode` declarative mutation directives on that field in order to add the newly created nodes, wrapped inside edges, to the specified connections (note that these directives also work on queries).
 
 These directives accept a `connections` parameter, which needs to be a GraphQL variable containing an array of connection IDs. Connection IDs can be obtained either by using the [`__id` field on connections](#accessing-connections-using-__id) or using the [`ConnectionHandler.getConnectionID`](#accessing-connections-using-connectionhandlergetconnectionid) API.
 
 
 #### `@appendEdge` / `@prependEdge`
 
-These directives work on edge fields. `@prependEdge` will add the selected edge to the beginning of each connection defined in the `connections` array, whereas `@appendEdge` will add the selected edge to the end of each connection in the array.
+These directives work on a field with a single edge or list of edges. `@prependEdge` will add the selected edges to the beginning of each connection defined in the `connections` array, whereas `@appendEdge` will add the selected edges to the end of each connection in the array.
 
 **Arguments:**
 - `connections`: An array of connection IDs. Connection IDs can be obtained either by using the [`__id` field on connections](#accessing-connections-using-__id) or using the [`ConnectionHandler.getConnectionID`](#accessing-connections-using-connectionhandlergetconnectionid) API.
@@ -133,10 +139,10 @@ These directives work on edge fields. `@prependEdge` will add the selected edge 
 **Example:**
 
 ```js
-// Get using the `__id` field
+// Get the connection ID using the `__id` field
 const connectionID = fragmentData?.comments?.__id;
 
-// Or get using `ConnectionHandler.getConnectionID()`
+// Or get it using `ConnectionHandler.getConnectionID()`
 const connectionID =  ConnectionHandler.getConnectionID(
   '<story-id>',
   'StoryComponent_story_comments_connection',
@@ -174,18 +180,18 @@ commitMutation<AppendCommentMutation>(environment, {
 
 #### `@appendNode` / `@prependNode`
 
-These directives work on node fields, and will create edges with the specified `edgeTypeName`. `@prependNode` will add the selected node to the beginning of each connection defined in the `connections` array, whereas `@appendNode` will add the selected node to the end of each connection in the array.
+These directives work on a field with a single node or list of nodes, and will create edges with the specified `edgeTypeName`. `@prependNode` will add edges containing the selected nodes to the beginning of each connection defined in the `connections` array, whereas `@appendNode` will add edges containing the selected nodes to the end of each connection in the array.
 
 **Arguments:**
 - `connections`: An array of connection IDs. Connection IDs can be obtained either by using the [`__id` field on connections](#accessing-connections-using-__id) or using the [`ConnectionHandler.getConnectionID`](#accessing-connections-using-connectionhandlergetconnectionid) API.
-- `edgeTypeName`: The typename of an edge, corresponding to the edge type argument in `ConnectionHandler.createEdge`.
+- `edgeTypeName`: The type name of the edge that contains the node, corresponding to the edge type argument in `ConnectionHandler.createEdge`.
 
 **Example:**
 ```js
-// Get using the `__id` field
+// Get the connection ID using the `__id` field
 const connectionID = fragmentData?.comments?.__id;
 
-// Or get using `ConnectionHandler.getConnectionID()`
+// Or get it using `ConnectionHandler.getConnectionID()`
 const connectionID =  ConnectionHandler.getConnectionID(
   '<story-id>',
   'StoryComponent_story_comments_connection',
@@ -370,10 +376,10 @@ Works on GraphQL fields that return an `ID` or `[ID]`. Will delete the edges wit
 **Example:**
 
 ```js
-// Get using the `__id` field
+// Get the connection ID using the `__id` field
 const connectionID = fragmentData?.comments?.__id;
 
-// Or get using `ConnectionHandler.getConnectionID()`
+// Or get it using `ConnectionHandler.getConnectionID()`
 const connectionID =  ConnectionHandler.getConnectionID(
   '<story-id>',
   'StoryComponent_story_comments_connection',

--- a/website/docs/guided-tour/list-data/updating-connections.md
+++ b/website/docs/guided-tour/list-data/updating-connections.md
@@ -143,7 +143,7 @@ These directives work on a field with a single edge or list of edges. `@prependE
 const connectionID = fragmentData?.comments?.__id;
 
 // Or get it using `ConnectionHandler.getConnectionID()`
-const connectionID =  ConnectionHandler.getConnectionID(
+const connectionID = ConnectionHandler.getConnectionID(
   '<story-id>',
   'StoryComponent_story_comments_connection',
 );
@@ -192,7 +192,7 @@ These directives work on a field with a single node or list of nodes, and will c
 const connectionID = fragmentData?.comments?.__id;
 
 // Or get it using `ConnectionHandler.getConnectionID()`
-const connectionID =  ConnectionHandler.getConnectionID(
+const connectionID = ConnectionHandler.getConnectionID(
   '<story-id>',
   'StoryComponent_story_comments_connection',
 );
@@ -380,7 +380,7 @@ Works on GraphQL fields that return an `ID` or `[ID]`. Will delete the edges wit
 const connectionID = fragmentData?.comments?.__id;
 
 // Or get it using `ConnectionHandler.getConnectionID()`
-const connectionID =  ConnectionHandler.getConnectionID(
+const connectionID = ConnectionHandler.getConnectionID(
   '<story-id>',
   'StoryComponent_story_comments_connection',
 );

--- a/website/versioned_docs/version-v11.0.0/guided-tour/list-data/updating-connections.md
+++ b/website/versioned_docs/version-v11.0.0/guided-tour/list-data/updating-connections.md
@@ -16,7 +16,7 @@ As explained in our [Updating Data](../../updating-data/) section, Relay holds a
 
 In Relay, connection fields that are marked with the `@connection` directive are stored as special records in the store, and they hold and accumulate *all* of the items that have been fetched for the connection so far. In order to add or remove items from a connection, we need to access the connection record using the connection `key`, which was provided when declaring a `@connection`; specifically, this allows us to access a connection inside an [`updater`](../../updating-data/graphql-mutations/#updater-functions) function using the `ConnectionHandler` APIs.
 
-For example, given the following fragment that declares a `@connection`, We can access the connection record inside an `updater` function in a few different ways:
+For example, given the following fragment that declares a `@connection`, we can access the connection record inside an `updater` function in a few different ways:
 
 ```js
 const {graphql} = require('react-relay');
@@ -68,6 +68,10 @@ function updater(store: RecordSourceSelectorProxy) {
 }
 ```
 
+:::note
+The `__id` field is not something that your GraphQL API needs to expose. Instead, it's an identifier that Relay automatically adds to identify the connection record.
+:::
+
 ### Accessing connections using `ConnectionHandler.getConnectionID`
 
 If we have access to the ID of the parent record that holds the connection, we can access the connection record by using the `ConnectionHandler.getConnectionID` API:
@@ -117,14 +121,16 @@ There are a couple of alternatives for adding edges to a connection:
 
 ### Using declarative directives
 
-Usually, mutation or subscription payloads will expose the new edge that was added on the server as an edge field. If your mutation or subscription exposes an edge field that you can query for in the response, then you can use the `@appendEdge`,  `@prependEdge` , `@prependNode`, `@appendNode` declarative mutation directives on the edge field in order to add the newly created edge to the connection (note that these directives also work on queries).
+Usually, mutation or subscription payloads will expose the new edges that were added on the server as a field with a single edge or list of edges. If your mutation or subscription exposes an edge or edges field that you can query for in the response, then you can use the `@appendEdge` and `@prependEdge` declarative mutation directives on that field in order to add the newly created edges to the specified connections (note that these directives also work on queries).
+
+Alternatively, mutation or subscription payloads might expose the new nodes that were added on the server as a field with a single node or list of nodes. If your mutation or subscription exposes a node or nodes field that you can query for in the response, then you can use the `@appendNode` and `@prependNode` declarative mutation directives on that field in order to add the newly created nodes, wrapped inside edges, to the specified connections (note that these directives also work on queries).
 
 These directives accept a `connections` parameter, which needs to be a GraphQL variable containing an array of connection IDs. Connection IDs can be obtained either by using the [`__id` field on connections](#accessing-connections-using-__id) or using the [`ConnectionHandler.getConnectionID`](#accessing-connections-using-connectionhandlergetconnectionid) API.
 
 
 #### `@appendEdge` / `@prependEdge`
 
-These directives work on edge fields. `@prependEdge` will add the selected edge to the beginning of each defined in the `connections` array, whereas `@appendEdge` will add the selected edge to the end of each connection in the array.
+These directives work on a field with a single edge or list of edges. `@prependEdge` will add the selected edges to the beginning of each connection defined in the `connections` array, whereas `@appendEdge` will add the selected edges to the end of each connection in the array.
 
 **Arguments:**
 - `connections`: An array of connection IDs. Connection IDs can be obtained either by using the [`__id` field on connections](#accessing-connections-using-__id) or using the [`ConnectionHandler.getConnectionID`](#accessing-connections-using-connectionhandlergetconnectionid) API.
@@ -133,11 +139,14 @@ These directives work on edge fields. `@prependEdge` will add the selected edge 
 **Example:**
 
 ```js
-// Get using the `__id` field
+// Get the connection ID using the `__id` field
 const connectionID = fragmentData?.comments?.__id;
 
-// Or get using `ConnectionHandler.getConnectionID()`
-const connectionID =  ConnectionHandler.getConnectionID('<story-id>', 'StoryComponent_story_comments_connection')
+// Or get it using `ConnectionHandler.getConnectionID()`
+const connectionID =  ConnectionHandler.getConnectionID(
+  '<story-id>',
+  'StoryComponent_story_comments_connection',
+);
 
 // ...
 
@@ -146,7 +155,7 @@ commitMutation<AppendCommentMutation>(environment, {
   mutation: graphql`
     mutation AppendCommentMutation(
       # Define a GraphQL variable for the connections array
-      $connections: [String!]!
+      $connections: [ID!]!
       $input: CommentCreateInput
     ) {
       commentCreate(input: $input) {
@@ -171,19 +180,22 @@ commitMutation<AppendCommentMutation>(environment, {
 
 #### `@appendNode` / `@prependNode`
 
-These directives work on Node fields, and will create edges with the specified `edgeTypeName`. `@prependNode` will add the selected node to the beginning of each defined in the `connections` array, whereas `@appendNode` will add the selected node to the end of each connection in the array.
+These directives work on a field with a single node or list of nodes, and will create edges with the specified `edgeTypeName`. `@prependNode` will add edges containing the selected nodes to the beginning of each connection defined in the `connections` array, whereas `@appendNode` will add edges containing the selected nodes to the end of each connection in the array.
 
 **Arguments:**
 - `connections`: An array of connection IDs. Connection IDs can be obtained either by using the [`__id` field on connections](#accessing-connections-using-__id) or using the [`ConnectionHandler.getConnectionID`](#accessing-connections-using-connectionhandlergetconnectionid) API.
-- `edgeTypeName`: The typename of an edge, corresponding to the edge type argument in `ConnectionHandler.createEdge`.
+- `edgeTypeName`: The type name of the edge that contains the node, corresponding to the edge type argument in `ConnectionHandler.createEdge`.
 
 **Example:**
 ```js
-// Get using the `__id` field
+// Get the connection ID using the `__id` field
 const connectionID = fragmentData?.comments?.__id;
 
-// Or get using `ConnectionHandler.getConnectionID()`
-const connectionID =  ConnectionHandler.getConnectionID('<story-id>', 'StoryComponent_story_comments_connection')
+// Or get it using `ConnectionHandler.getConnectionID()`
+const connectionID =  ConnectionHandler.getConnectionID(
+  '<story-id>',
+  'StoryComponent_story_comments_connection',
+);
 
 // ...
 
@@ -192,11 +204,11 @@ commitMutation<AppendCommentMutation>(environment, {
   mutation: graphql`
     mutation AppendCommentMutation(
       # Define a GraphQL variable for the connections array
-      $connections: [String!]!
+      $connections: [ID!]!
       $input: CommentCreateInput
     ) {
       commentCreate(input: $input) {
-        # Use @appendNode or @prependNode on the edge field
+        # Use @appendNode or @prependNode on the node field
         feedbackCommentNode @appendNode(connections: $connections, edgeTypeName: "CommentsEdge") {
           id
         }
@@ -216,9 +228,9 @@ commitMutation<AppendCommentMutation>(environment, {
 
 For all of these directives, they will be executed in the following order within the mutation or subscription, as per the [order of execution of updates](../../updating-data/graphql-mutations/#order-of-execution-of-updater-functions):
 
-* When the mutation is initiated, after the optimistic response is handled, and after the optimistic updater function is executed, the `@prependEdge` and `@appendEdge` directives wills be applied to the optimistic response.
-* If the mutation succeeds, after the data from the network response is merged with the existing values in the store, and after the updater function is executed, the `@prependEdge` and `@appendEdge` directives will be applied to the data in the network response.
-* If the mutation failed, the updates from processing the `@prependEdge` and `@appendEdge` directives will be rolled back.
+* When the mutation is initiated, after the optimistic response is handled, and after the optimistic updater function is executed, the `@prependEdge`, `@appendEdge`, `@prependNode`, and `@appendNode` directives will be applied to the optimistic response.
+* If the mutation succeeds, after the data from the network response is merged with the existing values in the store, and after the updater function is executed, the `@prependEdge`, `@appendEdge`, `@prependNode`, and `@appendNode` directives will be applied to the data in the network response.
+* If the mutation failed, the updates from processing the `@prependEdge`, `@appendEdge`, `@prependNode`, and `@appendNode` directives will be rolled back.
 
 
 ### Manually adding edges
@@ -355,7 +367,7 @@ Similarly to the [directives to add edges](#using-declarative-directives), we ca
 
 #### `@deleteEdge`
 
-Works on GraphQL fields that return an `ID` or `[ID]`. Will delete the edge with nodes that matches the `id` from each connection defined in the `connections` array.
+Works on GraphQL fields that return an `ID` or `[ID]`. Will delete the edges with nodes that match the `id` from each connection defined in the `connections` array.
 
 **Arguments:**
 - `connections`: An array of connection IDs. Connection IDs can be obtained either by using the [`__id` field on connections](#accessing-connections-using-__id) or using the [`ConnectionHandler.getConnectionID`](#accessing-connections-using-connectionhandlergetconnectionid) API.
@@ -364,21 +376,24 @@ Works on GraphQL fields that return an `ID` or `[ID]`. Will delete the edge with
 **Example:**
 
 ```js
-// Get using the `__id` field
+// Get the connection ID using the `__id` field
 const connectionID = fragmentData?.comments?.__id;
 
-// Or get using `ConnectionHandler.getConnectionID()`
-const connectionID =  ConnectionHandler.getConnectionID('<story-id>', 'StoryComponent_story_comments_connection')
+// Or get it using `ConnectionHandler.getConnectionID()`
+const connectionID =  ConnectionHandler.getConnectionID(
+  '<story-id>',
+  'StoryComponent_story_comments_connection',
+);
 
 // ...
 
 // Mutation
-commitMutation<AppendCommentMutation>(environment, {
+commitMutation<DeleteCommentsMutation>(environment, {
   mutation: graphql`
-    mutation AppendCommentMutation(
+    mutation DeleteCommentsMutation(
       # Define a GraphQL variable for the connections array
-      $connections: [String!]!
-      $input: CommentCreateInput
+      $connections: [ID!]!
+      $input: CommentsDeleteInput
     ) {
       commentsDelete(input: $input) {
         deletedCommentIds @deleteEdge(connections: $connections)

--- a/website/versioned_docs/version-v11.0.0/guided-tour/list-data/updating-connections.md
+++ b/website/versioned_docs/version-v11.0.0/guided-tour/list-data/updating-connections.md
@@ -143,7 +143,7 @@ These directives work on a field with a single edge or list of edges. `@prependE
 const connectionID = fragmentData?.comments?.__id;
 
 // Or get it using `ConnectionHandler.getConnectionID()`
-const connectionID =  ConnectionHandler.getConnectionID(
+const connectionID = ConnectionHandler.getConnectionID(
   '<story-id>',
   'StoryComponent_story_comments_connection',
 );
@@ -192,7 +192,7 @@ These directives work on a field with a single node or list of nodes, and will c
 const connectionID = fragmentData?.comments?.__id;
 
 // Or get it using `ConnectionHandler.getConnectionID()`
-const connectionID =  ConnectionHandler.getConnectionID(
+const connectionID = ConnectionHandler.getConnectionID(
   '<story-id>',
   'StoryComponent_story_comments_connection',
 );
@@ -380,7 +380,7 @@ Works on GraphQL fields that return an `ID` or `[ID]`. Will delete the edges wit
 const connectionID = fragmentData?.comments?.__id;
 
 // Or get it using `ConnectionHandler.getConnectionID()`
-const connectionID =  ConnectionHandler.getConnectionID(
+const connectionID = ConnectionHandler.getConnectionID(
   '<story-id>',
   'StoryComponent_story_comments_connection',
 );


### PR DESCRIPTION
This PR supersedes #3334.

**Changes:**
*  Fix typos and code examples in sections about declarative mutation directives.
* Improve the sections about the declarative mutation directives.

**CC:** @jstejada 