### PR TITLE
[OSS v13 Compiler] Generate exact imports when using CommonJS and output

### DIFF
--- a/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
+++ b/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
@@ -273,6 +273,7 @@ fn generate_operation(
                 normalization_operation,
                 schema,
                 project_config.js_module_format,
+                project_config.output.is_some(),
                 &project_config.typegen_config,
             )
         )
@@ -392,6 +393,7 @@ fn generate_split_operation(
                 normalization_operation,
                 schema,
                 project_config.js_module_format,
+                project_config.output.is_some(),
                 &project_config.typegen_config,
             )
         )
@@ -538,6 +540,7 @@ fn generate_fragment(
                 typegen_fragment,
                 schema,
                 project_config.js_module_format,
+                project_config.output.is_some(),
                 &project_config.typegen_config
             )
         )

--- a/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
@@ -55,6 +55,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     .unwrap();
 
     let js_module_format = JsModuleFormat::Haste;
+    let has_unified_output = false;
     let typegen_config = TypegenConfig {
         language: TypegenLanguage::Flow,
         ..Default::default()
@@ -72,6 +73,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
             normalization_operation,
             &schema,
             js_module_format,
+            has_unified_output,
             &typegen_config,
         )
     });
@@ -79,7 +81,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let mut fragments: Vec<_> = programs.typegen.fragments().collect();
     fragments.sort_by_key(|frag| frag.name.item);
     let fragment_strings = fragments.into_iter().map(|frag| {
-        relay_typegen::generate_fragment_type(frag, &schema, js_module_format, &typegen_config)
+        relay_typegen::generate_fragment_type(frag, &schema, js_module_format, has_unified_output, &typegen_config)
     });
 
     let mut result: Vec<String> = operation_strings.collect();

--- a/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
@@ -52,6 +52,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     .unwrap();
 
     let js_module_format = JsModuleFormat::Haste;
+    let has_unified_output = false;
     let typegen_config = TypegenConfig {
         language: TypegenLanguage::TypeScript,
         ..Default::default()
@@ -69,6 +70,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
             normalization_operation,
             &schema,
             js_module_format,
+            has_unified_output,
             &typegen_config,
         )
     });
@@ -76,7 +78,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let mut fragments: Vec<_> = programs.typegen.fragments().collect();
     fragments.sort_by_key(|frag| frag.name.item);
     let fragment_strings = fragments.into_iter().map(|frag| {
-        relay_typegen::generate_fragment_type(frag, &schema, js_module_format, &typegen_config)
+        relay_typegen::generate_fragment_type(frag, &schema, js_module_format, has_unified_output, &typegen_config)
     });
 
     let mut result: Vec<String> = operation_strings.collect();


### PR DESCRIPTION
The old JS compiler would generate exact `foo$fragmentType` imports when `artifactDirectory` is set since this allows the compiler to know where all the artifacts would be (all in the same directory).

The new compiler does not appear to support this currently. But this seemed easy enough to do, so I've taken a stab at it in this diff. I am not fluent in Rust (yet) so I am happy to take criticism on how to write this better!

Test plan:
`cargo test` passes

`cargo run --bin relay -- ../../../myproject/relay.config.json` produces the expected output.

Example file diff from the rc0 version of the compiler to this PR/Diff:
```diff
diff --git a/__generated__/BlogPostPageQuery.graphql.js b/__generated__/BlogPostPageQuery.graphql.js
index 96bd4fbf6..2911ddbd7 100644
--- a/__generated__/BlogPostPageQuery.graphql.js
+++ b/__generated__/BlogPostPageQuery.graphql.js
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e8ed1071e6aabf5e4f69fd2c87674a6b>>
+ * @generated SignedSource<<f722c4d69fbe60872e2b896ecba50897>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -12,7 +12,7 @@
 
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
-type BlogPost_post$fragmentType = any;
+import type { BlogPost_post$fragmentType } from "./BlogPost_post.graphql";
 export type BlogPostPageQuery$variables = {|
   relativePath: string,
 |};
```