### PR TITLE
fix error message source location

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -576,6 +576,7 @@ version = "0.0.0"
 dependencies = [
  "colored",
  "common",
+ "graphql-syntax",
 ]
 
 [[package]]

--- a/compiler/crates/graphql-cli/Cargo.toml
+++ b/compiler/crates/graphql-cli/Cargo.toml
@@ -9,3 +9,4 @@ license = "MIT"
 [dependencies]
 colored = "1.9"
 common = { path = "../common" }
+graphql-syntax = { path = "../graphql-syntax" }

--- a/compiler/crates/graphql-cli/examples/print-diagnostic.rs
+++ b/compiler/crates/graphql-cli/examples/print-diagnostic.rs
@@ -7,6 +7,7 @@
 
 use common::{Diagnostic, Location, SourceLocationKey, Span};
 use graphql_cli::DiagnosticPrinter;
+use graphql_syntax::GraphQLSource;
 
 const EXAMPLE: &str = "fragment Example on User {
   photo(size: 40) {
@@ -15,7 +16,7 @@ const EXAMPLE: &str = "fragment Example on User {
 }";
 
 fn main() {
-    let printer = DiagnosticPrinter::new(|_| Some(EXAMPLE.to_string()));
+    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(EXAMPLE.to_string())));
 
     let span_photo = Span::new(29, 34);
     let span_type = Span::new(20, 24);

