### PR TITLE
Ignore target in crates folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 npm-debug.log
 /compiler/target
+/compiler/crates/*/target
 /dist/
 /lib/
 /website/build


### PR DESCRIPTION
Rust generates some build artifacts in creates/x/target that should be ignored. I think this happens when using vscode rust extension.