### PR TITLE
Add repersist cli flag

### DIFF
--- a/compiler/crates/relay-compiler/src/main.rs
+++ b/compiler/crates/relay-compiler/src/main.rs
@@ -41,6 +41,10 @@ struct Opt {
 
     #[structopt(flatten)]
     cli_config: CliConfig,
+
+    /// Run the persister even if the query has not changed.
+    #[structopt(long)]
+    repersist: bool,
 }
 
 #[derive(StructOpt)]
@@ -108,6 +112,7 @@ async fn main() {
     } else {
         FileSourceKind::Glob
     };
+    config.repersist_operations = opt.repersist;
 
     if opt.watch && !matches!(&config.file_source_config, FileSourceKind::Watchman) {
         panic!(

--- a/packages/relay-compiler/README.md
+++ b/packages/relay-compiler/README.md
@@ -104,5 +104,6 @@ when you need to run the compiler.
 - `--src`               Relative path to the source code.
 - `--schema`            Relative path to schema file.
 - `--artifactDirectory` Compiler output directory.
+- `--repersist`         Run the persister even if the query has not changed.
 - `--watch`             Run compiler in `watch` mode
 (requires [`watchman`](https://facebook.github.io/watchman/) to be installed).


### PR DESCRIPTION
This adds the `repersist` flag that was available in the JS compiler. This runs the persistor even if queries did not change. Most of the logic was already there, but wasn't exposed as a cli argument.