### PR TITLE
Remove unnecessary null values from metadata

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -791,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/compiler/crates/common/src/feature_flags.rs
+++ b/compiler/crates/common/src/feature_flags.rs
@@ -49,6 +49,9 @@ pub struct FeatureFlags {
 
     #[serde(default)]
     pub enable_provided_variables: FeatureFlag,
+
+    #[serde(default)]
+    pub skip_printing_nulls: FeatureFlag,
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]

--- a/compiler/crates/relay-codegen/src/ast.rs
+++ b/compiler/crates/relay-codegen/src/ast.rs
@@ -73,6 +73,9 @@ pub enum Primitive {
     RawString(String),
     GraphQLModuleDependency(StringKey),
     JSModuleDependency(StringKey),
+    // Don't include the value in the output when
+    // skip_printing_nulls is enabled
+    NullOrNothing,
 }
 
 impl Primitive {

--- a/compiler/crates/relay-codegen/src/build_ast.rs
+++ b/compiler/crates/relay-codegen/src/build_ast.rs
@@ -190,7 +190,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
                     &fragment.used_global_variables),
             kind: Primitive::String(CODEGEN_CONSTANTS.fragment_value),
             metadata: if skip_metadata {
-                    Primitive::Null
+                    Primitive::NullOrNothing
                 } else {
                     self.build_fragment_metadata(fragment)
                 },
@@ -203,7 +203,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
                         fragment.type_condition,
                     ))
                 } else {
-                    Primitive::Null
+                    Primitive::NullOrNothing
                 },
         };
         self.object(object)
@@ -270,7 +270,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
                 };
                 Primitive::Key(self.object(connection_object))
             } else {
-                Primitive::Null
+                Primitive::NullOrNothing
             };
             let mut refetch_object = object! {
                 connection: refetch_connection,
@@ -299,7 +299,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
             })
         }
         if metadata.is_empty() {
-            Primitive::Null
+            Primitive::NullOrNothing
         } else {
             Primitive::Key(self.object(metadata))
         }
