### PR TITLE
Fix documentation about RelayEnvironmentProvider

### DIFF
--- a/website/versioned_docs/version-v11.0.0/api-reference/hooks/relay-environment-provider.md
+++ b/website/versioned_docs/version-v11.0.0/api-reference/hooks/relay-environment-provider.md
@@ -13,7 +13,7 @@ This component is used set a Relay environment in React Context. Usually, a *sin
 ```js
 const React = require('React');
 
-const {RelayEnvironmentProvider} = require('react-relay');
+const {RelayEnvironmentProvider} = require('react-relay/hooks');
 
 const Environment = createNewEnvironment();
 

--- a/website/versioned_docs/version-v11.0.0/guided-tour/rendering/environment.md
+++ b/website/versioned_docs/version-v11.0.0/guided-tour/rendering/environment.md
@@ -16,7 +16,7 @@ In order to render Relay components, you need to render a `RelayEnvironmentProvi
 ```js
 // App root
 
-const {RelayEnvironmentProvider} = require('react-relay');
+const {RelayEnvironmentProvider} = require('react-relay/hooks');
 const Environment = require('MyEnvironment');
 
 function Root() {

--- a/website/versioned_docs/version-v11.0.0/guides/testing-relay-with-preloaded-queries.md
+++ b/website/versioned_docs/version-v11.0.0/guides/testing-relay-with-preloaded-queries.md
@@ -25,7 +25,7 @@ In short, there are two steps that need to be performed **before rendering the c
 
 ```js
 
-const {RelayEnvironmentProvider} = require('react-relay');
+const {RelayEnvironmentProvider} = require('react-relay/hooks');
 const { MockPayloadGenerator, createMockEnvironment } = require('relay-test-utils');
 const {render} = require('testing-library-react');
 // at the time of writing, act is not re-exported by our internal testing-library-react


### PR DESCRIPTION
Several places in documentation uses:

```js
const {RelayEnvironmentProvider} = require('react-relay');
```

But this is not working because there is no export like this. It is missing
hooks "namespace".