### PR TITLE
Fix: "Add project" button is not visible on users page

### DIFF
--- a/website/src/pages/users.js
+++ b/website/src/pages/users.js
@@ -34,9 +34,7 @@ const Users = () => {
           </div>
           <div className="logos">{showcase}</div>
           <p>Are you using this project?</p>
-          <a
-            href="https://github.com/facebook/relay/edit/master/website/docusaurus.config.js"
-            className="button">
+          <a href="https://github.com/facebook/relay/edit/master/website/docusaurus.config.js">
             Add your project
           </a>
         </div>


### PR DESCRIPTION
https://relay.dev/users/

Not sure what the intended styles were here. But the "button" class makes the text white, making it completely invisible.
<img width="526" alt="Screenshot 2021-06-12 at 5 42 25 PM" src="https://user-images.githubusercontent.com/29686866/121775487-aa2c3b80-cba5-11eb-9d28-9e9d947a524b.png">

Removing the class makes the link show up in orange color with an underline on hover:
<img width="526" alt="Screenshot 2021-06-12 at 5 44 13 PM" src="https://user-images.githubusercontent.com/29686866/121775516-d3e56280-cba5-11eb-83a2-a34a12258385.png">
