### PR TITLE
[relay-compiler] Update Cargo.toml version when publishing `main` to NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,17 @@ jobs:
           toolchain: stable
           override: true
           target: ${{ matrix.target.target }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts
+      - name: Set `main` version
+        # if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
+        run: yarn gulp setCompilerMainVersion
+        env:
+          RELEASE_COMMIT_SHA: ${{ github.sha }}
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,15 @@ jobs:
           override: true
           target: ${{ matrix.target.target }}
       - uses: actions/setup-node@v2
+        if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
         with:
           node-version: 16.x
           cache: 'yarn'
       - name: Install dependencies
+        if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
         run: yarn install --frozen-lockfile --ignore-scripts
       - name: Set `main` version
-        # if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
         run: yarn gulp setCompilerMainVersion
         env:
           RELEASE_COMMIT_SHA: ${{ github.sha }}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -389,6 +389,26 @@ const setMainVersion = async () => {
   });
 };
 
+async function setCompilerMainVersion() {
+  if (!RELEASE_COMMIT_SHA) {
+    throw new Error('Expected the RELEASE_COMMIT_SHA env variable to be set.');
+  }
+  const currentVersion = require('./package.json').version;
+  const compilerCargoFile = path.join(
+    '.', 'compiler', 'crates', 'relay-compiler', 'Cargo.toml'
+  );
+  const cargo = fs.readFileSync(compilerCargoFile, 'utf8');
+  const updatedCargo = cargo.replace(
+    `version = "${currentVersion}"`,
+    `version = "${VERSION}"`,
+  );
+  fs.writeFileSync(
+    compilerCargoFile,
+    updatedCargo,
+    'utf8'
+  );
+}
+
 const cleanbuild = gulp.series(clean, dist);
 
 exports.clean = clean;
@@ -398,3 +418,4 @@ exports.mainrelease = gulp.series(cleanbuild, relayCompiler, setMainVersion);
 exports.release = gulp.series(cleanbuild, relayCompiler);
 exports.cleanbuild = cleanbuild;
 exports.default = cleanbuild;
+exports.setCompilerMainVersion = setCompilerMainVersion;


### PR DESCRIPTION
Fix for the https://github.com/facebook/relay/issues/3672

With this change the compiler in OSS will show the correct version:

Test Plan:

Logs in the CI indicating the correct version:
```
   Compiling relay-compiler v0.0.0-main-0f540a5c (/home/runner/work/relay/relay/compiler/crates/relay-compiler)
```

