### PR TITLE
Fix broken links for older website versions

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,6 +17,9 @@ module.exports = {
   tagline: 'The GraphQL client that scales with you.',
   url: 'https://relay.dev',
   baseUrl: '/',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
+  trailingSlash: true,
   organizationName: 'facebook',
   projectName: 'relay',
   scripts: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -320,7 +320,6 @@ module.exports = {
             to: '/docs/guides/type-emission/',
             from: [
               '/docs/en/type-emission',
-              '/docs/v3.0.0/type-emission',
               '/docs/type-emission',
             ],
           },

--- a/website/versioned_docs/version-classic/Classic-APIReference-Container.md
+++ b/website/versioned_docs/version-classic/Classic-APIReference-Container.md
@@ -607,7 +607,7 @@ Relay.createContainer(Child, {
 });
 ```
 
-In this example, whenever `Parent` is fetched, `Child`'s fragment will also be fetched. When rendering, `<Parent>` will only have access to the `props.foo.id` field;  data from the child fragment will be [_masked_](./thinking-in-relay#data-masking). By default, `childFragment` will use its corresponding initial variables. Relay will fetch `photo(size: 64)`. When `<Child>` is rendered it will also make the initial variables available as `props.relay.variables = {size: 64}`.
+In this example, whenever `Parent` is fetched, `Child`'s fragment will also be fetched. When rendering, `<Parent>` will only have access to the `props.foo.id` field;  data from the child fragment will be [_masked_](./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). By default, `childFragment` will use its corresponding initial variables. Relay will fetch `photo(size: 64)`. When `<Child>` is rendered it will also make the initial variables available as `props.relay.variables = {size: 64}`.
 
 #### Overriding Fragment Variables
 

--- a/website/versioned_docs/version-experimental/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-experimental/Modern-GraphQLInRelay.md
@@ -96,7 +96,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./a-guided-tour-of-relay#fragments), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `useFragment`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./a-guided-tour-of-relay#fragments), which is known as [data masking](./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `useFragment`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -148,7 +148,7 @@ export default createFragmentContainer(MyComponent, {
 
 ### `@relay(mask: Boolean)`
 
-Relay by default will only expose the data for fields explicitly requested by a [fragment](./a-guided-tour-of-relay#fragments), which is known as [data masking](./thinking-in-relay#data-masking).
+Relay by default will only expose the data for fields explicitly requested by a [fragment](./a-guided-tour-of-relay#fragments), which is known as [data masking](./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available to the parent, recursively including the data from the fields of the referenced fragment.
 

--- a/website/versioned_docs/version-v1.4.1/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v1.4.1/Introduction-InstallationAndSetup.md
@@ -37,11 +37,11 @@ Please note that the `"relay"` plugin should run before other plugins or
 presets to ensure the `graphql` template literals are correctly transformed. See
 Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#plugin-preset-ordering).
 
-See the [Migration Setup](./migration-setup) guide if upgrading an existing Relay app.
+See the [Migration Setup](./Modern-MigrationSetup.md) guide if upgrading an existing Relay app.
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -73,7 +73,7 @@ yarn run relay -- --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v1.4.1/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v1.4.1/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v1.4.1/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.4.1/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about wether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -312,13 +312,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -383,7 +383,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data to when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -436,7 +436,7 @@ export default ViewerTodoList extends React.Component {
 }
 ```
 
-Check out or docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out or docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -575,9 +575,9 @@ In the simplest case above, we just need to pass an `optimisticResponse` option,
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case, and in some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs), and an [`updater`](./mutations#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs), and an [`updater`](Modern-Mutations.md#updating-the-store-programatically-advanced) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v1.4.1/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v1.4.1/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-ConvertingMutations.md
@@ -44,11 +44,11 @@ This is no longer needed in Compatibility Mode for neither environments. Relay w
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -165,4 +165,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v1.4.1/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-FragmentContainer.md
@@ -30,7 +30,7 @@ createFragmentContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop in the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 
 ### Available Props
 
@@ -47,7 +47,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -210,7 +210,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -230,7 +230,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -293,4 +293,4 @@ export default createFragmentContainer(
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v1.4.1/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,13 +63,13 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](Modern-PaginationContainer.md#connection).
 
-**Note:** `@connection` is also supported in [compatibility mode](./relay-compat)
+**Note:** `@connection` is also supported in [compatibility mode](Modern-RelayCompat.md)
 
 ### `@relay(plural: Boolean)`
 
@@ -85,7 +85,7 @@ fragment TodoItems_items on TodoItem @relay(plural: true) {
 
 ### `@relay(mask: Boolean)`
 
-Relay by default will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+Relay by default will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available to the parent, recursively including the data from the fields of the referenced fragment.
 
@@ -148,7 +148,7 @@ The Relay Compiler is responsible for generating code as part of a build step wh
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -226,7 +226,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated flow types like so:
 

--- a/website/versioned_docs/version-v1.4.1/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-LocalStateManagement.md
@@ -43,7 +43,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -95,7 +95,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v1.4.1/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v1.4.1/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-Mutations.md
@@ -33,7 +33,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -41,13 +41,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -354,4 +354,4 @@ function commit(
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).

--- a/website/versioned_docs/version-v1.4.1/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v1.4.1/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v1.4.1/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
 
 Table of Contents:
 
@@ -116,12 +116,12 @@ type ConnectionData = {
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `connectionConfig`:
-    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](./relay-compat).
-    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](./relay-compat).
+    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](Modern-RelayCompat.md).
+    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](Modern-RelayCompat.md).
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -143,7 +143,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)

--- a/website/versioned_docs/version-v1.4.1/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-QueryRenderer.md
@@ -11,8 +11,8 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables if passed, the `QueryRenderer` will re-fetch the query.
 -   `render`: Function of type `({error, props}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.
     -   `props`: Object containing data obtained from the query; the shape of this object will match the shape of the query. If this object is not defined, it means that the data is still being fetched.

--- a/website/versioned_docs/version-v1.4.1/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
 
 Table of Contents:
 
@@ -30,7 +30,7 @@ createRefetchContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `refetchQuery`: A `graphql` tagged query to be fetched upon calling [`props.relay.refetch`](#refetch). As with any query, upon fetching this query, its result will be normalized into the store, any relevant subscriptions associated with the changed records will be fired, and subscribed components will re-render.
 
 ### Available Props
@@ -48,7 +48,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -86,7 +86,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ### Return Value
 

--- a/website/versioned_docs/version-v1.4.1/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v1.4.1/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v1.4.1/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v1.4.1/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-Subscriptions.md
@@ -36,7 +36,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v1.4.1/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-TypeEmission.md
@@ -351,7 +351,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v1.4.1/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v1.4.1/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v1.4.1/Modern-fetchQuery.md
@@ -27,7 +27,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v1.4.1/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v1.4.1/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document together [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document together [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v1.5.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v1.5.0/Introduction-InstallationAndSetup.md
@@ -37,11 +37,11 @@ Please note that the `"relay"` plugin should run before other plugins or
 presets to ensure the `graphql` template literals are correctly transformed. See
 Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#plugin-preset-ordering).
 
-See the [Migration Setup](./migration-setup) guide if upgrading an existing Relay app.
+See the [Migration Setup](./Modern-MigrationSetup.md) guide if upgrading an existing Relay app.
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -73,7 +73,7 @@ yarn run relay -- --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v1.5.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v1.5.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v1.5.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.5.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about wether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -312,13 +312,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -383,7 +383,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data to when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -436,7 +436,7 @@ export default ViewerTodoList extends React.Component {
 }
 ```
 
-Check out or docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out or docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -575,9 +575,9 @@ In the simplest case above, we just need to pass an `optimisticResponse` option,
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case, and in some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs), and an [`updater`](./mutations#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs), and an [`updater`](Modern-Mutations.md#updating-the-store-programatically-advanced) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v1.5.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v1.5.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-ConvertingMutations.md
@@ -44,11 +44,11 @@ This is no longer needed in Compatibility Mode for neither environments. Relay w
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -165,4 +165,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v1.5.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-FragmentContainer.md
@@ -30,7 +30,7 @@ createFragmentContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop in the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 
 ### Available Props
 
@@ -47,7 +47,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -210,7 +210,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -230,7 +230,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -293,4 +293,4 @@ export default createFragmentContainer(
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v1.5.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,13 +63,13 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](Modern-PaginationContainer.md#connection).
 
-**Note:** `@connection` is also supported in [compatibility mode](./relay-compat)
+**Note:** `@connection` is also supported in [compatibility mode](Modern-RelayCompat.md)
 
 ### `@relay(plural: Boolean)`
 
@@ -85,7 +85,7 @@ fragment TodoItems_items on TodoItem @relay(plural: true) {
 
 ### `@relay(mask: Boolean)`
 
-Relay by default will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+Relay by default will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available to the parent, recursively including the data from the fields of the referenced fragment.
 
@@ -148,7 +148,7 @@ The Relay Compiler is responsible for generating code as part of a build step wh
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -226,7 +226,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated flow types like so:
 

--- a/website/versioned_docs/version-v1.5.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-LocalStateManagement.md
@@ -43,7 +43,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -95,7 +95,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v1.5.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v1.5.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-Mutations.md
@@ -33,7 +33,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -41,13 +41,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -354,4 +354,4 @@ function commit(
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).

--- a/website/versioned_docs/version-v1.5.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v1.5.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v1.5.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
 
 Table of Contents:
 
@@ -116,12 +116,12 @@ type ConnectionData = {
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `connectionConfig`:
-    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](./relay-compat).
-    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](./relay-compat).
+    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](Modern-RelayCompat.md).
+    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](Modern-RelayCompat.md).
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -143,7 +143,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)

--- a/website/versioned_docs/version-v1.5.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-QueryRenderer.md
@@ -11,8 +11,8 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables if passed, the `QueryRenderer` will re-fetch the query.
 -   `render`: Function of type `({error, props}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.
     -   `props`: Object containing data obtained from the query; the shape of this object will match the shape of the query. If this object is not defined, it means that the data is still being fetched.

--- a/website/versioned_docs/version-v1.5.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
 
 Table of Contents:
 
@@ -30,7 +30,7 @@ createRefetchContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `refetchQuery`: A `graphql` tagged query to be fetched upon calling [`props.relay.refetch`](#refetch). As with any query, upon fetching this query, its result will be normalized into the store, any relevant subscriptions associated with the changed records will be fired, and subscribed components will re-render.
 
 ### Available Props
@@ -48,7 +48,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -86,7 +86,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ### Return Value
 

--- a/website/versioned_docs/version-v1.5.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v1.5.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v1.5.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v1.5.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-Subscriptions.md
@@ -36,7 +36,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v1.5.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-TypeEmission.md
@@ -351,7 +351,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v1.5.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v1.5.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v1.5.0/Modern-fetchQuery.md
@@ -27,7 +27,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v1.5.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v1.5.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document together [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document together [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v1.6.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v1.6.0/Introduction-InstallationAndSetup.md
@@ -37,11 +37,11 @@ Please note that the `"relay"` plugin should run before other plugins or
 presets to ensure the `graphql` template literals are correctly transformed. See
 Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#plugin-preset-ordering).
 
-See the [Migration Setup](./migration-setup) guide if upgrading an existing Relay app.
+See the [Migration Setup](./Modern-MigrationSetup.md) guide if upgrading an existing Relay app.
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -73,7 +73,7 @@ yarn run relay -- --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v1.6.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v1.6.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v1.6.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.6.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about wether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -312,13 +312,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -383,7 +383,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data to when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -436,7 +436,7 @@ export default ViewerTodoList extends React.Component {
 }
 ```
 
