### PR TITLE
Improve Persisted Queries documentation

### DIFF
--- a/website/docs/guides/persisted-queries.md
+++ b/website/docs/guides/persisted-queries.md
@@ -18,10 +18,10 @@ import {FbInternalOnly, OssOnly} from 'internaldocs-fb-helpers';
 
 The relay compiler supports persisted queries. This is useful because:
 
--   the client operation text becomes just an md5 hash which is usually shorter than the real
+-   The client operation text becomes just an md5 hash which is usually shorter than the real
     query string. This saves upload bytes from the client to the server.
 
--   the server can now whitelist queries which improves security by restricting the operations
+-   The server can now whitelist queries which improves security by restricting the operations
     that can be executed by a client.
 
 <OssOnly>

--- a/website/docs/guides/persisted-queries.md
+++ b/website/docs/guides/persisted-queries.md
@@ -228,7 +228,7 @@ Your server should then look up the query referenced by `doc_id` when responding
 <OssOnly>
 
 To execute client requests that send persisted queries instead of query text, your server will need to be able
-to lookup the query text corresponding to each id. Typically this will involve saving the output of the `queryMap.json` JSON file to a database or some other storage mechanism, and retrieving the corresponding text for the ID specified by a client.
+to lookup the query text corresponding to each ID. Typically this will involve saving the output of the `queryMap.json` JSON file to a database or some other storage mechanism, and retrieving the corresponding text for the ID specified by a client.
 
 Additionally, your implementation of `relayLocalPersisting.js` could directly save queries to the database or other storage.
 
@@ -256,8 +256,8 @@ Some possibilities of what you can do in `./pushQueries.js`:
 
 ### Run time push
 
-A second more complex option is to push your query maps to the server at runtime, without the server knowing the query ids at the start.
-The client optimistically sends a query id to the server, which does not have the query map. The server then in turn requests
+A second more complex option is to push your query maps to the server at runtime, without the server knowing the query IDs at the start.
+The client optimistically sends a query ID to the server, which does not have the query map. The server then in turn requests
 for the full query text from the client so it can cache the query map for subsequent requests. This is a more complex approach
 requiring the client and server to interact to exchange the query maps.
 

