### PR TITLE
Revert publish CI job to node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 14.x
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
It appears bfb1654b2af9b7f4a789b45e39e6dbe4c08778f1 broke publishing releases automatically to NPM. Checking if this was due to the Node version bump.