### PR TITLE
relay add readme files to packages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -249,6 +249,13 @@ builds.forEach((build) => {
         .src(['LICENSE'])
         .pipe(gulp.dest(path.join(DIST, build.package)));
     },
+    function copyReadmeFile() {
+      return gulp
+        .src(['README.md'], {
+          cwd: path.join(PACKAGES, build.package),
+        })
+        .pipe(gulp.dest(path.join(DIST, build.package)));
+    },
     function copyTestschema() {
       return gulp
         .src(['*.graphql'], {
@@ -334,7 +341,7 @@ const relayCompiler = gulp.parallel(
   },
   function copyPackageFiles() {
     return gulp
-      .src(['package.json', 'cli.js', 'index.js'], {
+      .src(['README.md','package.json', 'cli.js', 'index.js'], {
         cwd: path.join(PACKAGES, 'relay-compiler'),
       })
       .pipe(gulp.dest(path.join(DIST, 'relay-compiler')));

--- a/packages/babel-plugin-relay/README.md
+++ b/packages/babel-plugin-relay/README.md
@@ -1,0 +1,4 @@
+babel-plugin-relay
+---
+
+More details: https://relay.dev/docs/getting-started/installation-and-setup/#set-up-babel-plugin-relay

--- a/packages/react-relay/README.md
+++ b/packages/react-relay/README.md
@@ -1,0 +1,4 @@
+react-relay
+---
+
+More details: https://relay.dev/

--- a/packages/relay-runtime/README.md
+++ b/packages/relay-runtime/README.md
@@ -1,0 +1,4 @@
+relay-runtime
+---
+
+More details: https://relay.dev/

--- a/packages/relay-test-utils-internal/README.md
+++ b/packages/relay-test-utils-internal/README.md
@@ -1,0 +1,4 @@
+relay-test-utils-internal
+---
+
+A collection of internal helpers used for relay unit-tests.

--- a/packages/relay-test-utils/README.md
+++ b/packages/relay-test-utils/README.md
@@ -1,0 +1,4 @@
+relay-test-utils
+---
+
+More details: https://relay.dev/docs/guides/testing-relay-components/


### PR DESCRIPTION
This diff is adding README.md to the package on NPM,

We have our compiler documentation in the compiler README file already, but it is not visible on NPM.

We could also update other packages' REAMDE files to highlight their purpose, and point to the correct place on the documentation website for a more detailed version.

But for now, let's just add basic files, and populate content later.
