### PR TITLE
Use Array instead of ReadOnlyArray on input types

### DIFF
--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -42,6 +42,7 @@ impl Writer for FlowPrinter {
             AST::Identifier(identifier) => write!(&mut self.result, "{}", identifier),
             AST::RawType(raw) => write!(&mut self.result, "{}", raw),
             AST::Union(members) => self.write_union(members),
+            AST::Array(of_type) => self.write_array(of_type),
             AST::ReadOnlyArray(of_type) => self.write_read_only_array(of_type),
             AST::Nullable(of_type) => self.write_nullable(of_type),
             AST::ExactObject(props) => self.write_object(props, true),
@@ -174,6 +175,12 @@ impl FlowPrinter {
             write!(&mut self.result, "{}$fragmentType", fragment)?;
         }
         Ok(())
+    }
+
+    fn write_array(&mut self, of_type: &AST) -> FmtResult {
+        write!(&mut self.result, "Array<")?;
+        self.write(of_type)?;
+        write!(&mut self.result, ">")
     }
 
     fn write_read_only_array(&mut self, of_type: &AST) -> FmtResult {

--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -1506,7 +1506,7 @@ impl<'a> TypeGenerator<'a> {
     fn transform_non_nullable_input_type(&mut self, type_ref: &TypeReference) -> AST {
         match type_ref {
             TypeReference::List(of_type) => {
-                AST::ReadOnlyArray(Box::new(self.transform_input_type(of_type)))
+                AST::Array(Box::new(self.transform_input_type(of_type)))
             }
             TypeReference::Named(named_type) => match named_type {
                 Type::Scalar(scalar) => self.transform_graphql_scalar_type(*scalar),

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -45,6 +45,7 @@ impl Writer for TypeScriptPrinter {
             AST::Identifier(identifier) => write!(&mut self.result, "{}", identifier),
             AST::RawType(raw) => write!(&mut self.result, "{}", raw),
             AST::Union(members) => self.write_union(members),
+            AST::Array(of_type) => self.write_array(of_type),
             AST::ReadOnlyArray(of_type) => self.write_read_only_array(of_type),
             AST::Nullable(of_type) => self.write_nullable(of_type),
             AST::ExactObject(props) => self.write_object(props),
@@ -146,6 +147,12 @@ impl TypeScriptPrinter {
             self.write(member)?;
         }
         Ok(())
+    }
+
+    fn write_array(&mut self, of_type: &AST) -> FmtResult {
+        write!(&mut self.result, "Array<")?;
+        self.write(of_type)?;
+        write!(&mut self.result, ">")
     }
 
     fn write_read_only_array(&mut self, of_type: &AST) -> FmtResult {

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -11,6 +11,7 @@ use std::fmt::{Result as FmtResult, Write};
 #[derive(Debug, Clone)]
 pub enum AST {
     Union(Vec<AST>),
+    Array(Box<AST>),
     ReadOnlyArray(Box<AST>),
     Nullable(Box<AST>),
     Identifier(StringKey),

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-input-has-array.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-input-has-array.expected
@@ -9,7 +9,7 @@ mutation InputHasArray($input: UpdateAllSeenStateInput) @raw_response_type {
 ==================================== OUTPUT ===================================
 export type UpdateAllSeenStateInput = {|
   clientMutationId?: ?string,
-  storyIds?: ?$ReadOnlyArray<?string>,
+  storyIds?: ?Array<?string>,
 |};
 export type InputHasArray$variables = {|
   input?: ?UpdateAllSeenStateInput,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-client-extension.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-client-extension.expected
@@ -21,7 +21,7 @@ type Foo {
 ==================================== OUTPUT ===================================
 export type UpdateAllSeenStateInput = {|
   clientMutationId?: ?string,
-  storyIds?: ?$ReadOnlyArray<?string>,
+  storyIds?: ?Array<?string>,
 |};
 export type Test$variables = {|
   input?: ?UpdateAllSeenStateInput,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-enums-on-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-enums-on-fragment.expected
@@ -43,7 +43,7 @@ export type FeedbackcommentComment = {|
 export type CommentCreateMutation$variables = {|
   input: CommentCreateInput,
   first?: ?number,
-  orderBy?: ?$ReadOnlyArray<string>,
+  orderBy?: ?Array<string>,
 |};
 export type CommentCreateMutation$data = {|
   +commentCreate: ?{|

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-nested-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-nested-fragments.expected
@@ -46,7 +46,7 @@ export type FeedbackcommentComment = {|
 export type CommentCreateMutation$variables = {|
   input: CommentCreateInput,
   first?: ?number,
-  orderBy?: ?$ReadOnlyArray<string>,
+  orderBy?: ?Array<string>,
 |};
 export type CommentCreateMutation$data = {|
   +commentCreate: ?{|

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation.expected
@@ -29,7 +29,7 @@ export type FeedbackcommentComment = {|
 export type CommentCreateMutation$variables = {|
   input: CommentCreateInput,
   first?: ?number,
-  orderBy?: ?$ReadOnlyArray<string>,
+  orderBy?: ?Array<string>,
 |};
 export type CommentCreateMutation$data = {|
   +commentCreate: ?{|

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-input-has-array.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-input-has-array.expected
@@ -9,7 +9,7 @@ mutation InputHasArray($input: UpdateAllSeenStateInput) @raw_response_type {
 ==================================== OUTPUT ===================================
 export type UpdateAllSeenStateInput = {
   clientMutationId?: string | null;
-  storyIds?: ReadonlyArray<string | null> | null;
+  storyIds?: Array<string | null> | null;
 };
 export type InputHasArray$variables = {
   input?: UpdateAllSeenStateInput | null;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-client-extension.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-client-extension.expected
@@ -21,7 +21,7 @@ type Foo {
 ==================================== OUTPUT ===================================
 export type UpdateAllSeenStateInput = {
   clientMutationId?: string | null;
-  storyIds?: ReadonlyArray<string | null> | null;
+  storyIds?: Array<string | null> | null;
 };
 export type Test$variables = {
   input?: UpdateAllSeenStateInput | null;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-enums-on-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-enums-on-fragment.expected
@@ -43,7 +43,7 @@ export type FeedbackcommentComment = {
 export type CommentCreateMutation$variables = {
   input: CommentCreateInput;
   first?: number | null;
-  orderBy?: ReadonlyArray<string> | null;
+  orderBy?: Array<string> | null;
 };
 export type CommentCreateMutation$data = {
   readonly commentCreate: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-nested-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-nested-fragments.expected
@@ -46,7 +46,7 @@ export type FeedbackcommentComment = {
 export type CommentCreateMutation$variables = {
   input: CommentCreateInput;
   first?: number | null;
-  orderBy?: ReadonlyArray<string> | null;
+  orderBy?: Array<string> | null;
 };
 export type CommentCreateMutation$data = {
   readonly commentCreate: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation.expected
@@ -29,7 +29,7 @@ export type FeedbackcommentComment = {
 export type CommentCreateMutation$variables = {
   input: CommentCreateInput;
   first?: number | null;
-  orderBy?: ReadonlyArray<string> | null;
+  orderBy?: Array<string> | null;
 };
 export type CommentCreateMutation$data = {
   readonly commentCreate: {


### PR DESCRIPTION
I'm curious why ReadonlyArrays are needed on input objects. We have mutations with complex input types and use array methods like `push` to generate the input object. The types generated by `relay-compiler-language-typescript` did not use ReadonlyArrays on input objects.