### PR TITLE
Support tab-indented queries

### DIFF
--- a/compiler/crates/extract-graphql/src/lib.rs
+++ b/compiler/crates/extract-graphql/src/lib.rs
@@ -97,7 +97,7 @@ pub fn parse_chunks(input: &str) -> Vec<GraphQLSource> {
                             res.push(GraphQLSource::new(text, line_index, column_index));
                             continue 'code;
                         }
-                        ' ' | '\n' | '\r' => {}
+                        ' ' | '\n' | '\r' | '\t' => {}
                         'a'..='z' | 'A'..='Z' | '#' => {
                             if !has_visited_first_char {
                                 has_visited_first_char = true;

--- a/compiler/crates/extract-graphql/tests/extract/fixtures/tabbed.expected
+++ b/compiler/crates/extract-graphql/tests/extract/fixtures/tabbed.expected
@@ -1,0 +1,19 @@
+==================================== INPUT ====================================
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+graphql`
+	fragment Test on User {
+		name
+	}
+`
+==================================== OUTPUT ===================================
+line: 7, column: 8, text: <
+	fragment Test on User {
+		name
+	}
+>

--- a/compiler/crates/extract-graphql/tests/extract/fixtures/tabbed.js
+++ b/compiler/crates/extract-graphql/tests/extract/fixtures/tabbed.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+graphql`
+	fragment Test on User {
+		name
+	}
+`

--- a/compiler/crates/extract-graphql/tests/extract_test.rs
+++ b/compiler/crates/extract-graphql/tests/extract_test.rs
@@ -55,6 +55,13 @@ fn simple() {
 }
 
 #[test]
+fn tabbed() {
+    let input = include_str!("extract/fixtures/tabbed.js");
+    let expected = include_str!("extract/fixtures/tabbed.expected");
+    test_fixture(transform_fixture, "tabbed.js", "extract/fixtures/tabbed.expected", input, expected);
+}
+
+#[test]
 fn template_literal() {
     let input = include_str!("extract/fixtures/template_literal.js");
     let expected = include_str!("extract/fixtures/template_literal.expected");


### PR DESCRIPTION
I noticed that the tab character was not being handled when parsing files, causing it to immediately exit and not parse any operations.

This fixes #3642.