### PR TITLE
Force unix ending for fixture files

### DIFF
--- a/compiler/.gitattributes
+++ b/compiler/.gitattributes
@@ -1,0 +1,1 @@
+**/fixtures/* text eol=lf


### PR DESCRIPTION
Fixtures are compared byte by byte, we need these to be consistent
across platforms.

I tried running the unit tests on windows and noticed that the fixture files were loaded as `\r\n`. This due to automatic conversion when git checks out files. This config file turns this behavior off for files in the fixture directory.