### PR TITLE
use explicit rust version - 1.52.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.52.0
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.52.0
           override: true
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Internal FB builds system is using Rust version older than 1.53 (current stable?). 

With 1.53, one of our compiler tests is failing. This PR uses the 1.52 version while we're waiting for internal tools to be updated.
