### PR TITLE
Fix: Check if global exists before using it

### DIFF
--- a/packages/relay-runtime/util/withDuration.js
+++ b/packages/relay-runtime/util/withDuration.js
@@ -13,7 +13,7 @@
 'use strict';
 
 const isPerformanceNowAvailable =
-  global.performance != null && typeof global.performance.now === 'function';
+  global?.performance != null && typeof global.performance.now === 'function';
 
 function currentTimestamp(): number {
   if (isPerformanceNowAvailable) {

--- a/packages/relay-runtime/util/withDuration.js
+++ b/packages/relay-runtime/util/withDuration.js
@@ -13,11 +13,12 @@
 'use strict';
 
 const isPerformanceNowAvailable =
-  global?.performance != null && typeof global.performance.now === 'function';
+  typeof window !== 'undefined' &&
+  typeof window?.performance?.now === 'function';
 
 function currentTimestamp(): number {
   if (isPerformanceNowAvailable) {
-    return global.performance.now();
+    return window.performance.now();
   }
   return Date.now();
 }


### PR DESCRIPTION
Similar to #3465 calling global can be troublesome since it doesn't always exist, for instance when using vite.