-Check out or docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out or docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -575,9 +575,9 @@ In the simplest case above, we just need to pass an `optimisticResponse` option,
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case, and in some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs), and an [`updater`](./mutations#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs), and an [`updater`](Modern-Mutations.md#updating-the-store-programatically-advanced) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v1.6.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v1.6.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-ConvertingMutations.md
@@ -44,11 +44,11 @@ This is no longer needed in Compatibility Mode for neither environments. Relay w
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -165,4 +165,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v1.6.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-FragmentContainer.md
@@ -30,7 +30,7 @@ createFragmentContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop in the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 
 ### Available Props
 
@@ -47,7 +47,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -210,7 +210,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -230,7 +230,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -293,4 +293,4 @@ export default createFragmentContainer(
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v1.6.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,13 +63,13 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](Modern-PaginationContainer.md#connection).
 
-**Note:** `@connection` is also supported in [compatibility mode](./relay-compat)
+**Note:** `@connection` is also supported in [compatibility mode](Modern-RelayCompat.md)
 
 ### `@relay(plural: Boolean)`
 
@@ -85,7 +85,7 @@ fragment TodoItems_items on TodoItem @relay(plural: true) {
 
 ### `@relay(mask: Boolean)`
 
-Relay by default will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+Relay by default will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available to the parent, recursively including the data from the fields of the referenced fragment.
 
@@ -148,7 +148,7 @@ The Relay Compiler is responsible for generating code as part of a build step wh
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -226,7 +226,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated flow types like so:
 

--- a/website/versioned_docs/version-v1.6.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-LocalStateManagement.md
@@ -43,7 +43,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -95,7 +95,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v1.6.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v1.6.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-Mutations.md
@@ -33,7 +33,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -41,13 +41,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -354,4 +354,4 @@ function commit(
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).

--- a/website/versioned_docs/version-v1.6.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v1.6.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v1.6.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
 
 Table of Contents:
 
@@ -116,12 +116,12 @@ type ConnectionData = {
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `connectionConfig`:
-    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](./relay-compat).
-    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](./relay-compat).
+    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](Modern-RelayCompat.md).
+    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](Modern-RelayCompat.md).
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -143,7 +143,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)

--- a/website/versioned_docs/version-v1.6.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-QueryRenderer.md
@@ -11,8 +11,8 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables if passed, the `QueryRenderer` will re-fetch the query.
 -   `render`: Function of type `({error, props}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.
     -   `props`: Object containing data obtained from the query; the shape of this object will match the shape of the query. If this object is not defined, it means that the data is still being fetched.

--- a/website/versioned_docs/version-v1.6.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
 
 Table of Contents:
 
@@ -30,7 +30,7 @@ createRefetchContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `refetchQuery`: A `graphql` tagged query to be fetched upon calling [`props.relay.refetch`](#refetch). As with any query, upon fetching this query, its result will be normalized into the store, any relevant subscriptions associated with the changed records will be fired, and subscribed components will re-render.
 
 ### Available Props
@@ -48,7 +48,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -86,7 +86,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ### Return Value
 

--- a/website/versioned_docs/version-v1.6.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v1.6.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v1.6.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v1.6.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-Subscriptions.md
@@ -36,7 +36,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v1.6.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-TypeEmission.md
@@ -351,7 +351,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v1.6.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v1.6.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v1.6.0/Modern-fetchQuery.md
@@ -27,7 +27,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v1.6.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v1.6.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document together [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document together [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v1.6.1/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v1.6.1/Introduction-InstallationAndSetup.md
@@ -37,11 +37,11 @@ Please note that the `"relay"` plugin should run before other plugins or
 presets to ensure the `graphql` template literals are correctly transformed. See
 Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#plugin-preset-ordering).
 
-See the [Migration Setup](./migration-setup) guide if upgrading an existing Relay app.
+See the [Migration Setup](./Modern-MigrationSetup.md) guide if upgrading an existing Relay app.
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -73,7 +73,7 @@ yarn run relay -- --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v1.6.1/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v1.6.1/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v1.6.1/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.6.1/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about wether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -312,13 +312,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -383,7 +383,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data to when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -436,7 +436,7 @@ export default ViewerTodoList extends React.Component {
 }
 ```
 
-Check out or docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out or docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -575,9 +575,9 @@ In the simplest case above, we just need to pass an `optimisticResponse` option,
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case, and in some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs), and an [`updater`](./mutations#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs), and an [`updater`](Modern-Mutations.md#updating-the-store-programatically-advanced) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v1.6.1/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v1.6.1/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-ConvertingMutations.md
@@ -44,11 +44,11 @@ This is no longer needed in Compatibility Mode for neither environments. Relay w
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -165,4 +165,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v1.6.1/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-FragmentContainer.md
@@ -30,7 +30,7 @@ createFragmentContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop in the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 
 ### Available Props
 
@@ -47,7 +47,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -210,7 +210,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -230,7 +230,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -293,4 +293,4 @@ export default createFragmentContainer(
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v1.6.1/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,13 +63,13 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](Modern-PaginationContainer.md#connection).
 
-**Note:** `@connection` is also supported in [compatibility mode](./relay-compat)
+**Note:** `@connection` is also supported in [compatibility mode](Modern-RelayCompat.md)
 
 ### `@relay(plural: Boolean)`
 
@@ -85,7 +85,7 @@ fragment TodoItems_items on TodoItem @relay(plural: true) {
 
 ### `@relay(mask: Boolean)`
 
-Relay by default will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+Relay by default will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available to the parent, recursively including the data from the fields of the referenced fragment.
 
@@ -148,7 +148,7 @@ The Relay Compiler is responsible for generating code as part of a build step wh
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -226,7 +226,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated flow types like so:
 

--- a/website/versioned_docs/version-v1.6.1/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-LocalStateManagement.md
@@ -43,7 +43,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -95,7 +95,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v1.6.1/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v1.6.1/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-Mutations.md
@@ -33,7 +33,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -41,13 +41,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -354,4 +354,4 @@ function commit(
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).

--- a/website/versioned_docs/version-v1.6.1/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v1.6.1/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v1.6.1/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
 
 Table of Contents:
 
@@ -116,12 +116,12 @@ type ConnectionData = {
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `connectionConfig`:
-    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](./relay-compat).
-    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](./relay-compat).
+    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](Modern-RelayCompat.md).
+    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](Modern-RelayCompat.md).
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -143,7 +143,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)

--- a/website/versioned_docs/version-v1.6.1/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-QueryRenderer.md
@@ -11,8 +11,8 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables if passed, the `QueryRenderer` will re-fetch the query.
 -   `render`: Function of type `({error, props}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.
     -   `props`: Object containing data obtained from the query; the shape of this object will match the shape of the query. If this object is not defined, it means that the data is still being fetched.

--- a/website/versioned_docs/version-v1.6.1/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
 
 Table of Contents:
 
@@ -30,7 +30,7 @@ createRefetchContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `refetchQuery`: A `graphql` tagged query to be fetched upon calling [`props.relay.refetch`](#refetch). As with any query, upon fetching this query, its result will be normalized into the store, any relevant subscriptions associated with the changed records will be fired, and subscribed components will re-render.
 
 ### Available Props
@@ -48,7 +48,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -86,7 +86,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ### Return Value
 

--- a/website/versioned_docs/version-v1.6.1/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v1.6.1/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v1.6.1/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v1.6.1/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-Subscriptions.md
@@ -36,7 +36,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v1.6.1/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-TypeEmission.md
@@ -351,7 +351,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v1.6.1/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v1.6.1/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v1.6.1/Modern-fetchQuery.md
@@ -27,7 +27,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v1.6.1/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v1.6.1/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document together [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document together [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v1.6.2/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v1.6.2/Introduction-InstallationAndSetup.md
@@ -37,11 +37,11 @@ Please note that the `"relay"` plugin should run before other plugins or
 presets to ensure the `graphql` template literals are correctly transformed. See
 Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#plugin-preset-ordering).
 
-See the [Migration Setup](./migration-setup) guide if upgrading an existing Relay app.
+See the [Migration Setup](./Modern-MigrationSetup.md) guide if upgrading an existing Relay app.
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -73,7 +73,7 @@ yarn run relay -- --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v1.6.2/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v1.6.2/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v1.6.2/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.6.2/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a  [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and schema [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Envionment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about wether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -312,13 +312,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such, and even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -383,7 +383,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data to when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers, is that the parent will not have access to the data defined by the child container, i.e. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -436,7 +436,7 @@ export default ViewerTodoList extends React.Component {
 }
 ```
 
-Check out or docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out or docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -575,9 +575,9 @@ In the simplest case above, we just need to pass an `optimisticResponse` option,
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case, and in some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs), and an [`updater`](./mutations#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios, Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs), and an [`updater`](Modern-Mutations.md#updating-the-store-programatically-advanced) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v1.6.2/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v1.6.2/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-ConvertingMutations.md
@@ -44,11 +44,11 @@ This is no longer needed in Compatibility Mode for neither environments. Relay w
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -165,4 +165,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v1.6.2/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-FragmentContainer.md
@@ -30,7 +30,7 @@ createFragmentContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop in the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 
 ### Available Props
 
@@ -47,7 +47,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -210,7 +210,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -230,7 +230,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -293,4 +293,4 @@ export default createFragmentContainer(
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v1.6.2/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,13 +63,13 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](Modern-PaginationContainer.md#connection).
 
-**Note:** `@connection` is also supported in [compatibility mode](./relay-compat)
+**Note:** `@connection` is also supported in [compatibility mode](Modern-RelayCompat.md)
 
 ### `@relay(plural: Boolean)`
 
@@ -85,7 +85,7 @@ fragment TodoItems_items on TodoItem @relay(plural: true) {
 
 ### `@relay(mask: Boolean)`
 
-Relay by default will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+Relay by default will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available to the parent, recursively including the data from the fields of the referenced fragment.
 
@@ -148,7 +148,7 @@ The Relay Compiler is responsible for generating code as part of a build step wh
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -226,7 +226,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated flow types like so:
 

--- a/website/versioned_docs/version-v1.6.2/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-LocalStateManagement.md
@@ -43,7 +43,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -95,7 +95,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v1.6.2/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v1.6.2/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-Mutations.md
@@ -33,7 +33,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -41,13 +41,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -354,4 +354,4 @@ function commit(
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).

--- a/website/versioned_docs/version-v1.6.2/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v1.6.2/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v1.6.2/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
 
 Table of Contents:
 
@@ -116,12 +116,12 @@ type ConnectionData = {
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `connectionConfig`:
-    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](./relay-compat).
-    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](./relay-compat).
+    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](Modern-RelayCompat.md).
+    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](Modern-RelayCompat.md).
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -143,7 +143,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)

