### PR TITLE
Fix conflicting field warning when using treatMissingFieldsAsNull

### DIFF
--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -506,7 +506,7 @@ class RelayResponseNormalizer {
           this._validateConflictingFieldsWithIdenticalId(
             record,
             storageKey,
-            fieldValue,
+            null,
           );
         }
       }

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest32Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest32Query.graphql.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * 
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<8a2a0b8565235eea4a3010d6725a2ee4>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest } from 'relay-runtime';
+export type RelayResponseNormalizerTest32QueryVariables = {|
+  id?: ?string,
+|};
+export type RelayResponseNormalizerTest32QueryResponse = {|
+  +node: ?{|
+    +id: string,
+    +__typename: string,
+    +name?: ?string,
+    +friends?: ?{|
+      +edges: ?$ReadOnlyArray<?{|
+        +node: ?{|
+          +id: string,
+          +firstName: ?string,
+        |},
+      |}>,
+    |},
+  |},
+|};
+export type RelayResponseNormalizerTest32Query = {|
+  variables: RelayResponseNormalizerTest32QueryVariables,
+  response: RelayResponseNormalizerTest32QueryResponse,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      }
+    ],
+    "concreteType": null,
+    "kind": "LinkedField",
+    "name": "node",
+    "plural": false,
+    "selections": [
+      (v1/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 2
+              }
+            ],
+            "concreteType": "FriendsConnection",
+            "kind": "LinkedField",
+            "name": "friends",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FriendsEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "firstName",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "friends(first:2)"
+          }
+        ],
+        "type": "User",
+        "abstractKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayResponseNormalizerTest32Query",
+    "selections": (v2/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RelayResponseNormalizerTest32Query",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "05f4635aa7c4f8df5bc9dedecca00508",
+    "id": null,
+    "metadata": {},
+    "name": "RelayResponseNormalizerTest32Query",
+    "operationKind": "query",
+    "text": "query RelayResponseNormalizerTest32Query(\n  $id: ID\n) {\n  node(id: $id) {\n    id\n    __typename\n    ... on User {\n      name\n      friends(first: 2) {\n        edges {\n          node {\n            id\n            firstName\n          }\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "76403c7895d7066c845a957a4c4fc64b";
+}
+
+module.exports = node;

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest33Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest33Query.graphql.js
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * 
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<59e78d690ce728e14292a23c4bbeb1d6>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest } from 'relay-runtime';
+export type RelayResponseNormalizerTest33QueryVariables = {|
+  id?: ?string,
+  size?: ?$ReadOnlyArray<?number>,
+|};
+export type RelayResponseNormalizerTest33QueryResponse = {|
+  +node: ?{|
+    +id: string,
+    +__typename: string,
+    +firstName?: ?string,
+    +profilePicture?: ?{|
+      +uri: ?string,
+    |},
+  |},
+|};
+export type RelayResponseNormalizerTest33Query = {|
+  variables: RelayResponseNormalizerTest33QueryVariables,
+  response: RelayResponseNormalizerTest33QueryResponse,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "size"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      }
+    ],
+    "concreteType": null,
+    "kind": "LinkedField",
+    "name": "node",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "firstName",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "size",
+                "variableName": "size"
+              }
+            ],
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "profilePicture",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "uri",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "type": "User",
+        "abstractKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayResponseNormalizerTest33Query",
+    "selections": (v1/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RelayResponseNormalizerTest33Query",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "6a3b96ae87944da7484b8b843112b10a",
+    "id": null,
+    "metadata": {},
+    "name": "RelayResponseNormalizerTest33Query",
+    "operationKind": "query",
+    "text": "query RelayResponseNormalizerTest33Query(\n  $id: ID\n  $size: [Int]\n) {\n  node(id: $id) {\n    id\n    __typename\n    ... on User {\n      firstName\n      profilePicture(size: $size) {\n        uri\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "e738ea7dee378b790e46fa1469214539";
+}
+
+module.exports = node;

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest34Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest34Query.graphql.js
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * 
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<46e144618cbcb827cc1f071367a8e757>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest } from 'relay-runtime';
+export type RelayResponseNormalizerTest34QueryVariables = {|
+  id?: ?string,
+|};
+export type RelayResponseNormalizerTest34QueryResponse = {|
+  +node: ?{|
+    +id: string,
+    +__typename: string,
+    +firstName?: ?string,
+    +nickname?: ?string,
+    +foo?: ?{|
+      +bar: ?{|
+        +content: ?string,
+      |},
+    |},
+  |},
+|};
+export type RelayResponseNormalizerTest34Query = {|
+  variables: RelayResponseNormalizerTest34QueryVariables,
+  response: RelayResponseNormalizerTest34QueryResponse,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      }
+    ],
+    "concreteType": null,
+    "kind": "LinkedField",
+    "name": "node",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "firstName",
+            "storageKey": null
+          },
+          {
+            "kind": "ClientExtension",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "nickname",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Foo",
+                "kind": "LinkedField",
+                "name": "foo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Bar",
+                    "kind": "LinkedField",
+                    "name": "bar",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "content",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ]
+          }
+        ],
+        "type": "User",
+        "abstractKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayResponseNormalizerTest34Query",
+    "selections": (v1/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RelayResponseNormalizerTest34Query",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "43ebfae93fcf74bf989d71d49bb4739b",
+    "id": null,
+    "metadata": {},
+    "name": "RelayResponseNormalizerTest34Query",
+    "operationKind": "query",
+    "text": "query RelayResponseNormalizerTest34Query(\n  $id: ID\n) {\n  node(id: $id) {\n    id\n    __typename\n    ... on User {\n      firstName\n    }\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "d25f16f785bea376627a9b1fbe94db29";
+}
+
+module.exports = node;

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest35Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest35Query.graphql.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * 
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<8490c79b5998c1fe4964cdfcaef53ba1>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest } from 'relay-runtime';
+export type RelayResponseNormalizerTest35QueryVariables = {|
+  id?: ?string,
+|};
+export type RelayResponseNormalizerTest35QueryResponse = {|
+  +node: ?{|
+    +id: string,
+    +__typename: string,
+    +name?: ?string,
+    +friends?: ?{|
+      +edges: ?$ReadOnlyArray<?{|
+        +node: ?{|
+          +id: string,
+          +firstName: ?string,
+        |},
+      |}>,
+    |},
+  |},
+|};
+export type RelayResponseNormalizerTest35Query = {|
+  variables: RelayResponseNormalizerTest35QueryVariables,
+  response: RelayResponseNormalizerTest35QueryResponse,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      }
+    ],
+    "concreteType": null,
+    "kind": "LinkedField",
+    "name": "node",
+    "plural": false,
+    "selections": [
+      (v1/*: any*/),
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      },
+      {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 2
+              }
+            ],
+            "concreteType": "FriendsConnection",
+            "kind": "LinkedField",
+            "name": "friends",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FriendsEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "firstName",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "friends(first:2)"
+          }
+        ],
+        "type": "User",
+        "abstractKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayResponseNormalizerTest35Query",
+    "selections": (v2/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RelayResponseNormalizerTest35Query",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "33122a5765b6b34cf9470ae1c4b88f2e",
+    "id": null,
+    "metadata": {},
+    "name": "RelayResponseNormalizerTest35Query",
+    "operationKind": "query",
+    "text": "query RelayResponseNormalizerTest35Query(\n  $id: ID\n) {\n  node(id: $id) {\n    id\n    __typename\n    ... on User {\n      name\n      friends(first: 2) {\n        edges {\n          node {\n            id\n            firstName\n          }\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "1aaba7cd13bea63af442c5b5f73a0039";
+}
+
+module.exports = node;

--- a/scripts/config.tests.json
+++ b/scripts/config.tests.json
@@ -23,15 +23,14 @@
       "jsModuleFormat": "commonjs",
       "featureFlags": {
         "enable_flight_transform": true,
-        "enable_required_transform_for_prefix": "",
+        "enable_required_transform": true,
         "no_inline": {
           "kind": "enabled"
         },
         "actor_change_support": {
           "kind": "enabled"
         }
-      },
-      "haste": false
+      }
     }
   },
   "isDevVariableName": "__DEV__"


### PR DESCRIPTION
When using `treatMissingFieldsAsNull` the conflicting validation raises a false positive because the value is set using `null` but validated using `fieldValue` which at this point will be undefined. To fix this I changed the validation to use `null` instead of `fieldValue` so this matches the value that we actually set.

Before: `Warning: RelayResponseNormalizer: Invalid record. The record contains two instances of the same id: 'x' with conflicting field, y and its values: null and undefined. If two fields are different but share the same id, one field will overwrite the other.`

After: no warning