### PR TITLE
feat: added light mode and dark mode support for codeblocks

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -437,6 +437,11 @@ module.exports = {
         src: 'img/relay.svg',
       },
     },
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula'),
+      defaultLanguage: 'javascript',
+    },
     algolia: {
       apiKey: '3d7d5825d50ea36bca0e6ad06c926f06',
       indexName: 'relay',


### PR DESCRIPTION
added light mode support from docusaurus 2.0.0beta.1

earlier: 

<img width="1127" alt="image" src="https://user-images.githubusercontent.com/40708551/123577625-ceb52400-d7f1-11eb-8da0-df7ffec24bf2.png">


Now: 

https://user-images.githubusercontent.com/40708551/123577718-03c17680-d7f2-11eb-8b6c-7e147c6d2971.mov

<img width="1324" alt="image" src="https://user-images.githubusercontent.com/40708551/123577565-b47b4600-d7f1-11eb-8fc3-abd44cdc4245.png">