@@ -313,7 +313,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
             .iter()
             .map(|metadata| {
                 let path = match &metadata.path {
-                    None => Primitive::Null,
+                    None => Primitive::NullOrNothing,
                     Some(path) => Primitive::Key(
                         self.array(path.iter().cloned().map(Primitive::String).collect()),
                     ),
@@ -473,18 +473,18 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
         let primitive = Primitive::Key(self.object(object! {
             :build_alias(alias, name),
             args: match args {
-                    None => Primitive::Null,
+                    None => Primitive::NullOrNothing,
                     Some(key) => Primitive::Key(key),
                 },
             kind: kind,
             name: Primitive::String(name),
             storage_key: match args {
-                    None => Primitive::Null,
+                    None => Primitive::NullOrNothing,
                     Some(key) => {
                         if is_static_storage_key_available(&field.arguments) {
                             Primitive::StorageKey(name, key)
                         } else {
-                            Primitive::Null
+                            Primitive::NullOrNothing
                         }
                     }
                 },
@@ -505,13 +505,13 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
         for directive in handle_field_directives {
             let values = extract_values_from_handle_field_directive(directive);
             let filters = match values.filters {
-                None => Primitive::Null,
+                None => Primitive::NullOrNothing,
                 Some(strs) => {
                     Primitive::Key(self.array(strs.into_iter().map(Primitive::String).collect()))
                 }
             };
             let arguments = match self.build_arguments(&field.arguments) {
-                None => Primitive::Null,
+                None => Primitive::NullOrNothing,
                 Some(key) => Primitive::Key(key),
             };
             let mut object = object! {
@@ -556,11 +556,11 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
         let primitive = Primitive::Key(self.object(object! {
             :build_alias(alias, name),
             args: match args {
-                    None => Primitive::Null,
+                    None => Primitive::NullOrNothing,
                     Some(key) => Primitive::Key(key),
                 },
             concrete_type: if schema_field.type_.inner().is_abstract_type() {
-                    Primitive::Null
+                    Primitive::NullOrNothing
                 } else {
                     Primitive::String(self.schema.get_type_name(schema_field.type_.inner()))
                 },
@@ -569,12 +569,12 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
             plural: Primitive::Bool(schema_field.type_.is_list()),
             selections: selections,
             storage_key: match args {
-                None => Primitive::Null,
+                None => Primitive::NullOrNothing,
                 Some(key) => {
                     if is_static_storage_key_available(&field.arguments) {
                         Primitive::StorageKey(name, key)
                     } else {
-                        Primitive::Null
+                        Primitive::NullOrNothing
                     }
                 }
             },
@@ -599,7 +599,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
                 None => None,
             };
             let filters = match values.filters {
-                None => Primitive::Null,
+                None => Primitive::NullOrNothing,
                 Some(strings) => {
                     Primitive::Key(self.array(strings.into_iter().map(Primitive::String).collect()))
                 }
@@ -607,7 +607,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
             let mut object = object! {
                 :build_alias(field.alias.map(|a| a.item), field_name),
                 args: match self.build_arguments(&field.arguments) {
-                        None => Primitive::Null,
+                        None => Primitive::NullOrNothing,
                         Some(key) => Primitive::Key(key),
                     },
                 filters: filters,
@@ -682,7 +682,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
         let args = self.build_arguments(&frag_spread.arguments);
         let primitive = Primitive::Key(self.object(object! {
             args: match args {
-                    None => Primitive::Null,
+                    None => Primitive::NullOrNothing,
                     Some(key) => Primitive::Key(key),
                 },
             kind: Primitive::String(CODEGEN_CONSTANTS.fragment_spread),
@@ -737,7 +737,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
 
         Primitive::Key(self.object(object! {
                 args: match args {
-                        None => Primitive::Null,
+                        None => Primitive::NullOrNothing,
                         Some(key) => Primitive::Key(key),
                     },
                 fragment: Primitive::GraphQLModuleDependency(frag_spread.fragment.item),
@@ -973,7 +973,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
                                 type_condition,
                             ))
                         } else {
-                            Primitive::Null
+                            Primitive::NullOrNothing
                         },
                 }))
             }
@@ -1215,7 +1215,7 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
         };
         let selection = Primitive::Key(self.object(object! {
             args: match args {
-                None => Primitive::Null,
+                None => Primitive::NullOrNothing,
                 Some(key) => Primitive::Key(key),
             },
             document_name: Primitive::String(module_metadata.key),
@@ -1424,17 +1424,17 @@ impl<'schema, 'builder> CodegenBuilder<'schema, 'builder> {
                     :build_alias(alias, name),
                     name: Primitive::String(name),
                     storage_key: match args {
-                            None => Primitive::Null,
+                            None => Primitive::NullOrNothing,
                             Some(key) => {
                                 if is_static_storage_key_available(&linked_field.arguments) {
                                     Primitive::StorageKey(name, key)
                                 } else {
-                                    Primitive::Null
+                                    Primitive::NullOrNothing
                                 }
                             }
                         },
                     args: match args {
-                            None => Primitive::Null,
+                            None => Primitive::NullOrNothing,
                             Some(key) => Primitive::Key(key),
                         },
                     fragment_spread_property: Primitive::Key(fragment_spread_key),
@@ -1475,10 +1475,10 @@ fn value_contains_variable(value: &Value) -> bool {
 
 fn build_alias(alias: Option<StringKey>, name: StringKey) -> ObjectEntry {
     let alias = match alias {
-        None => Primitive::Null,
+        None => Primitive::NullOrNothing,
         Some(alias) => {
             if alias == name {
-                Primitive::Null
+                Primitive::NullOrNothing
             } else {
                 Primitive::String(alias)
             }

--- a/compiler/crates/relay-codegen/src/printer.rs
+++ b/compiler/crates/relay-codegen/src/printer.rs
@@ -192,6 +192,7 @@ pub struct JSONPrinter<'b> {
     eager_es_modules: bool,
     js_module_format: JsModuleFormat,
     top_level_statements: &'b mut TopLevelStatements,
+    skip_printing_nulls: bool,
 }
 
 impl<'b> JSONPrinter<'b> {
@@ -207,6 +208,10 @@ impl<'b> JSONPrinter<'b> {
             builder,
             js_module_format: project_config.js_module_format,
             eager_es_modules: project_config.typegen_config.eager_es_modules,
+            skip_printing_nulls: project_config
+                .feature_flags
+                .skip_printing_nulls
+                .is_fully_enabled(),
         }
     }
 
@@ -306,6 +311,10 @@ impl<'b> JSONPrinter<'b> {
                     let next_indent = indent + 1;
                     f.push('{');
                     for ObjectEntry { key, value } in object {
+                        match value {
+                            Primitive::NullOrNothing if self.skip_printing_nulls => continue,
+                            _ => (),
+                        }
                         f.push('\n');
                         print_indentation(f, next_indent);
                         write!(f, "\"{}\": ", key).unwrap();
@@ -333,6 +342,10 @@ impl<'b> JSONPrinter<'b> {
                     f.push('[');
                     let next_indent = indent + 1;
                     for value in array {
+                        match value {
+                            Primitive::NullOrNothing if self.skip_printing_nulls => continue,
+                            _ => (),
+                        }
                         f.push('\n');
                         print_indentation(f, next_indent);
                         self.print_primitive(f, value, next_indent, is_dedupe_var)
@@ -356,7 +369,7 @@ impl<'b> JSONPrinter<'b> {
         is_dedupe_var: bool,
     ) -> FmtResult {
         match primitive {
-            Primitive::Null => write!(f, "null"),
+            Primitive::Null | Primitive::NullOrNothing => write!(f, "null"),
             Primitive::Bool(b) => write!(f, "{}", if *b { "true" } else { "false" }),
             Primitive::RawString(str) => {
                 f.push('\"');
@@ -545,7 +558,7 @@ fn write_constant_value(f: &mut String, builder: &AstBuilder, value: &Primitive)
                 }
             }
         }
-        Primitive::Null => {
+        Primitive::Null | Primitive::NullOrNothing => {
             f.push_str("null");
             Ok(())
         }

--- a/compiler/crates/relay-codegen/tests/skip_printing_nulls/fixtures/kitchen-sink.expected
+++ b/compiler/crates/relay-codegen/tests/skip_printing_nulls/fixtures/kitchen-sink.expected
@@ -1,0 +1,309 @@
+==================================== INPUT ====================================
+query NodeQuery($id: ID!, $cond: Boolean!, $PictureSize: [Int]!) {
+  node(id: $id) {
+    id
+    ... on User @include(if: $cond) {
+      name
+    }
+    ...UserFragment @include(if: $cond) @arguments(size: $PictureSize)
+  }
+}
+
+fragment UserFragment on User
+  @argumentDefinitions(
+    after: {type: "ID"}
+    cond: {type: "Boolean!", defaultValue: false}
+    first: {type: "Int", defaultValue: 5}
+    size: {type: "[Int]"}
+    scale: {type: "Float", defaultValue: 2.0}
+  ) {
+  id
+  __typename
+  friends(after: $after, first: $first) {
+    count
+  }
+  name @include(if: $cond)
+  thumbnail: profilePicture(size: 32) {
+    height
+    width
+    src: uri
+  }
+  profilePicture(size: $size) {
+    height
+    width
+    src: uri
+  }
+  profile_picture(scale: $scale) {
+    height
+    width
+    src: uri
+  }
+  scaled: profilePicture(size: $PictureSize) {
+    uri
+  }
+}
+==================================== OUTPUT ===================================
+{
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "id"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "cond"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "PictureSize"
+    }
+  ],
+  "kind": "Operation",
+  "name": "NodeQuery",
+  "selections": [
+    {
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "id",
+          "variableName": "id"
+        }
+      ],
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "name": "id"
+        },
+        {
+          "condition": "cond",
+          "kind": "Condition",
+          "passingValue": true,
+          "selections": [
+            {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "name": "name"
+                }
+              ],
+              "type": "User"
+            }
+          ]
+        },
+        {
+          "condition": "cond",
+          "kind": "Condition",
+          "passingValue": true,
+          "selections": [
+            {
+              "args": [
+                {
+                  "kind": "Variable",
+                  "name": "size",
+                  "variableName": "PictureSize"
+                }
+              ],
+              "kind": "FragmentSpread",
+              "name": "UserFragment"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+{
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "PictureSize"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": false,
+      "kind": "LocalArgument",
+      "name": "cond"
+    },
+    {
+      "defaultValue": 5,
+      "kind": "LocalArgument",
+      "name": "first"
+    },
+    {
+      "defaultValue": 2,
+      "kind": "LocalArgument",
+      "name": "scale"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "size"
+    }
+  ],
+  "kind": "Fragment",
+  "name": "UserFragment",
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "name": "id"
+    },
+    {
+      "kind": "ScalarField",
+      "name": "__typename"
+    },
+    {
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "after",
+          "variableName": "after"
+        },
+        {
+          "kind": "Variable",
+          "name": "first",
+          "variableName": "first"
+        }
+      ],
+      "concreteType": "FriendsConnection",
+      "kind": "LinkedField",
+      "name": "friends",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "name": "count"
+        }
+      ]
+    },
+    {
+      "condition": "cond",
+      "kind": "Condition",
+      "passingValue": true,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "alias": "thumbnail",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 32
+        }
+      ],
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "profilePicture",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "name": "height"
+        },
+        {
+          "kind": "ScalarField",
+          "name": "width"
+        },
+        {
+          "alias": "src",
+          "kind": "ScalarField",
+          "name": "uri"
+        }
+      ],
+      "storageKey": "profilePicture(size:32)"
+    },
+    {
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "size",
+          "variableName": "size"
+        }
+      ],
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "profilePicture",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "name": "height"
+        },
+        {
+          "kind": "ScalarField",
+          "name": "width"
+        },
+        {
+          "alias": "src",
+          "kind": "ScalarField",
+          "name": "uri"
+        }
+      ]
+    },
+    {
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "scale",
+          "variableName": "scale"
+        }
+      ],
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "profile_picture",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "name": "height"
+        },
+        {
+          "kind": "ScalarField",
+          "name": "width"
+        },
+        {
+          "alias": "src",
+          "kind": "ScalarField",
+          "name": "uri"
+        }
+      ]
+    },
+    {
+      "alias": "scaled",
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "size",
+          "variableName": "PictureSize"
+        }
+      ],
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "profilePicture",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "name": "uri"
+        }
+      ]
+    }
+  ],
+  "type": "User"
+}

