### PR TITLE
[relay-compiler] Inline test-utils in JS relay compiler, update dependencies in test-utils/relay-compiler pacakges  

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fbjs": "^3.0.0",
     "flow-bin": "^0.163.0",
     "glob": "^7.1.1",
-    "graphql": "^15.0.0",
+    "graphql": "15.3.0",
     "gulp": "4.0.2",
     "gulp-babel": "8.0.0",
     "gulp-chmod": "3.0.0",

--- a/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
+++ b/packages/relay-compiler/bin/__tests__/RelayCompilerMain-test.js
@@ -17,7 +17,7 @@ const {
 const RelayLanguagePluginJavaScript = require('../../language/javascript/RelayLanguagePluginJavaScript');
 const RelayCompilerMain = require('../RelayCompilerMain');
 const path = require('path');
-const {testSchemaPath} = require('relay-test-utils-internal');
+const {testSchemaPath} = require('../../test-utils/TestSchema');
 
 const {getCodegenRunner, getLanguagePlugin, getWatchConfig, main} =
   RelayCompilerMain;
@@ -26,6 +26,7 @@ jest.mock('../../codegen/RelayFileWriter');
 jest.mock('../../core/GraphQLWatchmanClient');
 
 isWatchmanAvailable.mockImplementation(() => Promise.resolve(true));
+
 
 describe('RelayCompilerMain', () => {
   let config;

--- a/packages/relay-compiler/codegen/__tests__/compileRelayArtifacts-test.js
+++ b/packages/relay-compiler/codegen/__tests__/compileRelayArtifacts-test.js
@@ -18,10 +18,11 @@ const RelayIRTransforms = require('../../core/RelayIRTransforms');
 const CodeMarker = require('../../util/CodeMarker');
 const compileRelayArtifacts = require('../compileRelayArtifacts');
 const {RelayFeatureFlags} = require('relay-runtime');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
+
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
   printAST,
 } = require('relay-test-utils-internal');
 

--- a/packages/relay-compiler/core/RelayFindGraphQLTags.js
+++ b/packages/relay-compiler/core/RelayFindGraphQLTags.js
@@ -106,7 +106,7 @@ function validateTemplate(
 }
 
 // TODO: Not sure why this is defined here rather than imported, is it so that it doesn’t get stripped in prod?
-function invariant(condition, msg: $FlowFixMeEmpty, ...args) {
+function invariant(condition, msg: $FlowFixMe, ...args) {
   if (!condition) {
     throw new Error(util.format(msg, ...args));
   }

--- a/packages/relay-compiler/core/RelayParser.js
+++ b/packages/relay-compiler/core/RelayParser.js
@@ -11,7 +11,7 @@
 // flowlint ambiguous-object-type:error
 
 'use strict';
-import type {ObjectFieldNode} from '../../../../../../node_modules/graphql/language/ast.js';
+import type {ObjectFieldNode} from 'graphql/language/ast.js';
 
 import type {GetFieldDefinitionFn} from './getFieldDefinition';
 import type {

--- a/packages/relay-compiler/core/__tests__/CompilerContext-test.js
+++ b/packages/relay-compiler/core/__tests__/CompilerContext-test.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const {TestSchema} = require('relay-test-utils-internal');
+const {TestSchema} = require('../../test-utils/TestSchema');
 
 describe('CompilerContext', () => {
   let CompilerContext;

--- a/packages/relay-compiler/core/__tests__/IRPrinter-test.js
+++ b/packages/relay-compiler/core/__tests__/IRPrinter-test.js
@@ -16,8 +16,8 @@
 const CompilerContext = require('../CompilerContext');
 const IRPrinter = require('../IRPrinter');
 const RelayParser = require('../RelayParser');
+const {TestSchema} = require('../../test-utils/TestSchema');
 const {
-  TestSchema,
   generateTestsFromFixtures,
 } = require('relay-test-utils-internal');
 

--- a/packages/relay-compiler/core/__tests__/IRTransformer-test.js
+++ b/packages/relay-compiler/core/__tests__/IRTransformer-test.js
@@ -15,7 +15,8 @@
 
 const CompilerContext = require('../CompilerContext');
 const IRTransformer = require('../IRTransformer');
-const {TestSchema, parseGraphQLText} = require('relay-test-utils-internal');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 
 describe('IRTransformer', () => {
   it('visits all node types', () => {

--- a/packages/relay-compiler/core/__tests__/IRValidator-test.js
+++ b/packages/relay-compiler/core/__tests__/IRValidator-test.js
@@ -16,7 +16,8 @@
 const CompilerContext = require('../CompilerContext');
 const IRTransformer = require('../IRTransformer');
 const IRValidator = require('../IRValidator');
-const {TestSchema, parseGraphQLText} = require('relay-test-utils-internal');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 
 describe('IRValidator', () => {
   it('should have same behavior as the IRTransformer', () => {

--- a/packages/relay-compiler/core/__tests__/IRVisitor-test.js
+++ b/packages/relay-compiler/core/__tests__/IRVisitor-test.js
@@ -30,8 +30,9 @@ import type {
 const IRPrinter = require('../IRPrinter');
 const {visit} = require('../IRVisitor');
 const RelayParser = require('../RelayParser');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
 } = require('relay-test-utils-internal');
 

--- a/packages/relay-compiler/core/__tests__/RelayCompilerScope-test.js
+++ b/packages/relay-compiler/core/__tests__/RelayCompilerScope-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const {getFragmentScope, getRootScope} = require('../RelayCompilerScope');
-const {TestSchema} = require('relay-test-utils-internal');
+const {TestSchema} = require('../../test-utils/TestSchema');
 
 describe('scope', () => {
   const schema = TestSchema;

--- a/packages/relay-compiler/core/__tests__/RelayParser-test.js
+++ b/packages/relay-compiler/core/__tests__/RelayParser-test.js
@@ -15,8 +15,9 @@
 
 const MatchTransform = require('../../transforms/MatchTransform');
 const RelayParser = require('../RelayParser');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
   printAST,
 } = require('relay-test-utils-internal');

--- a/packages/relay-compiler/core/__tests__/filterContextForNode-test.js
+++ b/packages/relay-compiler/core/__tests__/filterContextForNode-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../CompilerContext');
 const filterContextForNode = require('../filterContextForNode');
 const IRPrinter = require('../IRPrinter');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 const MAIN_QUERY_NAME = 'MainQuery';

--- a/packages/relay-compiler/core/getFieldDefinition.js
+++ b/packages/relay-compiler/core/getFieldDefinition.js
@@ -14,7 +14,7 @@
 import type {
   DirectiveNode,
   ArgumentNode,
-} from '../../../../../../node_modules/graphql/language/ast.js';
+} from 'graphql/language/ast';
 
 import type {FieldID, Schema, TypeID} from './Schema';
 import type {FieldNode} from 'graphql';

--- a/packages/relay-compiler/language/javascript/__tests__/RelayFlowGenerator-test.js
+++ b/packages/relay-compiler/language/javascript/__tests__/RelayFlowGenerator-test.js
@@ -19,10 +19,10 @@ const CompilerContext = require('../../../core/CompilerContext');
 const RelayIRTransforms = require('../../../core/RelayIRTransforms');
 const RelayFlowGenerator = require('../RelayFlowGenerator');
 const {RelayFeatureFlags} = require('relay-runtime');
+const {TestSchema} = require('../../../test-utils/TestSchema');
+const parseGraphQLText = require('../../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 function generate(text, options: TypeGeneratorOptions, context?) {

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -31,9 +31,7 @@
     "nullthrows": "^1.1.1",
     "relay-runtime": "12.0.0",
     "signedsource": "^1.0.0",
-    "yargs": "^15.3.1"
-  },
-  "peerDependencies": {
-    "graphql": "^15.0.0"
+    "yargs": "^15.3.1",
+    "graphql": "15.3.0"
   }
 }

--- a/packages/relay-compiler/test-utils/TestSchema.js
+++ b/packages/relay-compiler/test-utils/TestSchema.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// flowlint ambiguous-object-type:error
+
+'use strict';
+
+import type {Schema} from '../core/Schema';
+
+const fs = require('fs');
+const {Source} = require('graphql');
+const path = require('path');
+const {
+  create
+} = require('../core/Schema');
+
+const testSchemaPath = (path.join(__dirname, 'testschema.graphql'): string);
+
+module.exports = ({
+  TestSchema: create(new Source(fs.readFileSync(testSchemaPath, 'utf8'))),
+  testSchemaPath,
+}: {|
+  +TestSchema: Schema,
+  +testSchemaPath: string,
+|});

--- a/packages/relay-compiler/test-utils/parseGraphQLText.js
+++ b/packages/relay-compiler/test-utils/parseGraphQLText.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// flowlint ambiguous-object-type:error
+
+'use strict';
+
+import type {Fragment, Root, Schema} from '../';
+
+const {parse} = require('graphql');
+const {Parser, convertASTDocuments} = require('../');
+
+function parseGraphQLText(
+  schema: Schema,
+  text: string,
+): {
+  definitions: $ReadOnlyArray<Fragment | Root>,
+  schema: Schema,
+  ...
+} {
+  const ast = parse(text);
+  const extendedSchema = schema.extend(ast);
+  const definitions = convertASTDocuments(
+    extendedSchema,
+    [ast],
+    Parser.transform.bind(Parser),
+  );
+  return {
+    definitions,
+    schema: extendedSchema,
+  };
+}
+
+module.exports = parseGraphQLText;

--- a/packages/relay-compiler/test-utils/testschema.graphql
+++ b/packages/relay-compiler/test-utils/testschema.graphql
@@ -1,0 +1,1248 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+directive @customDirective(level: Int!) on FIELD
+
+directive @fixme_fat_interface on FIELD
+
+directive @defer(
+  label: String!
+  if: Boolean = true
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @stream(
+  label: String!
+  initial_count: Int!
+  if: Boolean = true
+  use_customized_batch: Boolean = false
+) on FIELD
+
+directive @fetchable(field_name: String!) on OBJECT
+
+directive @relay_client_component_server(module_id: String!) on FRAGMENT_SPREAD
+
+directive @fb_actor_change on FIELD
+
+directive @live_query(
+  enabled: Boolean = true
+  polling_interval: Int
+  config_id: String
+  partial: Boolean
+  event_stream: String
+) on QUERY
+
+type Query {
+  checkinSearchQuery(query: CheckinSearchInput): CheckinSearchResult
+  defaultSettings: Settings
+  route(waypoints: [WayPoint!]!): Route
+  items(filter: ItemFilterInput): ItemFilterResult
+  maybeNodeInterface: MaybeNodeInterface
+  maybeNode: MaybeNode
+  neverNode: NeverNode
+  named: Named
+  me: User
+  node(id: ID): Node
+  node_id_required(id: ID!): Node
+  nodes(ids: [ID!]): [Node]
+  settings(environment: Environment): Settings
+  story: Story
+  task(number: Int): Task
+  username(name: String!): Actor
+  usernames(names: [String!]!): [Actor]
+  viewer: Viewer
+  _mutation: Mutation
+  fetch__User(id: ID!): User
+  fetch__NonNodeStory(input_fetch_id: ID!): NonNodeStory
+  nonNodeStory(id: ID!): NonNodeStory
+  userOrPage(id: ID!): UserOrPage
+}
+
+union UserOrPage = User | Page
+
+interface MaybeNodeInterface {
+  name: String
+}
+
+scalar JSON
+
+union MaybeNode = Story | FakeNode | NonNode
+
+interface AllConcreteTypesImplementNode {
+  count: Int
+}
+
+type FakeNode {
+  id: ID!
+}
+
+type NonNode {
+  id: String
+  name: String
+}
+
+type NonNodeNoID implements MaybeNodeInterface {
+  name: String
+}
+
+union NeverNode = FakeNode | NonNode
+
+type Task {
+  title: String
+}
+
+input WayPoint {
+  lat: String
+  lon: String
+}
+
+type Route {
+  steps: [RouteStep]
+}
+
+type RouteStep {
+  lat: String
+  lon: String
+  note: String
+}
+
+type Mutation {
+  actorSubscribe(input: ActorSubscribeInput): ActorSubscribeResponsePayload
+  actorNameChange(input: ActorNameChangeInput): ActorNameChangePayload
+  applicationRequestDeleteAll(
+    input: ApplicationRequestDeleteAllInput
+  ): ApplicationRequestDeleteAllResponsePayload
+  commentCreate(input: CommentCreateInput): CommentCreateResponsePayload
+  commentsCreate(input: CommentsCreateInput): CommentsCreateResponsePayload
+  commentDelete(input: CommentDeleteInput): CommentDeleteResponsePayload
+  commentsDelete(input: CommentsDeleteInput): CommentsDeleteResponsePayload
+  feedbackLike(input: FeedbackLikeInput): FeedbackLikeResponsePayload
+  feedbackLikeStrict(
+    input: FeedbackLikeInputStrict!
+  ): FeedbackLikeResponsePayload
+  feedbackLikeSubscribe(input: FeedbackLikeInput): FeedbackLikeResponsePayload
+  nodeSavedState(input: NodeSaveStateInput): NodeSavedStateResponsePayload
+  unfriend(input: UnfriendInput): UnfriendResponsePayload
+  viewerNotificationsUpdateAllSeenState(
+    input: UpdateAllSeenStateInput
+  ): ViewerNotificationsUpdateAllSeenStateResponsePayload
+  setLocation(input: LocationInput): setLocationResponsePayload
+  storyUpdate(input: StoryUpdateInput): StoryUpdateResponsePayload
+}
+
+type Subscription {
+  feedbackLikeSubscribe(input: FeedbackLikeInput): FeedbackLikeResponsePayload
+  commentCreateSubscribe(
+    input: CommentCreateSubscriptionInput
+  ): CommentCreateResponsePayload
+  configCreateSubscribe: ConfigCreateSubscriptResponsePayload
+}
+
+input ActorSubscribeInput {
+  clientMutationId: String
+  subscribeeId: ID
+}
+
+input ActorNameChangeInput {
+  clientMutationId: String
+  newName: String
+}
+
+input ApplicationRequestDeleteAllInput {
+  clientMutationId: String
+  deletedRequestIds: [ID]
+}
+
+input CommentCreateInput {
+  clientMutationId: String
+  feedbackId: ID
+  feedback: CommentfeedbackFeedback
+}
+
+input CommentsCreateInput {
+  clientMutationId: String
+  feedbackId: ID
+  feedback: [CommentfeedbackFeedback]
+}
+
+input CommentfeedbackFeedback {
+  comment: FeedbackcommentComment
+}
+
+input FeedbackcommentComment {
+  feedback: CommentfeedbackFeedback
+}
+
+input CommentCreateSubscriptionInput {
+  clientSubscriptionId: String
+  feedbackId: ID
+  text: String
+}
+
+input CommentDeleteInput {
+  clientMutationId: String
+  commentId: ID
+}
+
+input CommentsDeleteInput {
+  clientMutationId: String
+  commentIds: [ID]
+}
+
+input FeedbackLikeInput {
+  clientMutationId: String
+  feedbackId: ID
+}
+
+input FeedbackLikeInputStrict {
+  userID: ID!
+  clientMutationId: ID!
+  feedbackId: ID!
+  description: String
+}
+
+input NodeSaveStateInput {
+  clientMutationId: String
+  nodeId: ID
+}
+
+input UpdateAllSeenStateInput {
+  clientMutationId: String
+  storyIds: [ID]
+}
+
+input LocationInput {
+  longitude: Float
+  latitude: Float
+}
+
+type setLocationResponsePayload {
+  clientMutationId: String
+  viewer: Viewer
+}
+
+type ActorSubscribeResponsePayload {
+  clientMutationId: String
+  subscribee: Actor
+}
+
+type ActorNameChangePayload {
+  clientMutationId: String
+  actor: Actor
+}
+
+type ApplicationRequestDeleteAllResponsePayload {
+  clientMutationId: String
+  deletedRequestIds: [ID]
+}
+
+type CheckinSearchResult {
+  query: String
+}
+
+input CheckinSearchInput {
+  query: String
+  inputs: [CheckinSearchInput]
+}
+
+input StoryUpdateInput {
+  clientMutationId: String
+  body: InputText
+}
+
+type PlainCommentBody {
+  text: Text
+}
+
+type MarkdownCommentBody {
+  text: Text
+}
+
+union CommentBody = PlainCommentBody | MarkdownCommentBody
+
+type Comment implements Node {
+  actor: Actor
+  actors: [Actor]
+  actorCount: Int
+  address: StreetAddress
+  allPhones: [Phone]
+  author: User
+  backgroundImage: Image
+  birthdate: Date
+  body: Text
+  canViewerComment: Boolean
+  canViewerLike: Boolean
+  commentBody(supported: [String!]!): CommentBody
+  comments(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: String
+  ): CommentsConnection
+  doesViewerLike: Boolean
+  emailAddresses: [String]
+  feedback: Feedback
+  firstName(if: Boolean, unless: Boolean): String
+  friends(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: [String]
+    find: String
+    isViewerFriend: Boolean
+    if: Boolean
+    unless: Boolean
+    traits: [PersonalityTraits]
+  ): FriendsConnection
+  hometown: Page
+  id: ID!
+  lastName: String
+  likers(first: Int): LikersOfContentConnection
+  likeSentence: Text
+  message: Text
+  name: String
+  profilePicture(size: [Int], preset: PhotoSize): Image
+  # This is added in TestSchema.js
+  #
+  # profilePicture2(
+  #   size: [Int],
+  #   preset: PhotoSize,
+  #   cropPosition: CropPosition,
+  #   fileExtension: FileExtension,
+  #   additionalParameters: JSON
+  # ): Image
+  segments(first: Int): Segments
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: Int): SubscribersConnection
+  topLevelComments(first: Int): TopLevelCommentsConnection
+  tracking: String
+  url(relative: Boolean, site: String): String
+  websites: [String]
+  username: String
+  viewerSavedState: String
+}
+
+type ConfigCreateSubscriptResponsePayload {
+  config: Config
+}
+
+type CommentCreateResponsePayload {
+  clientMutationId: String
+  comment: Comment
+  feedback: Feedback
+  feedbackCommentEdge: CommentsEdge
+  viewer: Viewer
+}
+
+type CommentsCreateResponsePayload {
+  clientMutationId: String
+  comments: [Comment]
+  feedback: [Feedback]
+  feedbackCommentEdges: [CommentsEdge]
+  viewer: Viewer
+}
+
+type CommentDeleteResponsePayload {
+  clientMutationId: String
+  deletedCommentId: ID
+  feedback: Feedback
+}
+
+type CommentsDeleteResponsePayload {
+  clientMutationId: String
+  deletedCommentIds: [ID]
+  feedback: Feedback
+}
+
+type StoryUpdateResponsePayload {
+  clientMutationId: String
+  story: Story
+}
+
+type CommentsConnection {
+  count: Int
+  edges: [CommentsEdge]
+  pageInfo: PageInfo
+}
+
+type CommentsEdge {
+  cursor: String
+  node: Comment
+  source: Feedback
+}
+
+type CommentBodiesConnection {
+  count: Int
+  edges: [CommentBodiesEdge]
+  pageInfo: PageInfo
+}
+
+type CommentBodiesEdge {
+  cursor: String
+  node: CommentBody # union type
+  source: Feedback
+}
+
+type ConfigsConnection {
+  edges: [ConfigsConnectionEdge]
+  pageInfo: PageInfo
+}
+
+type ConfigsConnectionEdge {
+  node: Config
+}
+
+type Config {
+  name: String
+  isEnabled: Boolean
+}
+
+type Date {
+  day: Int
+  month: Int
+  year: Int
+}
+
+type Feedback implements Node & HasJsField {
+  js(module: String!, id: String): JSDependency
+  actor: Actor
+  actors: [Actor]
+  actorCount: Int
+  address: StreetAddress
+  allPhones: [Phone]
+  author: User
+  backgroundImage: Image
+  birthdate: Date
+  body: Text
+  canViewerComment: Boolean
+  canViewerLike: Boolean
+  comments(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: String
+  ): CommentsConnection
+  commentBodies(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: String
+  ): CommentBodiesConnection
+  doesViewerLike: Boolean
+  emailAddresses: [String]
+  feedback: Feedback
+  firstName(if: Boolean, unless: Boolean): String
+  friends(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: [String]
+    find: String
+    isViewerFriend: Boolean
+    if: Boolean
+    unless: Boolean
+    traits: [PersonalityTraits]
+  ): FriendsConnection
+  hometown: Page
+  id: ID!
+  lastName: String
+  likers(first: Int): LikersOfContentConnection
+  likeSentence: Text
+  message: Text
+  name: String
+  profilePicture(size: [Int], preset: PhotoSize): Image
+  segments(first: Int): Segments
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: Int): SubscribersConnection
+  topLevelComments(
+    orderBy: [TopLevelCommentsOrdering]
+    first: Int
+  ): TopLevelCommentsConnection
+  tracking: String
+  url(relative: Boolean, site: String): String
+  websites: [String]
+  username: String
+  viewedBy: [Actor]
+  viewerSavedState: String
+}
+
+type FeedbackLikeResponsePayload {
+  clientMutationId: String
+  clientSubscriptionId: String
+  feedback: Feedback
+}
+
+interface FeedUnit {
+  actor: Actor
+  actorCount: Int
+  feedback: Feedback
+  id: ID!
+  message: Text
+  tracking: String
+  actor_key: ID!
+}
+
+type FriendsConnection {
+  count: Int
+  edges: [FriendsEdge]
+  pageInfo: PageInfo
+}
+
+type FriendsEdge {
+  cursor: String
+  node: User
+  source: User
+}
+
+type Image {
+  uri: String
+  width: Int
+  height: Int
+  test_enums: TestEnums
+}
+
+type LikersOfContentConnection {
+  count: Int
+  edges: [LikersEdge]
+  pageInfo: PageInfo
+}
+
+type LikersEdge {
+  cursor: String
+  node: Actor
+}
+
+interface Named {
+  name: String
+}
+
+interface Entity {
+  url(relative: Boolean, site: String): String
+}
+
+type SimpleNamed implements Named {
+  name: String
+}
+
+type NewsFeedConnection {
+  edges: [NewsFeedEdge]
+  pageInfo: PageInfo
+}
+
+type NewsFeedEdge {
+  cursor: String
+  node: FeedUnit
+  sortKey: String
+  showBeeper: Boolean
+}
+
+interface Node {
+  actor: Actor
+  actors: [Actor]
+  actorCount: Int
+  address: StreetAddress
+  allPhones: [Phone]
+  author: User
+  backgroundImage: Image
+  birthdate: Date
+  body: Text
+  canViewerComment: Boolean
+  canViewerLike: Boolean
+  comments(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: String
+  ): CommentsConnection
+  doesViewerLike: Boolean
+  emailAddresses: [String]
+  feedback: Feedback
+  firstName(if: Boolean, unless: Boolean): String
+  friends(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: [String]
+    find: String
+    isViewerFriend: Boolean
+    if: Boolean
+    unless: Boolean
+    traits: [PersonalityTraits]
+  ): FriendsConnection
+  hometown: Page
+  id: ID!
+  lastName: String
+  likers(first: Int): LikersOfContentConnection
+  likeSentence: Text
+  message: Text
+  name: String
+  profilePicture(size: [Int], preset: PhotoSize): Image
+  segments(first: Int): Segments
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: Int): SubscribersConnection
+  topLevelComments(first: Int): TopLevelCommentsConnection
+  tracking: String
+  url(relative: Boolean, site: String): String
+  websites: [String]
+  username: String
+  viewerSavedState: String
+}
+
+interface Actor {
+  address: StreetAddress
+  allPhones: [Phone]
+  birthdate: Date
+  emailAddresses: [String]
+  firstName(if: Boolean, unless: Boolean): String
+  friends(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: [String]
+    find: String
+    isViewerFriend: Boolean
+    if: Boolean
+    unless: Boolean
+    traits: [PersonalityTraits]
+  ): FriendsConnection
+  hometown: Page
+  id: ID!
+  lastName: String
+  name: String
+  nameRenderer(supported: [String!]): UserNameRenderer
+  nameRenderable(supported: [String!]): UserNameRenderable
+  profilePicture(size: [Int], preset: PhotoSize): Image
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: Int): SubscribersConnection
+  url(relative: Boolean, site: String): String
+  websites: [String]
+  username: String
+  actor_key: ID!
+}
+
+type NodeSavedStateResponsePayload {
+  node: Node
+}
+
+type Page implements Node & Actor & Entity {
+  actor: Actor
+  actors: [Actor]
+  actorCount: Int
+  address: StreetAddress
+  allPhones: [Phone]
+  author: User
+  backgroundImage: Image
+  birthdate: Date
+  body: Text
+  canViewerComment: Boolean
+  canViewerLike: Boolean
+  comments(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: String
+  ): CommentsConnection
+  doesViewerLike: Boolean
+  emailAddresses: [String]
+  feedback: Feedback
+  firstName(if: Boolean, unless: Boolean): String
+  friends(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: [String]
+    find: String
+    isViewerFriend: Boolean
+    if: Boolean
+    unless: Boolean
+    traits: [PersonalityTraits]
+  ): FriendsConnection
+  hometown: Page
+  id: ID!
+  lastName: String
+  likers(first: Int): LikersOfContentConnection
+  likeSentence: Text
+  message: Text
+  name: String
+  nameRenderer(supported: [String!]): UserNameRenderer
+  nameRenderable(supported: [String!]): UserNameRenderable
+  profilePicture(size: [Int], preset: PhotoSize): Image
+  segments(first: Int): Segments
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: Int): SubscribersConnection
+  topLevelComments(first: Int): TopLevelCommentsConnection
+  tracking: String
+  url(relative: Boolean, site: String): String
+  websites: [String]
+  username: String
+  viewerSavedState: String
+  nameWithArgs(capitalize: Boolean!): String
+  nameWithDefaultArgs(capitalize: Boolean! = false): String
+  actor_key: ID!
+}
+
+type PageInfo {
+  hasPreviousPage: Boolean
+  hasNextPage: Boolean
+  endCursor: String
+  startCursor: String
+}
+
+type PendingPostsConnection {
+  count: Int
+  edges: [PendingPostsConnectionEdge]
+  pageInfo: PageInfo
+}
+
+type PendingPostsConnectionEdge {
+  cursor: String
+  node: PendingPost
+}
+
+type PendingPost {
+  text: String
+}
+
+type Phone {
+  isVerified: Boolean
+  phoneNumber: PhoneNumber
+}
+
+type PhoneNumber {
+  displayNumber: String
+  countryCode: String
+}
+
+type Screenname {
+  name: String
+  service: String
+}
+
+type Segments {
+  edges: SegmentsEdge
+}
+
+type SegmentsEdge {
+  node: String
+}
+
+type NonNodeStory implements FeedUnit @fetchable(field_name: "fetch_id") {
+  actor: Actor
+  actorCount: Int
+  feedback: Feedback
+  id: ID!
+  fetch_id: ID!
+  message: Text
+  tracking: String
+  comments(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: String
+  ): CommentsConnection
+  actor_key: ID!
+}
+
+type PhotoStory implements FeedUnit & Node {
+  # PhotoStory
+  photo: Image
+
+  # FeedUnit
+  canViewerDelete: Boolean
+  seenState: String
+
+  # Node
+  actor: Actor
+  actors: [Actor]
+  actorCount: Int
+  address: StreetAddress
+  allPhones: [Phone]
+  author: User
+  backgroundImage: Image
+  birthdate: Date
+  body: Text
+  canViewerComment: Boolean
+  canViewerLike: Boolean
+  comments(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: String
+  ): CommentsConnection
+  doesViewerLike: Boolean
+  emailAddresses: [String]
+  feedback: Feedback
+  firstName(if: Boolean, unless: Boolean): String
+  friends(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: [String]
+    find: String
+    isViewerFriend: Boolean
+    if: Boolean
+    unless: Boolean
+    traits: [PersonalityTraits]
+  ): FriendsConnection
+  hometown: Page
+  id: ID!
+  lastName: String
+  likers(first: Int): LikersOfContentConnection
+  likeSentence: Text
+  message: Text
+  name: String
+  profilePicture(size: [Int], preset: PhotoSize): Image
+  segments(first: Int): Segments
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: Int): SubscribersConnection
+  topLevelComments(first: Int): TopLevelCommentsConnection
+  tracking: String
+  url(relative: Boolean, site: String): String
+  websites: [String]
+  username: String
+  viewerSavedState: String
+  actor_key: ID!
+}
+
+type Story implements FeedUnit & Node & MaybeNodeInterface {
+  attachments: [StoryAttachment]
+
+  # FeedUnit
+  canViewerDelete: Boolean
+  seenState: String
+
+  # Node
+  actor: Actor
+  actors: [Actor]
+  actorCount: Int
+  address: StreetAddress
+  allPhones: [Phone]
+  author: User
+  backgroundImage: Image
+  birthdate: Date
+  body: Text
+  canViewerComment: Boolean
+  canViewerLike: Boolean
+  comments(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: String
+  ): CommentsConnection
+  doesViewerLike: Boolean
+  emailAddresses: [String]
+  feedback: Feedback
+  firstName(if: Boolean, unless: Boolean): String
+  friends(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: [String]
+    find: String
+    isViewerFriend: Boolean
+    if: Boolean
+    unless: Boolean
+    traits: [PersonalityTraits]
+  ): FriendsConnection
+  hometown: Page
+  id: ID!
+  lastName: String
+  likers(first: Int): LikersOfContentConnection
+  likeSentence: Text
+  message: Text
+  name: String
+  profilePicture(size: [Int], preset: PhotoSize): Image
+  segments(first: Int): Segments
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: Int): SubscribersConnection
+  topLevelComments(first: Int): TopLevelCommentsConnection
+  tracking: String
+  url(relative: Boolean, site: String): String
+  websites: [String]
+  username: String
+  viewerSavedState: String
+  flight(component: String, props: ReactFlightProps): ReactFlightComponent
+  actor_key: ID!
+}
+
+type StoryAttachment {
+  cache_id: ID!
+  target: Story
+  styleList: [String]
+}
+
+type StreetAddress {
+  city: String
+  country: String
+  postal_code: String
+  street: String
+}
+
+type SubscribersConnection {
+  count: Int
+  edges: [FriendsEdge]
+  pageInfo: PageInfo
+}
+
+type SubscribersEdge {
+  cursor: String
+  node: User
+  source: User
+}
+
+type Text {
+  text: String
+  ranges: [String]
+}
+
+input InputText {
+  text: String
+  ranges: [String]
+}
+
+type TimezoneInfo {
+  timezone: String
+}
+
+type TopLevelCommentsConnection {
+  count: Int
+  edges: [CommentsEdge]
+  pageInfo: PageInfo
+  totalCount: Int
+}
+
+input UnfriendInput {
+  clientMutationId: String
+  friendId: ID
+}
+
+type UnfriendResponsePayload {
+  actor: Actor
+  clientMutationId: String
+  formerFriend: User
+}
+
+scalar JSDependency
+
+interface HasJsField {
+  js(module: String!, id: String): JSDependency
+}
+
+type PlainUserNameRenderer implements HasJsField & UserNameRenderable {
+  plaintext: String
+  data: PlainUserNameData
+  user: User
+  js(module: String!, id: String): JSDependency
+  name: String
+}
+
+type PlainUserNameData {
+  id: ID
+  text: String
+}
+
+type MarkdownUserNameRenderer implements HasJsField & UserNameRenderable {
+  markdown: String
+  data: MarkdownUserNameData
+  user: User
+  js(module: String!, id: String): JSDependency
+  name: String
+}
+
+type MarkdownUserNameData {
+  id: ID
+  markup: String
+}
+
+type CustomNameRenderer {
+  customField: String
+  user: User
+}
+
+type PlainUserRenderer {
+  user: User
+  js(module: String!, id: String): JSDependency
+}
+
+union UserNameRenderer =
+    PlainUserNameRenderer
+  | MarkdownUserNameRenderer
+  | CustomNameRenderer
+
+interface UserNameRenderable {
+  name: String
+}
+
+input ProfilePictureOptions {
+  newName: String
+}
+
+type User implements Named & Node & Actor & HasJsField & Entity & AllConcreteTypesImplementNode {
+  actor: Actor
+  actors: [Actor]
+  actorCount: Int
+  address: StreetAddress
+  allPhones: [Phone]
+  author: User
+  backgroundImage: Image
+  birthdate: Date
+  body: Text
+  canViewerComment: Boolean
+  canViewerLike: Boolean
+  checkins(environments: [Environment!]!): CheckinSearchResult
+  comments(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: String
+  ): CommentsConnection
+  doesViewerLike: Boolean
+  emailAddresses: [String]
+  environment: Environment
+  feedback: Feedback
+  firstName(if: Boolean, unless: Boolean): String
+  friends(
+    after: ID
+    before: ID
+    first: Int
+    last: Int
+    orderby: [String]
+    named: String
+    scale: Float
+    find: String
+    isViewerFriend: Boolean
+    if: Boolean
+    unless: Boolean
+    traits: [PersonalityTraits]
+  ): FriendsConnection
+  hometown: Page
+  id: ID!
+  js(module: String!, id: String): JSDependency
+  lastName: String
+  likers(first: Int): LikersOfContentConnection
+  likeSentence: Text
+  message: Text
+  name: String
+  alternate_name: String
+  nameRenderable(supported: [String!]): UserNameRenderable
+  nameRendererNoSupportedArg: UserNameRenderer
+  nameRenderer(supported: [String!]): UserNameRenderer
+  nameRendererForContext(
+    context: NameRendererContext
+    supported: [String!]!
+  ): UserNameRenderer
+  nameRenderers(supported: [String!]): [UserNameRenderer]
+  storySearch(query: StorySearchInput): [Story]
+  storyCommentSearch(query: StoryCommentSearchInput): [Comment]
+  profilePicture(size: [Int], preset: PhotoSize): Image
+  profile_picture(scale: Float): Image
+  segments(first: Int): Segments
+  screennames: [Screenname]
+  subscribeStatus: String
+  subscribers(first: Int): SubscribersConnection
+  topLevelComments(first: Int): TopLevelCommentsConnection
+  tracking: String
+  traits: [PersonalityTraits]
+  url(relative: Boolean, site: String): String
+  websites: [String]
+  username: String
+  viewerSavedState: String
+  plainUserRenderer: PlainUserRenderer
+  profilePicture2(
+    size: [Int]
+    preset: PhotoSize
+    cropPosition: CropPosition
+    fileExtension: FileExtension
+    additionalParameters: JSON
+    options: ProfilePictureOptions
+  ): Image
+  neighbors: [User!]
+  nearest_neighbor: User!
+  parents: [User!]!
+  actor_key: ID!
+}
+
+enum NameRendererContext {
+  HEADER
+  OTHER
+}
+
+input StorySearchInput {
+  text: String
+  limit: Int
+  offset: Int
+  type: StoryType
+}
+
+input StoryCommentSearchInput {
+  text: String
+  limit: Int
+  offset: Int
+}
+
+type ItemFilterResult {
+  date: String
+}
+
+input ItemFilterInput {
+  date: String
+}
+
+type Viewer {
+  configs(named: [String]): ConfigsConnection
+  actor: Actor
+  account_user: User
+  allTimezones: [TimezoneInfo]
+  isFbEmployee: Boolean
+  newsFeed(after: ID, first: Int, find: ID): NewsFeedConnection
+  notificationStories(after: ID, first: Int): NewsFeedConnection
+  pendingPosts(first: Int): PendingPostsConnection
+  primaryEmail: String
+  timezoneEstimate: TimezoneInfo
+  marketplace_explore(
+    marketplace_browse_context: MarketplaceBrowseContext
+    with_price_between: [Float]
+  ): MarketplaceExploreConnection
+  marketplace_settings: MarketPlaceSettings
+}
+
+type MarketPlaceSettings {
+  location: MarketPlaceSellLocation
+  categories: [String]
+}
+
+type MarketPlaceSellLocation {
+  longitude: Float
+  latitude: Float
+}
+
+type MarketplaceExploreConnection {
+  count: Int
+}
+
+type ViewerNotificationsUpdateAllSeenStateResponsePayload {
+  stories: [Story]
+}
+
+enum Environment {
+  WEB
+  MOBILE
+}
+
+enum MarketplaceBrowseContext {
+  BROWSE_FEED
+  CATEGORY_FEED
+}
+
+enum PhotoSize {
+  SMALL
+  LARGE
+}
+
+enum PersonalityTraits {
+  CHEERFUL
+  DERISIVE
+  HELPFUL
+  SNARKY
+}
+
+enum StoryType {
+  DIRECTED
+  UNDIRECTED
+}
+
+enum TopLevelCommentsOrdering {
+  chronological
+  ranked_threaded
+  recent_activity
+  toplevel
+}
+
+enum CropPosition {
+  TOP
+  CENTER
+  BOTTOM
+  LEFT
+  RIGHT
+}
+
+enum FileExtension {
+  JPG
+  PNG
+}
+
+enum TestEnums {
+  mark
+  zuck
+}
+
+type Settings {
+  cache_id: ID
+  notificationSounds: Boolean
+  notifications(environment: Environment): Boolean
+}
+
+type IDFieldTests {
+  id_non_null: IDFieldIsIDNonNull
+  id: IDFieldIsID
+  list_of_id: IDFieldIsListOfID
+  string_non_null: IDFieldIsStringNonNull
+  string: IDFieldIsString
+  int_non_null: IDFieldIsIntNonNull
+  int: IDFieldIsInt
+  object: IDFieldIsObject
+}
+type IDFieldIsIDNonNull {
+  id: ID!
+}
+type IDFieldIsID {
+  id: ID
+}
+type IDFieldIsListOfID {
+  id: [ID]
+}
+type IDFieldIsStringNonNull {
+  id: String!
+}
+type IDFieldIsString {
+  id: String
+}
+type IDFieldIsIntNonNull {
+  id: Int!
+}
+type IDFieldIsInt {
+  id: Int
+}
+type IDFieldIsObject {
+  id: Node
+}
+
+scalar ReactFlightComponent
+scalar ReactFlightProps

--- a/packages/relay-compiler/transforms/__tests__/ApplyFragmentArgumentTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/ApplyFragmentArgumentTransform-test.js
@@ -17,8 +17,8 @@ const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const RelayParser = require('../../core/RelayParser');
 const ApplyFragmentArgumentTransform = require('../ApplyFragmentArgumentTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
 const {
-  TestSchema,
   generateTestsFromFixtures,
 } = require('relay-test-utils-internal');
 

--- a/packages/relay-compiler/transforms/__tests__/ClientExtensionsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/ClientExtensionsTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const ClientExtensionsTransform = require('../ClientExtensionsTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('ClientExtensionsTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/ConnectionTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/ConnectionTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const ConnectionTransform = require('../ConnectionTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 generateTestsFromFixtures(

--- a/packages/relay-compiler/transforms/__tests__/DeclarativeConnectionMutationTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/DeclarativeConnectionMutationTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const DeclarativeConnectionMutationTransform = require('../DeclarativeConnectionMutationTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 generateTestsFromFixtures(

--- a/packages/relay-compiler/transforms/__tests__/DeferStreamTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/DeferStreamTransform-test.js
@@ -17,10 +17,10 @@ const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const ConnectionTransform = require('../ConnectionTransform');
 const DeferStreamTransform = require('../DeferStreamTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('DeferStreamTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/DisallowIdAsAlias-test.js
+++ b/packages/relay-compiler/transforms/__tests__/DisallowIdAsAlias-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const DisallowIdAsAlias = require('../DisallowIdAsAlias');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 generateTestsFromFixtures(`${__dirname}/fixtures/DisallowIdAsAlias`, text => {

--- a/packages/relay-compiler/transforms/__tests__/DisallowTypeNameOnRoot-test.js
+++ b/packages/relay-compiler/transforms/__tests__/DisallowTypeNameOnRoot-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const DisallowTypenameOnRoot = require('../DisallowTypenameOnRoot');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 generateTestsFromFixtures(

--- a/packages/relay-compiler/transforms/__tests__/FieldHandleTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/FieldHandleTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const FieldHandleTransform = require('../FieldHandleTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('FieldHandleTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/FilterCompilerDirectivesTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/FilterCompilerDirectivesTransform-test.js
@@ -18,10 +18,10 @@ const IRPrinter = require('../../core/IRPrinter');
 const RelayIRTransforms = require('../../core/RelayIRTransforms');
 const FilterCompilerDirectivesTransform = require('../FilterCompilerDirectivesTransform');
 const {RelayFeatureFlags} = require('relay-runtime');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('FilterCompilerDirectivesTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/FilterDirectivesTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/FilterDirectivesTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const FilterDirectivesTransform = require('../FilterDirectivesTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('FilterDirectivesTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/FlattenTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/FlattenTransform-test.js
@@ -21,8 +21,8 @@ const RelayParser = require('../../core/RelayParser');
 const MatchTransform = require('../../transforms/MatchTransform');
 const FlattenTransform = require('../FlattenTransform');
 const RelayDirectiveTransform = require('../RelayDirectiveTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
 const {
-  TestSchema,
   generateTestsFromFixtures,
 } = require('relay-test-utils-internal');
 

--- a/packages/relay-compiler/transforms/__tests__/GenerateIDFieldTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/GenerateIDFieldTransform-test.js
@@ -17,8 +17,8 @@ const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const RelayParser = require('../../core/RelayParser');
 const GenerateIDFieldTransform = require('../GenerateIDFieldTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
 const {
-  TestSchema,
   generateTestsFromFixtures,
 } = require('relay-test-utils-internal');
 

--- a/packages/relay-compiler/transforms/__tests__/GenerateTypeNameTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/GenerateTypeNameTransform-test.js
@@ -18,8 +18,8 @@ const RelayParser = require('../../core/RelayParser');
 const FlattenTransform = require('../FlattenTransform');
 const GenerateTypeNameTransform = require('../GenerateTypeNameTransform');
 const InlineFragmentsTransform = require('../InlineFragmentsTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
 const {
-  TestSchema,
   generateTestsFromFixtures,
   printAST,
 } = require('relay-test-utils-internal');

--- a/packages/relay-compiler/transforms/__tests__/InlineDataFragmentTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/InlineDataFragmentTransform-test.js
@@ -15,10 +15,10 @@
 
 const InlineDataFragmentTransform = require('../InlineDataFragmentTransform');
 const {CompilerContext, Printer} = require('relay-compiler');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 const extendedSchema = TestSchema.extend([

--- a/packages/relay-compiler/transforms/__tests__/InlineFragmentsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/InlineFragmentsTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const InlineFragmentsTransform = require('../InlineFragmentsTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('InlineFragmentsTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/MaskTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/MaskTransform-test.js
@@ -17,10 +17,10 @@ const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const MaskTransform = require('../MaskTransform');
 const RelayDirectiveTransform = require('../RelayDirectiveTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('MaskTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/MatchTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/MatchTransform-test.js
@@ -17,10 +17,10 @@ const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const MatchTransform = require('../MatchTransform');
 const RelayDirectiveTransform = require('../RelayDirectiveTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('MatchTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/ReactFlightComponentTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/ReactFlightComponentTransform-test.js
@@ -18,8 +18,8 @@ const IRPrinter = require('../../core/IRPrinter');
 const RelayParser = require('../../core/RelayParser');
 const ReactFlightComponentTransform = require('../ReactFlightComponentTransform');
 const {RelayFeatureFlags} = require('relay-runtime');
+const {TestSchema} = require('../../test-utils/TestSchema');
 const {
-  TestSchema,
   generateTestsFromFixtures,
 } = require('relay-test-utils-internal');
 

--- a/packages/relay-compiler/transforms/__tests__/RefetchableFragmentTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/RefetchableFragmentTransform-test.js
@@ -18,10 +18,10 @@ const IRPrinter = require('../../core/IRPrinter');
 const ConnectionTransform = require('../ConnectionTransform');
 const RefetchableFragmentTransform = require('../RefetchableFragmentTransform');
 const RelayDirectiveTransform = require('../RelayDirectiveTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('RefetchableFragmentTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/RelayDirectiveTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/RelayDirectiveTransform-test.js
@@ -16,8 +16,8 @@
 const CompilerContext = require('../../core/CompilerContext');
 const RelayParser = require('../../core/RelayParser');
 const RelayDirectiveTransform = require('../RelayDirectiveTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
 const {
-  TestSchema,
   generateTestsFromFixtures,
   printAST,
 } = require('relay-test-utils-internal');

--- a/packages/relay-compiler/transforms/__tests__/RequiredFieldTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/RequiredFieldTransform-test.js
@@ -17,10 +17,10 @@ const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const RequiredFieldTransform = require('../RequiredFieldTransform');
 const {RelayFeatureFlags} = require('relay-runtime');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
   printAST,
 } = require('relay-test-utils-internal');
 

--- a/packages/relay-compiler/transforms/__tests__/SkipClientExtensionsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/SkipClientExtensionsTransform-test.js
@@ -17,10 +17,10 @@ const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const ClientExtensionsTransform = require('../ClientExtensionsTransform');
 const SkipClientExtensionsTransform = require('../SkipClientExtensionsTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('SkipClientExtensionsTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/SkipHandleFieldTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/SkipHandleFieldTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const SkipHandleFieldTransform = require('../SkipHandleFieldTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('SkipHandleFieldTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/SkipRedundantNodesTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/SkipRedundantNodesTransform-test.js
@@ -19,10 +19,10 @@ const InlineFragmentsTransform = require('../InlineFragmentsTransform');
 const MatchTransform = require('../MatchTransform');
 const RelayDirectiveTransform = require('../RelayDirectiveTransform');
 const SkipRedundantNodesTransform = require('../SkipRedundantNodesTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('SkipRedundantNodesTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/SkipSplitOperationTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/SkipSplitOperationTransform-test.js
@@ -17,10 +17,10 @@ const CompilerContext = require('../../core/CompilerContext');
 const MatchTransform = require('../MatchTransform');
 const SkipSplitOperationTransform = require('../SkipSplitOperationTransform');
 const SplitModuleImportTransform = require('../SplitModuleImportTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('SkipSplitOperationTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/SkipUnreachableNodeTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/SkipUnreachableNodeTransform-test.js
@@ -17,8 +17,8 @@ const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const RelayParser = require('../../core/RelayParser');
 const SkipUnreachableNodeTransform = require('../SkipUnreachableNodeTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
 const {
-  TestSchema,
   generateTestsFromFixtures,
 } = require('relay-test-utils-internal');
 

--- a/packages/relay-compiler/transforms/__tests__/SkipUnusedVariablesTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/SkipUnusedVariablesTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const IRPrinter = require('../../core/IRPrinter');
 const SkipUnusedVariablesTransform = require('../SkipUnusedVariablesTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 generateTestsFromFixtures(

--- a/packages/relay-compiler/transforms/__tests__/SplitModuleImportTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/SplitModuleImportTransform-test.js
@@ -18,10 +18,10 @@ const IRPrinter = require('../../core/IRPrinter');
 const MatchTransform = require('../MatchTransform');
 const RelayDirectiveTransform = require('../RelayDirectiveTransform');
 const SplitModuleImportTransform = require('../SplitModuleImportTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('MatchTransform', () => {

--- a/packages/relay-compiler/transforms/__tests__/TestOperationTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/TestOperationTransform-test.js
@@ -16,8 +16,8 @@
 const CompilerContext = require('../../core/CompilerContext');
 const RelayParser = require('../../core/RelayParser');
 const TestOperationTransform = require('../TestOperationTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
 const {
-  TestSchema,
   generateTestsFromFixtures,
   printAST,
 } = require('relay-test-utils-internal');

--- a/packages/relay-compiler/transforms/__tests__/ValidateGlobalVariablesTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/ValidateGlobalVariablesTransform-test.js
@@ -15,10 +15,10 @@
 
 const CompilerContext = require('../../core/CompilerContext');
 const ValidateGlobalVariablesTransform = require('../ValidateGlobalVariablesTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 generateTestsFromFixtures(

--- a/packages/relay-compiler/transforms/__tests__/ValidateRequiredArgumentsTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/ValidateRequiredArgumentsTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const RelayIRTransforms = require('../../core/RelayIRTransforms');
 const validateRelayRequiredArguments = require('../ValidateRequiredArgumentsTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('validateRelayRequiredArguments-test', () => {

--- a/packages/relay-compiler/transforms/__tests__/ValidateServerOnlyDirectivesTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/ValidateServerOnlyDirectivesTransform-test.js
@@ -16,10 +16,10 @@
 const CompilerContext = require('../../core/CompilerContext');
 const RelayIRTransforms = require('../../core/RelayIRTransforms');
 const validateRelayServerOnlyDirectives = require('../ValidateServerOnlyDirectivesTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 describe('ValidateServerOnlyDirectives', () => {

--- a/packages/relay-compiler/transforms/__tests__/ValidateUnusedVariablesTransform-test.js
+++ b/packages/relay-compiler/transforms/__tests__/ValidateUnusedVariablesTransform-test.js
@@ -15,10 +15,10 @@
 
 const CompilerContext = require('../../core/CompilerContext');
 const ValidateUnusedVariablesTransform = require('../ValidateUnusedVariablesTransform');
+const {TestSchema} = require('../../test-utils/TestSchema');
+const parseGraphQLText = require('../../test-utils/parseGraphQLText');
 const {
-  TestSchema,
   generateTestsFromFixtures,
-  parseGraphQLText,
 } = require('relay-test-utils-internal');
 
 generateTestsFromFixtures(

--- a/packages/relay-runtime/store/StoreInspector.js
+++ b/packages/relay-runtime/store/StoreInspector.js
@@ -100,7 +100,7 @@ if (__DEV__) {
         }
         return renderRecordHeader(obj);
       },
-      hasBody(obj: $FlowFixMeEmpty) {
+      hasBody(obj: $FlowFixMe) {
         return true;
       },
       body(obj) {

--- a/packages/relay-test-utils-internal/index.js
+++ b/packages/relay-test-utils-internal/index.js
@@ -17,10 +17,8 @@ const {
   generateTestsFromFixtures,
 } = require('./generateTestsFromFixtures');
 const Matchers = require('./Matchers');
-const parseGraphQLText = require('./parseGraphQLText');
 const printAST = require('./printAST');
 const simpleClone = require('./simpleClone');
-const {TestSchema, testSchemaPath} = require('./TestSchema');
 const {
   disallowWarnings,
   expectToWarn,
@@ -55,10 +53,7 @@ module.exports = {
   FIXTURE_TAG,
   generateTestsFromFixtures,
   matchers: Matchers,
-  parseGraphQLText,
   printAST,
   simpleClone,
-  TestSchema,
-  testSchemaPath,
   unwrapContainer,
 };

--- a/packages/relay-test-utils-internal/package.json
+++ b/packages/relay-test-utils-internal/package.json
@@ -13,11 +13,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "fbjs": "^3.0.0",
-    "relay-runtime": "12.0.0",
-    "relay-compiler": "12.0.0"
-  },
-  "peerDependencies": {
-    "graphql": "^15.0.0"
+    "relay-runtime": "12.0.0"
   },
   "directories": {
     "": "./"

--- a/packages/relay-test-utils/package.json
+++ b/packages/relay-test-utils/package.json
@@ -16,9 +16,6 @@
     "invariant": "^2.2.4",
     "relay-runtime": "12.0.0"
   },
-  "peerDependencies": {
-    "graphql": "^15.0.0"
-  },
   "directories": {
     "": "./"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3610,7 +3610,12 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-"graphql@^14.0.0 || ^15.0.0-rc.1", graphql@^15.0.0:
+graphql@15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
+  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
+
+"graphql@^14.0.0 || ^15.0.0-rc.1":
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
   integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==


### PR DESCRIPTION
- This diff removed internal dependencies on `relay-compiler` and `graphql` in Relay Test Utils and Internal Test Utils.
- TestSchema/parseGraphQLText added to `relay-compiler`. We eventually remove them, once rust-version is fully released
- `relay-compile` now depends on `graphql@15.3.0` (not as `peerDependency`) 