### PR TITLE
Make compiler transforms customizable and applied as a Vec of Transforms

### DIFF
--- a/compiler/crates/relay-compiler/src/build_project/log_program_stats.rs
+++ b/compiler/crates/relay-compiler/src/build_project/log_program_stats.rs
@@ -17,7 +17,7 @@ lazy_static! {
     static ref LOG_AST_STATS: bool = std::env::var("RELAY_LOG_AST_STATS").is_ok();
 }
 
-pub fn print_stats(extra_info: &'static str, program: &Program) {
+pub fn print_stats(extra_info: &str, program: &Program) {
     if *LOG_AST_STATS {
         let mut visitor = IRStatsVisitor::default();
         let stats = visitor.visit_program(program);

--- a/compiler/crates/relay-compiler/src/build_project/mod.rs
+++ b/compiler/crates/relay-compiler/src/build_project/mod.rs
@@ -41,7 +41,9 @@ use intern::string_key::{StringKey, StringKeySet};
 use log::{debug, info, warn};
 use rayon::{iter::IntoParallelRefIterator, slice::ParallelSlice};
 use relay_codegen::Printer;
-use relay_transforms::{apply_transforms, find_resolver_dependencies, DependencyMap, Programs};
+use relay_transforms::{
+    apply_transforms, find_resolver_dependencies, CustomTransformsConfig, DependencyMap, Programs,
+};
 use schema::SDLSchema;
 pub use source_control::add_to_mercurial;
 use std::iter::FromIterator;
@@ -120,6 +122,7 @@ pub fn transform_program(
     base_fragment_names: Arc<StringKeySet>,
     perf_logger: Arc<impl PerfLogger + 'static>,
     log_event: &impl PerfLogEvent,
+    custom_transforms_config: Option<&CustomTransformsConfig>,
 ) -> Result<Programs, BuildProjectFailure> {
     let timer = log_event.start("apply_transforms_time");
     let result = apply_transforms(
@@ -128,6 +131,7 @@ pub fn transform_program(
         base_fragment_names,
         perf_logger,
         Some(print_stats),
+        custom_transforms_config,
     )
     .map_err(|errors| BuildProjectFailure::Error(BuildProjectError::ValidationErrors { errors }));
 
@@ -192,6 +196,7 @@ pub fn build_programs(
         Arc::new(base_fragment_names),
         Arc::clone(&perf_logger),
         log_event,
+        config.custom_transforms.as_ref(),
     )?;
 
     Ok((programs, Arc::new(source_hashes)))

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -28,6 +28,7 @@ use relay_config::{
     FlowTypegenConfig, JsModuleFormat, SchemaConfig, TypegenConfig, TypegenLanguage,
 };
 pub use relay_config::{PersistConfig, ProjectConfig, SchemaLocation};
+use relay_transforms::CustomTransformsConfig;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
@@ -104,6 +105,9 @@ pub struct Config {
 
     /// Type of file source to use in the Compiler
     pub file_source_config: FileSourceKind,
+
+    // Provide extra custom transforms to apply
+    pub custom_transforms: Option<CustomTransformsConfig>,
 }
 
 pub enum FileSourceKind {
@@ -309,6 +313,7 @@ impl Config {
             additional_validations: None,
             is_dev_variable_name: config_file.is_dev_variable_name,
             file_source_config: FileSourceKind::Watchman,
+            custom_transforms: None,
         };
 
         let mut validation_errors = Vec::new();
@@ -458,7 +463,11 @@ impl fmt::Debug for Config {
         } = self;
 
         fn option_fn_to_string<T>(option: &Option<T>) -> &'static str {
-            if option.is_some() { "Some(Fn)" } else { "None" }
+            if option.is_some() {
+                "Some(Fn)"
+            } else {
+                "None"
+            }
         }
 
         f.debug_struct("Config")

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
@@ -117,6 +117,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         Default::default(),
         Arc::new(ConsoleLogger),
         None,
+        None,
     )
     .map_err(|diagnostics| diagnostics_to_sorted_string(fixture.content, &diagnostics))?;
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id/mod.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id/mod.rs
@@ -97,6 +97,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         Default::default(),
         Arc::new(ConsoleLogger),
         None,
+        None,
     )
     .map_err(|diagnostics| diagnostics_to_sorted_string(fixture.content, &diagnostics))?;
 

--- a/compiler/crates/relay-lsp/src/graphql_tools/mod.rs
+++ b/compiler/crates/relay-lsp/src/graphql_tools/mod.rs
@@ -17,7 +17,7 @@ use graphql_text_printer::print_full_operation;
 use intern::string_key::{Intern, StringKey};
 use lsp_types::{request::Request, Url};
 use relay_compiler::config::ProjectConfig;
-use relay_transforms::{apply_transforms, Programs};
+use relay_transforms::{apply_transforms, CustomTransformsConfig, Programs};
 use schema::SDLSchema;
 use schema_documentation::SchemaDocumentation;
 
@@ -126,6 +126,7 @@ fn transform_program<TPerfLogger: PerfLogger + 'static>(
     project_config: &ProjectConfig,
     program: Arc<Program>,
     perf_logger: Arc<TPerfLogger>,
+    custom_transforms_config: Option<&CustomTransformsConfig>,
 ) -> Result<Programs, String> {
     apply_transforms(
         project_config,
@@ -133,6 +134,7 @@ fn transform_program<TPerfLogger: PerfLogger + 'static>(
         Default::default(),
         perf_logger,
         None,
+        custom_transforms_config,
     )
     .map_err(|errors| format!("{:?}", errors))
 }
@@ -241,6 +243,7 @@ pub(crate) fn get_query_text<
                 project_config,
                 Arc::new(program),
                 Arc::clone(&state.perf_logger),
+                state.config.custom_transforms.as_ref(),
             )
             .map_err(LSPRuntimeError::UnexpectedError)?;
 

--- a/compiler/crates/relay-lsp/src/server/lsp_state_resources.rs
+++ b/compiler/crates/relay-lsp/src/server/lsp_state_resources.rs
@@ -390,6 +390,7 @@ impl<TPerfLogger: PerfLogger + 'static, TSchemaDocumentation: SchemaDocumentatio
             Arc::new(base_fragment_names),
             Arc::clone(&self.lsp_state.perf_logger),
             log_event,
+            self.lsp_state.config.custom_transforms.as_ref(),
         )?;
         Ok(())
     }