--- a/website/versioned_docs/version-v1.6.2/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-QueryRenderer.md
@@ -11,8 +11,8 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables if passed, the `QueryRenderer` will re-fetch the query.
 -   `render`: Function of type `({error, props}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.
     -   `props`: Object containing data obtained from the query; the shape of this object will match the shape of the query. If this object is not defined, it means that the data is still being fetched.

--- a/website/versioned_docs/version-v1.6.2/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component the new result.
 
 Table of Contents:
 
@@ -30,7 +30,7 @@ createRefetchContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `refetchQuery`: A `graphql` tagged query to be fetched upon calling [`props.relay.refetch`](#refetch). As with any query, upon fetching this query, its result will be normalized into the store, any relevant subscriptions associated with the changed records will be fired, and subscribed components will re-render.
 
 ### Available Props
@@ -48,7 +48,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -86,7 +86,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ### Return Value
 

--- a/website/versioned_docs/version-v1.6.2/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v1.6.2/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v1.6.2/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v1.6.2/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-Subscriptions.md
@@ -36,7 +36,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v1.6.2/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-TypeEmission.md
@@ -351,7 +351,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v1.6.2/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v1.6.2/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v1.6.2/Modern-fetchQuery.md
@@ -27,7 +27,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v1.6.2/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v1.6.2/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document together [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document together [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md) describe the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v1.7.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v1.7.0/Introduction-InstallationAndSetup.md
@@ -37,7 +37,7 @@ Please note that the `"relay"` plugin should run before other plugins or
 presets to ensure the `graphql` template literals are correctly transformed. See
 Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#pluginpreset-ordering).
 
-See the [Migration Setup](./migration-setup) guide if upgrading an existing Relay app.
+See the [Migration Setup](./Modern-MigrationSetup.md) guide if upgrading an existing Relay app.
 
 Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [babel-plugin-macros](https://github.com/kentcdodds/babel-plugin-macros). After installing `babel-plugin-macros` and adding it to your Babel config:
 
@@ -47,7 +47,7 @@ const graphql = require('babel-plugin-relay/macro');
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -87,7 +87,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v1.7.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v1.7.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v1.7.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v1.7.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -312,13 +312,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -383,7 +383,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -436,7 +436,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -583,9 +583,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#updating-the-store-programatically-advanced) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v1.7.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v1.7.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v1.7.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-FragmentContainer.md
@@ -30,7 +30,7 @@ createFragmentContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop in the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 
 ### Available Props
 
@@ -47,7 +47,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -210,7 +210,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -230,7 +230,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -293,4 +293,4 @@ export default createFragmentContainer(
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v1.7.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag are `GraphQLTaggedNode`s, which are used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+However, `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,13 +63,13 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and example, check out our docs on using `@connection` inside a Pagination Container [`here`](Modern-PaginationContainer.md#connection).
 
-**Note:** `@connection` is also supported in [compatibility mode](./relay-compat)
+**Note:** `@connection` is also supported in [compatibility mode](Modern-RelayCompat.md)
 
 ### `@relay(plural: Boolean)`
 
@@ -85,7 +85,7 @@ fragment TodoItems_items on TodoItem @relay(plural: true) {
 
 ### `@relay(mask: Boolean)`
 
-Relay by default will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+Relay by default will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available directly to the parent instead of being masked for a different container.
 
@@ -150,7 +150,7 @@ The Relay Compiler is responsible for generating code as part of a build step wh
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -228,7 +228,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 

--- a/website/versioned_docs/version-v1.7.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-LocalStateManagement.md
@@ -43,7 +43,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -95,7 +95,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v1.7.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v1.7.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -360,7 +360,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Commiting Local Updates
 

--- a/website/versioned_docs/version-v1.7.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v1.7.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v1.7.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://facebook.github.io/relay/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -116,12 +116,12 @@ type ConnectionData = {
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `connectionConfig`:
-    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](./relay-compat).
-    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](./relay-compat).
+    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](Modern-RelayCompat.md).
+    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](Modern-RelayCompat.md).
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -143,7 +143,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)

