### PR TITLE
[fix] experimental compiler: allow default args on required fields

### DIFF
--- a/compiler/crates/graphql-ir/src/build.rs
+++ b/compiler/crates/graphql-ir/src/build.rs
@@ -1081,6 +1081,7 @@ impl<'schema, 'signatures> Builder<'schema, 'signatures> {
         let missing_arg_names = argument_definitions
             .iter()
             .filter(|arg_def| arg_def.type_.is_non_null())
+            .filter(|arg_def| arg_def.default_value.is_none())
             .filter(|required_arg_def| {
                 arguments
                     .iter()

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/directive-generic.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/directive-generic.expected
@@ -19,7 +19,7 @@ fragment TestFragment on User {
                     alias: None,
                     definition: WithLocation {
                         location: directive-generic.graphql:34:36,
-                        item: FieldID(463),
+                        item: FieldID(464),
                     },
                     arguments: [],
                     directives: [

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/directive-include.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/directive-include.expected
@@ -43,7 +43,7 @@ fragment Foo on User {
                             alias: None,
                             definition: WithLocation {
                                 location: directive-include.graphql:34:36,
-                                item: FieldID(463),
+                                item: FieldID(464),
                             },
                             arguments: [],
                             directives: [],
@@ -76,7 +76,7 @@ fragment Foo on User {
                                     alias: None,
                                     definition: WithLocation {
                                         location: directive-include.graphql:97:106,
-                                        item: FieldID(460),
+                                        item: FieldID(461),
                                     },
                                     arguments: [],
                                     directives: [],
@@ -143,7 +143,7 @@ fragment Foo on User {
                     alias: None,
                     definition: WithLocation {
                         location: directive-include.graphql:168:170,
-                        item: FieldID(463),
+                        item: FieldID(464),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/enum-values.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/enum-values.expected
@@ -32,7 +32,7 @@ query EnumValueQuery {
                             alias: None,
                             definition: WithLocation {
                                 location: enum-values.graphql:34:48,
-                                item: FieldID(477),
+                                item: FieldID(478),
                             },
                             arguments: [
                                 Argument {

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/field-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/field-arguments.expected
@@ -86,7 +86,7 @@ query TestQuery {
                             alias: None,
                             definition: WithLocation {
                                 location: field-arguments.graphql:89:107,
-                                item: FieldID(517),
+                                item: FieldID(518),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fixme_fat_interface_on_union.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fixme_fat_interface_on_union.expected
@@ -31,7 +31,7 @@ query Test {
                             alias: None,
                             definition: WithLocation {
                                 location: fixme_fat_interface_on_union.graphql:51:53,
-                                item: FieldID(383),
+                                item: FieldID(384),
                             },
                             arguments: [],
                             directives: [

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-arguments.expected
@@ -94,7 +94,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-arguments.graphql:131:145,
-                        item: FieldID(477),
+                        item: FieldID(478),
                     },
                     arguments: [
                         Argument {
@@ -142,7 +142,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                     ),
                     definition: WithLocation {
                         location: fragment-with-arguments.graphql:198:212,
-                        item: FieldID(477),
+                        item: FieldID(478),
                     },
                     arguments: [
                         Argument {
@@ -253,7 +253,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-arguments.graphql:347:349,
-                        item: FieldID(463),
+                        item: FieldID(464),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-arguments.expected
@@ -90,7 +90,7 @@ fragment ChildFragment on User
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-literal-arguments.graphql:174:188,
-                        item: FieldID(477),
+                        item: FieldID(478),
                     },
                     arguments: [
                         Argument {

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list.expected
@@ -34,7 +34,7 @@ fragment ChildFragment on User
                     ),
                     definition: WithLocation {
                         location: fragment-with-literal-enum-arguments-into-enum-list.graphql:53:61,
-                        item: FieldID(454),
+                        item: FieldID(455),
                     },
                     arguments: [
                         Argument {
@@ -137,7 +137,7 @@ fragment ChildFragment on User
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-literal-enum-arguments-into-enum-list.graphql:253:261,
-                        item: FieldID(454),
+                        item: FieldID(455),
                     },
                     arguments: [
                         Argument {

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-arguments.expected
@@ -58,7 +58,7 @@ fragment ChildFragment on Query
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-enum-arguments.graphql:90:98,
-                                item: FieldID(516),
+                                item: FieldID(517),
                             },
                             arguments: [],
                             directives: [],
@@ -159,7 +159,7 @@ fragment ChildFragment on Query
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-enum-arguments.graphql:292:300,
-                                item: FieldID(516),
+                                item: FieldID(517),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-list-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-list-arguments.expected
@@ -34,7 +34,7 @@ fragment ChildFragment on User
                     ),
                     definition: WithLocation {
                         location: fragment-with-literal-enum-list-arguments.graphql:53:61,
-                        item: FieldID(454),
+                        item: FieldID(455),
                     },
                     arguments: [
                         Argument {
@@ -141,7 +141,7 @@ fragment ChildFragment on User
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-literal-enum-list-arguments.graphql:255:263,
-                        item: FieldID(454),
+                        item: FieldID(455),
                     },
                     arguments: [
                         Argument {

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-variable-definitions-syntax.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-variable-definitions-syntax.expected
@@ -94,7 +94,7 @@ fragment Foo($localId: ID!) on User {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-variable-definitions-syntax.graphql:131:145,
-                        item: FieldID(477),
+                        item: FieldID(478),
                     },
                     arguments: [
                         Argument {
@@ -142,7 +142,7 @@ fragment Foo($localId: ID!) on User {
                     ),
                     definition: WithLocation {
                         location: fragment-with-variable-definitions-syntax.graphql:198:212,
-                        item: FieldID(477),
+                        item: FieldID(478),
                     },
                     arguments: [
                         Argument {
@@ -244,7 +244,7 @@ fragment Foo($localId: ID!) on User {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-variable-definitions-syntax.graphql:317:319,
-                        item: FieldID(463),
+                        item: FieldID(464),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment_with_arguments_defaulting.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment_with_arguments_defaulting.expected
@@ -158,7 +158,7 @@ fragment F2 on Query @argumentDefinitions(
                             alias: None,
                             definition: WithLocation {
                                 location: fragment_with_arguments_defaulting.graphql:342:352,
-                                item: FieldID(520),
+                                item: FieldID(521),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/inline-untyped-fragment.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/inline-untyped-fragment.expected
@@ -25,7 +25,7 @@ fragment InlineUntypedFragment on User {
                             alias: None,
                             definition: WithLocation {
                                 location: inline-untyped-fragment.graphql:53:57,
-                                item: FieldID(469),
+                                item: FieldID(470),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field-with-filters.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field-with-filters.expected
@@ -36,7 +36,7 @@ fragment LinkedHandleField on User {
                     alias: None,
                     definition: WithLocation {
                         location: linked-handle-field-with-filters.graphql:39:46,
-                        item: FieldID(461),
+                        item: FieldID(462),
                     },
                     arguments: [
                         Argument {

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field-with-key.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field-with-key.expected
@@ -22,7 +22,7 @@ fragment LinkedHandleField on User {
                     alias: None,
                     definition: WithLocation {
                         location: linked-handle-field-with-key.graphql:39:46,
-                        item: FieldID(461),
+                        item: FieldID(462),
                     },
                     arguments: [
                         Argument {

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field.expected
@@ -23,7 +23,7 @@ fragment LinkedHandleField on User {
                     alias: None,
                     definition: WithLocation {
                         location: linked-handle-field.graphql:39:46,
-                        item: FieldID(461),
+                        item: FieldID(462),
                     },
                     arguments: [
                         Argument {

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-filter.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-filter.expected
@@ -23,7 +23,7 @@ fragment LinkedHandleField on User {
                     alias: None,
                     definition: WithLocation {
                         location: linked-handle-filter.graphql:39:46,
-                        item: FieldID(461),
+                        item: FieldID(462),
                     },
                     arguments: [
                         Argument {

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/list-of-enums.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/list-of-enums.expected
@@ -19,7 +19,7 @@ fragment TestFragment on User {
                     alias: None,
                     definition: WithLocation {
                         location: list-of-enums.graphql:34:40,
-                        item: FieldID(486),
+                        item: FieldID(487),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/null-values.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/null-values.expected
@@ -56,7 +56,7 @@ query NullValuesQuery {
                             alias: None,
                             definition: WithLocation {
                                 location: null-values.graphql:60:64,
-                                item: FieldID(497),
+                                item: FieldID(498),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/scalar-handle-field.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/scalar-handle-field.expected
@@ -21,7 +21,7 @@ fragment ScalarHandleField on User {
                     alias: None,
                     definition: WithLocation {
                         location: scalar-handle-field.graphql:39:43,
-                        item: FieldID(469),
+                        item: FieldID(470),
                     },
                     arguments: [],
                     directives: [

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/simple-fragment.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/simple-fragment.expected
@@ -19,7 +19,7 @@ fragment TestFragment on User {
                     alias: None,
                     definition: WithLocation {
                         location: simple-fragment.graphql:34:36,
-                        item: FieldID(463),
+                        item: FieldID(464),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/client-fields.expected
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/client-fields.expected
@@ -130,7 +130,7 @@ type Foo {
                     alias: None,
                     definition: WithLocation {
                         location: client-fields.graphql:171:173,
-                        item: FieldID(463),
+                        item: FieldID(464),
                     },
                     arguments: [],
                     directives: [],
@@ -139,7 +139,7 @@ type Foo {
                     alias: None,
                     definition: WithLocation {
                         location: client-fields.graphql:226:238,
-                        item: FieldID(520),
+                        item: FieldID(521),
                     },
                     arguments: [],
                     directives: [],
@@ -175,7 +175,7 @@ type Foo {
                                             alias: None,
                                             definition: WithLocation {
                                                 location: client-fields.graphql:287:289,
-                                                item: FieldID(463),
+                                                item: FieldID(464),
                                             },
                                             arguments: [],
                                             directives: [],
@@ -197,7 +197,7 @@ type Foo {
                                     alias: None,
                                     definition: WithLocation {
                                         location: client-fields.graphql:325:336,
-                                        item: FieldID(299),
+                                        item: FieldID(300),
                                     },
                                     arguments: [],
                                     directives: [],
@@ -216,7 +216,7 @@ type Foo {
                             alias: None,
                             definition: WithLocation {
                                 location: client-fields.graphql:367:370,
-                                item: FieldID(521),
+                                item: FieldID(522),
                             },
                             arguments: [],
                             directives: [],
@@ -239,7 +239,7 @@ type Foo {
                                             alias: None,
                                             definition: WithLocation {
                                                 location: client-fields.graphql:470:472,
-                                                item: FieldID(522),
+                                                item: FieldID(523),
                                             },
                                             arguments: [],
                                             directives: [],
@@ -268,7 +268,7 @@ type Foo {
                     alias: None,
                     definition: WithLocation {
                         location: client-fields.graphql:526:528,
-                        item: FieldID(522),
+                        item: FieldID(523),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/relay-test-schema/src/testschema.graphql
+++ b/compiler/crates/relay-test-schema/src/testschema.graphql
@@ -686,6 +686,7 @@ type Page implements Node & Actor {
   viewerSavedState: String
   nameWithArgs(capitalize: Boolean!): String
   nameWithDefaultArgs(capitalize: Boolean = false): String
+  nameWithRequiredDefaultArgs(capitalize: Boolean! = false): String
   actor_key: ID!
 }
 

--- a/compiler/crates/relay-transforms/tests/validate_required_arguments/fixtures/default-argument-on-field.expected
+++ b/compiler/crates/relay-transforms/tests/validate_required_arguments/fixtures/default-argument-on-field.expected
@@ -4,6 +4,7 @@ query defaultArgumentOnFieldTestQuery {
     hometown {
       a: nameWithDefaultArgs
       b: nameWithDefaultArgs(capitalize: true)
+      c: nameWithRequiredDefaultArgs
     }
   }
 }

--- a/compiler/crates/relay-transforms/tests/validate_required_arguments/fixtures/default-argument-on-field.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_required_arguments/fixtures/default-argument-on-field.graphql
@@ -3,6 +3,7 @@ query defaultArgumentOnFieldTestQuery {
     hometown {
       a: nameWithDefaultArgs
       b: nameWithDefaultArgs(capitalize: true)
+      c: nameWithRequiredDefaultArgs
     }
   }
 }


### PR DESCRIPTION
At Coinbase, we were trying out the experimental compiler and this was the first issue we ran into. 

The JS compiler allowed this and it seems valid. Let me know if this is out of spec.

CC @kassens @captbaritone 