### PR TITLE
Docs: return Adeira Relay Example

### DIFF
--- a/website/versioned_docs/version-v11.0.0/community/learning-resources.md
+++ b/website/versioned_docs/version-v11.0.0/community/learning-resources.md
@@ -13,6 +13,7 @@ import {FbInternalOnly, OssOnly} from 'internaldocs-fb-helpers';
 These projects serve as an example of how to use Relay in real world applications.
 
 -   [github.com/relayjs/relay-examples](https://github.com/relayjs/relay-examples)
+-   [github.com/adeira/relay-example](https://github.com/adeira/relay-example)
 
 ## Guides and articles:
 


### PR DESCRIPTION
This example was already part of the docs for version 10 (see: https://relay.dev/docs/v10.1.3/community-learning-resources/). I would like to add it again for version 11 because we are keeping the code up-to-date to our best knowledge and possibilities for the OSS world.