### PR TITLE
[relay-compiler] Run build for the test project in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,10 @@ jobs:
           # add --locked back when we have a better way to ensure it's up to date
           args: --manifest-path=compiler/Cargo.toml
       - uses: actions-rs/cargo@v1
-      - name: 'Compiling the `test-project`.'
-        working-directory: ./compiler
         with:
           command: run
           args: --manifest-path=Cargo.toml --bin relay ./test-project/relay.json
+        working-directory: ./compiler
 
   build-compiler:
     name: Build Rust Compiler (${{ matrix.target.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,9 @@ jobs:
       - uses: actions-rs/cargo@v1
       - name: 'Compiling the `test-project`.'
         working-directory: ./compiler
-        with:gi
+        with:
           command: run
-          args: --bin relay ./test-project/relay.json
+          args: --manifest-path=Cargo.toml --bin relay ./test-project/relay.json
 
   build-compiler:
     name: Build Rust Compiler (${{ matrix.target.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
           command: test
           # add --locked back when we have a better way to ensure it's up to date
           args: --manifest-path=compiler/Cargo.toml
+      - uses: actions-rs/cargo@v1
+      - name: 'Compiling the `test-project`.'
+        working-directory: ./compiler
+        with:gi
+          command: run
+          args: --bin relay ./test-project/relay.json
 
   build-compiler:
     name: Build Rust Compiler (${{ matrix.target.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,8 @@ jobs:
           command: test
           # add --locked back when we have a better way to ensure it's up to date
           args: --manifest-path=compiler/Cargo.toml
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path=Cargo.toml --bin relay ./test-project/relay.json
+      - name: "Build test project"
+        run: cargo run --manifest-path=Cargo.toml --bin relay ./test-project/relay.json
         working-directory: ./compiler
 
   build-compiler:


### PR DESCRIPTION
This is a "smoke" test, to make sure we can build an example project on all platforms without errors.

I think later, we can also add snapshot testing/flow test on this project to make sure we don't have unexpected changes in the output. 

Test Plan:
The output of the new step:
```
     Running `target\debug\relay.exe ./test-project/relay.json`
[test] compiling...
[test] compiled documents: 2 reader, 1 normalization, 2 operation text
Done
```