### PR TITLE
Update website to indicate community chat has moved from Slack to Discord

### DIFF
--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -46,16 +46,11 @@ class Help extends React.Component {
       {
         content: (
           <span>
-            Many developers and users idle on Slack in the{' '}
-            <a href="https://graphql.slack.com/messages/relay">#relay</a>{' '}
-            channel of{' '}
-            <a href="https://graphql-slack.herokuapp.com/">
-              the GraphQL Slack community
-            </a>
-            .
+            Many developers and users idle in the #relay channel of the{' '}
+            <a href="https://discord.gg/Kb3SFkUeQt">GraphQL Discord server</a>.
           </span>
         ),
-        title: 'Slack',
+        title: 'Discord',
       },
       {
         content: (


### PR DESCRIPTION
My understanding is the the Slack server is moving to Discord, and I think it makes sense to move with them.

![Screen Shot 2021-07-15 at 2 19 11 PM](https://user-images.githubusercontent.com/162735/125859374-471f6cfc-93cb-4c9e-b6fe-6c8611d59b4a.png)
