### PR TITLE
Replace `fbjs/lib/invariant` with `invariant`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "gulp-header": "2.0.9",
     "gulp-rename": "^2.0.0",
     "gulp-util": "3.0.8",
+    "invariant": "^2.2.4",
     "immutable": "~3.7.6",
     "jest": "^26.6.3",
     "nullthrows": "^1.1.1",

--- a/packages/react-relay/package.json
+++ b/packages/react-relay/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "fbjs": "^3.0.0",
+    "invariant": "^2.2.4",
     "nullthrows": "^1.1.1",
     "relay-runtime": "11.0.1"
   },

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -27,6 +27,7 @@
     "fbjs": "^3.0.0",
     "glob": "^7.1.1",
     "immutable": "~3.7.6",
+    "invariant": "^2.2.4",
     "nullthrows": "^1.1.1",
     "relay-runtime": "11.0.1",
     "signedsource": "^1.0.0",

--- a/packages/relay-runtime/package.json
+++ b/packages/relay-runtime/package.json
@@ -12,7 +12,8 @@
   "repository": "facebook/relay",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "fbjs": "^3.0.0"
+    "fbjs": "^3.0.0",
+    "invariant": "^2.2.4"
   },
   "directories": {
     "": "./"

--- a/packages/relay-test-utils/package.json
+++ b/packages/relay-test-utils/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "fbjs": "^3.0.0",
+    "invariant": "^2.2.4",
     "relay-runtime": "11.0.1"
   },
   "peerDependencies": {

--- a/scripts/getBabelOptions.js
+++ b/scripts/getBabelOptions.js
@@ -32,7 +32,6 @@ module.exports = function(options) {
           map: {
             Promise: 'promise-polyfill',
             areEqual: 'fbjs/lib/areEqual',
-            invariant: 'fbjs/lib/invariant',
             warning: 'fbjs/lib/warning',
           },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3953,7 +3953,7 @@ interpret@^1.4.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-invariant@^2.2.2:
+invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==


### PR DESCRIPTION
Migrates Relay off `fbjs/lib/invariant` onto the `invariant` npm package.

**Test Plan:**
Ran `yarn` and `yarn test` successfully.