--- a/website/versioned_docs/version-v1.7.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-QueryRenderer.md
@@ -11,8 +11,8 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables is passed, the `QueryRenderer` will re-fetch the query.
 -   `render`: Function of type `({error, props, retry}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.

--- a/website/versioned_docs/version-v1.7.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -30,7 +30,7 @@ createRefetchContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `refetchQuery`: A `graphql` tagged query to be fetched upon calling [`props.relay.refetch`](#refetch). As with any query, upon fetching this query, its result will be normalized into the store, any relevant subscriptions associated with the changed records will be fired, and subscribed components will re-render.
 
 ### Available Props
@@ -48,7 +48,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -86,7 +86,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ### Return Value
 

--- a/website/versioned_docs/version-v1.7.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v1.7.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v1.7.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v1.7.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v1.7.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-TypeEmission.md
@@ -351,7 +351,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v1.7.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v1.7.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v1.7.0/Modern-fetchQuery.md
@@ -28,8 +28,8 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 
 ## Return Value

--- a/website/versioned_docs/version-v1.7.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v1.7.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v10.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.0.0/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v10.0.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v10.0.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v10.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.0.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v10.0.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v10.0.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v10.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v10.0.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v10.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v10.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v10.0.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v10.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-Mutations.md
@@ -35,7 +35,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -43,13 +43,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
     -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
@@ -360,7 +360,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v10.0.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v10.0.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v10.0.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v10.0.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v10.0.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v10.0.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v10.0.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v10.0.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -514,7 +514,7 @@ const friends = user && user.getLinkedRecord('friends');
 const edges = friends && friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v10.0.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-Subscriptions.md
@@ -43,7 +43,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
 ## Example

--- a/website/versioned_docs/version-v10.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v10.0.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v10.0.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v10.0.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v10.0.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v10.0.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v10.0.1/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.0.1/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v10.0.1/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v10.0.1/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v10.0.1/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.0.1/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v10.0.1/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v10.0.1/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v10.0.1/Modern-Debugging.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v10.0.1/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v10.0.1/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v10.0.1/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v10.0.1/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v10.0.1/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-Mutations.md
@@ -35,7 +35,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -43,13 +43,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
     -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
@@ -360,7 +360,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v10.0.1/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v10.0.1/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v10.0.1/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v10.0.1/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v10.0.1/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v10.0.1/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v10.0.1/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v10.0.1/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -514,7 +514,7 @@ const friends = user && user.getLinkedRecord('friends');
 const edges = friends && friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v10.0.1/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-Subscriptions.md
@@ -43,7 +43,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
 ## Example
@@ -90,7 +90,7 @@ requestSubscription(
 
 # Configure Network
 
-You will need to Configure your [Network](./network-layer) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
+You will need to Configure your [Network](Modern-NetworkLayer.md) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
 
 ```javascript
 import {

--- a/website/versioned_docs/version-v10.0.1/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v10.0.1/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v10.0.1/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v10.0.1/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v10.0.1/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v10.0.1/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v10.1.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.1.0/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v10.1.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v10.1.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v10.1.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.1.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares its data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v10.1.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v10.1.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v10.1.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v10.1.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v10.1.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v10.1.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v10.1.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v10.1.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-Mutations.md
@@ -35,7 +35,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -43,13 +43,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
     -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
@@ -360,7 +360,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v10.1.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v10.1.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v10.1.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v10.1.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v10.1.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v10.1.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v10.1.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v10.1.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -514,7 +514,7 @@ const friends = user && user.getLinkedRecord('friends');
 const edges = friends && friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v10.1.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-Subscriptions.md
@@ -43,7 +43,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
 ## Example
@@ -90,7 +90,7 @@ requestSubscription(
 
 # Configure Network
 
-You will need to Configure your [Network](./network-layer) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
+You will need to Configure your [Network](Modern-NetworkLayer.md) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
 
 ```javascript
 import {

--- a/website/versioned_docs/version-v10.1.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v10.1.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v10.1.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v10.1.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v10.1.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v10.1.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v10.1.1/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.1.1/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v10.1.1/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v10.1.1/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v10.1.1/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.1.1/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares its data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v10.1.1/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v10.1.1/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v10.1.1/Modern-Debugging.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v10.1.1/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v10.1.1/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v10.1.1/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v10.1.1/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v10.1.1/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-Mutations.md
@@ -35,7 +35,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -43,13 +43,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
     -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
@@ -360,7 +360,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v10.1.1/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v10.1.1/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v10.1.1/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v10.1.1/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v10.1.1/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v10.1.1/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v10.1.1/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v10.1.1/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -514,7 +514,7 @@ const friends = user && user.getLinkedRecord('friends');
 const edges = friends && friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v10.1.1/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-Subscriptions.md
@@ -43,7 +43,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
 ## Example
@@ -90,7 +90,7 @@ requestSubscription(
 
 # Configure Network
 
-You will need to Configure your [Network](./network-layer) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
+You will need to Configure your [Network](Modern-NetworkLayer.md) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
 
 ```javascript
 import {

--- a/website/versioned_docs/version-v10.1.1/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v10.1.1/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v10.1.1/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v10.1.1/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v10.1.1/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v10.1.1/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v10.1.2/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.1.2/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v10.1.2/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v10.1.2/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v10.1.2/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.1.2/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares its data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v10.1.2/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v10.1.2/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v10.1.2/Modern-Debugging.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v10.1.2/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v10.1.2/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v10.1.2/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v10.1.2/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v10.1.2/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-Mutations.md
@@ -35,7 +35,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -43,13 +43,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
     -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
@@ -360,7 +360,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v10.1.2/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v10.1.2/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v10.1.2/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v10.1.2/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v10.1.2/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v10.1.2/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v10.1.2/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v10.1.2/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -514,7 +514,7 @@ const friends = user && user.getLinkedRecord('friends');
 const edges = friends && friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v10.1.2/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-Subscriptions.md
@@ -43,7 +43,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
 ## Example
@@ -90,7 +90,7 @@ requestSubscription(
 
 # Configure Network
 
-You will need to Configure your [Network](./network-layer) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
+You will need to Configure your [Network](Modern-NetworkLayer.md) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
 
 ```javascript
 import {

--- a/website/versioned_docs/version-v10.1.2/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v10.1.2/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v10.1.2/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v10.1.2/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v10.1.2/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v10.1.2/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v10.1.3/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v10.1.3/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v10.1.3/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v10.1.3/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v10.1.3/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v10.1.3/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares its data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v10.1.3/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v10.1.3/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v10.1.3/Modern-Debugging.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v10.1.3/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v10.1.3/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v10.1.3/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v10.1.3/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v10.1.3/Modern-Mutations.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-Mutations.md
@@ -35,7 +35,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -43,13 +43,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
     -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
@@ -360,7 +360,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v10.1.3/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v10.1.3/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v10.1.3/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v10.1.3/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v10.1.3/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v10.1.3/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v10.1.3/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v10.1.3/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -512,7 +512,7 @@ const friends = user && user.getLinkedRecord('friends');
 const edges = friends && friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v10.1.3/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-Subscriptions.md
@@ -43,7 +43,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options
 
 ## Example
@@ -90,7 +90,7 @@ requestSubscription(
 
 # Configure Network
 
-You will need to Configure your [Network](./network-layer) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
+You will need to Configure your [Network](Modern-NetworkLayer.md) to handle subscriptions. The below example uses [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws):
 
 ```javascript
 import {

--- a/website/versioned_docs/version-v10.1.3/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v10.1.3/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v10.1.3/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v10.1.3/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v10.1.3/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v10.1.3/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v2.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v2.0.0/Introduction-InstallationAndSetup.md
@@ -37,7 +37,7 @@ Please note that the `"relay"` plugin should run before other plugins or
 presets to ensure the `graphql` template literals are correctly transformed. See
 Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#pluginpreset-ordering).
 
-See the [Migration Setup](./migration-setup) guide if upgrading an existing Relay app.
+See the [Migration Setup](./Modern-MigrationSetup.md) guide if upgrading an existing Relay app.
 
 Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [babel-plugin-macros](https://github.com/kentcdodds/babel-plugin-macros). After installing `babel-plugin-macros` and adding it to your Babel config:
 
@@ -47,7 +47,7 @@ const graphql = require('babel-plugin-relay/macro');
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -87,7 +87,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v2.0.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v2.0.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v2.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v2.0.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -312,13 +312,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -383,7 +383,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -436,7 +436,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -583,9 +583,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#updating-the-store-programatically-advanced) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v2.0.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v2.0.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v2.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v2.0.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-FragmentContainer.md
@@ -30,7 +30,7 @@ createFragmentContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop in the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 
 ### Available Props
 
@@ -47,7 +47,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -210,7 +210,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -230,7 +230,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -293,4 +293,4 @@ export default createFragmentContainer(
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v2.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,13 +63,13 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
-**Note:** `@connection` is also supported in [compatibility mode](./relay-compat)
+**Note:** `@connection` is also supported in [compatibility mode](Modern-RelayCompat.md)
 
 ### `@relay(plural: Boolean)`
 
@@ -94,7 +94,7 @@ fragment TodoApp_app on App {
 
 ### `@relay(mask: Boolean)`
 
-By default Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+By default Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available directly to the parent instead of being masked for a different container.
 
@@ -172,11 +172,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -254,7 +254,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 

--- a/website/versioned_docs/version-v2.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-LocalStateManagement.md
@@ -43,7 +43,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -95,7 +95,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v2.0.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v2.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -362,7 +362,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v2.0.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v2.0.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v2.0.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://facebook.github.io/relay/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -116,12 +116,12 @@ type ConnectionData = {
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `connectionConfig`:
-    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](./relay-compat).
-    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](./relay-compat).
+    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](Modern-RelayCompat.md).
+    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](Modern-RelayCompat.md).
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -143,7 +143,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)

--- a/website/versioned_docs/version-v2.0.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-QueryRenderer.md
@@ -11,8 +11,8 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables is passed, the `QueryRenderer` will re-fetch the query.
 -   `render`: Function of type `({error, props, retry}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.

--- a/website/versioned_docs/version-v2.0.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -30,7 +30,7 @@ createRefetchContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `refetchQuery`: A `graphql` tagged query to be fetched upon calling [`props.relay.refetch`](#refetch). As with any query, upon fetching this query, its result will be normalized into the store, any relevant subscriptions associated with the changed records will be fired, and subscribed components will re-render.
 
 ### Available Props
@@ -48,7 +48,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -86,7 +86,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ### Return Value
 

--- a/website/versioned_docs/version-v2.0.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v2.0.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v2.0.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v2.0.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v2.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-TypeEmission.md
@@ -351,7 +351,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v2.0.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v2.0.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v2.0.0/Modern-fetchQuery.md
@@ -28,8 +28,8 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 
 ## Return Value

--- a/website/versioned_docs/version-v2.0.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v2.0.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v3.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v3.0.0/Introduction-InstallationAndSetup.md
@@ -37,7 +37,7 @@ Please note that the `"relay"` plugin should run before other plugins or
 presets to ensure the `graphql` template literals are correctly transformed. See
 Babel's [documentation on this topic](https://babeljs.io/docs/plugins/#pluginpreset-ordering).
 
-See the [Migration Setup](./migration-setup) guide if upgrading an existing Relay app.
+See the [Migration Setup](./Modern-MigrationSetup.md) guide if upgrading an existing Relay app.
 
 Alternatively, instead of using `babel-plugin-relay`, you can use Relay with [babel-plugin-macros](https://github.com/kentcdodds/babel-plugin-macros). After installing `babel-plugin-macros` and adding it to your Babel config:
 
@@ -47,7 +47,7 @@ const graphql = require('babel-plugin-relay/macro');
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -87,7 +87,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v3.0.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v3.0.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v3.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v3.0.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -312,13 +312,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -383,7 +383,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -436,7 +436,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -583,9 +583,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#updating-the-store-programatically-advanced) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v3.0.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v3.0.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v3.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v3.0.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-FragmentContainer.md
@@ -30,7 +30,7 @@ createFragmentContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop in the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 
 ### Available Props
 
@@ -47,7 +47,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -210,7 +210,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -230,7 +230,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -293,4 +293,4 @@ export default createFragmentContainer(
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v3.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,13 +63,13 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
-**Note:** `@connection` is also supported in [compatibility mode](./relay-compat)
+**Note:** `@connection` is also supported in [compatibility mode](Modern-RelayCompat.md)
 
 ### `@relay(plural: Boolean)`
 
@@ -94,7 +94,7 @@ fragment TodoApp_app on App {
 
 ### `@relay(mask: Boolean)`
 
-By default Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+By default Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available directly to the parent instead of being masked for a different container.
 
@@ -172,11 +172,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -254,7 +254,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 

--- a/website/versioned_docs/version-v3.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-LocalStateManagement.md
@@ -43,7 +43,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -95,7 +95,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v3.0.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v3.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -362,7 +362,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v3.0.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v3.0.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v3.0.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://facebook.github.io/relay/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -116,12 +116,12 @@ type ConnectionData = {
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `connectionConfig`:
-    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](./relay-compat).
-    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](./relay-compat).
+    -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive. **Note:** `direction` is not optional in [compatibility mode](Modern-RelayCompat.md).
+    -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details. **Note:** `getConnectionFromProps` is not optional in [compatibility mode](Modern-RelayCompat.md).
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -143,7 +143,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)

--- a/website/versioned_docs/version-v3.0.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-QueryRenderer.md
@@ -11,8 +11,8 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables is passed, the `QueryRenderer` will re-fetch the query.
 -   `render`: Function of type `({error, props, retry}) => React.Node`. The output of this function will be rendered by the `QueryRenderer`.

--- a/website/versioned_docs/version-v3.0.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -30,7 +30,7 @@ createRefetchContainer(
     -   A `graphql` tagged fragment. If the fragment uses the name convention `<FileName><...>_<propName>`, the fragment's data will be available to the Component as a prop with the given `<propName>`.
         If the fragment name doesn't specify a prop name, the data will be available as a `data` prop.
     -   An object whose keys are prop names and values are `graphql` tagged fragments. Each key specified in this object will correspond to a prop available to the resulting Component.
-    -   **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
+    -   **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces fragments to be named as `<FileName>_<propName>`.
 -   `refetchQuery`: A `graphql` tagged query to be fetched upon calling [`props.relay.refetch`](#refetch). As with any query, upon fetching this query, its result will be normalized into the store, any relevant subscriptions associated with the changed records will be fired, and subscribed components will re-render.
 
 ### Available Props
@@ -48,7 +48,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -86,7 +86,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ### Return Value
 

--- a/website/versioned_docs/version-v3.0.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v3.0.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v3.0.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v3.0.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v3.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-TypeEmission.md
@@ -343,7 +343,7 @@ At its simplest, we can consider Haste as a single directory that contains all m
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v3.0.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v3.0.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v3.0.0/Modern-fetchQuery.md
@@ -28,8 +28,8 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
--   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](./relay-compat), `relay-compiler` enforces the query to be named as `<FileName>Query`.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
+-   `query`: The `graphql` tagged query. **Note:** To enable [compatibility mode](Modern-RelayCompat.md), `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 
 ## Return Value

--- a/website/versioned_docs/version-v3.0.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v3.0.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v4.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v4.0.0/Introduction-InstallationAndSetup.md
@@ -61,7 +61,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -101,7 +101,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v4.0.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v4.0.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v4.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v4.0.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -311,13 +311,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -382,7 +382,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -434,7 +434,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -581,9 +581,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#updating-the-store-programatically-advanced) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#updating-the-store-programatically-advanced) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v4.0.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v4.0.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v4.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v4.0.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v4.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@relay(mask: Boolean)`
 
-By default Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+By default Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available directly to the parent instead of being masked for a different container.
 
@@ -170,11 +170,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -252,7 +252,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -293,9 +293,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by requesting it in a query.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by requesting it in a query.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v4.0.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v4.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -362,7 +362,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v4.0.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v4.0.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v4.0.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://facebook.github.io/relay/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://facebook.github.io/relay/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)

--- a/website/versioned_docs/version-v4.0.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value. **Note:** If a new set of variables is passed, the `QueryRenderer` will re-fetch the query.

--- a/website/versioned_docs/version-v4.0.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ### Return Value
 

--- a/website/versioned_docs/version-v4.0.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v4.0.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v4.0.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v4.0.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v4.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-TypeEmission.md
@@ -343,7 +343,7 @@ At its simplest, we can consider Haste as a single directory that contains all m
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v4.0.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v4.0.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v4.0.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 

--- a/website/versioned_docs/version-v4.0.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v4.0.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v5.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v5.0.0/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v5.0.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v5.0.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v5.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v5.0.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v5.0.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v5.0.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v5.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v5.0.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v5.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@relay(mask: Boolean)`
 
-By default Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking).
+By default Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking).
 
 However, `@relay(mask: false)` can be used to prevent data masking; when including a fragment and annotating it with `@relay(mask: false)`, its data will be available directly to the parent instead of being masked for a different container.
 
@@ -170,11 +170,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -252,7 +252,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -293,9 +293,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by requesting it in a query.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by requesting it in a query.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v5.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v5.0.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v5.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -362,7 +362,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v5.0.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v5.0.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v5.0.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v5.0.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `dataFrom?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `STORE_THEN_NETWORK` key. Using the `NETWORK_ONLY ` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v5.0.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v5.0.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v5.0.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v5.0.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v5.0.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v5.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v5.0.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v5.0.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v5.0.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 

--- a/website/versioned_docs/version-v5.0.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v5.0.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v6.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v6.0.0/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v6.0.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v6.0.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v6.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v6.0.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v6.0.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v6.0.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v6.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v6.0.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v6.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v6.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v6.0.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v6.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -362,7 +362,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v6.0.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v6.0.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v6.0.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v6.0.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v6.0.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v6.0.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v6.0.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v6.0.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v6.0.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v6.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v6.0.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v6.0.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v6.0.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 

--- a/website/versioned_docs/version-v6.0.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v6.0.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v7.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v7.0.0/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v7.0.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v7.0.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v7.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v7.0.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v7.0.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v7.0.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v7.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v7.0.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v7.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v7.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v7.0.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v7.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -362,7 +362,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v7.0.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v7.0.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v7.0.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v7.0.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v7.0.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v7.0.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v7.0.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v7.0.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v7.0.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v7.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v7.0.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v7.0.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v7.0.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v7.0.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v7.0.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v7.1.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v7.1.0/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v7.1.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v7.1.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v7.1.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v7.1.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v7.1.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v7.1.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v7.1.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v7.1.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v7.1.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v7.1.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v7.1.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v7.1.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -362,7 +362,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v7.1.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v7.1.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v7.1.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v7.1.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v7.1.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v7.1.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v7.1.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v7.1.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -477,7 +477,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v7.1.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v7.1.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v7.1.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v7.1.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v7.1.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v7.1.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v7.1.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v8.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v8.0.0/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v8.0.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v8.0.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v8.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v8.0.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v8.0.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v8.0.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v8.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v8.0.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v8.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v8.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v8.0.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v8.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -358,7 +358,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v8.0.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v8.0.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v8.0.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v8.0.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v8.0.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v8.0.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v8.0.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v8.0.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -514,7 +514,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v8.0.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v8.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v8.0.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v8.0.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v8.0.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v8.0.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v8.0.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v9.0.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v9.0.0/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v9.0.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v9.0.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v9.0.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v9.0.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v9.0.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v9.0.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v9.0.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v9.0.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v9.0.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v9.0.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v9.0.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v9.0.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -358,7 +358,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v9.0.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v9.0.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v9.0.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v9.0.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v9.0.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v9.0.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v9.0.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v9.0.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -514,7 +514,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v9.0.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v9.0.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v9.0.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v9.0.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v9.0.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v9.0.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v9.0.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 

--- a/website/versioned_docs/version-v9.1.0/Introduction-InstallationAndSetup.md
+++ b/website/versioned_docs/version-v9.1.0/Introduction-InstallationAndSetup.md
@@ -87,7 +87,7 @@ module.exports = {
 
 ## Set up relay-compiler
 
-Relay's ahead-of-time compilation requires the [Relay Compiler](./graphql-in-relay#relay-compiler), which you can install via `yarn` or `npm`:
+Relay's ahead-of-time compilation requires the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler), which you can install via `yarn` or `npm`:
 
 ```sh
 
@@ -127,7 +127,7 @@ yarn run relay --watch
 
 ```
 
-For more details, check out our [Relay Compiler docs](./graphql-in-relay#relay-compiler).
+For more details, check out our [Relay Compiler docs](Modern-GraphQLInRelay.md#relay-compiler).
 
 ## JavaScript environment requirements
 

--- a/website/versioned_docs/version-v9.1.0/Introduction-Prerequisites.md
+++ b/website/versioned_docs/version-v9.1.0/Introduction-Prerequisites.md
@@ -15,7 +15,7 @@ We also assume basic understanding of [GraphQL](http://graphql.org/learn/). In o
 
 A description of your data model with an associated set of resolve methods that know how to fetch any data your application could ever need.
 
-GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](./graphql-server-specification).
+GraphQL is designed to support a wide range of data access patterns. In order to understand the structure of an application's data, Relay requires that you follow certain conventions when defining your schema. These are documented in the [GraphQL Server Specification](GraphQL-ServerSpecification.md).
 
 -   **[graphql-js](https://github.com/graphql/graphql-js)** on [npm](https://www.npmjs.com/package/graphql)
 

--- a/website/versioned_docs/version-v9.1.0/Introduction-QuickStartGuide.md
+++ b/website/versioned_docs/version-v9.1.0/Introduction-QuickStartGuide.md
@@ -19,7 +19,7 @@ Table of Contents:
 
 ## Setup
 
-Before starting, make sure to check out our [Prerequisites](./prerequisites) and [Installation and Setup](./installation-and-setup) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
+Before starting, make sure to check out our [Prerequisites](Introduction-Prerequisites.md) and [Installation and Setup](Introduction-InstallationAndSetup.md) guides. As mentioned in the prerequisites, we need to make sure that we've set up a GraphQL server and schema.
 
 Fortunately, we are going to be using this [example todo list app](https://github.com/relayjs/relay-examples/tree/main/todo), which already has a [server](https://github.com/relayjs/relay-examples/blob/main/todo/server.js) and [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql) available for us to use:
 
@@ -42,7 +42,7 @@ Additionally, we will be using [Flow](https://flow.org/) inside our JavaScript c
 
 ## Relay Environment
 
-Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](./relay-environment). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
+Before we can start rendering pixels on the screen, we need to configure Relay via a [Relay Environment](Modern-RelayEnvironment.md). The environment bundles together the configuration, cache storage, and network-handling that Relay needs in order to operate.
 
 For the purposes of our example, we are simply going to configure our environment to communicate with our existing GraphQL server:
 
@@ -80,13 +80,13 @@ const environment = new Environment({
 export default environment;
 ```
 
-A Relay Environment requires at least a [Store](./relay-store) and a [Network Layer](./network-layer). The above code uses the default implementation for `Store`, and creates a [Network Layer](./network-layer) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
+A Relay Environment requires at least a [Store](Modern-RelayStore.md) and a [Network Layer](Modern-NetworkLayer.md). The above code uses the default implementation for `Store`, and creates a [Network Layer](Modern-NetworkLayer.md) using a simple `fetchQuery` function to fetch a GraphQL query from our server.
 
 Usually we'd want a single environment in our app, so you could export this environment as a singleton instance from a module to make it accessible across your app.
 
 ## Rendering GraphQL Queries
 
-Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](./query-renderer) component provided by `react-relay`.
+Now that we've configured our Relay Environment, we can start fetching queries and rendering data on the screen. The entry point to render data from a GraphQL query is the [`QueryRenderer`](Modern-QueryRenderer.md) component provided by `react-relay`.
 
 To start, let's assume we just want to render the user id on the screen. From our [schema](https://github.com/relayjs/relay-examples/blob/main/todo/data/schema.graphql#L66), we know that we can get the current `User` via the `viewer` field, so let's write a sample query to fetch the current user id:
 
@@ -138,13 +138,13 @@ export default class App extends React.Component {
 Our app is rendering a `QueryRenderer` in the above code, like any other React Component, but let's see what's going on in the props that we are passing to it:
 
 -   We're passing the `environment` we defined earlier.
--   We're using the [`graphql`](./graphql-in-relay) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](./graphql-in-relay#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](./graphql-in-relay) docs.
+-   We're using the [`graphql`](Modern-GraphQLInRelay.md) function to define our GraphQL query. `graphql` is a template tag that is never executed at runtime, but rather used by the [Relay Compiler](Modern-GraphQLInRelay.md#relay-compiler) to generate the runtime artifacts that Relay requires to operate. We don't need to worry about this right now; for more details check out our [GraphQL in Relay](Modern-GraphQLInRelay.md) docs.
 -   We're passing an empty set of `variables`. We'll look into how to use variables in the next section.
 -   We're passing a `render` function; as you can tell from the code, Relay gives us some information about whether an error occurred, or if we're still fetching the query. If everything succeeds, the data we requested will be available inside `props`, with the same shape as the one specified in the query.
 
-In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](./installation-and-setup), we can just run `yarn relay`.
+In order to run this app, we need to first compile our query using the Relay Compiler. Assuming the setup from [Installation and Setup](Introduction-InstallationAndSetup.md), we can just run `yarn relay`.
 
-For more details on `QueryRenderer`, check out the [docs](./query-renderer).
+For more details on `QueryRenderer`, check out the [docs](Modern-QueryRenderer.md).
 
 ## Using Query Variables
 
@@ -314,13 +314,13 @@ The above code highlights one of Relay's most important principles which is colo
 -   It becomes obvious at a glance what data is required to render a given component, without having to search which query in our app is fetching the required data.
 -   As a corollary, the component is de-coupled from the query that renders it. We can change the data dependencies for the component without having to update the queries that render them or worrying about breaking other components.
 
-Check out our [Thinking in Relay](./thinking-in-relay) guide for more details behind Relay's principles.
+Check out our [Thinking in Relay](PrinciplesAndArchitecture-ThinkingInRelay.md) guide for more details behind Relay's principles.
 
 Before proceeding, don't forget to run the Relay Compiler with `yarn relay`.
 
 ## Composing Fragments
 
-Given that [Fragment Containers](./fragment-container) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
+Given that [Fragment Containers](Modern-FragmentContainer.md) are just React components, we can compose them as such. We can even re-use fragment containers within other fragment containers. As an example, let's see how we would define a `TodoList` component that just renders a list of todo items, and whether all have been completed or not:
 
 ```javascript
 // TodoList.js
@@ -387,7 +387,7 @@ export default createFragmentContainer(
 
 As with the first fragment container we defined, `TodoList` declares it's data dependencies via a fragment. However, this component additionally re-uses the fragment previously defined by the `Todo` component, and passes the appropriate data when rendering the child `Todo` components (a.k.a. fragment containers).
 
-One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](./thinking-in-relay#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
+One final thing to note when composing fragment containers is that the parent will not have access to the data defined by the child container. Relay only allows components to access data they specifically ask for in GraphQL fragments — nothing more. This is called [Data Masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking), and it's intentional to prevent components from depending on data they didn't declare as a dependency.
 
 ## Rendering Fragments
 
@@ -439,7 +439,7 @@ export default class ViewerTodoList extends React.Component {
 }
 ```
 
-Check out our docs for [Fragment Containers](./fragment-container) for more details, and our guides on [Refetch](./refetch-container) and [Pagination](./pagination-container) for more advanced usage of containers.
+Check out our docs for [Fragment Containers](Modern-FragmentContainer.md) for more details, and our guides on [Refetch](Modern-RefetchContainer.md) and [Pagination](Modern-PaginationContainer.md) for more advanced usage of containers.
 
 ## Mutating Data
 
@@ -586,9 +586,9 @@ You can inspect the network request or response to see the exact shape.
 
 By default, Relay will know to update the fields on the records referenced by the mutation payload, (i.e. the `todo` in our example). However, this is only the simplest case. In some cases updating the local data isn't as simple as just updating the fields in a record.
 
-For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](./mutations#configs) and an [`updater`](./mutations#using-updater-and-optimisticupdater) function for full control over the update.
+For instance, we might be updating a collection of items, or we might be deleting a record entirely. For these more advanced scenarios Relay allows us to pass a set of options for us to control how we update the local data from a server response, including a set of [`configs`](Modern-Mutations.md#configs) and an [`updater`](Modern-Mutations.md#using-updater-and-optimisticupdater) function for full control over the update.
 
-For more details and advanced use cases on mutations and updates, check out our [Mutations](./mutations) docs.
+For more details and advanced use cases on mutations and updates, check out our [Mutations](Modern-Mutations.md) docs.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-v9.1.0/Modern-ConversionPlaybook.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-ConversionPlaybook.md
@@ -7,7 +7,7 @@ Incrementally modernize your Relay Classic app in these steps:
 
 ## Step 0: Install and configure your environment
 
-Follow the steps outlined in the [Migration Setup](./migration-setup) guide.
+Follow the steps outlined in the [Migration Setup](./Modern-MigrationSetup.md) guide.
 
 ## Step 1: Incrementally convert to Relay Compat
 

--- a/website/versioned_docs/version-v9.1.0/Modern-ConvertingMutations.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-ConvertingMutations.md
@@ -48,11 +48,11 @@ This is no longer needed in Compatibility Mode for neither environments. Simply 
 
 ### RANGE_ADD
 
-`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./mutations#range-add)
+`RANGE_ADD` needs one additional property in the config named `connectionInfo` to work with the new environment. Learn more about `connectionInfo` [Mutation/RANGE_ADD](./Modern-Mutations.md#range-add)
 
 ### RANGE_DELETE
 
-`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./mutations#range-delete)
+`RANGE_DELETE` needs one additional property in the config named `connectionKeys` to work with the new environment. Learn more about `connectionKeys` [Mutation/RANGE_DELETE](./Modern-Mutations.md#range-delete)
 
 ### NODE_DELETE
 
@@ -169,4 +169,4 @@ function commit(environment: CompatEnvironment, args) {
 }
 ```
 
-See [Mutation](./mutations) for additional options on `commitMutation` for more complex mutations.
+See [Mutation](./Modern-Mutations.md) for additional options on `commitMutation` for more complex mutations.

--- a/website/versioned_docs/version-v9.1.0/Modern-Debugging.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-Debugging.md
@@ -11,7 +11,7 @@ If you're new to Relay, we provide some basic debugging strategies that should s
 
 **A few questions to ask yourself:**
 
--   _Is my [compilation](./installation-and-setup#set-up-relay-compiler) up-to-date?_
+-   _Is my [compilation](./Introduction-InstallationAndSetup.md#set-up-relay-compiler) up-to-date?_
 -   _Is my query valid?_ You can test this on your GraphiQL endpoint.
 
 **If so:**

--- a/website/versioned_docs/version-v9.1.0/Modern-FragmentContainer.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-FragmentContainer.md
@@ -44,7 +44,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
 
 ## Example
 
@@ -173,7 +173,7 @@ Note that when composing fragments, the type of the composed fragment must match
 
 #### `@argumentDefinitions`
 
-When defining a fragment, you can use the [`@argumentDefinitions`](./graphql-in-relay#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
+When defining a fragment, you can use the [`@argumentDefinitions`](Modern-GraphQLInRelay.md#argumentdefinitions) directive to specify any arguments, with potentially default values, that the fragment expects.
 
 For example, let's redefine our `TodoList_list` fragment to take some arguments using `@argumentDefinitions`:
 
@@ -193,7 +193,7 @@ Any arguments defined inside `@argumentDefinitions` will be local variables avai
 
 #### `@arguments`
 
-In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](./graphql-in-relay#arguments) directive.
+In order to pass arguments to a fragment that has `@argumentDefinitions`, you need to use the [`@arguments`](Modern-GraphQLInRelay.md#arguments) directive.
 
 Following our `TodoList_list` example, we would pass arguments to the fragment like so:
 
@@ -205,4 +205,4 @@ query TodoListQuery($count: Int, $userID: ID) {
 
 ## Rendering Containers
 
-As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](./query-renderer) docs for more details.
+As we've learned, Relay fragment containers only declare data requirements as GraphQL fragments. In order to actually fetch and render the specified data, we need to use a `QueryRenderer` component to render a root query and any fragment containers included within. Please refer to our [`QueryRenderer`](Modern-QueryRenderer.md) docs for more details.

--- a/website/versioned_docs/version-v9.1.0/Modern-GraphQLInRelay.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-GraphQLInRelay.md
@@ -25,9 +25,9 @@ graphql`
 `;
 ```
 
-The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](./query-renderer), [Fragment Containers](./fragment-container), [Refetch Containers](./refetch-container), [Pagination Containers](./pagination-container), etc.
+The result of using the `graphql` template tag is a `GraphQLTaggedNode`; a runtime representation of the GraphQL document which can be used to define [Query Renderers](Modern-QueryRenderer.md), [Fragment Containers](Modern-FragmentContainer.md), [Refetch Containers](Modern-RefetchContainer.md), [Pagination Containers](Modern-PaginationContainer.md), etc.
 
-Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Note that `graphql` template tags are **never executed at runtime**. Instead, they are compiled ahead of time by the [Relay Compiler](#relay-compiler) into generated artifacts that live alongside your source code, and which Relay requires to operate at runtime. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 ## Directives
 
@@ -45,7 +45,7 @@ query TodoListQuery($userID: ID) {
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@argumentDefinitions`
 
@@ -63,11 +63,11 @@ fragment TodoList_list on TodoList @argumentDefinitions(
 }
 ```
 
-See the [Fragment Container docs](./fragment-container#passing-arguments-to-a-fragment) for more details.
+See the [Fragment Container docs](Modern-FragmentContainer.md#passing-arguments-to-a-fragment) for more details.
 
 ### `@connection(key: String!, filters: [String])`
 
-When using the [Pagination Container](./pagination-container), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](./pagination-container#connection).
+When using the [Pagination Container](Modern-PaginationContainer.md), Relay expects connection fields to be annotated with a `@connection` directive. For more detailed information and an example, check out the [docs on using `@connection` inside a Pagination Container](Modern-PaginationContainer.md#connection).
 
 ### `@relay(plural: Boolean)`
 
@@ -92,7 +92,7 @@ fragment TodoApp_app on App {
 
 ### `@inline`
 
-By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](./fragment-container#createfragmentcontainer), which is known as [data masking](./thinking-in-relay#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
+By default, Relay will only expose the data for fields explicitly requested by a [component's fragment](Modern-FragmentContainer.md#createfragmentcontainer), which is known as [data masking](PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking). Fragment data is unmasked for use in React components by `createFragmentContainer`. However, you may want to use fragment data in non-React functions that are called from React.
 
 Non-React functions can also take advantage of data masking. A fragment can be defined with the `@inline` directive and stored in a local variable. The non-React function can then "unmask" the data using the `readInlineData` function.
 
@@ -222,11 +222,11 @@ Persisted queries can be enabled by instructing Relay Compiler to emit metadata 
 Relay Compiler will then create the id =&gt; query text mapping in the path you specify. You can then use this complete
 json file in your server side to map query ids to operation text.
 
-For more details, refer to the [Persisted Queries section](./persisted-queries).
+For more details, refer to the [Persisted Queries section](Modern-PersistedQueries.md).
 
 ### Set up relay-compiler
 
-See our relay-compiler section in our [Installation and Setup guide](./installation-and-setup#set-up-relay-compiler).
+See our relay-compiler section in our [Installation and Setup guide](Introduction-InstallationAndSetup.md#set-up-relay-compiler).
 
 ### GraphQL Schema
 
@@ -304,7 +304,7 @@ This would produce three generated files, and two `__generated__` directories:
 
 ### Importing generated definitions
 
-Typically you will not need to import your generated definitions. The [Relay Babel plugin](./installation-and-setup#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
+Typically you will not need to import your generated definitions. The [Relay Babel plugin](Introduction-InstallationAndSetup.md#setup-babel-plugin-relay) will then convert the `graphql` literals in your code into `require()` calls for the generated files.
 
 However the Relay Compiler also automatically generates [Flow](https://flow.org) types as [type comments](https://flow.org/en/docs/types/comments/). For example, you can import the generated Flow types like so:
 
@@ -345,9 +345,9 @@ extend type Root {
 }
 ```
 
-Any fields specified in the client schema, can be fetched from the [Relay Store](./relay-store), by selecting it in a query or fragment.
+Any fields specified in the client schema, can be fetched from the [Relay Store](Modern-RelayStore.md), by selecting it in a query or fragment.
 
-For more details, refer to the [Local state management section](./local-state-management).
+For more details, refer to the [Local state management section](Modern-LocalStateManagement.md).
 
 ### Advanced usage
 

--- a/website/versioned_docs/version-v9.1.0/Modern-LocalStateManagement.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-LocalStateManagement.md
@@ -44,7 +44,7 @@ extend type User {
 Accessing local data is no different from querying your GraphQL server, although you are required to include atleast one server field in the query.
 The field can be from the server schema, or it can be schema agnostic, like an introspection field (i.e. `__typename`).
 
-Here, we use a [QueryRenderer](./query-renderer) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
+Here, we use a [QueryRenderer](Modern-QueryRenderer.md) to get the current `User` via the `viewer` field, along with their id, name and the local list of notes.
 
 ```javascript
 // Example.js
@@ -96,7 +96,7 @@ const Example = (props) => {
 
 ## Mutating local state
 
-All local data lives in the [Relay Store](./relay-store).
+All local data lives in the [Relay Store](Modern-RelayStore.md).
 Updating local state can be done with any `updater` function.
 The `commitLocalUpdate` function is especially ideal for this, because writes to local state are usually executed outside of a mutation.
 

--- a/website/versioned_docs/version-v9.1.0/Modern-MigrationSetup.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-MigrationSetup.md
@@ -5,7 +5,7 @@ original_id: migration-setup
 ---
 ## Installation
 
-Follow the installation instructions from the [Installation and Setup](./installation-and-setup) guide.
+Follow the installation instructions from the [Installation and Setup](Introduction-InstallationAndSetup.md) guide.
 
 ## Set up babel-plugin-relay for Relay Classic
 
@@ -20,7 +20,7 @@ Relay Classic `Relay.QL` literals. Most importantly, include a reference to your
 }
 ```
 
-## Set up babel-plugin-relay for "[compatibility mode](./relay-compat)"
+## Set up babel-plugin-relay for "[compatibility mode](Modern-RelayCompat.md)"
 
 When incrementally converting a Relay Classic app to Relay Modern, `graphql`
 literals can be translated to be usable by _both_ runtimes if configured to use

--- a/website/versioned_docs/version-v9.1.0/Modern-Mutations.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-Mutations.md
@@ -34,7 +34,7 @@ commitMutation(
 
 ### Arguments
 
--   `environment`: The [Relay Environment](./relay-environment). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md). **Note:** To ensure the mutation is performed on the correct `environment`, it's recommended to use the environment available within components (from `this.props.relay.environment`), instead of referencing a global environment.
 -   `config`:
     -   `mutation`: The `graphql` tagged mutation query.
     -   `variables`: Object containing the variables needed for the mutation. For example, if the mutation defines an `$input` variable, this object should contain an `input` key, whose shape must match the shape of the data expected by the mutation as defined by the GraphQL schema.
@@ -42,13 +42,13 @@ commitMutation(
     -   `onError`: Callback function executed if Relay encounters an error during the request.
     -   `optimisticResponse`: Object containing the data to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. This object must have the same shape as the mutation's response type, as defined by the GraphQL schema. If provided, Relay will use the `optimisticResponse` data to update the fields on the relevant records in the local data store, _before_ `optimisticUpdater` is executed. If an error occurs during the mutation request, the optimistic update will be rolled back.
     -   `optimisticUpdater`: Function used to optimistically update the local in-memory store, i.e. immediately, before the mutation request has completed. If an error occurs during the mutation request, the optimistic update will be rolled back.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
         **Please note:**
         -   It is usually preferable to just pass an `optimisticResponse` option instead of an `optimisticUpdater`, unless you need to perform updates on the local records that are more complicated than just updating fields (e.g. deleting records or adding items to collections).
         -   If you do decide to use an `optimisticUpdater`, often times it can be the same function as `updater`.
     -   `updater`: Function used to update the local in-memory store based on the **real** server response from the mutation. If `updater` is not provided, by default, Relay will know to automatically update the fields on the records referenced in the mutation response; however, you should pass an `updater` if you need to make more complicated updates than just updating fields (e.g. deleting records or adding items to collections).
         When the server response comes back, Relay first reverts any changes introduced by `optimisticUpdater` or `optimisticResponse` and will then execute `updater`.
-        This function takes a `store`, which is a proxy of the in-memory [Relay Store](./relay-store). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](./relay-store).
+        This function takes a `store`, which is a proxy of the in-memory [Relay Store](Modern-RelayStore.md). In this function, the client defines 'how to' update the local data based on the server response via the `store` instance. For details on how to use the `store`, please refer to our [Relay Store API Reference](Modern-RelayStore.md).
     -   `configs`:  Array containing objects describing `optimisticUpdater`/`updater` configurations. `configs` provides a convenient way to specify the `updater` behavior without having to write an `updater` function. See our section on [Updater Configs](#updater-configs) for more details.
 
 ## Simple Example
@@ -358,7 +358,7 @@ function commit(environment, text, user) {
 }
 ```
 
-For details on how to interact with the Relay Store, please refer to our Relay Store [docs](./relay-store).
+For details on how to interact with the Relay Store, please refer to our Relay Store [docs](Modern-RelayStore.md).
 
 ## Committing Local Updates
 

--- a/website/versioned_docs/version-v9.1.0/Modern-NetworkLayer.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-NetworkLayer.md
@@ -3,7 +3,7 @@ id: network-layer
 title: Network Layer
 original_id: network-layer
 ---
-In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](./relay-environment). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
+In order to know how to access your GraphQL server, Relay Modern requires developers to provide an object implementing the `NetworkLayer` interface when creating an instance of a [Relay Environment](Modern-RelayEnvironment.md). The environment uses this network layer to execute queries, mutations, and (if your server supports them) subscriptions. This allows developers to use whatever transport (HTTP, WebSockets, etc) and authentication is most appropriate for their application, decoupling the environment from the particulars of each application's network configuration.
 
 Currently the easiest way to create a network layer is via a helper from the `relay-runtime` package:
 

--- a/website/versioned_docs/version-v9.1.0/Modern-NewInRelayModern.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-NewInRelayModern.md
@@ -12,12 +12,12 @@ A summary of the improvements and new features in Relay Modern.
 Compared to Relay Classic, the Relay Modern API has the following differentiating features:
 
 -   A simpler, more predictable mutation API. The restrictions on mutation queries from Relay Classic are also removed: mutation queries are static, fields can be arbitrarily nested, and may use arbitrary arguments.
--   When using [`QueryRenderer`](./query-renderer), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
--   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./routing).
--   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](./fragment-container) are optional and can be used as your application grows in size and complexity.
+-   When using [`QueryRenderer`](Modern-QueryRenderer.md), the restrictions on queries from Relay Classic are removed: queries may contain multiple root fields that use arbitrary arguments and return singular or plural values. The `viewer` root field is now optional.
+-   Routes are now optional: `QueryRenderer` can be used without defining a route. More in the [routing guide](./Modern-Routing.md).
+-   `QueryRenderer` supports rendering small amounts of data directly, instead of requiring a container to access data. [Containers](Modern-FragmentContainer.md) are optional and can be used as your application grows in size and complexity.
 -   The API is overall simpler and more predictable.
 
-You can use [Compat mode](./relay-compat) to incrementally adopt Relay Modern APIs in an existing Relay app.
+You can use [Compat mode](Modern-RelayCompat.md) to incrementally adopt Relay Modern APIs in an existing Relay app.
 
 ## Modern Runtime
 

--- a/website/versioned_docs/version-v9.1.0/Modern-PaginationContainer.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-PaginationContainer.md
@@ -3,7 +3,7 @@ id: pagination-container
 title: Pagination Container
 original_id: pagination-container
 ---
-Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](./fragment-container), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
+Pagination Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html), similar to a [Fragment Container](Modern-FragmentContainer.md), that is designed to simplify the workflow of loading more items in a list — in many cases, we don't want to fetch all the data at once but lazily load more data. It relies on a GraphQL server exposing connections in a standardized way. For a detailed spec, please check out [this page](https://relay.dev/graphql/connections.htm).
 
 Table of Contents:
 
@@ -17,7 +17,7 @@ Table of Contents:
 
 ## `@connection`
 
-Pagination Container works in a very similar way to the [Fragment Container](./fragment-container) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
+Pagination Container works in a very similar way to the [Fragment Container](Modern-FragmentContainer.md) in that you also specify the data requirements for a component via GraphQL fragments in the `fragmentSpec`.
 
 However, when [specifying connection fragments](#createpaginationcontainer) for a Pagination Container, it is expected that at least one of the fragments contains a [GraphQL connection](https://relay.dev/graphql/connections.htm) to paginate over, and that the connection field is annotated with a `@connection` directive.
 
@@ -118,7 +118,7 @@ type ConnectionData = {
     -   `direction`: Either "forward" to indicate forward pagination using after/first, or "backward" to indicate backwards pagination using before/last. If not provided, Relay will infer the direction based on the provided `@connection` directive.
     -   `getConnectionFromProps`: Function that should indicate which connection to paginate over, given the fragment props (i.e. the props corresponding to the `fragmentSpec`). This is necessary in most cases because the Relay can't automatically tell which connection you mean to paginate over (a container might fetch multiple fragments and connections, but can only paginate one of them). If not provided, Relay will try infer the correct connection to paginate over based on the provided `@connection` directive. See our [example](#pagination-example) for more details.
     -   `getFragmentVariables`: Function that should return the bag of variables  to use for reading out the data from the store when re-rendering the component. This function takes the previous set of variables passed to the pagination `query`, and the number of elements that have been fetched in total so far. Specifically, this indicates which variables to use when reading out the data from the
-        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](./refetch-container#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
+        local data store _after_ the new pagination `query` has been fetched. If not specified, Relay will default to using all of the previous variables and using the total count for the `count` variable. This option is analogous to [`renderVariables`](Modern-RefetchContainer.md#refetch) in the Refetch Container. See our [example](#pagination-example) for more details.
     -   `getVariables`: Function that should return the variables to pass to the pagination `query` when fetching it from the server, given the current `props`, `count` and `cursor`. You may set whatever variables here, as well as modify the defaults to use for after/first/before/last arguments. See our [example](#pagination-example) for more details.
     -   `query`: A `graphql` tagged query to be used as the pagination query to fetch more data upon calling [`loadMore`](#loadmore).
 
@@ -140,7 +140,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `hasMore`: See `hasMore` [docs](#hasmore)
     -   `isLoading`: See `isLoading` [docs](#isloading)
     -   `loadMore`: See `loadMore` [docs](#loadmore)
@@ -182,7 +182,7 @@ loadMore(
 -   `pageSize`: The number of **additional** items to fetch (not the total).
 -   `callback`: Function called when the new page has been fetched. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
 
 ## `refetchConnection`
 

--- a/website/versioned_docs/version-v9.1.0/Modern-QueryRenderer.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-QueryRenderer.md
@@ -11,7 +11,7 @@ However, a `QueryRenderer` will not start loading its data until it is mounted, 
 
 ## Props
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`. Optional, if not provided, an empty `props` object is passed to the `render` callback.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 -   `fetchPolicy?`: Optional prop to indicate if data already present in the store should be used to render immediately and updated from the network afterwards using the `store-and-network` key. Using the `network-only` key, which is the default behavior, ignores data already present in the store and waits for the network results to come back.

--- a/website/versioned_docs/version-v9.1.0/Modern-RefetchContainer.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-RefetchContainer.md
@@ -3,7 +3,7 @@ id: refetch-container
 title: Refetch Container
 original_id: refetch-container
 ---
-A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](./fragment-container), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
+A Refetch Container is also a [higher-order component](https://reactjs.org/docs/higher-order-components.html) that works like a regular [Fragment Container](Modern-FragmentContainer.md), but provides the additional ability to fetch a new GraphQL query with different variables and re-render the component with the new result.
 
 Table of Contents:
 
@@ -45,7 +45,7 @@ type Props = {
 ```
 
 -   `relay`:
-    -   `environment`: The current [Relay Environment](./relay-environment)
+    -   `environment`: The current [Relay Environment](Modern-RelayEnvironment.md)
     -   `refetch`: See `refetch` [docs](#refetch)
 
 ## `refetch`
@@ -83,7 +83,7 @@ refetch(
     local data store _after_ the new query has been fetched. If not specified, the `refetchVariables` will be used. This is useful when the data you need to render in your component doesn't necessarily match the data you queried the server for. For example, to implement pagination, you would fetch a page with variables like `{first: 5, after: '<cursor>'}`, but you might want to render the full collection with `{first: 10}`.
 -   `callback`: Function to be called after the refetch has completed. If an error occurred during refetch, this function will receive that error as an argument.
 -   `options`: Optional object containing set of options.
-    -   `force`: If the [Network Layer](./network-layer) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
+    -   `force`: If the [Network Layer](Modern-NetworkLayer.md) has been configured with a cache, this option forces a refetch even if the data for this query and variables is already available in the cache.
     -   `fetchPolicy`: If the data is already present in the store, using the `'store-or-network'` option will use that data without making an additional network request. Using the `'network-only'` option, which is the default behavior, will ignore any data present in the store and make a network request.
 
 ### Return Value

--- a/website/versioned_docs/version-v9.1.0/Modern-RelayCompat.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-RelayCompat.md
@@ -8,7 +8,7 @@ scratch. Instead, convert one component at a time to the Relay Modern API while
 continuing to have a working app. Once all components have been converted, the
 smaller and faster Relay Modern runtime can be used.
 
-During this migration, use the [Relay Compat](./relay-compat) tools and APIs to work with both Relay Classic and Relay Modern.
+During this migration, use the [Relay Compat](Modern-RelayCompat.md) tools and APIs to work with both Relay Classic and Relay Modern.
 
 ## API and Runtime
 

--- a/website/versioned_docs/version-v9.1.0/Modern-RelayEnvironment.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-RelayEnvironment.md
@@ -31,9 +31,9 @@ const environment = new Environment({
 });
 ```
 
-For more details on creating a Network, see the [NetworkLayer guide](./network-layer).
+For more details on creating a Network, see the [NetworkLayer guide](Modern-NetworkLayer.md).
 
-Once you have an environment, you can pass it in to your [`QueryRenderer`](./query-renderer) instance, or into mutations via the `commitUpdate` function (see "[Mutations](./mutations)").
+Once you have an environment, you can pass it in to your [`QueryRenderer`](Modern-QueryRenderer.md) instance, or into mutations via the `commitUpdate` function (see "[Mutations](Modern-Mutations.md)").
 
 ## Adding a `handlerProvider`
 

--- a/website/versioned_docs/version-v9.1.0/Modern-RelayStore.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-RelayStore.md
@@ -3,7 +3,7 @@ id: relay-store
 title: Relay Store
 original_id: relay-store
 ---
-The Relay Store can be used to programmatically update client-side data inside [`updater` functions](./mutations#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
+The Relay Store can be used to programmatically update client-side data inside [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater). The following is a reference of the Relay Store interface.
 
 Table of Contents:
 
@@ -13,7 +13,7 @@ Table of Contents:
 
 ## RecordSourceSelectorProxy
 
-The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](./mutations#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
+The `RecordSourceSelectorProxy` is the type of the `store` that [`updater` functions](Modern-Mutations.md#using-updater-and-optimisticupdater) receive as an argument. The following is the `RecordSourceSelectorProxy` interface:
 
 ```javascript
 interface RecordSourceSelectorProxy {
@@ -514,7 +514,7 @@ const friends = user && user.getLinkedRecord(user, 'friends');
 const edges = friends.getLinkedRecords('edges');
 ```
 
-In a [pagination container](./pagination-container), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
+In a [pagination container](Modern-PaginationContainer.md), we usually annotate the actual connection field with `@connection` to tell Relay which part needs to be paginated:
 
 ```graphql
 fragment FriendsFragment on User {

--- a/website/versioned_docs/version-v9.1.0/Modern-Subscriptions.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-Subscriptions.md
@@ -42,7 +42,7 @@ Now let's take a closer look at the `config`:
     the server, with the raw GraphQL response payload.
 -   `updater`: an optional function that can supply custom logic for updating the
     in-memory Relay store based on the server response.
--   `configs`: an array containing the updater configurations. It is the same as [`configs`](./mutations#updater-configs) in `commitMutation`.
+-   `configs`: an array containing the updater configurations. It is the same as [`configs`](Modern-Mutations.md#updater-configs) in `commitMutation`.
 
 ## Example
 

--- a/website/versioned_docs/version-v9.1.0/Modern-TypeEmission.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-TypeEmission.md
@@ -352,7 +352,7 @@ By default, Flow types are emitted inside of comments to avoid forcing your proj
 
 If you are looking to create your own language plugin, refer to the `relay-compiler` [language plugin interface][plugin-interface].
 
-[data-masking]: ./thinking-in-relay#data-masking
+[data-masking]: ./PrinciplesAndArchitecture-ThinkingInRelay.md#data-masking
 
 [Haste]: https://twitter.com/dan_abramov/status/758655309212704768
 

--- a/website/versioned_docs/version-v9.1.0/Modern-UpgradingSetVariables.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-UpgradingSetVariables.md
@@ -38,7 +38,7 @@ fragment on User {
 }
 ```
 
-This should be upgraded to use a [`PaginationContainer`](./pagination-container).
+This should be upgraded to use a [`PaginationContainer`](Modern-PaginationContainer.md).
 
 ## Changing Arguments
 
@@ -62,7 +62,7 @@ fragment on User {
 }
 ```
 
-This can be upgraded by using a [`RefetchContainer`](./refetch-container) which allows you to specify the exact query to use to fetch the new data.
+This can be upgraded by using a [`RefetchContainer`](Modern-RefetchContainer.md) which allows you to specify the exact query to use to fetch the new data.
 
 ## Show More
 
@@ -86,6 +86,6 @@ fragment on FeedbackTarget {
 }
 ```
 
-This can be upgraded by conditionally rendering a [`QueryRenderer`](./query-renderer) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
+This can be upgraded by conditionally rendering a [`QueryRenderer`](Modern-QueryRenderer.md) which will load the data once it is rendered. The code overhead of doing this is dramatically reduced with the new API.
 
-Alternatively a [`RefetchContainer`](./refetch-container) can also be used.
+Alternatively a [`RefetchContainer`](Modern-RefetchContainer.md) can also be used.

--- a/website/versioned_docs/version-v9.1.0/Modern-fetchQuery.md
+++ b/website/versioned_docs/version-v9.1.0/Modern-fetchQuery.md
@@ -28,7 +28,7 @@ fetchQuery(environment, query, variables)
 
 ## Arguments
 
--   `environment`: The [Relay Environment](./relay-environment)
+-   `environment`: The [Relay Environment](Modern-RelayEnvironment.md)
 -   `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 -   `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
 -   `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache. See [the types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/relay-runtime/lib/util/RelayRuntimeTypes.d.ts#L22-L35) for more `cacheConfig` options.

--- a/website/versioned_docs/version-v9.1.0/PrinciplesAndArchitecture-Overview.md
+++ b/website/versioned_docs/version-v9.1.0/PrinciplesAndArchitecture-Overview.md
@@ -3,7 +3,7 @@ id: architecture-overview
 title: Architecture Overview
 original_id: architecture-overview
 ---
-This document, together with [Runtime Architecture](./runtime-architecture) and [Compiler Architecture](./compiler-architecture), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
+This document, together with [Runtime Architecture](./PrinciplesAndArchitecture-Runtime.md) and [Compiler Architecture](./PrinciplesAndArchitecture-Compiler.md), describes the high-level architecture of Relay "Modern". The intended audience includes developers interested in contributing to Relay, developers hoping to utilize the building blocks of Relay to create higher-level APIs, and anyone interested in understanding more about Relay internals. For developers wanting to learn more about _using_ Relay to build products, the other sections might be more helpful.
 
 ## Core Modules
 


### PR DESCRIPTION
The current relay website has over 1.6k broken links. Which are caused by an optional trailing slash(can be added by the hosting provider) and unspecified extensions in markdown links' urls. One way this can be fixed is to force trailing extensions for all pages at the build time in docusaurus and to throw during build for invalid links. A similar PR was in hydra project recently [hydra#1900](https://github.com/facebookresearch/hydra/pull/1900).

This PR introduces 3 changes that were split into separate commits to make it easier to review

1. Remove unused redirect that causes a build warning.
2. Enable trailing slashes and throw for invalid links during the build.
3. Replace relative urls to the files, that would be resolve to correct urls during the build.

## Steps to reproduce

1. Go to [relay.dev/docs/v9.1.0/relay-debugging](https://relay.dev/docs/v9.1.0/relay-debugging), note how this url does not have a trailing slash, but as you open the page you get 301 with redirect to a url with a trailing slash
2. Click on a link `compilation`
3. See "Page not found"

## Sidenote

While verifying that the changed links work I discovered that there were a few more broken urls that were broken for a different reason. In particular these:

```json
[
    {
        "page": "https://relay.dev/docs/v1.4.1/graphql-server-specification/",
        "href": "/graphql/connections.htm/",
        "linkText": "GraphQL Cursor Connections"
    },
    {
        "page": "https://relay.dev/docs/v1.4.1/graphql-server-specification/",
        "href": "/graphql/connections.htm/",
        "linkText": "Relay cursor connection"
    },
    {
        "page": "https://relay.dev/docs/v1.5.0/graphql-server-specification/",
        "href": "/graphql/connections.htm/",
        "linkText": "GraphQL Cursor Connections"
    },
    {
        "page": "https://relay.dev/docs/v1.5.0/graphql-server-specification/",
        "href": "/graphql/connections.htm/",
        "linkText": "Relay cursor connection"
    },
    {
        "page": "https://relay.dev/docs/v1.6.0/graphql-server-specification/",
        "href": "/graphql/connections.htm/",
        "linkText": "GraphQL Cursor Connections"
    },
    {
        "page": "https://relay.dev/docs/v1.6.0/graphql-server-specification/",
        "href": "/graphql/connections.htm/",
        "linkText": "Relay cursor connection"
    }
]
```

