### PR TITLE
Flow error in createPayloadFor3DField.js

### DIFF
--- a/packages/relay-runtime/util/createPayloadFor3DField.js
+++ b/packages/relay-runtime/util/createPayloadFor3DField.js
@@ -19,7 +19,7 @@ const {
 } = require('../store/RelayStoreUtils');
 
 import type {NormalizationSplitOperation} from './NormalizationNode';
-import type {JSResourceReference} from 'JSResourceReference';
+import type {JSResourceReference} from './JSResourceTypes.flow.js';
 
 export opaque type Local3DPayload<
   +DocumentName: string,


### PR DESCRIPTION
I got a flow error in this file about the JSResourceReference module not being able to be resolved. I changed importing type JSResourceReference from 'JSResourceReference'. It seems that the type is correctly imported from ./JSResourceTypes.flow.js instead.