### PR TITLE
Replace env_logger by simplelog

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -170,6 +170,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,19 +369,6 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "errors"
@@ -735,15 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
 name = "hyper"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1043,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,12 +1252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,7 +1382,6 @@ dependencies = [
  "common-path",
  "dashmap",
  "dependency-analyzer",
- "env_logger",
  "errors",
  "extract-graphql",
  "fixture-tests",
@@ -1414,6 +1417,7 @@ dependencies = [
  "serde_json",
  "sha-1",
  "signedsource",
+ "simplelog",
  "structopt",
  "thiserror",
  "tokio",
@@ -1523,6 +1527,7 @@ dependencies = [
  "fnv",
  "graphql-ir",
  "graphql-syntax",
+ "graphql-test-helpers",
  "indexmap",
  "intern",
  "itertools",
@@ -1767,6 +1772,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplelog"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1348164456f72ca0116e4538bdaabb0ddb622c7d9f16387c725af3e96d6001c"
+dependencies = [
+ "chrono",
+ "log",
+ "termcolor",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1927,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/compiler/crates/relay-compiler/Cargo.toml
+++ b/compiler/crates/relay-compiler/Cargo.toml
@@ -25,7 +25,6 @@ common = { path = "../common" }
 common-path = "1.0.0"
 dashmap = { version = "4.0.2", features = ["rayon", "serde"] }
 dependency-analyzer = { path = "../dependency-analyzer" }
-env_logger = "0.7"
 errors = { path = "../errors" }
 extract-graphql = { path = "../extract-graphql" }
 fnv = "1.0"
@@ -58,6 +57,7 @@ serde_bser = "0.3"
 serde_json = { version = "1.0.64", features = ["float_roundtrip", "unbounded_depth"] }
 sha-1 = "0.8"
 signedsource = { path = "../signedsource" }
+simplelog = "0.11.2"
 structopt = "0.3.23"
 thiserror = "1.0.29"
 tokio = { version = "1.10", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/relay-compiler/src/main.rs
+++ b/compiler/crates/relay-compiler/src/main.rs
@@ -6,22 +6,27 @@
  */
 
 use common::ConsoleLogger;
-use env_logger::Env;
-use log::{error, info, Level};
+use simplelog::{
+    TermLogger,
+    LevelFilter,
+    ColorChoice,
+    TerminalMode, 
+    ConfigBuilder
+};
+use log::{error, info};
 use relay_compiler::{
     compiler::Compiler,
     config::{Config, SingleProjectConfigFile},
     FileSourceKind, RemotePersister,
 };
 use relay_typegen::TypegenLanguage;
-use std::io::Write;
 use std::{
     env::{self, current_dir},
     path::PathBuf,
     process::Command,
     sync::Arc,
 };
-use structopt::StructOpt;
+use structopt::{StructOpt, clap::arg_enum};
 
 #[derive(StructOpt)]
 #[structopt(
@@ -45,6 +50,19 @@ struct Opt {
     /// Run the persister even if the query has not changed.
     #[structopt(long)]
     repersist: bool,
+
+    /// Verbosity level
+    #[structopt(long, possible_values = &OutputKind::variants(), case_insensitive = true, default_value = "verbose")]
+    output: OutputKind,
+}
+
+arg_enum! {
+    enum OutputKind {
+        Quiet,
+        Debug,
+        Verbose,
+        QuietWithErrors,
+    }
 }
 
 #[derive(StructOpt)]
@@ -81,18 +99,25 @@ impl From<CliConfig> for SingleProjectConfigFile {
 
 #[tokio::main]
 async fn main() {
-    env_logger::Builder::from_env(Env::default().default_filter_or("info"))
-        .format(|buf, record| {
-            let style = buf.default_level_style(record.level());
-            if record.level() == Level::Info {
-                writeln!(buf, "{}", record.args())
-            } else {
-                writeln!(buf, "[{}] {}", style.value(record.level()), record.args())
-            }
-        })
-        .init();
-
     let opt = Opt::from_args();
+
+    let log_level = match opt.output {
+        OutputKind::Quiet => LevelFilter::Off,
+        OutputKind::Debug => LevelFilter::Debug,
+        OutputKind::Verbose => LevelFilter::Info,
+        OutputKind::QuietWithErrors => LevelFilter::Error,
+    };
+
+    let config = ConfigBuilder::new()
+        .set_time_level(LevelFilter::Off)
+        .build();
+
+    TermLogger::init(
+        log_level,
+        config,
+        TerminalMode::Mixed,
+        ColorChoice::Auto,
+    ).unwrap();
 
     let config_result = if let Some(config_path) = opt.config {
         Config::load(config_path)


### PR DESCRIPTION
Possible fix for #3743 and #3362

`evn_logger` has been replaced by `simplelog` which allows splitting stdout/stderr output.

I'm not sure about desired API, so added new options only as command line arguments.