### PR TITLE
Add fb_only features flag to unit-tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
         with:
           command: test
           # add --locked back when we have a better way to ensure it's up to date
-          args: --manifest-path=compiler/Cargo.toml
+          args: --manifest-path=compiler/Cargo.toml --features relay-transforms/fb_only
+          # NOTE: we run unit-tests with fb_only features to match the snapshot
+          # output in the internal CI
       - name: "Build test project"
         run: cargo run --manifest-path=Cargo.toml --bin relay ./test-project/relay.json
         working-directory: ./compiler


### PR DESCRIPTION
This change will ensure that the tests in OSS run with the same features as in the internal CI.