### PR TITLE
A better intro/description to the usePreloadedQuery hook

### DIFF
--- a/website/versioned_docs/version-v11.0.0/guided-tour/rendering/queries.md
+++ b/website/versioned_docs/version-v11.0.0/guided-tour/rendering/queries.md
@@ -65,7 +65,7 @@ Sample response:
 
 ## Rendering Queries
 
-To *render* a query in Relay, you can use the `usePreloadedQuery` Hook:
+To *render* a query in Relay, you can use the `usePreloadedQuery` Hook. `usePreloadedQuery` takes a query definition and a query reference, and returns the corresponding data for that query and reference. 
 
 ```js
 import type {HomeTabQuery} from 'HomeTabQuery.graphql';


### PR DESCRIPTION
Instead of straight away asking the reader to go through the code and then understand what the hook does, the committed line gives a better intro of what the hook does. Also, what the inputs to the hook are and what it's output is. I feel like this important detail should be highlighted better. It gives a better context before reading the code