### PR TITLE
Fix windows directory name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
             artifact-name: relay-compiler-macos-x64
           - os: windows-latest
             build-name: relay.exe
-            artifact-name: relay-compiler-win-x64.exe
+            artifact-name: relay-compiler-win-x64
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v2
@@ -125,11 +125,11 @@ jobs:
         with:
           name: relay-compiler-macos-x64
           path: artifacts/macos-x64
-      - name: Download artifact relay-compiler-win-x64.exe
+      - name: Download artifact relay-compiler-win-x64
         uses: actions/download-artifact@v2
         with:
-          name: relay-compiler-win-x64.exe
-          path: artifacts/win-x64.exe
+          name: relay-compiler-win-x64
+          path: artifacts/win-x64
       - name: Mark binaries as executable
         working-directory: artifacts
         run: |


### PR DESCRIPTION
The name here refers to a directory which contains `relay.exe`. The directory shouldn't have the `.exe` suffix.

Test Plan:
doitlive