### PR TITLE
Fixed Repository Reference in monorepo package.json files

### DIFF
--- a/packages/babel-plugin-relay/package.json
+++ b/packages/babel-plugin-relay/package.json
@@ -11,7 +11,11 @@
   "license": "MIT",
   "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
-  "repository": "facebook/relay",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/relay.git",
+    "directory": "packages/babel-plugin-relay"
+  },
   "dependencies": {
     "babel-plugin-macros": "^2.0.0"
   },

--- a/packages/react-relay/package.json
+++ b/packages/react-relay/package.json
@@ -10,7 +10,11 @@
   "license": "MIT",
   "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
-  "repository": "facebook/relay",
+  "repository":  {
+    "type": "git",
+    "url": "https://github.com/facebook/relay.git",
+    "directory": "packages/react-relay"
+  },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "fbjs": "^3.0.0",

--- a/packages/relay-compiler-experimental/package.json
+++ b/packages/relay-compiler-experimental/package.json
@@ -9,7 +9,11 @@
   "license": "MIT",
   "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
-  "repository": "facebook/relay",
+  "repository":  {
+    "type": "git",
+    "url": "https://github.com/facebook/relay.git",
+    "directory": "packages/relay-compiler-experimental"
+  },
   "main": "index.js",
   "bin": "cli.js"
 }

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -9,7 +9,11 @@
   "license": "MIT",
   "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
-  "repository": "facebook/relay",
+  "repository":  {
+    "type": "git",
+    "url": "https://github.com/facebook/relay.git",
+    "directory": "packages/relay-compiler"
+  },
   "main": "index.js",
   "bin": {
     "relay-compiler": "bin/relay-compiler"

--- a/packages/relay-config/package.json
+++ b/packages/relay-config/package.json
@@ -9,7 +9,11 @@
   "license": "MIT",
   "homepage": "https://facebook.github.io/relay/",
   "bugs": "https://github.com/facebook/relay/issues",
-  "repository": "facebook/relay",
+  "repository":  {
+    "type": "git",
+    "url": "https://github.com/facebook/relay.git",
+    "directory": "packages/relay-config"
+  },
   "main": "index.js",
   "dependencies": {
     "cosmiconfig": "^5.0.5"

--- a/packages/relay-runtime/package.json
+++ b/packages/relay-runtime/package.json
@@ -9,7 +9,11 @@
   "license": "MIT",
   "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
-  "repository": "facebook/relay",
+  "repository":  {
+    "type": "git",
+    "url": "https://github.com/facebook/relay.git",
+    "directory": "packages/relay-runtime"
+  },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "fbjs": "^3.0.0",

--- a/packages/relay-test-utils-internal/package.json
+++ b/packages/relay-test-utils-internal/package.json
@@ -9,7 +9,11 @@
   "license": "MIT",
   "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
-  "repository": "facebook/relay",
+  "repository":  {
+    "type": "git",
+    "url": "https://github.com/facebook/relay.git",
+    "directory": "packages/relay-test-utils-internal"
+  },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "fbjs": "^3.0.0",

--- a/packages/relay-test-utils/package.json
+++ b/packages/relay-test-utils/package.json
@@ -9,7 +9,11 @@
   "license": "MIT",
   "homepage": "https://relay.dev",
   "bugs": "https://github.com/facebook/relay/issues",
-  "repository": "facebook/relay",
+  "repository":  {
+    "type": "git",
+    "url": "https://github.com/facebook/relay.git",
+    "directory": "packages/relay-test-utils"
+  },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "fbjs": "^3.0.0",


### PR DESCRIPTION
Based on the documentation for the `package.json` syntax on the `repository` field, this PR adds support for subdirectory information (See https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository).