### PR TITLE
[OSS v13 Compiler] Evaluate custom scalars first

### DIFF
--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -1228,16 +1228,14 @@ impl<'a> TypeGenerator<'a> {
 
     fn transform_graphql_scalar_type(&mut self, scalar: ScalarID) -> AST {
         let scalar_name = self.schema.scalar(scalar).name;
-        if scalar_name == *TYPE_ID || scalar_name == *TYPE_STRING {
+        if let Some(&custom_scalar) = self.typegen_config.custom_scalar_types.get(&scalar_name) {
+            AST::RawType(custom_scalar)
+        } else if scalar_name == *TYPE_ID || scalar_name == *TYPE_STRING {
             AST::String
         } else if scalar_name == *TYPE_FLOAT || scalar_name == *TYPE_INT {
             AST::Number
         } else if scalar_name == *TYPE_BOOLEAN {
             AST::Boolean
-        } else if let Some(&custom_scalar) =
-            self.typegen_config.custom_scalar_types.get(&scalar_name)
-        {
-            AST::RawType(custom_scalar)
         } else {
             if self.typegen_config.require_custom_scalar_types {
                 panic!(

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-raw-response-on-conditional.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-raw-response-on-conditional.expected
@@ -19,7 +19,7 @@ fragment FriendFragment on User {
 import type { FriendFragment$fragmentType } from "FriendFragment.graphql";
 export type ExampleQuery$variables = {|
   id: string,
-  condition: boolean,
+  condition: CustomBoolean,
 |};
 export type ExampleQuery$data = {|
   +node: ?{|

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream-connection.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream-connection.expected
@@ -52,7 +52,7 @@ export type TestDefer$rawResponse = {|
       |}>,
       +pageInfo: ?{|
         +endCursor: ?string,
-        +hasNextPage: ?boolean,
+        +hasNextPage: ?CustomBoolean,
       |},
     |},
   |} | {|

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream.expected
@@ -46,7 +46,7 @@ export type TestStream$rawResponse = {|
       |}>,
       +pageInfo: ?{|
         +endCursor: ?string,
-        +hasNextPage: ?boolean,
+        +hasNextPage: ?CustomBoolean,
       |},
     |},
   |} | {|

--- a/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
@@ -7,7 +7,8 @@
 
 use common::{ConsoleLogger, FeatureFlag, FeatureFlags, SourceLocationKey};
 use fixture_tests::Fixture;
-use fnv::FnvHashMap;
+use fnv::{FnvHashMap, FnvBuildHasher};
+use indexmap::{IndexMap};
 use graphql_ir::{build, Program};
 use graphql_syntax::parse_executable;
 use intern::string_key::Intern;
@@ -16,6 +17,8 @@ use relay_test_schema::{get_test_schema, get_test_schema_with_extensions};
 use relay_transforms::{apply_transforms, ConnectionInterface};
 use relay_typegen::{self, TypegenConfig, TypegenLanguage};
 use std::sync::Arc;
+
+type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts = fixture.content.split("%extensions%").collect::<Vec<_>>();
@@ -56,8 +59,11 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
 
     let js_module_format = JsModuleFormat::Haste;
     let has_unified_output = false;
+    let mut custom_scalar_types = FnvIndexMap::default();
+    custom_scalar_types.insert("Boolean".intern(), "CustomBoolean".intern());
     let typegen_config = TypegenConfig {
         language: TypegenLanguage::Flow,
+        custom_scalar_types: custom_scalar_types,
         ..Default::default()
     };
 


### PR DESCRIPTION
I have a custom scalar type on a private project that replaces the graphal `ID` type with a Flow `newtype`. The JS relay compiler supported the ability to replace built-ins, but the new Rust compiler seems to lack this ability.

With this change, custom scalars are evaluated first, then built-ins, then `any` (or panic). AFAIK this matches the old compiler's behavior.

My `cargo fmt` is not working right now for some reason, so I present this patch unformatted. If GitHub Actions doesn't complain, I assume Meta-internal formatters will catch and fix this if necessary.

Test plan:
`cargo test` passes

`cargo run --bin relay -- ../../../myproject/relay.config.json` now replaces `ID` types with `GraphQLID` instead of `string` as it does in the rc0 version