### PR TITLE
Fix eagerEsModules flag in babel-plugin-relay

### DIFF
--- a/packages/babel-plugin-relay/BabelPluginRelay.js
+++ b/packages/babel-plugin-relay/BabelPluginRelay.js
@@ -41,7 +41,7 @@ export type RelayPluginOptions = {
   isDevVariableName?: string,
 
   // enable generating eager es modules for modern runtime
-  eagerESModules?: boolean,
+  eagerEsModules?: boolean,
 
   // Directory as specified by artifactDirectory when running relay-compiler
   artifactDirectory?: string,

--- a/packages/babel-plugin-relay/__tests__/BabelPluginRelay-esm-test.js
+++ b/packages/babel-plugin-relay/__tests__/BabelPluginRelay-esm-test.js
@@ -16,7 +16,7 @@ describe('`development` option', () => {
   it('tests the hash when `development` is set', () => {
     expect(
       transformerWithOptions(
-        {eagerESModules: true},
+        {eagerEsModules: true},
         'development',
       )('graphql`fragment TestFrag on Node { id }`'),
     ).toMatchSnapshot();
@@ -25,7 +25,7 @@ describe('`development` option', () => {
   it('tests the hash when `isDevVariable` is set', () => {
     expect(
       transformerWithOptions({
-        eagerESModules: true,
+        eagerEsModules: true,
         isDevVariableName: 'IS_DEV',
       })('graphql`fragment TestFrag on Node { id }`'),
     ).toMatchSnapshot();
@@ -36,7 +36,7 @@ describe('`development` option', () => {
       transformerWithOptions(
         {
           buildCommand: 'relay-compiler',
-          eagerESModules: true,
+          eagerEsModules: true,
         },
         'development',
       )('graphql`fragment TestFrag on Node { id }`'),
@@ -46,7 +46,7 @@ describe('`development` option', () => {
   it('does not test the hash when `development` is not set', () => {
     expect(
       transformerWithOptions(
-        {eagerESModules: true},
+        {eagerEsModules: true},
         'production',
       )('graphql`fragment TestFrag on Node { id }`'),
     ).toMatchSnapshot();

--- a/packages/babel-plugin-relay/compileGraphQLTag.js
+++ b/packages/babel-plugin-relay/compileGraphQLTag.js
@@ -56,7 +56,7 @@ function compileGraphQLTag(
     );
   }
 
-  const eagerESModules = state.opts?.eagerESModules ?? false;
+  const eagerEsModules = state.opts?.eagerEsModules ?? false;
   const isHasteMode = state.opts?.jsModuleFormat === 'haste';
   const isDevVariable = state.opts?.isDevVariableName;
   const artifactDirectory = state.opts?.artifactDirectory;
@@ -67,7 +67,7 @@ function compileGraphQLTag(
 
   return createNode(t, state, path, definition, {
     artifactDirectory,
-    eagerESModules,
+    eagerEsModules,
     buildCommand,
     isDevelopment,
     isHasteMode,
@@ -90,7 +90,7 @@ function createNode(
     // If an output directory is specified when running relay-compiler this should point to that directory
     artifactDirectory: ?string,
     // Generate eager es modules instead of lazy require
-    eagerESModules: boolean,
+    eagerEsModules: boolean,
     // The command to run to compile Relay files, used for error messages.
     buildCommand: string,
     // Generate extra validation, defaults to true.
@@ -136,7 +136,7 @@ function createNode(
     ),
   );
 
-  if (options.eagerESModules) {
+  if (options.eagerEsModules) {
     const importDeclaration = t.ImportDeclaration(
       [t.ImportDefaultSpecifier(id)],
       t.StringLiteral(requiredPath),


### PR DESCRIPTION
The flag was renamed along with new compiler implementation,
fixed in docs but forgotten in babel plugin.

Using old flag makes compiler to panic and the only workaround now is
overriding flag in babel config.