### PR TITLE
docs: add missing bar field in query

### DIFF
--- a/website/versioned_docs/version-v11.0.0/principles-and-architecture/compiler-architecture.md
+++ b/website/versioned_docs/version-v11.0.0/principles-and-architecture/compiler-architecture.md
@@ -89,7 +89,9 @@ foo {
     id
   }
   ... on FooType @include(if: $cond) { # can't be flattened due to conditional
-    id # but this field is guaranteed to be fetched regardless
+    bar {
+      id # but this field is guaranteed to be fetched regardless
+    }
   }
 }
 


### PR DESCRIPTION
Add missing bar field SkipRedundantNodeTransform example query