### PR TITLE
chore: Add type name log for _handleTypeFieldsStrict duplication error

### DIFF
--- a/packages/relay-compiler/core/Schema.js
+++ b/packages/relay-compiler/core/Schema.js
@@ -1695,7 +1695,7 @@ class TypeMap {
   ) {
     if (this._fields.has(type)) {
       throw createCompilerError(
-        '_handleTypeFieldsStrict: Unable to parse schema file. Duplicate definition for object type',
+        `_handleTypeFieldsStrict: Unable to parse schema file. Duplicate definition for object type ${type}.`
       );
     }
     this._handleTypeFields(type, fields, isClient);


### PR DESCRIPTION
Just a small improvement. Right now it fails with 

![image](https://user-images.githubusercontent.com/16926049/116885435-8d105e80-ac30-11eb-8165-c3cff8e3c9a1.png)
