### PR TITLE
Rename old references to master branch to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,9 +10,9 @@ The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 
 Some of the core team will be working directly on GitHub. These changes will be public from the beginning. Other changesets will come via a bridge with Facebook's internal source control. This is a necessity as it allows engineers at Facebook outside of the core team to move fast and contribute from an environment they are comfortable in.
 
-### `master` is unsafe
+### `main` is unsafe
 
-We will do our best to keep `master` in good shape, with tests passing at all times. But in order to move fast, we will make API changes that your application might not be compatible with. We will do our best to communicate these changes and always version appropriately so you can lock into a specific version if need be.
+We will do our best to keep `main` in good shape, with tests passing at all times. But in order to move fast, we will make API changes that your application might not be compatible with. We will do our best to communicate these changes and always version appropriately so you can lock into a specific version if need be.
 
 ### Pull Requests
 
@@ -20,7 +20,7 @@ The core team will be monitoring for pull requests. When we get one, we'll run s
 
 *Before* submitting a pull request, please make sure the following is done:
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes (`yarn test` or `npm test`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,10 @@ jobs:
           name: ${{ matrix.target.artifact-name }}
           path: compiler/target/release/${{ matrix.target.build-name }}
 
-  master-release:
-    name: Publish master tag to npm
+  main-release:
+    name: Publish main tag to npm
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
     needs: [js-tests, js-lint, typecheck, rust-tests, build-compiler]
     steps:
       - uses: actions/checkout@v1
@@ -127,12 +127,12 @@ jobs:
         run: |
           chmod +x linux-x64/relay
           chmod +x macos-x64/relay
-      - name: Build master version
-        run:  RELEASE_COMMIT_SHA=${{github.sha}} yarn gulp masterrelease
+      - name: Build main version
+        run:  RELEASE_COMMIT_SHA=${{github.sha}} yarn gulp mainrelease
       - name: Publish to npm
         run: |
           for pkg in dist/*; do
-            npm publish "$pkg" --tag master
+            npm publish "$pkg" --tag main
           done
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -8,7 +8,7 @@ name: Docusaurus
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-deploy:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Relay](https://relay.dev) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/relay/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/react-relay.svg??style=flat)](https://www.npmjs.com/package/react-relay)
+# [Relay](https://relay.dev) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebook/relay/blob/main/LICENSE) [![npm version](https://img.shields.io/npm/v/react-relay.svg??style=flat)](https://www.npmjs.com/package/react-relay)
 
 Relay is a JavaScript framework for building data-driven React applications.
 

--- a/compiler/crates/graphql-syntax/src/parser.rs
+++ b/compiler/crates/graphql-syntax/src/parser.rs
@@ -34,7 +34,7 @@ pub struct Parser<'a> {
 }
 
 /// Parser for the *executable* subset of the GraphQL specification:
-/// https://github.com/graphql/graphql-spec/blob/master/spec/Appendix%20B%20--%20Grammar%20Summary.md
+/// https://github.com/graphql/graphql-spec/blob/main/spec/Appendix%20B%20--%20Grammar%20Summary.md
 impl<'a> Parser<'a> {
     pub fn new(
         source: &'a str,

--- a/compiler/crates/graphql-syntax/tests/parse_schema_document/fixtures/schema_kitchen_sink.expected
+++ b/compiler/crates/graphql-syntax/tests/parse_schema_document/fixtures/schema_kitchen_sink.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# source: https://github.com/graphql/graphql-js/blob/master/src/__fixtures__/schema-kitchen-sink.graphql
+# source: https://github.com/graphql/graphql-js/blob/main/src/__fixtures__/schema-kitchen-sink.graphql
 
 """This is a description of the schema as a whole."""
 schema {

--- a/compiler/crates/graphql-syntax/tests/parse_schema_document/fixtures/schema_kitchen_sink.graphql
+++ b/compiler/crates/graphql-syntax/tests/parse_schema_document/fixtures/schema_kitchen_sink.graphql
@@ -1,4 +1,4 @@
-# source: https://github.com/graphql/graphql-js/blob/master/src/__fixtures__/schema-kitchen-sink.graphql
+# source: https://github.com/graphql/graphql-js/blob/5d109ec32f60b593b721037cd2944d2c07420006/src/__fixtures__/schema-kitchen-sink.graphql
 
 """This is a description of the schema as a whole."""
 schema {

--- a/compiler/crates/relay-compiler/src/file_source/watchman_file_source.rs
+++ b/compiler/crates/relay-compiler/src/file_source/watchman_file_source.rs
@@ -376,6 +376,8 @@ impl WatchmanFileSourceSubscription {
 
 /// Base revision in this case is a common ancestor of two revisions:
 /// `master` and current commit hash or `.`
+///
+/// TODO: Make this dynamic on the default branch name.
 fn get_base_revision(commit_hash: Option<String>) -> String {
     let output = Command::new("hg")
         .arg("log".to_string())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ const babelOptions = require('./scripts/getBabelOptions')({
     '@babel/plugin-transform-flow-strip-types',
     [
       '@babel/plugin-transform-runtime',
-      {version: require('@babel/runtime/package.json').version},
+      { version: require('@babel/runtime/package.json').version },
     ],
     '@babel/plugin-proposal-nullish-coalescing-operator',
     '@babel/plugin-proposal-optional-catch-binding',
@@ -43,12 +43,12 @@ const RELEASE_COMMIT_SHA = process.env.RELEASE_COMMIT_SHA;
 if (RELEASE_COMMIT_SHA && RELEASE_COMMIT_SHA.length !== 40) {
   throw new Error(
     'If the RELEASE_COMMIT_SHA env variable is set, it should be set to the ' +
-      '40 character git commit hash.',
+    '40 character git commit hash.',
   );
 }
 
 const VERSION = RELEASE_COMMIT_SHA
-  ? `0.0.0-master-${RELEASE_COMMIT_SHA.substr(0, 8)}`
+  ? `0.0.0-main-${RELEASE_COMMIT_SHA.substr(0, 8)}`
   : process.env.npm_package_version;
 
 const SCRIPT_HASHBANG = '#!/usr/bin/env node\n';
@@ -66,7 +66,7 @@ const PRODUCTION_HEADER = `/**
  */
 `;
 
-const buildDist = function(filename, opts, isProduction) {
+const buildDist = function (filename, opts, isProduction) {
   const webpackOpts = {
     externals: [/^[-/a-zA-Z0-9]+$/, /^@babel\/.+$/],
     target: opts.target,
@@ -97,7 +97,7 @@ const buildDist = function(filename, opts, isProduction) {
       minimize: true,
     };
   }
-  return webpackStream(webpackOpts, webpack, function(err, stats) {
+  return webpackStream(webpackOpts, webpack, function (err, stats) {
     if (err) {
       throw new gulpUtil.PluginError('webpack', err);
     }
@@ -275,7 +275,7 @@ const flowDefs = gulp.parallel(
           .src(['**/*.js', '!**/__tests__/**/*.js', '!**/__mocks__/**/*.js'], {
             cwd: PACKAGES + '/' + build.package,
           })
-          .pipe(rename({extname: '.js.flow'}))
+          .pipe(rename({ extname: '.js.flow' }))
           .pipe(gulp.dest(path.join(DIST, build.package)));
       },
   ),
@@ -319,7 +319,7 @@ const exportsFiles = gulp.series(
             fs.writeFileSync(
               path.join(DIST, build.package, exportName + '.js'),
               PRODUCTION_HEADER +
-                `\nmodule.exports = require('./lib/${build.exports[exportName]}');\n`,
+              `\nmodule.exports = require('./lib/${build.exports[exportName]}');\n`,
             ),
           );
           done();
@@ -380,7 +380,7 @@ const bundlesMin = gulp.series(bundlesMinTasks);
 const clean = () => del(DIST);
 const dist = gulp.series(exportsFiles, bins, bundles, bundlesMin);
 const watch = gulp.series(dist, () =>
-  gulp.watch(INCLUDE_GLOBS, {cwd: PACKAGES}, dist),
+  gulp.watch(INCLUDE_GLOBS, { cwd: PACKAGES }, dist),
 );
 
 const experimentalCompiler = gulp.parallel(
@@ -407,9 +407,9 @@ const experimentalCompiler = gulp.parallel(
 
 /**
  * Updates the package.json files `/dist/` with a version to release to npm under
- * the master tag.
+ * the main tag.
  */
-const setMasterVersion = async () => {
+const setMainVersion = async () => {
   if (!RELEASE_COMMIT_SHA) {
     throw new Error('Expected the RELEASE_COMMIT_SHA env variable to be set.');
   }
@@ -444,10 +444,10 @@ const cleanbuild = gulp.series(clean, dist);
 exports.clean = clean;
 exports.dist = dist;
 exports.watch = watch;
-exports.masterrelease = gulp.series(
+exports.mainrelease = gulp.series(
   cleanbuild,
   experimentalCompiler,
-  setMasterVersion,
+  setMainVersion,
 );
 exports.cleanbuild = cleanbuild;
 exports.default = cleanbuild;

--- a/meta/roadmaps/2016-H1.md
+++ b/meta/roadmaps/2016-H1.md
@@ -1,6 +1,6 @@
 # H1 2016
 
-These reflect the current plans of Relay Team as of the [14 March 2016 Sync](https://github.com/facebook/relay/blob/master/meta/meeting-notes/2016-03-14-team-sync.md). For the latest information as plans evolve, see the [Meeting Notes](https://github.com/facebook/relay/blob/master/meta/meeting-notes).
+These reflect the current plans of Relay Team as of the [14 March 2016 Sync](https://github.com/facebook/relay/blob/main/meta/meeting-notes/2016-03-14-team-sync.md). For the latest information as plans evolve, see the [Meeting Notes](https://github.com/facebook/relay/blob/main/meta/meeting-notes).
 
 ## Themes
 
@@ -20,7 +20,7 @@ These reflect the current plans of Relay Team as of the [14 March 2016 Sync](htt
 * Persisted queries.
 * RelayConnection API.
 * Unified response handling (GraphMode).
-* Simpler/faster core ([#559](https://github.com/facebook/relay/issues/559), also ideas in [Potential Projects](https://github.com/facebook/relay/blob/master/meta/roadmaps/2016-H1.md#potential-projects)).
+* Simpler/faster core ([#559](https://github.com/facebook/relay/issues/559), also ideas in [Potential Projects](https://github.com/facebook/relay/blob/main/meta/roadmaps/2016-H1.md#potential-projects)).
 
 ## Potential Projects
 

--- a/packages/relay-compiler/README.md
+++ b/packages/relay-compiler/README.md
@@ -6,7 +6,7 @@ The GraphQL-Compiler package [exports library code](./GraphQLCompilerPublic.js) 
 
 The following graph illustrates the high-level architecture of a complete GraphQL code-generation pipeline:
 
-![CodegenPipeline](https://github.com/facebook/relay/raw/master/packages/relay-compiler/docs/Architecture.png)
+![CodegenPipeline](https://github.com/facebook/relay/raw/main/packages/relay-compiler/docs/Architecture.png)
 
 To understand the underlying workflow of the core compilation step, which is what happens in the "GraphQL Compiler" block in the above graph, please refer [HERE](./ARCHITECTURE.md).
 

--- a/scripts/publish_packages
+++ b/scripts/publish_packages
@@ -37,9 +37,11 @@ error () {
   exit 1
 }
 
-# Check if master is checked out
-if [ "$GITBRANCHNAME" != "master" ]; then
-  confirm "Git not on ${B}master${X} but ${B}${GITBRANCHNAME}${X}."
+# Check if main is checked out
+if [ "$GITBRANCHNAME" == "master" ]; then
+  error "Your branch is on ${B}master${X}${R}, this branch got renamed to ${B}main${X}${R}, please update your local branch."
+elif [ "$GITBRANCHNAME" != "main" ]; then
+  confirm "Git not on ${B}main${X} but ${B}${GITBRANCHNAME}${X}."
 fi
 
 # Check if branch is synced with remote

--- a/website/docs/getting-started/installation-and-setup.md
+++ b/website/docs/getting-started/installation-and-setup.md
@@ -75,7 +75,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/docs/getting-started/step-by-step-guide.md
+++ b/website/docs/getting-started/step-by-step-guide.md
@@ -170,7 +170,7 @@ Next let's configure Relay compiler. We'll need a copy of the schema as a `.grap
 
 ```bash
 cd your-app-name
-curl https://raw.githubusercontent.com/relayjs/relay-examples/master/issue-tracker/schema/schema.graphql > schema.graphql
+curl https://raw.githubusercontent.com/relayjs/relay-examples/main/issue-tracker/schema/schema.graphql > schema.graphql
 ```
 *Note:* On Windows, the `.graphql` file has to be explicitly saved with UTF-8 encoding, not the default UTF-16. See this [issue](https://github.com/prisma-labs/get-graphql-schema/issues/30) for more details.
 
@@ -304,7 +304,7 @@ At this point we have an app configured to use Relay. We recommend checking out 
 
 * The [Guided Tour](../../guided-tour/) describes how to implement many common use-cases.
 * The [API Reference](../../api-reference/use-fragment/) has full details on the Relay Hooks APIs.
-* The [Example App](https://github.com/relayjs/relay-examples/tree/master/issue-tracker) is a more sophisticated version of what we've started building here. It includes routing integration and uses React Concurrent Mode and Suspense for smooth transitions between pages.
+* The [Example App](https://github.com/relayjs/relay-examples/tree/main/issue-tracker) is a more sophisticated version of what we've started building here. It includes routing integration and uses React Concurrent Mode and Suspense for smooth transitions between pages.
 
 
 <DocsRating />

--- a/website/docs/guided-tour/reusing-cached-data/presence-of-data.md
+++ b/website/docs/guided-tour/reusing-cached-data/presence-of-data.md
@@ -72,7 +72,7 @@ const store = new Store(source, {gcScheduler});
 ```
 
 * By default, if a `gcScheduler` option is not provided, Relay will schedule garbage collection using the `resolveImmediate` function.
-* You can provide a scheduler function to make GC scheduling less aggressive than the default, for example based on time or [scheduler](https://github.com/facebook/react/tree/master/packages/scheduler) priorities, or any other heuristic. By convention, implementations should not execute the callback immediately.
+* You can provide a scheduler function to make GC scheduling less aggressive than the default, for example based on time or [scheduler](https://github.com/facebook/react/tree/main/packages/scheduler) priorities, or any other heuristic. By convention, implementations should not execute the callback immediately.
 
 
 ### GC Release Buffer Size

--- a/website/docs/guides/graphql-server-specification.md
+++ b/website/docs/guides/graphql-server-specification.md
@@ -442,6 +442,6 @@ Complete details on how the server should behave are available in the [GraphQL C
 
 This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/graphql/connections.htm) model, the [GraphQL global object identification](https://graphql.org/learn/global-object-identification/) model are all available.
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes and connections; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes and connections; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
 
 <DocsRating />

--- a/website/docs/guides/testing-relay-components.md
+++ b/website/docs/guides/testing-relay-components.md
@@ -573,7 +573,7 @@ https://phabricator.internmc.facebook.com/diffusion/FBS/browse/master/xplat/js/R
 
 <OssOnly>
 
-The best source of example tests is in [the relay-experimental package](https://github.com/facebook/relay/tree/master/packages/relay-experimental/__tests__).
+The best source of example tests is in [the relay-experimental package](https://github.com/facebook/relay/tree/main/packages/relay-experimental/__tests__).
 
 </OssOnly>
 

--- a/website/docs/guides/type-emission.md
+++ b/website/docs/guides/type-emission.md
@@ -455,6 +455,6 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js
 
 <DocsRating />

--- a/website/docs/migration-and-compatibility/relay-hooks-and-legacy-container-apis.md
+++ b/website/docs/migration-and-compatibility/relay-hooks-and-legacy-container-apis.md
@@ -118,7 +118,7 @@ export default function Home() {
 
 Unlike `useLazyLoadQuery`, using [`useQueryLoader`](../../api-reference/use-query-loader/) in combination with [`usePreloadedQuery`](../../api-reference/use-preloaded-query/) will start fetching the data *ahead* of render, following the "render-as-you-fetch" pattern. This means that the data fetch will start sooner, and potentially speed up the time it takes to show content to users.
 
-To make best use of this pattern, query loading is usually integrated at the router level, or other parts of your UI infra. To see a full example, see our [`issue-tracker`](https://github.com/relayjs/relay-examples/blob/master/issue-tracker/src/routes.js) example app.
+To make best use of this pattern, query loading is usually integrated at the router level, or other parts of your UI infra. To see a full example, see our [`issue-tracker`](https://github.com/relayjs/relay-examples/blob/main/issue-tracker/src/routes.js) example app.
 
 
 To convert a `QueryRenderer` to `useQueryLoader`, you need to take the following steps:

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,7 +11,7 @@
 
 const versions = require('./versions.json');
 
-const {fbContent, isInternal} = require('internaldocs-fb-helpers');
+const { fbContent, isInternal } = require('internaldocs-fb-helpers');
 
 module.exports = {
   title: 'Relay',
@@ -206,7 +206,7 @@ module.exports = {
             internal: false,
             external: true,
           }),
-          editUrl: 'https://github.com/facebook/relay/edit/master/website/',
+          editUrl: 'https://github.com/facebook/relay/tree/main/website',
 
           path: './docs/',
 
@@ -246,7 +246,7 @@ module.exports = {
     [
       '@docusaurus/plugin-client-redirects',
       {
-        createRedirects: function(toPath) {
+        createRedirects: function (toPath) {
           if (toPath.startsWith('/docs/')) {
             const docPath = toPath.substring(6);
             const fromPaths = ['/docs/en/' + docPath];

--- a/website/package.json
+++ b/website/package.json
@@ -11,8 +11,8 @@
     "rename-version": "docusaurus-rename-version",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
-    "crowdin-upload": "crowdin-cli --config ../crowdin.yaml upload sources --auto-update -b master",
-    "crowdin-download": "crowdin-cli --config ../crowdin.yaml download -b master",
+    "crowdin-upload": "crowdin-cli --config ../crowdin.yaml upload sources --auto-update -b main",
+    "crowdin-download": "crowdin-cli --config ../crowdin.yaml download -b main",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "docusaurus": "docusaurus"

--- a/website/src/pages/users.js
+++ b/website/src/pages/users.js
@@ -15,7 +15,7 @@ import * as React from 'react';
 /* eslint-enable lint/no-value-import */
 
 const Users = () => {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
   const showcase = siteConfig.customFields.users.map(user => {
     return (
       <a href={user.infoLink} key={user.caption}>
@@ -34,7 +34,7 @@ const Users = () => {
           </div>
           <div className="logos">{showcase}</div>
           <p>Are you using this project?</p>
-          <a href="https://github.com/facebook/relay/edit/master/website/docusaurus.config.js">
+          <a href="https://github.com/facebook/relay/edit/main/website/docusaurus.config.js">
             Add your project
           </a>
         </div>

--- a/website/versioned_docs/version-classic/Classic-APIReference-GraphQLMutation.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-GraphQLMutation.md
@@ -271,4 +271,4 @@ Rolls back an optimistic mutation.
 
 ## See also
 
-A number of more detailed usage examples can be found [in the test suite](https://github.com/facebook/relay/blob/master/packages/react-relay/classic/mutation/__tests__/RelayGraphQLMutation-test.js).
+A number of more detailed usage examples can be found [in the test suite](https://github.com/facebook/relay/blob/main/packages/react-relay/classic/mutation/__tests__/RelayGraphQLMutation-test.js).

--- a/website/versioned_docs/version-experimental/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-experimental/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-experimental/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-experimental/Modern-GraphQLInRelay.md
@@ -349,6 +349,6 @@ Any fields specified in the client schema, can be fetched from the Relay Store b
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-experimental/RelayHooks-AGuidedTourOfRelay.md
+++ b/website/versioned_docs/version-experimental/RelayHooks-AGuidedTourOfRelay.md
@@ -10,7 +10,7 @@ In this guide, we're going to go over how to use Relay to build out some of the 
 
 ## Example App
 
-To see a full example using Relay Hooks and our integration with [Suspense for Data Fetching](https://reactjs.org/docs/concurrent-mode-suspense.html), check out: [relay-examples/issue-tracker](https://github.com/relayjs/relay-examples/tree/master/issue-tracker).
+To see a full example using Relay Hooks and our integration with [Suspense for Data Fetching](https://reactjs.org/docs/concurrent-mode-suspense.html), check out: [relay-examples/issue-tracker](https://github.com/relayjs/relay-examples/tree/main/issue-tracker).
 
 ## Setup and Workflow
 
@@ -56,7 +56,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further, you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further, you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 ### Relay Compiler
 
@@ -1341,7 +1341,7 @@ const store = new Store(source, {gcScheduler});
 ```
 
 -   By default, if a `gcScheduler` option is not provided, Relay will schedule garbage collection using the `resolveImmediate` function.
--   You can provide a scheduler function to make GC scheduling less aggressive than the default, for example based on time or [scheduler](https://github.com/facebook/react/tree/master/packages/scheduler) priorities, or any other heuristic. By convention, implementations should not execute the callback immediately.
+-   You can provide a scheduler function to make GC scheduling less aggressive than the default, for example based on time or [scheduler](https://github.com/facebook/react/tree/main/packages/scheduler) priorities, or any other heuristic. By convention, implementations should not execute the callback immediately.
 
 ###### GC Release Buffer Size
 

--- a/website/versioned_docs/version-experimental/RelayHooks-ApiReference.md
+++ b/website/versioned_docs/version-experimental/RelayHooks-ApiReference.md
@@ -9,7 +9,7 @@ original_id: api-reference
 
 For a usage guide, see: [**A Guided Tour of Relay**](a-guided-tour-of-relay).
 
-For a full example using Relay Hooks and our integration with [Suspense for Data Fetching](https://reactjs.org/docs/concurrent-mode-suspense.html), check out [relay-examples/issue-tracker](https://github.com/relayjs/relay-examples/tree/master/issue-tracker).
+For a full example using Relay Hooks and our integration with [Suspense for Data Fetching](https://reactjs.org/docs/concurrent-mode-suspense.html), check out [relay-examples/issue-tracker](https://github.com/relayjs/relay-examples/tree/main/issue-tracker).
 
 ### Benefits
 

--- a/website/versioned_docs/version-experimental/RelayHooks-StepByStep.md
+++ b/website/versioned_docs/version-experimental/RelayHooks-StepByStep.md
@@ -172,7 +172,7 @@ Next let's configure Relay compiler. We'll need a copy of the schema as a `.grap
 ```bash
 
 cd your-app-name
-curl https://raw.githubusercontent.com/relayjs/relay-examples/master/issue-tracker/schema/schema.graphql > schema.graphql
+curl https://raw.githubusercontent.com/relayjs/relay-examples/main/issue-tracker/schema/schema.graphql > schema.graphql
 
 ```
 
@@ -311,4 +311,4 @@ At this point we have an app configured to use Relay. We recommend checking out 
 
 -   The [Guided Tour](./a-guided-tour-of-relay) describes how to implement many common use-cases.
 -   The [API Reference](./api-reference) has full details on the Relay Hooks APIs.
--   The [Example App](https://github.com/relayjs/relay-examples/tree/master/issue-tracker) is a more sophisticated version of what we've started building here. It includes routing integration and uses React Concurrent Mode and Suspense for smooth transitions between pages.
+-   The [Example App](https://github.com/relayjs/relay-examples/tree/main/issue-tracker) is a more sophisticated version of what we've started building here. It includes routing integration and uses React Concurrent Mode and Suspense for smooth transitions between pages.

--- a/website/versioned_docs/version-v1.4.1/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v1.4.1/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v1.4.1/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.4.1/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -248,7 +248,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -442,7 +442,7 @@ Check out or docs for [Fragment Containers](./fragment-container) for more detai
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -455,7 +455,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v1.4.1/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-GraphQLInRelay.md
@@ -236,6 +236,6 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v1.4.1/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-Mutations.md
@@ -258,7 +258,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -291,7 +291,7 @@ function sharedUpdater(store, user, newEdge) {
   // Get the user's Todo List using ConnectionHandler helper
   const conn = ConnectionHandler.getConnection(
     userProxy,
-    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L68
+    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L68
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v1.4.1/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-TypeEmission.md
@@ -355,4 +355,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v1.5.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v1.5.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v1.5.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.5.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -248,7 +248,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -442,7 +442,7 @@ Check out or docs for [Fragment Containers](./fragment-container) for more detai
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -455,7 +455,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v1.5.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-GraphQLInRelay.md
@@ -236,6 +236,6 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v1.5.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-Mutations.md
@@ -258,7 +258,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -291,7 +291,7 @@ function sharedUpdater(store, user, newEdge) {
   // Get the user's Todo List using ConnectionHandler helper
   const conn = ConnectionHandler.getConnection(
     userProxy,
-    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L68
+    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L68
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v1.5.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-TypeEmission.md
@@ -355,4 +355,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v1.6.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v1.6.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v1.6.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.6.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -248,7 +248,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -442,7 +442,7 @@ Check out or docs for [Fragment Containers](./fragment-container) for more detai
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -455,7 +455,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v1.6.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-GraphQLInRelay.md
@@ -236,6 +236,6 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v1.6.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-Mutations.md
@@ -258,7 +258,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -291,7 +291,7 @@ function sharedUpdater(store, user, newEdge) {
   // Get the user's Todo List using ConnectionHandler helper
   const conn = ConnectionHandler.getConnection(
     userProxy,
-    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L68
+    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L68
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v1.6.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-TypeEmission.md
@@ -355,4 +355,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v1.6.1/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v1.6.1/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v1.6.1/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.6.1/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -248,7 +248,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -442,7 +442,7 @@ Check out or docs for [Fragment Containers](./fragment-container) for more detai
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -455,7 +455,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v1.6.1/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-GraphQLInRelay.md
@@ -236,6 +236,6 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v1.6.1/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-Mutations.md
@@ -258,7 +258,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -291,7 +291,7 @@ function sharedUpdater(store, user, newEdge) {
   // Get the user's Todo List using ConnectionHandler helper
   const conn = ConnectionHandler.getConnection(
     userProxy,
-    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L68
+    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L68
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v1.6.1/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-TypeEmission.md
@@ -355,4 +355,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v1.6.2/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v1.6.2/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v1.6.2/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.6.2/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parametrized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -248,7 +248,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -442,7 +442,7 @@ Check out or docs for [Fragment Containers](./fragment-container) for more detai
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -455,7 +455,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v1.6.2/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-GraphQLInRelay.md
@@ -236,6 +236,6 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v1.6.2/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-Mutations.md
@@ -258,7 +258,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -291,7 +291,7 @@ function sharedUpdater(store, user, newEdge) {
   // Get the user's Todo List using ConnectionHandler helper
   const conn = ConnectionHandler.getConnection(
     userProxy,
-    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L68
+    'TodoList_todos', // This is the connection identifier, defined here: https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L68
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v1.6.2/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-TypeEmission.md
@@ -355,4 +355,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v1.7.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v1.7.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v1.7.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.7.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -248,7 +248,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -442,7 +442,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -455,7 +455,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v1.7.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-GraphQLInRelay.md
@@ -238,6 +238,6 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v1.7.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-Mutations.md
@@ -269,7 +269,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -303,7 +303,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L68
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L68
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v1.7.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-TypeEmission.md
@@ -355,4 +355,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v10.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v10.0.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/master/src/utilities/printSchema.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/main/src/utilities/printSchema.js).
 
 ```
 
@@ -536,4 +536,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v10.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.0.0/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v10.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.0.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v10.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v10.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-Mutations.md
@@ -272,7 +272,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -306,7 +306,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v10.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v10.0.1/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v10.0.1/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/master/src/utilities/printSchema.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/main/src/utilities/printSchema.js).
 
 ```
 
@@ -536,4 +536,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v10.0.1/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.0.1/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v10.0.1/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.0.1/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v10.0.1/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v10.0.1/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-Mutations.md
@@ -272,7 +272,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -306,7 +306,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v10.0.1/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v10.1.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v10.1.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/master/src/utilities/printSchema.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/main/src/utilities/printSchema.js).
 
 ```
 
@@ -536,4 +536,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v10.1.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.1.0/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v10.1.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.1.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v10.1.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v10.1.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-Mutations.md
@@ -272,7 +272,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -306,7 +306,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v10.1.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v10.1.1/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v10.1.1/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/master/src/utilities/printSchema.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/main/src/utilities/printSchema.js).
 
 ```
 
@@ -536,4 +536,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v10.1.1/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.1.1/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v10.1.1/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.1.1/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v10.1.1/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v10.1.1/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-Mutations.md
@@ -272,7 +272,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -306,7 +306,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v10.1.1/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v10.1.2/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v10.1.2/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/master/src/utilities/printSchema.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/main/src/utilities/printSchema.js).
 
 ```
 
@@ -536,4 +536,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model, the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v10.1.2/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.1.2/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v10.1.2/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.1.2/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v10.1.2/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v10.1.2/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-Mutations.md
@@ -272,7 +272,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -306,7 +306,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v10.1.2/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v10.1.3/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v10.1.3/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/master/src/utilities/printSchema.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`printSchema`](https://github.com/graphql/graphql-js/blob/main/src/utilities/printSchema.js).
 
 ```
 
@@ -536,4 +536,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v10.1.3/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.1.3/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v10.1.3/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.1.3/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v10.1.3/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v10.1.3/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-Mutations.md
@@ -272,7 +272,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here's a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here's a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -306,7 +306,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v10.1.3/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v11.0.0/getting-started/installation-and-setup.md
+++ b/website/versioned_docs/version-v11.0.0/getting-started/installation-and-setup.md
@@ -69,7 +69,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v11.0.0/getting-started/step-by-step-guide.md
+++ b/website/versioned_docs/version-v11.0.0/getting-started/step-by-step-guide.md
@@ -167,7 +167,7 @@ Next let's configure Relay compiler. We'll need a copy of the schema as a `.grap
 
 ```bash
 cd your-app-name
-curl https://raw.githubusercontent.com/relayjs/relay-examples/master/issue-tracker/schema/schema.graphql > schema.graphql
+curl https://raw.githubusercontent.com/relayjs/relay-examples/main/issue-tracker/schema/schema.graphql > schema.graphql
 ```
 *Note:* On Windows, the `.graphql` file has to be explicitly saved with UTF-8 encoding, not the default UTF-16. See this [issue](https://github.com/prisma-labs/get-graphql-schema/issues/30) for more details.
 
@@ -301,7 +301,7 @@ At this point we have an app configured to use Relay. We recommend checking out 
 
 * The [Guided Tour](../../guided-tour/) describes how to implement many common use-cases.
 * The [API Reference](../../api-reference/use-fragment/) has full details on the Relay Hooks APIs.
-* The [Example App](https://github.com/relayjs/relay-examples/tree/master/issue-tracker) is a more sophisticated version of what we've started building here. It includes routing integration and uses React Concurrent Mode and Suspense for smooth transitions between pages.
+* The [Example App](https://github.com/relayjs/relay-examples/tree/main/issue-tracker) is a more sophisticated version of what we've started building here. It includes routing integration and uses React Concurrent Mode and Suspense for smooth transitions between pages.
 
 
 <DocsRating />

--- a/website/versioned_docs/version-v11.0.0/guided-tour/reusing-cached-data/presence-of-data.md
+++ b/website/versioned_docs/version-v11.0.0/guided-tour/reusing-cached-data/presence-of-data.md
@@ -69,7 +69,7 @@ const store = new Store(source, {gcScheduler});
 ```
 
 * By default, if a `gcScheduler` option is not provided, Relay will schedule garbage collection using the `resolveImmediate` function.
-* You can provide a scheduler function to make GC scheduling less aggressive than the default, for example based on time or [scheduler](https://github.com/facebook/react/tree/master/packages/scheduler) priorities, or any other heuristic. By convention, implementations should not execute the callback immediately.
+* You can provide a scheduler function to make GC scheduling less aggressive than the default, for example based on time or [scheduler](https://github.com/facebook/react/tree/main/packages/scheduler) priorities, or any other heuristic. By convention, implementations should not execute the callback immediately.
 
 
 ### GC Release Buffer Size

--- a/website/versioned_docs/version-v11.0.0/guides/graphql-server-specification.md
+++ b/website/versioned_docs/version-v11.0.0/guides/graphql-server-specification.md
@@ -453,6 +453,6 @@ Complete details on how the server should behave are available in the [GraphQL C
 
 This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the [Relay cursor connection](/graphql/connections.htm) model, the [GraphQL global object identification](https://graphql.org/learn/global-object-identification/) model are all available.
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes and connections; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes and connections; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
 
 <DocsRating />

--- a/website/versioned_docs/version-v11.0.0/guides/testing-relay-components.md
+++ b/website/versioned_docs/version-v11.0.0/guides/testing-relay-components.md
@@ -564,7 +564,7 @@ https://phabricator.internmc.facebook.com/diffusion/FBS/browse/master/xplat/js/R
 
 <OssOnly>
 
-The best source of example tests is in [the relay-experimental package](https://github.com/facebook/relay/tree/master/packages/relay-experimental/__tests__).
+The best source of example tests is in [the relay-experimental package](https://github.com/facebook/relay/tree/main/packages/relay-experimental/__tests__).
 
 </OssOnly>
 

--- a/website/versioned_docs/version-v11.0.0/guides/type-emission.md
+++ b/website/versioned_docs/version-v11.0.0/guides/type-emission.md
@@ -461,6 +461,6 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js
 
 <DocsRating />

--- a/website/versioned_docs/version-v11.0.0/migration-and-compatibility/relay-hooks-and-legacy-container-apis.md
+++ b/website/versioned_docs/version-v11.0.0/migration-and-compatibility/relay-hooks-and-legacy-container-apis.md
@@ -109,7 +109,7 @@ export default function Home() {
 
 Unlike `useLazyLoadQuery`, using [`useQueryLoader`](../../api-reference/use-query-loader/) in combination with [`usePreloadedQuery`](../../api-reference/use-preloaded-query/) will start fetching the data *ahead* of render, following the "render-as-you-fetch" pattern. This means that the data fetch will start sooner, and potentially speed up the time it takes to show content to users.
 
-To make best use of this pattern, query loading is usually integrated at the router level, or other parts of your UI infra. To see a full example, see our [`issue-tracker`](https://github.com/relayjs/relay-examples/blob/master/issue-tracker/src/routes.js) example app.
+To make best use of this pattern, query loading is usually integrated at the router level, or other parts of your UI infra. To see a full example, see our [`issue-tracker`](https://github.com/relayjs/relay-examples/blob/main/issue-tracker/src/routes.js) example app.
 
 
 To convert a `QueryRenderer` to `useQueryLoader`, you need to take the following steps:

--- a/website/versioned_docs/version-v2.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v2.0.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v2.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v2.0.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -248,7 +248,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -442,7 +442,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -455,7 +455,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v2.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-GraphQLInRelay.md
@@ -264,6 +264,6 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v2.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-Mutations.md
@@ -271,7 +271,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -305,7 +305,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L68
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L68
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v2.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-TypeEmission.md
@@ -355,4 +355,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v3.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v3.0.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v3.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v3.0.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -248,7 +248,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -442,7 +442,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -455,7 +455,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v3.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-GraphQLInRelay.md
@@ -264,6 +264,6 @@ import type {DictionaryComponent_word} from './__generated__/DictionaryComponent
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/RelayCompilerPublic.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v3.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-Mutations.md
@@ -271,7 +271,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -305,7 +305,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L68
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L68
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v3.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-TypeEmission.md
@@ -347,4 +347,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v4.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v4.0.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v4.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v4.0.0/Introduction-InstallationAndSetup.md
@@ -43,7 +43,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v4.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v4.0.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -440,7 +440,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -453,7 +453,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v4.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-GraphQLInRelay.md
@@ -299,6 +299,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v4.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-Mutations.md
@@ -271,7 +271,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -305,7 +305,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v4.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-TypeEmission.md
@@ -347,4 +347,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v5.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v5.0.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v5.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v5.0.0/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v5.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v5.0.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v5.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-GraphQLInRelay.md
@@ -299,6 +299,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v5.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-Mutations.md
@@ -271,7 +271,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -305,7 +305,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v5.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v6.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v6.0.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v6.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v6.0.0/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v6.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v6.0.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v6.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v6.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-Mutations.md
@@ -271,7 +271,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -305,7 +305,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v6.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v7.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v7.0.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v7.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v7.0.0/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v7.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v7.0.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L107), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v7.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v7.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-Mutations.md
@@ -271,7 +271,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -305,7 +305,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v7.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v7.1.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v7.1.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -543,4 +543,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">Relay global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v7.1.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v7.1.0/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v7.1.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v7.1.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v7.1.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v7.1.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-Mutations.md
@@ -271,7 +271,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -305,7 +305,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v7.1.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v8.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v8.0.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -536,4 +536,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v8.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v8.0.0/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v8.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v8.0.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v8.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v8.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-Mutations.md
@@ -270,7 +270,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -304,7 +304,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v8.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v9.0.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v9.0.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -536,4 +536,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v9.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v9.0.0/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v9.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v9.0.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v9.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v9.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-Mutations.md
@@ -270,7 +270,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -304,7 +304,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v9.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js

--- a/website/versioned_docs/version-v9.1.0/GraphQL-ServerSpecification.md
+++ b/website/versioned_docs/version-v9.1.0/GraphQL-ServerSpecification.md
@@ -35,7 +35,7 @@ It is also assumed that the reader is already familiar with [Star Wars](https://
 
 ## Schema
 
-The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/master/src/utilities/schemaPrinter.js).
+The schema described below will be used to demonstrate the functionality that a GraphQL server used by Relay should implement. The two core types are a faction and a ship in the Star Wars universe, where a faction has many ships associated with it. The schema below is the output of the GraphQL.js [`schemaPrinter`](https://github.com/graphql/graphql-js/blob/main/src/utilities/schemaPrinter.js).
 
 ```
 
@@ -536,4 +536,4 @@ and we'll get this result:
 
 <p>This concludes the overview of the GraphQL Server Specifications. For the detailed requirements of a Relay-compliant GraphQL server, a more formal description of the <a href={useBaseUrl('graphql/connections.htm')}>Relay cursor connection</a> model and the <a href="https://graphql.org/learn/global-object-identification/">GraphQL global object identification</a> model are all available.</p>
 
-To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/master/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.
+To see code implementing the specification, the [GraphQL.js Relay library](https://github.com/graphql/graphql-relay-js) provides helper functions for creating nodes, connections, and mutations; that repository's [`__tests__`](https://github.com/graphql/graphql-relay-js/tree/main/src/__tests__) folder contains an implementation of the above example as integration tests for the repository.

--- a/website/versioned_docs/version-v9.1.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v9.1.0/Introduction-InstallationAndSetup.md
@@ -70,7 +70,7 @@ Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [ba
 const graphql = require('babel-plugin-relay/macro');
 ```
 
-If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental).
+If you need to configure `babel-plugin-relay` further (e.g. to enable `compat` mode), you can do so by [specifying the options in a number of ways](https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md#config-experimental).
 
 For example:
 

--- a/website/versioned_docs/version-v9.1.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v9.1.0/Introduction-QuickStartGuide.md
@@ -21,11 +21,11 @@ Table of Contents:
 
 Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
-Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/master/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/master/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql) available for us to use:
+Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
 ```graphql
 # From schema.graphql
-# https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql
+# https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql
 
 type Query {
   viewer: User
@@ -88,7 +88,7 @@ Usually we'd want a single environment in our app, so you could export this envi
 
 Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
 
-To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
+To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
 ```graphql
 query UserQuery {
@@ -148,7 +148,7 @@ For more details on `QueryRenderer`, check out the [docs](./query-renderer).
 
 ## Using Query Variables
 
-Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
+Let's assume for a moment that in our app we want to be able to view data for different users, so we're going to somehow need to query users by id. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L69), we know we can query nodes given an id, so let's write a parameterized query to get a user by id:
 
 ```graphql
 query UserQuery($userID: ID!) {
@@ -247,7 +247,7 @@ export default class Todo extends React.Component<Props> {
 }
 ```
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L112), we know that we can query this data on the `Todo` type. However, we don't want to have to send a separate query for each todo item; that would defeat the purpose of using GraphQL over a traditional REST API. We could manually query for these fields directly in our `QueryRenderer` query, but that would hurt re-usability: what if we want to query the same set of fields as part of a different query? Additionally, we wouldn't know which component needs the data we're querying, which is a problem Relay directly tries to address.
 
 Instead, we can define a reusable [Fragment](http://graphql.org/learn/queries/#fragments), which allows us to define a set of fields on a type and reuse them within our queries wherever we need to:
 
@@ -445,7 +445,7 @@ Check out our docs for [Fragment Containers](./fragment-container) for more deta
 
 Now that we know how to query for and render data, let's move on to changing our data. We know that to change any data in our server, we need to use GraphQL [Mutations](http://graphql.org/learn/queries/#mutations).
 
-From our [schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
+From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L35), we know that we have some mutations available to us, so let's start by writing a mutation to change the `complete` status of a given todo item (i.e. mark or unmark it as done):
 
 ```graphql
 mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
@@ -458,7 +458,7 @@ mutation ChangeTodoStatusMutation($input: ChangeTodoStatusInput!) {
 }
 ```
 
-This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
+This mutation allows us to query back some data as a [result of the mutation](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L18), so we're going to query for the updated `complete` status on the todo item.
 
 In order to execute this mutation in Relay, we're going to write a new mutation using Relay's `commitMutation` api:
 

--- a/website/versioned_docs/version-v9.1.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-GraphQLInRelay.md
@@ -351,6 +351,6 @@ For more details, refer to the [Local state management section](./local-state-ma
 
 ### Advanced usage
 
-In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/master/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
+In addition to the bin script, the `relay-compiler` package also [exports library code](https://github.com/facebook/relay/blob/main/packages/relay-compiler/index.js) which you may use to create more complex configurations for the compiler, or to extend the compiler with your own custom output.
 
 If you find you need to do something unique (like generate types that conform to an older version of Flow, or to parse non-javascript source files), you can build your own version of the Compiler by swapping in your own `FileWriter` and `ASTCache`, or by adding on an additional `IRTransform`. Note, the internal APIs of the `RelayCompiler` are under constant iteration, so rolling your own version may lead to incompatibilities with future releases.

--- a/website/versioned_docs/version-v9.1.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-Mutations.md
@@ -270,7 +270,7 @@ When you provide these functions, this is roughly what happens during the mutati
 -   Relay will then automatically update the fields under the record corresponding to the ids in the response payload.
 -   If an `updater` was provided, Relay will execute it and update the store accordingly. The server payload will be available to the `updater` as a root field in the store.
 
-Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/master/todo/data/schema.graphql#L36):
+Here are a quick example of adding a todo item to a Todo list using this [example schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L36):
 
 ```javascript
 // AddTodoMutation.js
@@ -304,7 +304,7 @@ function sharedUpdater(store, user, newEdge) {
   const conn = ConnectionHandler.getConnection(
     userProxy,
     'TodoList_todos', // This is the connection identifier, defined here
-    // https://github.com/relayjs/relay-examples/blob/master/todo/js/components/TodoList.js#L76
+    // https://github.com/relayjs/relay-examples/blob/main/todo/js/components/TodoList.js#L76
   );
 
   // Insert the new todo into the Todo List connection

--- a/website/versioned_docs/version-v9.1.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-TypeEmission.md
@@ -356,4 +356,4 @@ If you are looking to create your own language plugin, refer to the `relay-compi
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 
-[plugin-interface]: https://github.com/facebook/relay/blob/master/packages/relay-compiler/language/RelayLanguagePluginInterface.js
+[plugin-interface]: https://github.com/facebook/relay/blob/main/packages/relay-compiler/language/RelayLanguagePluginInterface.js


### PR DESCRIPTION
Manual updates in the build scripts plus a whole bunch search and replace in the docs.

This includes updates for other GitHub repositories that renamed their default branch as well.

Test Plan:
manually checked some of the updated links.