### PR TITLE
docs: fix typo

### DIFF
--- a/website/docs/guides/testing-relay-components.md
+++ b/website/docs/guides/testing-relay-components.md
@@ -168,7 +168,7 @@ Operation with the @relay_test_operation directive will have additional metadata
     return 123.456;
   },
   Boolean(context) {
-    if (contex.name === 'can_edit') {
+    if (context.name === 'can_edit') {
       return true;
     }
     return false;


### PR DESCRIPTION
Fixes typo in code at `guides/testing-relay-components.md`.