### PR TITLE
Publish relay releases from github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
   main-release:
     name: Publish main tag to npm
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.repository == 'facebook/relay'
     needs: [js-tests, js-lint, typecheck, rust-tests, build-compiler]
     steps:
       - uses: actions/checkout@v2
@@ -138,12 +138,26 @@ jobs:
         run: |
           chmod +x linux-x64/relay
           chmod +x macos-x64/relay
-      - name: Build main version
-        run:  RELEASE_COMMIT_SHA=${{github.sha}} yarn gulp mainrelease
+
+      - name: Build latest (main) version
+        if: github.ref == 'refs/heads/main'
+        run: yarn gulp mainrelease
+        env:
+          RELEASE_COMMIT_SHA: ${{ github.sha }} 
+
+      - name: Build release version
+        if: github.ref_type == 'tag' && startsWith(github.ref_name, "v")
+        run: yarn gulp release
+        evn:
+          npm_package_version: ${{ github.ref_name }}
+
       - name: Publish to npm
         run: |
           for pkg in dist/*; do
-            npm publish "$pkg" --tag main
+            npm publish "$pkg" ${TAG}
           done
         env:
+          TAG: ${{ 
+            github.ref == "refs/heads/main" && "--tag=main" || 
+            (github.ref_type == 'tag' && startsWith(github.ref_name, "v") && contains(github.ref_name, "-rc.") && "--tag=dev") || "" }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           RELEASE_COMMIT_SHA: ${{ github.sha }} 
 
       - name: Build release version
-        if: github.ref_type == 'tag' && startsWith(github.ref_name, "v")
+        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
         run: yarn gulp release
         env:
           npm_package_version: ${{ github.ref_name }}
@@ -157,5 +157,5 @@ jobs:
             npm publish "$pkg" ${TAG}
           done
         env:
-          TAG: ${{ github.ref == "refs/heads/main" && "--tag=main" || ((github.ref_type == 'tag' && startsWith(github.ref_name, "v") && contains(github.ref_name, "-rc.") && "--tag=dev") || "" )}}
+          TAG: ${{ github.ref == 'refs/heads/main' && '--tag=main' || ((github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && contains(github.ref_name, '-rc.') && '--tag=dev') || '' )}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,5 @@ jobs:
             npm publish "$pkg" ${TAG}
           done
         env:
-          TAG: ${{ 
-            github.ref == "refs/heads/main" && "--tag=main" || 
-            (github.ref_type == 'tag' && startsWith(github.ref_name, "v") && contains(github.ref_name, "-rc.") && "--tag=dev") || "" }}
+          TAG: ${{ github.ref == "refs/heads/main" && "--tag=main" || ((github.ref_type == 'tag' && startsWith(github.ref_name, "v") && contains(github.ref_name, "-rc.") && "--tag=dev") || "" )}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Build release version
         if: github.ref_type == 'tag' && startsWith(github.ref_name, "v")
         run: yarn gulp release
-        evn:
+        env:
           npm_package_version: ${{ github.ref_name }}
 
       - name: Publish to npm

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -404,5 +404,6 @@ exports.clean = clean;
 exports.dist = dist;
 exports.watch = watch;
 exports.mainrelease = gulp.series(cleanbuild, relayCompiler, setMainVersion);
+exports.release = gulp.series(cleanbuild, relayCompiler);
 exports.cleanbuild = cleanbuild;
 exports.default = cleanbuild;


### PR DESCRIPTION
We already publishing all versions as `main` to NPM. Let's also integrate this process with our tags.

- For all pushed commits to the `main` branch everything stays the same
- If a new tag is published, the action will build a release version (using a tag name)
- if GitHub tag contains `-rc.` suffix, `--tag=dev` will be used during `npm publish`.
