### PR TITLE
Hide internal-only glossary item

### DIFF
--- a/website/docs/glossary/glossary.md
+++ b/website/docs/glossary/glossary.md
@@ -644,9 +644,13 @@ A directive that allows you to turn off data masking.
 
 See the documentation.
 
+<FbInternalOnly>
+
 ## @relay_early_flush
 
-TODO
+Used for a WWW static resource delivery optimization.
+
+</FbInternalOnly>
 
 ## Relay Classic
 


### PR DESCRIPTION
@relay_early_flush is something that's just used for a specifc internal
optimization specific to the static resource pipeline used on
facebook.com.