--- a/compiler/crates/graphql-cli/examples/print-source.rs
+++ b/compiler/crates/graphql-cli/examples/print-source.rs
@@ -46,7 +46,7 @@ fn main() {
     for test_case in test_cases.into_iter() {
         let mut res = String::new();
         printer
-            .write_span(&mut res, &test_case.into(), EXAMPLE)
+            .write_span(&mut res, &test_case.into(), EXAMPLE, 0)
             .unwrap();
         println!("{}\n ---------\n", res);
     }

--- a/compiler/crates/graphql-cli/src/diagnostic_printer.rs
+++ b/compiler/crates/graphql-cli/src/diagnostic_printer.rs
@@ -8,6 +8,7 @@
 use crate::SourcePrinter;
 use colored::*;
 use common::{Diagnostic, Location, SourceLocationKey};
+use graphql_syntax::GraphQLSource;
 use std::fmt::Write;
 
 pub struct DiagnosticPrinter<T: Sources> {
@@ -69,14 +70,14 @@ impl<TSources: Sources> DiagnosticPrinter<TSources> {
     fn write_source<W: Write>(&self, writer: &mut W, location: Location) -> std::fmt::Result {
         let source_printer = SourcePrinter::default();
         if let Some(source) = self.sources.get(location.source_location()) {
-            let range = location.span().to_range(&source, 0, 0);
+            let range = location.span().to_range(&source.text, source.line_index, source.column_index);
             writeln!(
                 writer,
                 "  {}{}",
                 location.source_location().path().underline(),
                 format!(":{}:{}", range.start.line + 1, range.start.character + 1).dimmed()
             )?;
-            source_printer.write_span(writer, location.span(), &source)?;
+            source_printer.write_span(writer, location.span(), &source.text, source.line_index)?;
         } else {
             writeln!(
                 writer,
@@ -89,14 +90,14 @@ impl<TSources: Sources> DiagnosticPrinter<TSources> {
 }
 
 pub trait Sources {
-    fn get(&self, source_location: SourceLocationKey) -> Option<String>;
+    fn get(&self, source_location: SourceLocationKey) -> Option<GraphQLSource>;
 }
 
 impl<F> Sources for F
 where
-    F: Fn(SourceLocationKey) -> Option<String>,
+    F: Fn(SourceLocationKey) -> Option<GraphQLSource>,
 {
-    fn get(&self, source_location: SourceLocationKey) -> Option<String> {
+    fn get(&self, source_location: SourceLocationKey) -> Option<GraphQLSource> {
         self(source_location)
     }
 }

--- a/compiler/crates/graphql-cli/src/source_printer.rs
+++ b/compiler/crates/graphql-cli/src/source_printer.rs
@@ -20,6 +20,7 @@ impl SourcePrinter {
         writer: &mut W,
         span: &Span,
         source: &str,
+        line_offset: usize,
     ) -> std::fmt::Result {
         let start_char_index = span.start as usize;
         let end_char_index = span.end as usize;
@@ -84,7 +85,7 @@ impl SourcePrinter {
             write!(
                 writer,
                 "{}",
-                format!(" {:>4} \u{2502} ", line_index + 1).bold()
+                format!(" {:>4} \u{2502} ", line_index + line_offset + 1).bold()
             )
             .unwrap();
             let mut something_highlighted_on_line = false;

--- a/compiler/crates/graphql-ir/tests/parse/mod.rs
+++ b/compiler/crates/graphql-ir/tests/parse/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use fnv::FnvHashMap;
 use graphql_cli::DiagnosticPrinter;
 use graphql_ir::build;
-use graphql_syntax::{parse_executable_with_features, ParserFeatures};
+use graphql_syntax::{parse_executable_with_features, ParserFeatures, GraphQLSource};
 use relay_test_schema::TEST_SCHEMA;
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
@@ -28,7 +28,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
             errors
                 .into_iter()
                 .map(|error| {
-                    let printer = DiagnosticPrinter::new(|_| Some(fixture.content.to_string()));
+                    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(fixture.content.to_string())));
                     printer.diagnostic_to_string(&error)
                 })
                 .collect::<Vec<_>>()

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions/mod.rs
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use fnv::FnvHashMap;
 use graphql_cli::DiagnosticPrinter;
 use graphql_ir::build;
-use graphql_syntax::parse_executable;
+use graphql_syntax::{parse_executable, GraphQLSource};
 use relay_test_schema::get_test_schema_with_extensions;
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
@@ -31,7 +31,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
                 errors
                     .into_iter()
                     .map(|error| {
-                        let printer = DiagnosticPrinter::new(|_| Some(fixture.content.to_string()));
+                        let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(fixture.content.to_string())));
                         printer.diagnostic_to_string(&error)
                     })
                     .collect::<Vec<_>>()

--- a/compiler/crates/graphql-ir/tests/parse_with_provider/mod.rs
+++ b/compiler/crates/graphql-ir/tests/parse_with_provider/mod.rs
@@ -12,7 +12,7 @@ use graphql_cli::DiagnosticPrinter;
 use graphql_ir::{
     build_ir_with_extra_features, BuilderOptions, FragmentVariablesSemantic, RelayMode,
 };
-use graphql_syntax::{parse_executable_with_features, ParserFeatures};
+use graphql_syntax::{parse_executable_with_features, ParserFeatures, GraphQLSource};
 use relay_test_schema::TEST_SCHEMA;
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
@@ -40,7 +40,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
             errors
                 .into_iter()
                 .map(|error| {
-                    let printer = DiagnosticPrinter::new(|_| Some(fixture.content.to_string()));
+                    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(fixture.content.to_string())));
                     printer.diagnostic_to_string(&error)
                 })
                 .collect::<Vec<_>>()

--- a/compiler/crates/graphql-syntax/tests/parse_document/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_document/mod.rs
@@ -8,7 +8,7 @@
 use common::{Diagnostic, SourceLocationKey};
 use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
-use graphql_syntax::parse_document;
+use graphql_syntax::{parse_document, GraphQLSource};
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_document(
@@ -21,7 +21,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
 
 // NOTE: copied from graphql-test-helpers to avoid cyclic dependency breaking Rust Analyzer
 fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
-    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(source.to_string())));
     let mut printed = diagnostics
         .iter()
         .map(|diagnostic| printer.diagnostic_to_string(diagnostic))

--- a/compiler/crates/graphql-syntax/tests/parse_executable_document/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_executable_document/mod.rs
@@ -8,7 +8,7 @@
 use common::{Diagnostic, SourceLocationKey};
 use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
-use graphql_syntax::parse_executable;
+use graphql_syntax::{parse_executable, GraphQLSource};
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_executable(
@@ -21,7 +21,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
 
 // NOTE: copied from graphql-test-helpers to avoid cyclic dependency breaking Rust Analyzer
 fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
-    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(source.to_string())));
     let mut printed = diagnostics
         .iter()
         .map(|diagnostic| printer.diagnostic_to_string(diagnostic))

--- a/compiler/crates/graphql-syntax/tests/parse_executable_document_with_error_recovery/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_executable_document_with_error_recovery/mod.rs
@@ -8,7 +8,7 @@
 use common::{Diagnostic, SourceLocationKey};
 use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
-use graphql_syntax::parse_executable_with_error_recovery;
+use graphql_syntax::{parse_executable_with_error_recovery, GraphQLSource};
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let result = parse_executable_with_error_recovery(
@@ -24,7 +24,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
 
 // NOTE: copied from graphql-test-helpers to avoid cyclic dependency breaking Rust Analyzer
 fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
-    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(source.to_string())));
     let mut printed = diagnostics
         .iter()
         .map(|diagnostic| printer.diagnostic_to_string(diagnostic))

