### PR TITLE
Update documented example for useRefetchableFragment()

### DIFF
--- a/website/docs/api-reference/hooks/use-refetchable-fragment.md
+++ b/website/docs/api-reference/hooks/use-refetchable-fragment.md
@@ -40,6 +40,7 @@ function CommentBody(props: Props) {
   const [data, refetch] = useRefetchableFragment<CommentBodyRefetchQuery, _>(
     graphql`
       fragment CommentBody_comment on Comment
+      @argumentDefinitions($lang: String)
       @refetchable(queryName: "CommentBodyRefetchQuery") {
         body(lang: $lang) {
           text
@@ -50,7 +51,7 @@ function CommentBody(props: Props) {
   );
 
   return (
-    <>
+    <React.Suspense fallback={"Loading…"}
       <p>{data.body?.text}</p>
       <Button
         onClick={() => {
@@ -59,7 +60,7 @@ function CommentBody(props: Props) {
       >
         Translate Comment
       </Button>
-    </>
+    </React.Suspense>
   );
 }
 


### PR DESCRIPTION
Adds `<React.Suspense>` and `@argumentDefinitions` to the `useRefetchableFragment()` hook example. Without these, using the example as a reference becomes a lot less useful without any errors pointing as to what is missing.