--- a/compiler/crates/relay-transforms/src/lib.rs
+++ b/compiler/crates/relay-transforms/src/lib.rs
@@ -81,7 +81,9 @@ pub type DependencySet = HashSet<OperationName, BuildIdHasher<u32>>;
 pub use crate::errors::ValidationMessage;
 pub use applied_fragment_name::get_applied_fragment_name;
 pub use apply_fragment_arguments::apply_fragment_arguments;
-pub use apply_transforms::{apply_transforms, Programs};
+pub use apply_transforms::{
+    apply_transforms, CustomTransform, CustomTransforms, CustomTransformsConfig, Programs,
+};
 pub use assignable_fragment_spread::{
     transform_assignable_fragment_spreads_in_regular_queries,
     transform_assignable_fragment_spreads_in_updatable_queries, validate_assignable_directive,

--- a/compiler/crates/relay-transforms/src/remove_base_fragments.rs
+++ b/compiler/crates/relay-transforms/src/remove_base_fragments.rs
@@ -9,13 +9,12 @@ use graphql_ir::{FragmentDefinition, OperationDefinition};
 
 use graphql_ir::{Program, Transformed, Transformer};
 use intern::string_key::StringKeySet;
-use std::sync::Arc;
 
 /// This transform removes the given list of base fragments from the Program.
 /// This is useful if earlier steps need access to fragments from some base
 /// project, but we don't want to write output files for them and can skip over
 /// some transform steps.
-pub fn remove_base_fragments(program: &Program, base_fragment_names: Arc<StringKeySet>) -> Program {
+pub fn remove_base_fragments(program: &Program, base_fragment_names: &StringKeySet) -> Program {
     if base_fragment_names.is_empty() {
         // Nothing to remove.
         return program.clone();

--- a/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
@@ -32,7 +32,6 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
 
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
-
     let mut sources = FnvHashMap::default();
     sources.insert(source_location, source);
     let ast = parse_executable(source, source_location)
@@ -72,9 +71,9 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         Default::default(),
         Arc::new(ConsoleLogger),
         None,
+        None,
     )
     .map_err(|diagnostics| diagnostics_to_sorted_string(source, &diagnostics))?;
-
 
     let mut operations: Vec<_> = programs.typegen.operations().collect();
     operations.sort_by_key(|op| op.name.item);

--- a/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/mod.rs
@@ -36,7 +36,6 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
 
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
-
     let mut sources = FnvHashMap::default();
     sources.insert(source_location, source);
     let ast = parse_executable(source, source_location).unwrap_or_else(|e| {
@@ -83,9 +82,9 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         Default::default(),
         Arc::new(ConsoleLogger),
         None,
+        None,
     )
     .unwrap();
-
 
     let mut operations: Vec<_> = programs.typegen.operations().collect();
     operations.sort_by_key(|op| op.name.item);

--- a/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
@@ -56,6 +56,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         Default::default(),
         Arc::new(ConsoleLogger),
         None,
+        None,
     )
     .unwrap();
 


### PR DESCRIPTION
Some advanced usages of Relay benefit from customizing the compiler so that users can provide custom transformations to the documents to affect how artifacts are generated. This PR adds the capability to specify these transformations in the `ProjectConfig` as a vector of `Transform`s.

In order to support this flexibility, I refactored the `apply_transforms` module in `relay-transforms` to apply transforms from a vector, and create default vectors for each of the steps in the execution pipeline (common, reader, operation, typegen, etc). These are used when there's no configuration for custom transforms, and are also exposed in the `relay-transforms` crate so they can be used and customized before setting them in the configuration.

The `Transform` is a new struct that takes a name, and a transform function, which takes a `project_config`, the `program`, and `base_fragment_names`, and returns a `DiagnosticResult<Program>`. I created closures for each of the current transforms to accommodate to this signature (wrapping the result in an `Ok` whenever the transform returned just the `Program`). Maybe it could be useful to enforce this signature in the transforms themselves at some point, to avoid the closure.

Now we have a generic function that takes the transforms vector, and applies it in order. It also wraps each transform call to log the time with the perf logger, and conditionally prints stats. Given that only the normalization step was explicitly passing the configuration to print stats, I made it so that the other steps explicitly pass `None` to this param.

One thing to note, is that I made a slight modification in how stats are printed in the normalization step. Before, we were printing the stats before starting the process with the string "normalization start", but now, since we have a generic function that does this, this is printed with the step function name, so this will show up as "apply_normalization_transforms start". Hope this change is acceptable, otherwise we will need to pass an extra string param there.

Also, this is my first time using Rust, so there's probably a lot of things that could be done in a more efficient/idiomatic way.

_Note: This ended up being a big PR, I'm happy to split it up into smaller chunks if needed, just wanted to get feedback on the approach_