--- a/website/docs/guides/persisted-queries.md
+++ b/website/docs/guides/persisted-queries.md
@@ -40,7 +40,7 @@ In your relay configiration section in `package.json` you'll need specify
 },
 "relay": {
   "src": "./src",
-  "schema": "./schema.graphq",
+  "schema": "./schema.graphql",
   "persistConfig": {
     "url": "http://localhost:2999",
     "params": {}
@@ -48,7 +48,7 @@ In your relay configiration section in `package.json` you'll need specify
 }
 ```
 
-Specifiying `persistConfig` in the config will do the folling:
+Specifiying `persistConfig` in the config will do the following:
 
 1.  It converts all query and mutation operation texts to md5 hashes.
 
@@ -88,9 +88,9 @@ Specifiying `persistConfig` in the config will do the folling:
 
     ```
 
-2.  It will sent an HTTP POST request with `text` parameter to the
+2.  It will send an HTTP POST request with a `text` parameter to the
 specified `url`.
-You can also add additional request body parameters to via `params` option.
+You can also add additional request body parameters via the `params` option.
 
 ```
 "scripts": {
@@ -98,7 +98,7 @@ You can also add additional request body parameters to via `params` option.
 },
 "relay": {
   "src": "./src",
-  "schema": "./schema.graphq",
+  "schema": "./schema.graphql",
   "persistConfig": {
     "url": "http://localhost:2999",
     "params": {}
@@ -108,7 +108,7 @@ You can also add additional request body parameters to via `params` option.
 
 ### Example implemetation of `relayLocalPersisting.js`
 
-A simple persist server that will save query text to the `queryMap.json` file.
+Here's an example of a simple persist server that will save query text to the `queryMap.json` file.
 
 
 ```javascript

--- a/website/docs/guides/persisted-queries.md
+++ b/website/docs/guides/persisted-queries.md
@@ -289,7 +289,7 @@ It is possible to continuously generate the query map files by using the `persis
 This only makes sense for universal applications i.e. if your client and server code are in a single project
 and you run them both together on localhost during development. Furthermore, in order for the server to pick up changes
 to the `queryMap.json`, you'll need to have server side hot-reloading set up. The details on how to set this up
-is out of the scope of this document.
+are out of the scope of this document.
 
 </OssOnly>
 

--- a/website/docs/guides/persisted-queries.md
+++ b/website/docs/guides/persisted-queries.md
@@ -271,7 +271,7 @@ perform the matching using the `matchQueryMiddleware` from [relay-compiler-plus]
 
 ```javascript
 import Express from 'express';
-import expressGraphql from 'express-graphql';
+import {graphqlHTTP} from 'express-graphql';
 import {matchQueryMiddleware} from 'relay-compiler-plus';
 import queryMapJson from './path/to/queryMap.json';
 
@@ -279,7 +279,7 @@ const app = Express();
 
 app.use('/graphql',
   matchQueryMiddleware(queryMapJson),
-  expressGraphl({schema}),
+  graphqlHTTP({schema}),
 );
 ```
 

--- a/website/docs/guides/persisted-queries.md
+++ b/website/docs/guides/persisted-queries.md
@@ -199,7 +199,7 @@ To use this, you'll need to update `package.json`:
 You'll need to modify your network layer fetch implementation to pass an ID parameter in the POST body (e.g., `doc_id`) instead of a query parameter:
 
 ```javascript
-function fetchQuery(operation, variables,) {
+function fetchQuery(operation, variables) {
   return fetch('/graphql', {
     method: 'POST',
     headers: {
@@ -279,7 +279,8 @@ const app = Express();
 
 app.use('/graphql',
   matchQueryMiddleware(queryMapJson),
-  expressGraphql({schema}));
+  expressGraphl({schema}),
+);
 ```
 
 ## Using `persistConfig` and `--watch`

--- a/website/docs/guides/persisted-queries.md
+++ b/website/docs/guides/persisted-queries.md
@@ -250,9 +250,9 @@ to push the query map at compile time to a location accessible by your server:
 
 Some possibilities of what you can do in `./pushQueries.js`:
 
--   `git push` to your server repo
+-   `git push` to your server repo.
 
--   save the query maps to a database
+-   Save the query maps to a database.
 
 ### Run time push
 

--- a/website/docs/guides/persisted-queries.md
+++ b/website/docs/guides/persisted-queries.md
@@ -267,18 +267,22 @@ Once your server has access to the query map, you can perform the mapping. The s
 database technologies you use, so we'll just cover the most common and basic example here.
 
 If you use `express-graphql` and have access to the query map file, you can import it directly and
-perform the matching using the `matchQueryMiddleware` from [relay-compiler-plus](https://github.com/yusinto/relay-compiler-plus).
+perform the matching using the `persistedQueries` middleware from [express-graphql-persisted-queries](https://github.com/kyarik/express-graphql-persisted-queries).
 
 ```javascript
-import Express from 'express';
+import express from 'express';
 import {graphqlHTTP} from 'express-graphql';
-import {matchQueryMiddleware} from 'relay-compiler-plus';
-import queryMapJson from './path/to/queryMap.json';
+import {persistedQueries} from 'express-graphql-persisted-queries';
+import queryMap from './path/to/queryMap.json';
 
-const app = Express();
+const app = express();
 
-app.use('/graphql',
-  matchQueryMiddleware(queryMapJson),
+app.use(
+  '/graphql',
+  persistedQueries({
+    queryMap,
+    queryIdKey: 'doc_id',
+  }),
   graphqlHTTP({schema}),
 );
 ```

--- a/website/docs/guides/persisted-queries.md
+++ b/website/docs/guides/persisted-queries.md
@@ -196,7 +196,7 @@ To use this, you'll need to update `package.json`:
 
 ### Network layer changes
 
-You'll need to modify your network layer fetch implementation to pass a `doc_id` parameter in the POST body instead of a query parameter:
+You'll need to modify your network layer fetch implementation to pass an ID parameter in the POST body (e.g., `doc_id`) instead of a query parameter:
 
 ```javascript
 function fetchQuery(operation, variables,) {

--- a/website/versioned_docs/version-v13.0.0/guides/persisted-queries.md
+++ b/website/versioned_docs/version-v13.0.0/guides/persisted-queries.md
@@ -18,10 +18,10 @@ import {FbInternalOnly, OssOnly} from 'internaldocs-fb-helpers';
 
 The relay compiler supports persisted queries. This is useful because:
 
--   the client operation text becomes just an md5 hash which is usually shorter than the real
+-   The client operation text becomes just an md5 hash which is usually shorter than the real
     query string. This saves upload bytes from the client to the server.
 
--   the server can now whitelist queries which improves security by restricting the operations
+-   The server can now whitelist queries which improves security by restricting the operations
     that can be executed by a client.
 
 <OssOnly>
@@ -40,7 +40,7 @@ In your relay configiration section in `package.json` you'll need specify
 },
 "relay": {
   "src": "./src",
-  "schema": "./schema.graphq",
+  "schema": "./schema.graphql",
   "persistConfig": {
     "url": "http://localhost:2999",
     "params": {}
@@ -48,7 +48,7 @@ In your relay configiration section in `package.json` you'll need specify
 }
 ```
 
-Specifiying `persistConfig` in the config will do the folling:
+Specifiying `persistConfig` in the config will do the following:
 
 1.  It converts all query and mutation operation texts to md5 hashes.
 
@@ -88,9 +88,9 @@ Specifiying `persistConfig` in the config will do the folling:
 
     ```
 
-2.  It will sent an HTTP POST request with `text` parameter to the
+2.  It will send an HTTP POST request with a `text` parameter to the
 specified `url`.
-You can also add additional request body parameters to via `params` option.
+You can also add additional request body parameters via the `params` option.
 
 ```
 "scripts": {
@@ -98,7 +98,7 @@ You can also add additional request body parameters to via `params` option.
 },
 "relay": {
   "src": "./src",
-  "schema": "./schema.graphq",
+  "schema": "./schema.graphql",
   "persistConfig": {
     "url": "http://localhost:2999",
     "params": {}
@@ -108,7 +108,7 @@ You can also add additional request body parameters to via `params` option.
 
 ### Example implemetation of `relayLocalPersisting.js`
 
-A simple persist server that will save query text to the `queryMap.json` file.
+Here's an example of a simple persist server that will save query text to the `queryMap.json` file.
 
 
 ```javascript
@@ -196,10 +196,10 @@ To use this, you'll need to update `package.json`:
 
 ### Network layer changes
 
-You'll need to modify your network layer fetch implementation to pass a `doc_id` parameter in the POST body instead of a query parameter:
+You'll need to modify your network layer fetch implementation to pass an ID parameter in the POST body (e.g., `doc_id`) instead of a query parameter:
 
 ```javascript
-function fetchQuery(operation, variables,) {
+function fetchQuery(operation, variables) {
   return fetch('/graphql', {
     method: 'POST',
     headers: {
@@ -228,7 +228,7 @@ Your server should then look up the query referenced by `doc_id` when responding
 <OssOnly>
 
 To execute client requests that send persisted queries instead of query text, your server will need to be able
-to lookup the query text corresponding to each id. Typically this will involve saving the output of the `queryMap.json` JSON file to a database or some other storage mechanism, and retrieving the corresponding text for the ID specified by a client.
+to lookup the query text corresponding to each ID. Typically this will involve saving the output of the `queryMap.json` JSON file to a database or some other storage mechanism, and retrieving the corresponding text for the ID specified by a client.
 
 Additionally, your implementation of `relayLocalPersisting.js` could directly save queries to the database or other storage.
 
@@ -250,14 +250,14 @@ to push the query map at compile time to a location accessible by your server:
 
 Some possibilities of what you can do in `./pushQueries.js`:
 
--   `git push` to your server repo
+-   `git push` to your server repo.
 
--   save the query maps to a database
+-   Save the query maps to a database.
 
 ### Run time push
 
-A second more complex option is to push your query maps to the server at runtime, without the server knowing the query ids at the start.
-The client optimistically sends a query id to the server, which does not have the query map. The server then in turn requests
+A second more complex option is to push your query maps to the server at runtime, without the server knowing the query IDs at the start.
+The client optimistically sends a query ID to the server, which does not have the query map. The server then in turn requests
 for the full query text from the client so it can cache the query map for subsequent requests. This is a more complex approach
 requiring the client and server to interact to exchange the query maps.
 
@@ -267,19 +267,24 @@ Once your server has access to the query map, you can perform the mapping. The s
 database technologies you use, so we'll just cover the most common and basic example here.
 
 If you use `express-graphql` and have access to the query map file, you can import it directly and
-perform the matching using the `matchQueryMiddleware` from [relay-compiler-plus](https://github.com/yusinto/relay-compiler-plus).
+perform the matching using the `persistedQueries` middleware from [express-graphql-persisted-queries](https://github.com/kyarik/express-graphql-persisted-queries).
 
 ```javascript
-import Express from 'express';
-import expressGraphql from 'express-graphql';
-import {matchQueryMiddleware} from 'relay-compiler-plus';
-import queryMapJson from './path/to/queryMap.json';
+import express from 'express';
+import {graphqlHTTP} from 'express-graphql';
+import {persistedQueries} from 'express-graphql-persisted-queries';
+import queryMap from './path/to/queryMap.json';
 
-const app = Express();
+const app = express();
 
-app.use('/graphql',
-  matchQueryMiddleware(queryMapJson),
-  expressGraphql({schema}));
+app.use(
+  '/graphql',
+  persistedQueries({
+    queryMap,
+    queryIdKey: 'doc_id',
+  }),
+  graphqlHTTP({schema}),
+);
 ```
 
 ## Using `persistConfig` and `--watch`
@@ -288,7 +293,7 @@ It is possible to continuously generate the query map files by using the `persis
 This only makes sense for universal applications i.e. if your client and server code are in a single project
 and you run them both together on localhost during development. Furthermore, in order for the server to pick up changes
 to the `queryMap.json`, you'll need to have server side hot-reloading set up. The details on how to set this up
-is out of the scope of this document.
+are out of the scope of this document.
 
 </OssOnly>
 


### PR DESCRIPTION
This PR introduces the following improvements to the [Persisted Queries docs](https://relay.dev/docs/guides/persisted-queries/):
- Mention `doc_id` as an example for the persisted query ID parameter, rather than making it potentially sound as a requirement.
- Capitalize "ID" properly.
- Fix capitalization and punctuation in list about `pushQueries.js` possibilities.
- Capitalize sentences in the list about persisted queries usefulness.
- Improve formatting of persisted queries code examples.
- Fix verb in a sentence about persisted queries.
- Fix [`express-graphql`](https://github.com/graphql/express-graphql) import in persisted queries code example. We need to import the `graphqlHTTP` named export in the latest version of `express-graphql` since it no longer has a default export.
- Use [`express-graphql-persisted-queries`](https://github.com/kyarik/express-graphql-persisted-queries) in the simple server example. This is actually an open source library that I created because I couldn't find an existing solution flexible enough to: 
  - Allow to send HTTP GET requests with persisted queries (necessary to preload queries with `<link rel="preload">`, for example).
  - Allow a custom way to map a query ID to an actual query (not necessarily using an object, but a custom function that queries a DB, for example).
  - Allow to specify whether you want to allow only persisted queries for enhanced security (this is mentioned in the docs, yet I couldn't find a solution supporting this).
  - Allow to specify a custom query ID key (rather than forcing a specific query ID key, like `queryId`).
  - Be lightweight, with minimal dependencies.

Considering the flexibility that this library gives, I think it makes more sense to mention it in the example, as I think many people will find it useful.