### PR TITLE
Add new example project in learning resources documentation

### DIFF
--- a/website/versioned_docs/version-v11.0.0/community/learning-resources.md
+++ b/website/versioned_docs/version-v11.0.0/community/learning-resources.md
@@ -12,6 +12,7 @@ import DocsRating from '@site/src/core/DocsRating';
 These projects serve as an example of how to use Relay in real world applications.
 
 -   [github.com/relayjs/relay-examples](https://github.com/relayjs/relay-examples)
+-   [github.com/juffalow/react-relay-example](https://github.com/juffalow/react-relay-example)
 
 ## Guides and articles:
 


### PR DESCRIPTION
I updated my React Relay example project to use latest Relay (version 11). It might be useful for some users to have more example projects. This one is also with available backend in Node or PHP.