### PR TITLE
Remove unused import from example

### DIFF
--- a/website/docs/getting-started/step-by-step-guide.md
+++ b/website/docs/getting-started/step-by-step-guide.md
@@ -236,7 +236,6 @@ Now that Relay is installed and configured we can change `App.js` to use it inst
 ```javascript
 import React from 'react';
 import './App.css';
-import fetchGraphQL from './fetchGraphQL';
 import graphql from 'babel-plugin-relay/macro';
 import {
   RelayEnvironmentProvider,


### PR DESCRIPTION
When following the step-by-step guide, there is a code snippet with an unused import. This PR removes that.