### PR TITLE
fix: do not emit extension in compiler includes

### DIFF
--- a/packages/relay-compiler/codegen/__tests__/createPrintRequireModuleDependency-test.js
+++ b/packages/relay-compiler/codegen/__tests__/createPrintRequireModuleDependency-test.js
@@ -16,12 +16,11 @@
 const createPrintRequireModuleDependency = require('../createPrintRequireModuleDependency');
 
 describe('createPrintRequireModuleDependency', () => {
-  it('outputs the correct dependency path', () => {
-    const extension = 'js';
+  it('outputs the correct dependency path without the extension', () => {
     const moduleName = 'module';
-    const printModuleDependency = createPrintRequireModuleDependency(extension);
+    const printModuleDependency = createPrintRequireModuleDependency();
     const moduleDependency = printModuleDependency(moduleName);
 
-    expect(moduleDependency).toEqual(`require('./${moduleName}.${extension}')`);
+    expect(moduleDependency).toEqual(`require('./${moduleName}')`);
   });
 });

--- a/packages/relay-compiler/codegen/createPrintRequireModuleDependency.js
+++ b/packages/relay-compiler/codegen/createPrintRequireModuleDependency.js
@@ -12,10 +12,8 @@
 
 'use strict';
 
-function createPrintRequireModuleDependency(
-  extension: string,
-): string => string {
-  return moduleName => `require('./${moduleName}.${extension}')`;
+function createPrintRequireModuleDependency(): string => string {
+  return moduleName => `require('./${moduleName}')`;
 }
 
 module.exports = createPrintRequireModuleDependency;

--- a/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
+++ b/packages/relay-compiler/codegen/writeRelayGeneratedFile.js
@@ -58,7 +58,7 @@ function writeRelayGeneratedFile(
   extension: string,
   printModuleDependency: (
     moduleName: string,
-  ) => string = createPrintRequireModuleDependency(extension),
+  ) => string = createPrintRequireModuleDependency(),
   shouldRepersist: boolean,
   writeQueryParameters: (
     dir: CodegenDirectory,


### PR DESCRIPTION
when a generated relay query includes a "require" statement, do not include the file extension in the "require" call.

fixes https://github.com/facebook/relay/issues/3499