### PR TITLE
Add build for linux-musl target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,12 @@ jobs:
             os: ubuntu-latest
             build-name: relay
             artifact-name: relay-compiler-linux-x64
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            build-name: relay
+            artifact-name: relay-compiler-linux-musl
+            packages: musl-tools
+            features: vendored
           - target: x86_64-apple-darwin
             os: macos-latest
             build-name: relay
@@ -120,11 +126,14 @@ jobs:
         run: yarn gulp setCompilerMainVersion
         env:
           RELEASE_COMMIT_SHA: ${{ github.sha }}
+      - name: Install packages
+        if: matrix.target.os == 'ubuntu-latest' && matrix.target.packages
+        run: sudo apt install ${{ matrix.target.packages }} -y
       - uses: actions-rs/cargo@v1
         with:
           command: build
           # add --locked back when we have a better way to ensure it's up to date
-          args: --manifest-path=compiler/Cargo.toml --release --target ${{ matrix.target.target }}
+          args: --manifest-path=compiler/Cargo.toml --release --target ${{ matrix.target.target }} ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.target.artifact-name }}
@@ -149,6 +158,11 @@ jobs:
         with:
           name: relay-compiler-linux-x64
           path: artifacts/linux-x64
+      - name: Download artifact relay-compiler-linux-musl
+        uses: actions/download-artifact@v2
+        with:
+          name: relay-compiler-linux-musl
+          path: artifacts/linux-musl
       - name: Download artifact relay-compiler-macos-x64
         uses: actions/download-artifact@v2
         with:
@@ -168,6 +182,7 @@ jobs:
         working-directory: artifacts
         run: |
           chmod +x linux-x64/relay
+          chmod +x linux-musl/relay
           chmod +x macos-x64/relay
           chmod +x macos-arm64/relay
 

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1094,6 +1094,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.17.0+1.1.1m"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1111,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1523,6 +1533,7 @@ dependencies = [
  "fnv",
  "graphql-ir",
  "graphql-syntax",
+ "graphql-test-helpers",
  "indexmap",
  "intern",
  "itertools",

--- a/compiler/crates/persist-query/Cargo.toml
+++ b/compiler/crates/persist-query/Cargo.toml
@@ -13,3 +13,8 @@ serde = { version = "1.0.126", features = ["derive", "rc"] }
 serde_json = { version = "1.0.64", features = ["float_roundtrip", "unbounded_depth"] }
 thiserror = "1.0.29"
 url = "2.2.2"
+
+[features]
+# Force openssl-sys to staticly link in the openssl library. Necessary when
+# cross compiling to x86_64-unknown-linux-musl.
+vendored = ["hyper-tls/vendored"]

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cosmiconfig": "^5.0.5",
     "cross-env": "^7.0.2",
     "del": "6.0.0",
+    "detect-libc": "^1.0.3",
     "eslint": "5.4.0",
     "eslint-config-fbjs": "2.1.0",
     "eslint-plugin-babel": "5.1.0",

--- a/packages/relay-compiler/index.js
+++ b/packages/relay-compiler/index.js
@@ -11,12 +11,15 @@
 'use strict';
 
 const path = require('path');
+const { isNonGlibcLinux } = require('detect-libc');
 
 let binary;
 if (process.platform === 'darwin' && process.arch === 'x64') {
   binary = path.join(__dirname, 'macos-x64', 'relay');
 } else if (process.platform === 'darwin' && process.arch === 'arm64') {
   binary = path.join(__dirname, 'macos-arm64', 'relay');
+} else if (process.platform === 'linux' && isNonGlibcLinux) {
+  binary = path.join(__dirname, 'linux-musl', 'relay');
 } else if (process.platform === 'linux' && process.arch === 'x64') {
   binary = path.join(__dirname, 'linux-x64', 'relay');
 } else if (process.platform === 'win32' && process.arch === 'x64') {

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -11,5 +11,8 @@
   "bugs": "https://github.com/facebook/relay/issues",
   "repository": "facebook/relay",
   "main": "index.js",
-  "bin": "cli.js"
+  "bin": "cli.js",
+  "dependencies": {
+    "detect-libc": "^1.0.3"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,6 +2586,11 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"


### PR DESCRIPTION
This PR attempts to fix #3725 and #3739.

A new target `x86_64-unknown-linux-musl` has been added to `ci.yml` along with the additional `musl-tools` package (can be removed in the future when [this issue](https://github.com/actions-rs/toolchain/issues/102) is resolved) and the `hyper-tls/vendored` feature which allow to build openssl-sys package for the new target.

I ended up with building directly on GitHub Action VM without custom docker image because it allows to implement it just as a new target in matrix. Building in docker image requires a [separated job](https://github.com/ch1ffa/relay/blob/1c4651ff81cb901a487e4d9ca0a719058833f5a0/.github/workflows/ci.yml#L133).

[detect-libc](https://www.npmjs.com/package/detect-libc) is using for detecting correct platform.

Compiled binary has been tested inside `node:alpine` image. I'm not sure how to test it in the Bazel Sandbox, maybe it is better to ask the issue author.
