### PR TITLE
Watch js,jsx files with watchman with typescript

### DIFF
--- a/compiler/crates/relay-compiler/src/file_source/watchman_query_builder.rs
+++ b/compiler/crates/relay-compiler/src/file_source/watchman_query_builder.rs
@@ -29,7 +29,12 @@ pub fn get_watchman_expr(config: &Config) -> Expr {
                     Expr::Suffix(match &project.typegen_config.language {
                         TypegenLanguage::Flow => vec![PathBuf::from("js"), PathBuf::from("jsx")],
                         TypegenLanguage::TypeScript => {
-                            vec![PathBuf::from("ts"), PathBuf::from("tsx")]
+                            vec![
+                                PathBuf::from("js"),
+                                PathBuf::from("jsx"),
+                                PathBuf::from("ts"),
+                                PathBuf::from("tsx"),
+                            ]
                         }
                     }),
                     // In the related source root.


### PR DESCRIPTION
Updates the watchman query builder to match what the glob file source already does: https://github.com/facebook/relay/blob/main/compiler/crates/relay-compiler/src/file_source/glob_file_source.rs#L49-L50

It's useful in projects that are not 100% typescript