### PR TITLE
Add a JSON file query persister strategy to relay-compiler

### DIFF
--- a/compiler/crates/relay-compiler/src/build_project/mod.rs
+++ b/compiler/crates/relay-compiler/src/build_project/mod.rs
@@ -292,22 +292,19 @@ pub async fn commit_project(
         return Err(BuildProjectFailure::Cancelled);
     }
 
-    if let Some(ref operation_persister) = config.operation_persister {
-        if let Some(ref persist_config) = project_config.persist {
-            let persist_operations_timer = log_event.start("persist_operations_time");
-            persist_operations::persist_operations(
-                &mut artifacts,
-                &config.root_dir,
-                persist_config,
-                config,
-                project_config,
-                operation_persister.as_ref(),
-                &log_event,
-                &programs,
-            )
-            .await?;
-            log_event.stop(persist_operations_timer);
-        }
+    if let Some(ref operation_persister) = project_config.operation_persister {
+        let persist_operations_timer = log_event.start("persist_operations_time");
+        persist_operations::persist_operations(
+            &mut artifacts,
+            &config.root_dir,
+            config,
+            project_config,
+            operation_persister.as_ref(),
+            &log_event,
+            &programs,
+        )
+        .await?;
+        log_event.stop(persist_operations_timer);
     }
 
     if source_control_update_status.is_started() {

--- a/compiler/crates/relay-compiler/src/build_project/persist_operations.rs
+++ b/compiler/crates/relay-compiler/src/build_project/persist_operations.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     config::{Config, ProjectConfig},
-    config::{OperationPersister, PersistConfig},
+    config::{OperationPersister},
     errors::BuildProjectError,
     Artifact, ArtifactContent,
 };
@@ -29,7 +29,6 @@ lazy_static! {
 pub async fn persist_operations(
     artifacts: &mut [Artifact],
     root_dir: &PathBuf,
-    persist_config: &PersistConfig,
     config: &Config,
     project_config: &ProjectConfig,
     operation_persister: &'_ (dyn OperationPersister + Send + Sync),
@@ -68,7 +67,7 @@ pub async fn persist_operations(
                         let text = text.clone();
                         Some(async move {
                             operation_persister
-                                .persist_artifact(text, persist_config)
+                                .persist_artifact(text)
                                 .await
                                 .map(|id| {
                                     *id_and_text_hash = Some(QueryID::Persisted { id, text_hash });

--- a/compiler/crates/relay-compiler/src/file_persister.rs
+++ b/compiler/crates/relay-compiler/src/file_persister.rs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::OperationPersister;
+use async_trait::async_trait;
+use persist_query::PersistError;
+use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct FilePersistConfig {
+  /// Path to a file to persist the document to.
+  pub file_path: PathBuf,
+}
+
+pub struct FilePersister {
+  file_path: PathBuf,
+}
+
+impl FilePersister {
+  pub fn new(path: PathBuf, root_path: PathBuf) -> Self {
+    // Append the incoming path to the project's root.
+    let mut file_path = root_path.clone();
+    file_path.push(path);
+    Self { file_path }
+  }
+
+  fn hash_operation(&self, operation_text: String) -> String {
+    let mut hash = Sha1::new();
+    hash.input(&operation_text);
+    hex::encode(hash.result())
+  }
+}
+
+#[async_trait]
+impl OperationPersister for FilePersister {
+  async fn persist_artifact(&self, operation_text: String) -> Result<String, PersistError> {
+    let mut map: HashMap<String, String> = if self.file_path.exists() {
+      let existing_content = std::fs::read_to_string(&self.file_path);
+      match existing_content {
+        Ok(content) => serde_json::from_str(&content).unwrap(),
+        Err(_e) => HashMap::new(),
+      }
+    } else {
+      HashMap::new()
+    };
+
+    let op_hash = self.hash_operation(operation_text.clone());
+
+    map.insert(op_hash.clone(), operation_text);
+    let content = serde_json::to_string_pretty(&map).unwrap();
+    std::fs::write(&self.file_path, content).unwrap();
+
+    Ok(op_hash)
+  }
+
+  fn worker_count(&self) -> usize {
+    0
+  }
+}

--- a/compiler/crates/relay-compiler/src/lib.rs
+++ b/compiler/crates/relay-compiler/src/lib.rs
@@ -19,6 +19,7 @@ mod file_source;
 mod graphql_asts;
 mod red_to_green;
 mod remote_persister;
+mod file_persister;
 pub mod saved_state;
 pub mod status_reporter;
 
@@ -40,3 +41,4 @@ pub use file_source::{
 };
 pub use graphql_asts::GraphQLAsts;
 pub use remote_persister::RemotePersister;
+pub use file_persister::FilePersister;

--- a/compiler/crates/relay-compiler/src/main.rs
+++ b/compiler/crates/relay-compiler/src/main.rs
@@ -11,7 +11,7 @@ use log::{error, info, Level};
 use relay_compiler::{
     compiler::Compiler,
     config::{Config, SingleProjectConfigFile, TypegenLanguage},
-    FileSourceKind, RemotePersister,
+    FileSourceKind,
 };
 use std::io::Write;
 use std::{
@@ -101,7 +101,6 @@ async fn main() {
         error!("{}", err);
         std::process::exit(1);
     });
-    config.operation_persister = Some(Box::new(RemotePersister));
     config.file_source_config = if should_use_watchman() {
         FileSourceKind::Watchman
     } else {

--- a/compiler/crates/relay-compiler/src/remote_persister.rs
+++ b/compiler/crates/relay-compiler/src/remote_persister.rs
@@ -5,21 +5,40 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use crate::{OperationPersister, PersistConfig};
+use crate::OperationPersister;
 use async_trait::async_trait;
+use fnv::FnvBuildHasher;
+use indexmap::IndexMap;
 use persist_query::{persist, PersistError};
+use serde::{Deserialize, Serialize};
 
-pub struct RemotePersister;
+type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemotePersistConfig {
+    /// URL to send a POST request to to persist.
+    pub url: String,
+    /// The document will be in a POST parameter `text`. This map can contain
+    /// additional parameters to send.
+    pub params: FnvIndexMap<String, String>,
+}
+
+pub struct RemotePersister {
+    config: RemotePersistConfig,
+}
+
+impl RemotePersister {
+    pub fn new(config: RemotePersistConfig) -> Self {
+        Self { config }
+    }
+}
 
 #[async_trait]
 impl OperationPersister for RemotePersister {
-    async fn persist_artifact(
-        &self,
-        operation_text: String,
-        persist_config: &PersistConfig,
-    ) -> Result<String, PersistError> {
-        let params = &persist_config.params;
-        let url = &persist_config.url;
+    async fn persist_artifact(&self, operation_text: String) -> Result<String, PersistError> {
+        let params = &self.config.params;
+        let url = &self.config.url;
         persist(&operation_text, url, params).await
     }
 

--- a/packages/relay-compiler/README.md
+++ b/packages/relay-compiler/README.md
@@ -80,6 +80,11 @@ yarn relay --config ./relay.json
   - `params`            The document will be in a `POST`
                         parameter `text`. This map can contain additional
                         parameters to send.                             [object]
+  - `filePath`          Relative path to JSON file where you want queries to be
+                        locally persisted to. Note that if you set this
+                        property you cannot also have the `url` or `params`
+                        properties set.
+                                                                        [string]
 
 ### CLI configuration
 


### PR DESCRIPTION
**NOTE**: This is essentially the first time I've developed in Rust so feel free to eviscerate it because...

![I have no idea what I'm doing](https://user-images.githubusercontent.com/1398555/144315265-3529ef64-6096-446f-91c0-07710ede5c34.jpg)

# Summary

Previously in the new rust relay-compiler your only option for persisting queries is to use the remote persister which makes POST requests to a given endpoint with the operation text to be persisted. This PR adds the option to instead persist your queries to a local JSON file in a very similar way to how the JS compiler originally did it.

If you had a basic remote persister config like this:

```js
persistConfig: {
  url: "http://localhost:3000",
  params: {}
}
```

changing it to a local JSON file persister means updating the config to:

```js
persistConfig: {
  filePath: "./queries.json"
}
```

When this is enabled and a new query is persisted the compiler will first attempt to read the local file if it exists as a hash map (creating a new one if there is no existing data), hashes the operation text, adds the operation text to the hashmap keyed by the hashed version of the operation, and then serializes & writes the resulting map to the configured path.

# Test Plan

Leveraging my own [simple repo](https://github.com/vincentriemer/new-relay-compiler-issues-repro) I've been using for reproducing issues with the new relay compiler, installed the relay-compiler to a version including this PR's changes, and updated the `relay.config.js` file as such:

```diff
module.exports = {
  "src": "./src",
  "schema": "./schema.graphql",
  "artifactDirectory": "./src/__generated__",
  "language": "typescript",
  "persistConfig": {
-    "url": "http://localhost:3000",
-    "params": {}
+    filePath: "./queries.json"
  }
};
```

Then after running the relay compiler I verified that it created a `queries.json` file and it contained the expected persisted query json output:

```json
{
  "00dc69b2cfc4c1da3528e9aaf65a05091740fc71": "query AppQuery {\n  viewer {\n    submission(name: \"t3_qvyl2j\") {\n      ...Post_submission\n      id\n    }\n  }\n}\n\nfragment Post_submission on Submission {\n  title\n  author\n  selftext {\n    html\n  }\n}\n"
}
```