### PR TITLE
Fix filling-in-missing-data.md example code

### DIFF
--- a/website/versioned_docs/version-v11.0.0/guided-tour/reusing-cached-data/filling-in-missing-data.md
+++ b/website/versioned_docs/version-v11.0.0/guided-tour/reusing-cached-data/filling-in-missing-data.md
@@ -67,7 +67,7 @@ const missingFieldHandlers = [
         // value of $story_id.
         return argValues.story_id;
       }
-      return null;
+      return undefined;
     },
     kind: 'linked',
   },


### PR DESCRIPTION
I come across this feature today when I was trying to fix a partial rendering behavior in my app. 

I thought any query on `node(id: ID)` would re-use the cache on the store and perform partial rendering by default, but it seems that it is not the case. 

For the code snippet below, it seems that the return value for "Not handled" should be `undefined` rather than `null` 
```javascript
const missingFieldHandlers = [
    {
        handle(field, record, argValues) {
            if (
                record != null &&
                record.__typename === ROOT_TYPE &&
                field.name === 'node' &&
                argValues.hasOwnProperty('id')
            ) {
                // If field is node(id: $id), look up the record by the value of $id
                return argValues.id;
            }

            // should return undefined instead of null if this handle function does not handle the given inputs.
            return undefined; 
        },
        kind: 'linked',
    }
];
```

According to this: https://github.com/facebook/relay/blob/9d0e3adef51c29838e0f0d2a451e8065e37836d1/packages/relay-runtime/store/DataChecker.js#L275-L286

If the return value is `null`, here  https://github.com/facebook/relay/blob/9d0e3adef51c29838e0f0d2a451e8065e37836d1/packages/relay-runtime/store/DataChecker.js#L553-L558 sets the value to null and declares `queryAvailability` as `available` status instead of `missing` at the end.
