### PR TITLE
Fix small warning in an example from the step by step guide

### DIFF
--- a/website/docs/getting-started/step-by-step-guide.md
+++ b/website/docs/getting-started/step-by-step-guide.md
@@ -126,7 +126,7 @@ function App() {
     return () => {
       isMounted = false;
     };
-  }, [fetchGraphQL]);
+  }, []);
 
   // Render "Loading" until the query completes
   return (


### PR DESCRIPTION
When following the step by step guide, the example provided throws the following warning:

```
Line 36:6:  React Hook useEffect has an unnecessary dependency: 'fetchGraphQL'. Either exclude it or remove the dependency array. Outer scope values like 'fetchGraphQL' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
```

This PR fixes the warning by removing the unnecessary dependency from the dependencies list of `useEffect`.