--- a/compiler/crates/graphql-syntax/tests/parse_schema_document/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_schema_document/mod.rs
@@ -8,7 +8,7 @@
 use common::{Diagnostic, SourceLocationKey};
 use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
-use graphql_syntax::parse_schema_document;
+use graphql_syntax::{parse_schema_document, GraphQLSource};
 
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_schema_document(
@@ -21,7 +21,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
 
 // NOTE: copied from graphql-test-helpers to avoid cyclic dependency breaking Rust Analyzer
 fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
-    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(source.to_string())));
     let mut printed = diagnostics
         .iter()
         .map(|diagnostic| printer.diagnostic_to_string(diagnostic))

--- a/compiler/crates/graphql-test-helpers/src/lib.rs
+++ b/compiler/crates/graphql-test-helpers/src/lib.rs
@@ -11,7 +11,7 @@ use graphql_cli::DiagnosticPrinter;
 use graphql_ir::{
     build_ir_with_extra_features, BuilderOptions, FragmentVariablesSemantic, Program, RelayMode,
 };
-use graphql_syntax::parse_executable;
+use graphql_syntax::{parse_executable, GraphQLSource};
 use graphql_text_printer::{print_fragment, print_operation, PrinterOptions};
 use relay_test_schema::get_test_schema;
 use std::sync::Arc;
@@ -65,7 +65,7 @@ where
 }
 
 pub fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
-    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(source.to_string())));
     let mut printed = diagnostics
         .iter()
         .map(|diagnostic| printer.diagnostic_to_string(diagnostic))

--- a/compiler/crates/relay-compiler/src/status_reporter.rs
+++ b/compiler/crates/relay-compiler/src/status_reporter.rs
@@ -77,7 +77,6 @@ impl ConsoleStatusReporter {
     fn print_diagnostic(&self, diagnostic: &Diagnostic) {
         let printer = DiagnosticPrinter::new(|source_location| {
             source_for_location(&self.root_dir, source_location, self.source_reader.as_ref())
-                .map(|source| source.text)
         });
         error!("{}", printer.diagnostic_to_string(diagnostic));
     }

--- a/compiler/crates/relay-transforms/tests/validate_global_variables/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_global_variables/mod.rs
@@ -11,7 +11,7 @@ use graphql_cli::DiagnosticPrinter;
 use graphql_ir::{
     build_ir_with_extra_features, BuilderOptions, FragmentVariablesSemantic, Program, RelayMode,
 };
-use graphql_syntax::parse_executable;
+use graphql_syntax::{parse_executable, GraphQLSource};
 use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_global_variables;
@@ -40,7 +40,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
             let mut errs = errors
                 .into_iter()
                 .map(|err| {
-                    let printer = DiagnosticPrinter::new(|_| Some(fixture.content.to_string()));
+                    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(fixture.content.to_string())));
                     printer.diagnostic_to_string(&err)
                 })
                 .collect::<Vec<_>>();

