### PR TITLE
Fix: Check if global exists before calling ErrorUtils

### DIFF
--- a/packages/relay-runtime/store/RelayPublishQueue.js
+++ b/packages/relay-runtime/store/RelayPublishQueue.js
@@ -55,7 +55,7 @@ type PendingUpdater = {|
 |};
 
 const applyWithGuard =
-  global.ErrorUtils?.applyWithGuard ??
+  global?.ErrorUtils?.applyWithGuard ??
   ((callback, context, args, onError, name) => callback.apply(context, args));
 
 /**


### PR DESCRIPTION
I was experiencing some `global is not defined`'s from `RelayPublishQueue.js` when using Relay in Vite. And I think this change will solve it for the cases where global is not yet defined.