### PR TITLE
Add new example project in learning resources documentation

### DIFF
--- a/docs/Community-LearningResources.md
+++ b/docs/Community-LearningResources.md
@@ -9,6 +9,7 @@ These projects serve as an example of how to use Relay in real world application
 -   [github.com/relayjs/relay-examples](https://github.com/relayjs/relay-examples)
 -   [github.com/adeira/relay-example](https://github.com/adeira/relay-example)
 -   [github.com/juffalow/react-relay-example](https://github.com/juffalow/react-relay-example)
+-   [github.com/sibelius/relay-workshop](https://github.com/sibelius/relay-workshop)
 
 ## Learn basics
 


### PR DESCRIPTION
- Adding the Relay Workshop to Community Learning Resources as a Relay example projects, I think it will help.
- Relay-Workshop (by @sibelius): https://github.com/sibelius/relay-workshop