### PR TITLE
[rust]: properly output typescript artifacts

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -480,6 +480,8 @@ dependencies = [
  "graphql-syntax",
  "interner",
  "relay-test-schema",
+ "relay-transforms",
+ "schema",
 ]
 
 [[package]]

--- a/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
+++ b/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
@@ -306,17 +306,20 @@ fn generate_operation(
         )
         .unwrap();
     }
+
+    let node_request = printer.print_request(
+        schema,
+        normalization_operation,
+        &operation_fragment,
+        request_parameters,
+    );
+
     if let TypegenLanguage::Flow = project_config.typegen_config.language { 
         writeln!(content, "*/\n").unwrap();
         writeln!(
             content,
             "var node/*: ConcreteRequest*/ = {};\n",
-            printer.print_request(
-                schema,
-                normalization_operation,
-                &operation_fragment,
-                request_parameters,
-            )
+            node_request
         )
         .unwrap();
     } else {
@@ -324,12 +327,7 @@ fn generate_operation(
         writeln!(
             content,
             "var node: ConcreteRequest = {};\n",
-            printer.print_request(
-                schema,
-                normalization_operation,
-                &operation_fragment,
-                request_parameters,
-            )
+            node_request
         )
         .unwrap();
     }
@@ -403,12 +401,15 @@ fn generate_split_operation(
         .unwrap();
     }
     writeln!(content, "*/\n").unwrap();
+
+    let node_operation = printer.print_operation(schema, normalization_operation);
+
     if let TypegenLanguage::Flow = project_config.typegen_config.language { 
         writeln!(content, "*/\n").unwrap();
         writeln!(
             content,
             "var node/*: NormalizationSplitOperation*/ = {};\n",
-            printer.print_operation(schema, normalization_operation)
+            node_operation
         )
         .unwrap();
     } else {
@@ -416,7 +417,7 @@ fn generate_split_operation(
         writeln!(
             content,
             "var node: NormalizationSplitOperation = {};\n",
-            printer.print_operation(schema, normalization_operation)
+            node_operation
         )
         .unwrap();
     }
@@ -516,13 +517,15 @@ fn generate_fragment(
         .unwrap();
     }
 
+    let node_fragment = printer.print_fragment(schema, reader_fragment);
+
     if let TypegenLanguage::Flow = project_config.typegen_config.language { 
         writeln!(content, "*/\n").unwrap();
         writeln!(
             content,
             "var node/*: {}*/ = {};\n",
             reader_node_flow_type,
-            printer.print_fragment(schema, reader_fragment)
+            node_fragment
         )
         .unwrap();
     } else {
@@ -531,7 +534,7 @@ fn generate_fragment(
             content,
             "var node:{} = {};\n",
             reader_node_flow_type,
-            printer.print_fragment(schema, reader_fragment)
+            node_fragment
         )
         .unwrap();
     }

--- a/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
+++ b/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
@@ -222,7 +222,7 @@ fn generate_operation(
         directives: reader_operation.directives.clone(),
         type_condition: reader_operation.type_,
     };
-    let mut content = get_content_start(config, project_config);
+    let mut content = get_content_start(config);
     writeln!(content, " * {}", SIGNING_TOKEN).unwrap();
     if let Some(operation_hash) = operation_hash {
         writeln!(content, " * @relayHash {}", operation_hash).unwrap();
@@ -236,6 +236,9 @@ fn generate_operation(
         writeln!(content, " * @codegen-command: {}", codegen_command).unwrap();
     }
     writeln!(content, " */\n").unwrap();
+    if let TypegenLanguage::TypeScript = project_config.typegen_config.language {
+        writeln!(content, "// @ts-nocheck").unwrap();    
+    }
     writeln!(content, "/* eslint-disable */\n").unwrap();
     writeln!(content, "'use strict';\n").unwrap();
     if let Some(id) = &request_parameters.id {
@@ -354,7 +357,7 @@ fn generate_split_operation(
     typegen_operation: &Option<Arc<OperationDefinition>>,
     source_hash: &str,
 ) -> Vec<u8> {
-    let mut content = get_content_start(config, project_config);
+    let mut content = get_content_start(config);
     writeln!(content, " * {}", SIGNING_TOKEN).unwrap();
 
     if let TypegenLanguage::Flow = project_config.typegen_config.language {
@@ -367,6 +370,9 @@ fn generate_split_operation(
         writeln!(content, " * @codegen-command: {}", codegen_command).unwrap();
     }
     writeln!(content, " */\n").unwrap();
+    if let TypegenLanguage::TypeScript = project_config.typegen_config.language {
+        writeln!(content, "// @ts-nocheck").unwrap();    
+    }
     writeln!(content, "/* eslint-disable */\n").unwrap();
     writeln!(content, "'use strict';\n").unwrap();
     let type_syntax = if project_config.typegen_config.use_import_type_syntax {
@@ -438,7 +444,7 @@ fn generate_fragment(
     source_hash: &str,
     skip_types: bool,
 ) -> Vec<u8> {
-    let mut content = get_content_start(config, project_config);
+    let mut content = get_content_start(config);
     writeln!(content, " * {}", SIGNING_TOKEN).unwrap();
 
     if let TypegenLanguage::Flow = project_config.typegen_config.language {
@@ -451,6 +457,9 @@ fn generate_fragment(
         writeln!(content, " * @codegen-command: {}", codegen_command).unwrap();
     }
     writeln!(content, " */\n").unwrap();
+    if let TypegenLanguage::TypeScript = project_config.typegen_config.language {
+        writeln!(content, "// @ts-nocheck").unwrap();    
+    }
     writeln!(content, "/* eslint-disable */\n").unwrap();
     writeln!(content, "'use strict';\n").unwrap();
     let data_driven_dependency_metadata = reader_fragment
@@ -545,13 +554,8 @@ fn generate_fragment(
     sign_file(&content).into_bytes()
 }
 
-fn get_content_start(config: &Config, project_config: &ProjectConfig) -> String {
+fn get_content_start(config: &Config) -> String {
     let mut content = String::new();
-
-    if let TypegenLanguage::TypeScript = project_config.typegen_config.language {
-        writeln!(content, "// @ts-nocheck").unwrap();
-    }
-
     writeln!(content, "/**").unwrap();
     if !config.header.is_empty() {
         for header_line in &config.header {

--- a/compiler/crates/relay-compiler/src/file_source/file_categorizer.rs
+++ b/compiler/crates/relay-compiler/src/file_source/file_categorizer.rs
@@ -170,7 +170,7 @@ impl FileCategorizer {
         let extension = path
             .extension()
             .unwrap_or_else(|| panic!("Got unexpected path without extension: `{:?}`.", path));
-        if extension == "js" {
+        if extension == "js" || extension == "ts" || extension == "tsx" {
             let source_set = self.source_mapping.get(path);
             if self.in_relative_generated_dir(path) {
                 if let SourceSet::SourceSetName(source_set_name) = source_set {


### PR DESCRIPTION
- Producing ts artifacts were actually "typescript" typegen, but wrapped in flow things. So this will now instead print ts things
- introduce `@ts-nocheck`
- file categorizer didnt like seeing tsx ts files.