### PR TITLE
Add MacOS ARM64 build target to relay-compiler for better M1 Mac support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
             os: macos-latest
             build-name: relay
             artifact-name: relay-compiler-macos-arm64
-          - target: x86_64-pc-windows-gnu
+          - target: x86_64-pc-windows-msvc
             os: windows-latest
             build-name: relay.exe
             artifact-name: relay-compiler-win-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,20 @@ jobs:
     strategy:
       matrix:
         target:
-          - os: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
             build-name: relay
             artifact-name: relay-compiler-linux-x64
-          - os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
             build-name: relay
             artifact-name: relay-compiler-macos-x64
-          - os: windows-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            build-name: relay
+            artifact-name: relay-compiler-macos-arm64
+          - target: x86_64-pc-windows-gnu
+            os: windows-latest
             build-name: relay.exe
             artifact-name: relay-compiler-win-x64
     runs-on: ${{ matrix.target.os }}
@@ -94,11 +101,12 @@ jobs:
         with:
           toolchain: stable
           override: true
+          target: ${{ matrix.target.target }}
       - uses: actions-rs/cargo@v1
         with:
           command: build
           # add --locked back when we have a better way to ensure it's up to date
-          args: --manifest-path=compiler/Cargo.toml --release
+          args: --manifest-path=compiler/Cargo.toml --release --target ${{ matrix.target.target }}
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.target.artifact-name }}
@@ -128,6 +136,11 @@ jobs:
         with:
           name: relay-compiler-macos-x64
           path: artifacts/macos-x64
+      - name: Download artifact relay-compiler-macos-arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: relay-compiler-macos-arm64
+          path: artifacts/macos-arm64
       - name: Download artifact relay-compiler-win-x64
         uses: actions/download-artifact@v2
         with:
@@ -138,6 +151,7 @@ jobs:
         run: |
           chmod +x linux-x64/relay
           chmod +x macos-x64/relay
+          chmod +x macos-arm64/relay
       - name: Build main version
         run:  RELEASE_COMMIT_SHA=${{github.sha}} yarn gulp mainrelease
       - name: Publish to npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.target.artifact-name }}
-          path: compiler/target/release/${{ matrix.target.build-name }}
+          path: compiler/target/${{ matrix.target.target }}/release/${{ matrix.target.build-name }}
 
   main-release:
     name: Publish main tag to npm

--- a/packages/relay-compiler/index.js
+++ b/packages/relay-compiler/index.js
@@ -13,8 +13,10 @@
 const path = require('path');
 
 let binary;
-if (process.platform === 'darwin') {
+if (process.platform === 'darwin' && process.arch === 'x64') {
   binary = path.join(__dirname, 'macos-x64', 'relay');
+} else if (process.platform === 'darwin' && process.arch === 'arm64') {
+  binary = path.join(__dirname, 'macos-arm64', 'relay');
 } else if (process.platform === 'linux' && process.arch === 'x64') {
   binary = path.join(__dirname, 'linux-x64', 'relay');
 } else if (process.platform === 'win32' && process.arch === 'x64') {


### PR DESCRIPTION
idk what the performance difference is since I don't have a project large enough where I can notice a difference but I figured there's no harm in at least providing an M1 native executable for the new relay-compiler.

Verified on my M1 MacBook Pro by manually downloading the new macOS-arm64 artifact built from the GH workflow and replacing a local executable which still runs successfully.