### PR TITLE
Adds Viewer as a TODO in the glossary

### DIFF
--- a/website/versioned_docs/version-v12.0.0/glossary/glossary.md
+++ b/website/versioned_docs/version-v12.0.0/glossary/glossary.md
@@ -853,4 +853,8 @@ GraphQL variables are a construct that allows referencing dynamic values inside 
 
 See the [variables section of the guided tour](../guided-tour/rendering/variables) and compare with [@argumentDefinitions](#argumentdefinitions).
 
+## Viewer
+
+TODO
+
 <DocsRating />


### PR DESCRIPTION
I have my own sense of it (in Artsy we didn't necessarily use `viewer` if I recall) but it's a good item for the glossary IMO