### PR TITLE
[relay-compiler][win] Use the primary separator of path components for the current platform

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio",
+ "walkdir",
  "watchman_client",
  "zstd",
 ]
@@ -1587,6 +1588,15 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2135,6 +2145,17 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/compiler/crates/relay-lsp/src/code_action/create_name_suggestion.rs
+++ b/compiler/crates/relay-lsp/src/code_action/create_name_suggestion.rs
@@ -178,6 +178,7 @@ fn create_impactful_part() -> String {
     format!("{}{}", adjective, noun)
 }
 
+#[cfg(not(windows))]
 #[cfg(test)]
 mod tests {
     use super::{
@@ -299,6 +300,24 @@ mod tests {
                 DefinitionNameSuffix::Query
             ),
             Some("ReactFileTestQuery".to_string())
+        );
+    }
+}
+
+#[cfg(windows)]
+#[cfg(test)]
+mod tests {
+    use super::{create_default_name, DefinitionNameSuffix};
+
+    #[test]
+    fn test_create_default_name() {
+        assert_eq!(
+            create_default_name("C:\\user\\ReactFile.js", DefinitionNameSuffix::Query),
+            Some("ReactFileQuery".to_string())
+        );
+        assert_eq!(
+            create_default_name("\\\\?\\D:\\data\\user\\react-file.js", DefinitionNameSuffix::Query),
+            Some("reactFileQuery".to_string())
         );
     }
 }

--- a/compiler/crates/relay-transforms/src/validations/validate_module_names/extract_module_name.rs
+++ b/compiler/crates/relay-transforms/src/validations/validate_module_names/extract_module_name.rs
@@ -66,6 +66,7 @@ fn to_camel_case(non_camelized_string: String) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(not(windows))]
     #[test]
     fn extract_module_names_test() {
         assert_eq!(
@@ -159,6 +160,19 @@ mod tests {
         assert_eq!(
             extract_module_name("/path/non-numeric-end-.js"),
             Some("nonNumericEnd".to_string())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn extract_module_names_test() {
+        assert_eq!(
+            extract_module_name("C:\\path\\Button.ios.js"),
+            Some("ButtonIos".to_string())
+        );
+        assert_eq!(
+            extract_module_name("\\path\\Button.android.js"),
+            Some("ButtonAndroid".to_string())
         );
     }
 }

--- a/compiler/crates/relay-transforms/src/validations/validate_module_names/extract_module_name.rs
+++ b/compiler/crates/relay-transforms/src/validations/validate_module_names/extract_module_name.rs
@@ -27,7 +27,7 @@ pub fn extract_module_name(path: &str) -> Option<String> {
 }
 
 fn get_final_non_index_js_segment(path: &str) -> Option<&str> {
-    let mut iter = path.split('/');
+    let mut iter = path.split(std::path::MAIN_SEPARATOR);
     let last_segment = iter.next_back()?;
     if last_segment == "index.js"
         || last_segment == "index.jsx"


### PR DESCRIPTION
Test plan:
Before this change (on Windows) running compiler in the test project

```
cd compiler
cargo run --bin relay .\test-project\relay.json
```

```
[ERROR] ✖︎ Queries in graphql tags must start with the module name ('compilerTestProjectSrcApp') and end with 'Query'. Got 'AppQuery' instead.

  compiler\test-project\src\App.js:3:9
    1 │ 
    2 │   query AppQuery {
      │         ^^^^^^^^
    3 │     node(id: "test") {

[ERROR] ✖︎ Fragments in graphql tags must start with the module name ('compilerTestProjectSrcComponent'). Got 'Component_node' instead.

  compiler\test-project\src\Component.js:3:12
    1 │ 
    2 │   fragment Component_node on Node {
      │            ^^^^^^^^^^^^^^
    3 │     id
[ERROR] Compilation failed.
```