### PR TITLE
Update error-states.md

### DIFF
--- a/website/docs/guided-tour/rendering/error-states.md
+++ b/website/docs/guided-tour/rendering/error-states.md
@@ -27,9 +27,9 @@ const React = require('React');
 type State = {error: ?Error};
 
 class ErrorBoundary extends React.Component<Props, State> {
-  static getDerivedStateFromError(error): State {
+  static getDerivedStateFromError(error) {
     // Set some state derived from the caught error
-    return {error: error};
+    return {error};
   }
 }
 ```
@@ -78,9 +78,9 @@ const React = require('React');
 // NOTE: This is NOT actual production code;
 // it is only used to illustrate example
 class ErrorBoundaryWithRetry extends React.Component<Props, State> {
-  state = {error: null};
+  state: State = {error: null};
 
-  static getDerivedStateFromError(error): State {
+  static getDerivedStateFromError(error) {
     return {error: error};
   }
 
@@ -178,10 +178,10 @@ const React = require('React');
 // NOTE: This is NOT actual production code;
 // it is only used to illustrate example
 class ErrorBoundaryWithRetry extends React.Component<Props, State> {
-  state = {error: null, fetchKey: 0};
+  state: State = {error: null, fetchKey: 0};
 
-  static getDerivedStateFromError(error): State {
-    return {error: error, fetchKey: 0};
+  static getDerivedStateFromError(error) {
+    return {error};
   }
 
   _retry = () => {


### PR DESCRIPTION
For issue #3506

In the example for `ErrorBoundaryWithRetry` if `getDerivedStateFromError` resets the `fetchKey` in each error, then the `fetchKey` will not change every time you retry, and therefore relay is not triggering the fetch else just returning the same `error` probably in cache. While if we just reset the error `return {error};` we can see the fetch working in the network all the time.

Another fix are the TS typings, by default and without any extra anotation we are able to return `Partial<State>` ... that makes more sense for the case mentioned above, but also for the other examples in this file.

```ts
// Type definitions for React 16.9

type GetDerivedStateFromError<P, S> =. (error: any) => Partial<S> | null;
```