--- a/compiler/crates/relay-codegen/tests/skip_printing_nulls/fixtures/kitchen-sink.graphql
+++ b/compiler/crates/relay-codegen/tests/skip_printing_nulls/fixtures/kitchen-sink.graphql
@@ -1,0 +1,43 @@
+query NodeQuery($id: ID!, $cond: Boolean!, $PictureSize: [Int]!) {
+  node(id: $id) {
+    id
+    ... on User @include(if: $cond) {
+      name
+    }
+    ...UserFragment @include(if: $cond) @arguments(size: $PictureSize)
+  }
+}
+
+fragment UserFragment on User
+  @argumentDefinitions(
+    after: {type: "ID"}
+    cond: {type: "Boolean!", defaultValue: false}
+    first: {type: "Int", defaultValue: 5}
+    size: {type: "[Int]"}
+    scale: {type: "Float", defaultValue: 2.0}
+  ) {
+  id
+  __typename
+  friends(after: $after, first: $first) {
+    count
+  }
+  name @include(if: $cond)
+  thumbnail: profilePicture(size: 32) {
+    height
+    width
+    src: uri
+  }
+  profilePicture(size: $size) {
+    height
+    width
+    src: uri
+  }
+  profile_picture(scale: $scale) {
+    height
+    width
+    src: uri
+  }
+  scaled: profilePicture(size: $PictureSize) {
+    uri
+  }
+}

