### PR TITLE
Fix version of the GraphQL.js version to 15.3.0 in babel-plugin-relay

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fbjs": "^3.0.0",
     "flow-bin": "^0.163.0",
     "glob": "^7.1.1",
-    "graphql": "^15.0.0",
+    "graphql": "15.3.0",
     "gulp": "4.0.2",
     "gulp-babel": "8.0.0",
     "gulp-chmod": "3.0.0",

--- a/packages/babel-plugin-relay/package.json
+++ b/packages/babel-plugin-relay/package.json
@@ -13,13 +13,11 @@
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
   "dependencies": {
-    "babel-plugin-macros": "^2.0.0"
+    "babel-plugin-macros": "^2.0.0",
+    "graphql": "15.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",
     "prettier": "^2.4.1"
-  },
-  "peerDependencies": {
-    "graphql": "^15.0.0"
   }
 }

--- a/packages/babel-plugin-relay/yarn.lock
+++ b/packages/babel-plugin-relay/yarn.lock
@@ -325,6 +325,11 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
+graphql@15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
+  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3610,7 +3610,12 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-"graphql@^14.0.0 || ^15.0.0-rc.1", graphql@^15.0.0:
+graphql@15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
+  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
+
+"graphql@^14.0.0 || ^15.0.0-rc.1":
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
   integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==


### PR DESCRIPTION
The goals here is to:

1) Make sure that the output of the parse/print in `babel-plugin-relay` is matches the output we have in the rust version of the compiler. And I think in 15.3.0 it matches. This should resolve: https://github.com/facebook/relay/issues/3437

2) With the release on new Rust based compiler we no longer need to include `graphql-js` as a peer dependency in the `relay-compiler`, so we can update our installation instructions and remove `graphql-js` from there.

Eventually, since we're only using parse/print functions from `graphql-js` here it is probably make sense to just inline them here.
 