### PR TITLE
Fixes connections spec link not opening properly

### DIFF
--- a/website/docs/guided-tour/list-data/connections.md
+++ b/website/docs/guided-tour/list-data/connections.md
@@ -17,7 +17,7 @@ There are several scenarios in which we'll want to query a list of data from the
 
 Specifically in Relay, we do this via GraphQL fields known as [Connections](https://graphql.org/learn/pagination/#complete-connection-model). Connections are GraphQL fields that take a set of arguments to specify which "slice" of the list to query, and include in their response both the "slice" of the list that was requested, as well as  information to indicate if there is more data available in the list and how to query it; this additional information can be used in order to perform pagination by querying for more "slices" or pages on the list.
 
-More specifically, we perform *cursor-based pagination,* in which the input used to query for "slices" of the list is a `cursor` and a `count`. Cursors are essentially opaque tokens that serve as markers or pointers to a position in the list. If you're curious to learn more about the details of cursor-based pagination and connections, check out <a href={useBaseUrl('graphql/connections.htm')}>the spec</a>.
+More specifically, we perform *cursor-based pagination,* in which the input used to query for "slices" of the list is a `cursor` and a `count`. Cursors are essentially opaque tokens that serve as markers or pointers to a position in the list. If you're curious to learn more about the details of cursor-based pagination and connections, check out <a href={useBaseUrl('graphql/connections.htm')} target="_blank">the spec</a>.
 
 
 <DocsRating />

--- a/website/versioned_docs/version-v11.0.0/guided-tour/list-data/connections.md
+++ b/website/versioned_docs/version-v11.0.0/guided-tour/list-data/connections.md
@@ -13,7 +13,7 @@ There are several scenarios in which we'll want to query a list of data from the
 
 Specifically in Relay, we do this via GraphQL fields known as [Connections](https://graphql.org/learn/pagination/#complete-connection-model). Connections are GraphQL fields that take a set of arguments to specify which "slice" of the list to query, and include in their response both the "slice" of the list that was requested, as well as  information to indicate if there is more data available in the list and how to query it; this additional information can be used in order to perform pagination by querying for more "slices" or pages on the list.
 
-More specifically, we perform *cursor-based pagination,* in which the input used to query for "slices" of the list is a `cursor` and a `count`. Cursors are essentially opaque tokens that serve as markers or pointers to a position in the list. If you're curious to learn more about the details of cursor-based pagination and connections, check out <a href={useBaseUrl('graphql/connections.htm')}>the spec</a>.
+More specifically, we perform *cursor-based pagination,* in which the input used to query for "slices" of the list is a `cursor` and a `count`. Cursors are essentially opaque tokens that serve as markers or pointers to a position in the list. If you're curious to learn more about the details of cursor-based pagination and connections, check out <a href={useBaseUrl('graphql/connections.htm')} target="_blank">the spec</a>.
 
 
 <DocsRating />


### PR DESCRIPTION
I was reading through the docs when I realized that the "the spec" link on the Connections page was not opening properly when opened on the same tab.

# Before
![Before](https://user-images.githubusercontent.com/25781956/127233480-6c2e70df-32f5-4b0e-95a7-2b75bd37108d.gif)

# After
![After](https://user-images.githubusercontent.com/25781956/127233504-fad5f763-172e-4a2a-ae8f-8853e48ef840.gif)