--- a/compiler/crates/relay-codegen/tests/skip_printing_nulls/mod.rs
+++ b/compiler/crates/relay-codegen/tests/skip_printing_nulls/mod.rs
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use common::SourceLocationKey;
+use fixture_tests::Fixture;
+use graphql_ir::{build, ExecutableDefinition};
+use graphql_syntax::parse_executable;
+use relay_codegen::{print_fragment, print_operation};
+use relay_config::ProjectConfig;
+use relay_test_schema::TEST_SCHEMA;
+use common::{FeatureFlag,FeatureFlags};
+use std::sync::Arc;
+
+pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+    let ast = parse_executable(
+        fixture.content,
+        SourceLocationKey::standalone(fixture.file_name),
+    )
+    .unwrap();
+    let feature_flags = FeatureFlags {
+        skip_printing_nulls: FeatureFlag::Enabled,
+        ..Default::default()
+    };
+
+    build(&TEST_SCHEMA, &ast.definitions)
+        .map(|definitions| {
+            definitions
+                .iter()
+                .map(|def| match def {
+                    ExecutableDefinition::Operation(operation) => {
+                        let mut import_statements = Default::default();
+
+                        let operation = print_operation(
+                            &TEST_SCHEMA,
+                            operation,
+                            &ProjectConfig {
+                                feature_flags: Arc::new(feature_flags.clone()),
+                                ..Default::default()
+                            },
+                            &mut import_statements,
+                        );
+                        format!("{}{}", import_statements, operation)
+                    }
+                    ExecutableDefinition::Fragment(fragment) => {
+                        let mut import_statements = Default::default();
+
+                        let fragment = print_fragment(
+                            &TEST_SCHEMA,
+                            fragment,
+                            &ProjectConfig {
+                                feature_flags: Arc::new(feature_flags.clone()),
+                                ..Default::default()
+                            },
+                            &mut import_statements,
+                        );
+                        format!("{}{}", import_statements, fragment)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n")
+        })
+        .map_err(|errors| {
+            errors
+                .into_iter()
+                .map(|error| format!("{:?}", error))
+                .collect::<Vec<_>>()
+                .join("\n\n")
+        })
+}

--- a/compiler/crates/relay-codegen/tests/skip_printing_nulls_test.rs
+++ b/compiler/crates/relay-codegen/tests/skip_printing_nulls_test.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<c76fde417081b2595591a1ffa8f5fa64>>
+ */
+
+mod skip_printing_nulls;
+
+use skip_printing_nulls::transform_fixture;
+use fixture_tests::test_fixture;
+
+#[test]
+fn kitchen_sink() {
+    let input = include_str!("skip_printing_nulls/fixtures/kitchen-sink.graphql");
+    let expected = include_str!("skip_printing_nulls/fixtures/kitchen-sink.expected");
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "skip_printing_nulls/fixtures/kitchen-sink.expected", input, expected);
+}

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
@@ -46,6 +46,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         text_artifacts: FeatureFlag::Disabled,
         enable_client_edges: FeatureFlag::Enabled,
         enable_provided_variables: FeatureFlag::Enabled,
+        skip_printing_nulls: FeatureFlag::Disabled,
     };
 
     let default_project_config = ProjectConfig {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id/mod.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id/mod.rs
@@ -75,6 +75,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         text_artifacts: FeatureFlag::Disabled,
         enable_client_edges: FeatureFlag::Enabled,
         enable_provided_variables: FeatureFlag::Enabled,
+        skip_printing_nulls: FeatureFlag::Disabled,
     };
 
     let project_config = ProjectConfig {

--- a/packages/relay-runtime/util/NormalizationNode.js
+++ b/packages/relay-runtime/util/NormalizationNode.js
@@ -31,27 +31,27 @@ export type NormalizationHandle =
 
 export type NormalizationLinkedHandle = {|
   +kind: 'LinkedHandle',
-  +alias: ?string,
+  +alias?: ?string,
   +name: string,
-  +args: ?$ReadOnlyArray<NormalizationArgument>,
+  +args?: ?$ReadOnlyArray<NormalizationArgument>,
   +handle: string,
   +key: string,
   // NOTE: this property is optional because it's expected to be rarely used
   +dynamicKey?: ?NormalizationArgument,
-  +filters: ?$ReadOnlyArray<string>,
+  +filters?: ?$ReadOnlyArray<string>,
   +handleArgs?: $ReadOnlyArray<NormalizationArgument>,
 |};
 
 export type NormalizationScalarHandle = {|
   +kind: 'ScalarHandle',
-  +alias: ?string,
+  +alias?: ?string,
   +name: string,
-  +args: ?$ReadOnlyArray<NormalizationArgument>,
+  +args?: ?$ReadOnlyArray<NormalizationArgument>,
   +handle: string,
   +key: string,
   // NOTE: this property is optional because it's expected to be rarely used
   +dynamicKey?: ?NormalizationArgument,
-  +filters: ?$ReadOnlyArray<string>,
+  +filters?: ?$ReadOnlyArray<string>,
   +handleArgs?: $ReadOnlyArray<NormalizationArgument>,
 |};
 
@@ -82,22 +82,22 @@ export type NormalizationInlineFragment = {|
   +kind: 'InlineFragment',
   +selections: $ReadOnlyArray<NormalizationSelection>,
   +type: string,
-  +abstractKey: ?string,
+  +abstractKey?: ?string,
 |};
 
 export type NormalizationFragmentSpread = {|
   +kind: 'FragmentSpread',
   +fragment: NormalizationSplitOperation,
-  +args: ?$ReadOnlyArray<NormalizationArgument>,
+  +args?: ?$ReadOnlyArray<NormalizationArgument>,
 |};
 
 export type NormalizationLinkedField = {|
   +kind: 'LinkedField',
-  +alias: ?string,
+  +alias?: ?string,
   +name: string,
-  +storageKey: ?string,
-  +args: ?$ReadOnlyArray<NormalizationArgument>,
-  +concreteType: ?string,
+  +storageKey?: ?string,
+  +args?: ?$ReadOnlyArray<NormalizationArgument>,
+  +concreteType?: ?string,
   +plural: boolean,
   +selections: $ReadOnlyArray<NormalizationSelection>,
 |};
@@ -108,7 +108,7 @@ export type NormalizationActorChange = {|
 |};
 
 export type NormalizationModuleImport = {|
-  +args: ?$ReadOnlyArray<NormalizationArgument>,
+  +args?: ?$ReadOnlyArray<NormalizationArgument>,
   +kind: 'ModuleImport',
   +documentName: string,
   +fragmentPropName: string,
@@ -146,10 +146,10 @@ export type NormalizationNode =
 
 export type NormalizationScalarField = {|
   +kind: 'ScalarField',
-  +alias: ?string,
+  +alias?: ?string,
   +name: string,
-  +args: ?$ReadOnlyArray<NormalizationArgument>,
-  +storageKey: ?string,
+  +args?: ?$ReadOnlyArray<NormalizationArgument>,
+  +storageKey?: ?string,
 |};
 
 export type NormalizationFlightField = {|

--- a/packages/relay-runtime/util/ReaderNode.js
+++ b/packages/relay-runtime/util/ReaderNode.js
@@ -18,7 +18,7 @@ import type {ConcreteRequest} from './RelayConcreteNode';
 export type ReaderFragmentSpread = {|
   +kind: 'FragmentSpread',
   +name: string,
-  +args: ?$ReadOnlyArray<ReaderArgument>,
+  +args?: ?$ReadOnlyArray<ReaderArgument>,
 |};
 
 export type ReaderInlineDataFragmentSpread = {|
@@ -31,8 +31,8 @@ export type ReaderFragment = {|
   +kind: 'Fragment',
   +name: string,
   +type: string,
-  +abstractKey: ?string,
-  +metadata: ?{|
+  +abstractKey?: ?string,
+  +metadata?: ?{|
     +connection?: $ReadOnlyArray<ConnectionMetadata>,
     +mask?: boolean,
     +plural?: boolean,
@@ -64,7 +64,7 @@ export type ReaderPaginationFragment = {|
 |};
 
 export type ReaderRefetchMetadata = {|
-  +connection: ?ReaderPaginationMetadata,
+  +connection?: ?ReaderPaginationMetadata,
   +operation: string | ConcreteRequest,
   +fragmentPathInResult: Array<string>,
   +identifierField?: ?string,
@@ -122,26 +122,26 @@ export type ReaderInlineFragment = {|
   +kind: 'InlineFragment',
   +selections: $ReadOnlyArray<ReaderSelection>,
   +type: string,
-  +abstractKey: ?string,
+  +abstractKey?: ?string,
 |};
 
 export type ReaderLinkedField = {|
   +kind: 'LinkedField',
-  +alias: ?string,
+  +alias?: ?string,
   +name: string,
-  +storageKey: ?string,
-  +args: ?$ReadOnlyArray<ReaderArgument>,
-  +concreteType: ?string,
+  +storageKey?: ?string,
+  +args?: ?$ReadOnlyArray<ReaderArgument>,
+  +concreteType?: ?string,
   +plural: boolean,
   +selections: $ReadOnlyArray<ReaderSelection>,
 |};
 
 export type ReaderActorChange = {|
   +kind: 'ActorChange',
-  +alias: ?string,
+  +alias?: ?string,
   +name: string,
-  +storageKey: ?string,
-  +args: ?$ReadOnlyArray<ReaderArgument>,
+  +storageKey?: ?string,
+  +args?: ?$ReadOnlyArray<ReaderArgument>,
   +fragmentSpread: ReaderFragmentSpread,
 |};
 
@@ -186,10 +186,10 @@ export type ReaderNode =
 
 export type ReaderScalarField = {|
   +kind: 'ScalarField',
-  +alias: ?string,
+  +alias?: ?string,
   +name: string,
-  +args: ?$ReadOnlyArray<ReaderArgument>,
-  +storageKey: ?string,
+  +args?: ?$ReadOnlyArray<ReaderArgument>,
+  +storageKey?: ?string,
 |};
 
 export type ReaderFlightField = {|


### PR DESCRIPTION
Hey folks 👋

We at Atlassian have some bundle size tooling that was flagging a larger query contributing about 200KB to our page load. That tooling _isn't_ compression aware, so the actual size is more like 9KB when gzipped so it's not too big of a concern.

But it got me looking at what contributes to that size, and what we can do to reduce it. I noticed that the majority of metadata is null values. Whilst these compress really well, they still contribute a lot of unnecessary extra bytes over the wire. Removing these nulls reduces our gzipped metadata size by about 1/3.

The code in `relay-runtime` uses loose equality, either as `field.X != null`, or `field.X ?? default`, or `if (field.X) {`, which means that we can safely remove these fields over the wire without runtime changes. 

As you can see by the stats on this PR, this removes a lot of LOC. Even though each individual impact is small, the number of queries / fragments involved mean it will probably have a decent production impact. For you at Meta, with persisted queries, it should look even better than our 1/3 reduction.

This PR addresses the following fields:
 - `"alias": null`
 - `"args": null`
 - `"concreteType": null`
 - `"storageKey": null`
 - `"abstractKey": null`
 - `"metadata": null`
 - `"plural": false`. Most fields are non-plural, so we can use non-plural as a default

### Rust compiler
In the rust compiler, this was quite easy to achieve. Instead of building objects as `object(items: Vec<ObjectEntry>)`, I've replaced these with `object_filter_none(items: Vec<Option<ObjectEntry>>)` which then filters out None values. Replacing `Primitive::Null` values with a None just means inverting where the test happens.

### JS compiler
In the JS compiler, I've currently maintained the field order so that the snapshot diffs are clear. But I've also currently scattered a lot of $FlowFixMes there. Just want to check the approach first.

The JS compiler uses the same types as the runtime. Those types are all currently read-only, exact objects. This makes it a little difficult to "build" the fields / nodes

```
const field = {
    alias: null // works with read-only
}
if (needs_alias){
    field.alias = alias // needs to be writable now
}
```

There's a few options here:
 - Move the `read-only` from field variance (`+alias: ?string`) to the utility `$ReadOnly<>`.
 - Move all the `$ReadOnly` annotations off the shared types and into the runtime (so the runtime can't write fields, but the shared types become writable for `relay-compiler` to use)
 - Use `$Shape<>` to build the objects in `relay-compiler` and then assert their output types after building them (don't let non-exact or writable types escape the functions in ReaderCodeGenerator, NormalizationCodeGenerator, but treat them as in-exact / writable within).
 - Use object spreads (as some fields like handleArgs already do) and maybe stableSort the snapshots so the fields output consitently


### Questions
This is a large PR right now. I'll break this down into clearer steps in order to ship it, but I wanted feedback before I go ahead with that. Questions:
 - Are you happy to accept a contribution to remove these `null`s from the metadata sent to the client?
 - Which fields does this make sense for? I.e. `plural` might be stretching it a bit far.
 - Would you like me to feature flag this?
 - Any suggestions on how you'd like the Normalization* and Reader* types to look if I change them to be more amenable to allowing field writing in the JS compiler.