--- a/compiler/crates/relay-transforms/tests/validate_selection_conflict/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_selection_conflict/mod.rs
@@ -9,7 +9,7 @@ use common::SourceLocationKey;
 use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
 use graphql_ir::{build, Program};
-use graphql_syntax::parse_executable;
+use graphql_syntax::{parse_executable, GraphQLSource};
 use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_selection_conflict;
@@ -26,7 +26,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
             let mut errs = errors
                 .into_iter()
                 .map(|err| {
-                    let printer = DiagnosticPrinter::new(|_| Some(fixture.content.to_string()));
+                    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(fixture.content.to_string())));
                     printer.diagnostic_to_string(&err)
                 })
                 .collect::<Vec<_>>();

--- a/compiler/crates/schema/Cargo.toml
+++ b/compiler/crates/schema/Cargo.toml
@@ -25,3 +25,4 @@ thiserror = "1.0.29"
 [dev-dependencies]
 fixture-tests = { path = "../fixture-tests" }
 graphql-cli = { path = "../graphql-cli" }
+graphql-syntax = { path = "../graphql-syntax" }

--- a/compiler/crates/schema/tests/build_schema/mod.rs
+++ b/compiler/crates/schema/tests/build_schema/mod.rs
@@ -8,6 +8,7 @@
 use common::{Diagnostic, SourceLocationKey};
 use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
+use graphql_syntax::GraphQLSource;
 use schema::{
     build_schema_from_flat_buffer, build_schema_with_extensions, serialize_as_flatbuffer,
     SDLSchema, Schema, Type,
@@ -108,7 +109,7 @@ unions: {:#?}
 
 // NOTE: copied from graphql-test-helpers to avoid cyclic dependency breaking Rust Analyzer
 fn diagnostics_to_sorted_string(source: &str, diagnostics: &[Diagnostic]) -> String {
-    let printer = DiagnosticPrinter::new(|_| Some(source.to_string()));
+    let printer = DiagnosticPrinter::new(|_| Some(GraphQLSource::from_whole_document(source.to_string())));
     let mut printed = diagnostics
         .iter()
         .map(|diagnostic| printer.diagnostic_to_string(diagnostic))


### PR DESCRIPTION
Fixes #3735 

Diagnostic printer doesn't have access to the actual `line_index` and `column_index` from source files and operates only on extracted GraphQL text.

The simplest way to fix it is to change the `Sources` trait return type from `Option<String>` to `Option<GraphQLSource>`.

Implementation of diagnostic_reporter in `relay-lsp` is correct  and utilises source_reader, while `graphql-cli` doesn't have access to it. Maybe status_reporter in `relay-compiler` should be refactored to be more similar to `relay-lsp` and should contain its own implementation of diagnostic_reporter independent from `graphql-cli`.

This PR doesn't fix source location for the Validation message output:
```bash
 - Validation errors:
 - Variable was defined as type 'ID' but used where a variable of type 'ID!' is expected.:src/views/DataModel/components/ModelTreeDetails/ModelTreeDetails.tsx:63:66
```

Source fragment printed in `compile` method:
https://github.com/facebook/relay/blob/31c156a5658cd4360f0733e7213fea8c286b7627/compiler/crates/relay-compiler/src/compiler.rs#L157-L159
but Validation error is printed by macro and doesn't have access to the source_reader
https://github.com/facebook/relay/blob/31c156a5658cd4360f0733e7213fea8c286b7627/compiler/crates/relay-compiler/src/main.rs#L135-L137