### PR TITLE
Stop @preloadable Typescript code generation from emitting an inline require

### DIFF
--- a/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
+++ b/compiler/crates/relay-compiler/src/build_project/artifact_content.rs
@@ -311,11 +311,22 @@ fn generate_operation(
     .unwrap();
 
     if is_operation_preloadable(normalization_operation) && id_and_text_hash.is_some() {
-        writeln!(
-            content,
-            "require('relay-runtime').PreloadableQueryRegistry.set((node.params/*: any*/).id, node);\n",
-        )
-        .unwrap();
+        match project_config.typegen_config.language {
+            TypegenLanguage::Flow => {
+                writeln!(
+                    content,
+                    "require('relay-runtime').PreloadableQueryRegistry.set((node.params/*: any*/).id, node);\n",
+                )
+                .unwrap();
+            }
+            TypegenLanguage::TypeScript => {
+                writeln!(
+                    content,
+                    "import {{ PreloadableQueryRegistry }} from 'relay-runtime';\nPreloadableQueryRegistry.set(node.params.id, node);\n",
+                )
+                .unwrap();
+            }
+        }
     }
 
     let node_type = if skip_types {


### PR DESCRIPTION
# Summary

Fixes #3683

I found that when I added the `@preloadable` directive to a query in a TS project it would cause my application to crash at runtime because my bundler didn't transpire the `require` call that the `relay-compiler` generated in order to populate the `PreloadableQueryRegistry` map. This PR addresses this by changing it to an eager esmodule import when the code generation language is set to Typescript.

# Test Plan

* Tests still pass
* Locally built and utilized a version of relay-compiler in my minimal repro repo (https://github.com/vincentriemer/new-relay-compiler-issues-repro) and verified the `AppQuery.graphql.ts` generated output contained the eager esmodule import instead of an inline require.