### PR TITLE
Fix typo in config.src doc string

### DIFF
--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -98,7 +98,7 @@ pub struct Config {
 #[derive(StructOpt)]
 #[structopt(rename_all = "camel_case")]
 pub struct CliConfig {
-    /// Path for the directory where to search fo a source code
+    /// Path for the directory where to search for source code
     #[structopt(long)]
     pub src: Option<PathBuf>,
     /// Path to schema file


### PR DESCRIPTION
I think this is meant to be "where to search for source code," since "fo a" doesn't make sense.