### PR TITLE
Use $PropertyType instead of indexed access for backwards Flow compat

### DIFF
--- a/packages/react-relay/ReactRelayTestMocker.js
+++ b/packages/react-relay/ReactRelayTestMocker.js
@@ -41,7 +41,7 @@ export type DataWriteConfig = {
 export type NetworkWriteConfig = {
   query: ConcreteRequest,
   variables?: Variables,
-  payload: GraphQLSingularResponse | (Variables => GraphQLSingularResponse),
+  payload: GraphQLSingularResponse | ((Variables) => GraphQLSingularResponse),
   ...
 };
 
@@ -65,7 +65,7 @@ let nextId = 0;
 
 class ReactRelayTestMocker {
   _environment: IEnvironment;
-  _defaults: {[string]: NetworkWriteConfig['payload'], ...} = {};
+  _defaults: {[string]: $PropertyType<NetworkWriteConfig, 'payload'>, ...} = {};
   _pendingFetches: Array<PendingFetch> = [];
 
   constructor(env: IEnvironment) {
@@ -125,7 +125,7 @@ class ReactRelayTestMocker {
         'actorId',
       ];
       const strippedVariables = {...variables, input: {...variables.input}};
-      toRemove.forEach(item => (strippedVariables.input[item] = undefined));
+      toRemove.forEach((item) => (strippedVariables.input[item] = undefined));
       return strippedVariables;
     }
 
@@ -172,7 +172,7 @@ class ReactRelayTestMocker {
     };
 
     const isLoading = (ident: string): boolean => {
-      return this._pendingFetches.some(pending => pending.ident === ident);
+      return this._pendingFetches.some((pending) => pending.ident === ident);
     };
 
     const resolveRawQuery = (
@@ -180,7 +180,7 @@ class ReactRelayTestMocker {
       payload: GraphQLSingularResponse,
     ): void => {
       this._pendingFetches = this._pendingFetches.filter(
-        pending => pending !== toResolve,
+        (pending) => pending !== toResolve,
       );
 
       const {deferred} = toResolve;
@@ -192,7 +192,7 @@ class ReactRelayTestMocker {
       payload: {error: PayloadError, ...},
     ): void => {
       this._pendingFetches = this._pendingFetches.filter(
-        pending => pending !== toResolve,
+        (pending) => pending !== toResolve,
       );
 
       const {deferred} = toResolve;
@@ -282,7 +282,7 @@ class ReactRelayTestMocker {
     }
 
     let toResolve;
-    this._pendingFetches.forEach(pending => {
+    this._pendingFetches.forEach((pending) => {
       const pendingVars = pending.variables;
       if (pending.ident === ident) {
         invariant(

--- a/packages/react-relay/ReactRelayTypes.js
+++ b/packages/react-relay/ReactRelayTypes.js
@@ -94,7 +94,7 @@ export type RefetchOptions = {|
  *
  */
 export type $FragmentRef<T> = {
-  +$fragmentSpreads: T['$fragmentType'],
+  +$fragmentSpreads: $PropertyType<T, '$fragmentType'>,
   ...
 };
 

--- a/packages/react-relay/relay-hooks/EntryPointTypes.flow.js
+++ b/packages/react-relay/relay-hooks/EntryPointTypes.flow.js
@@ -75,7 +75,7 @@ export type PreloadedQueryInner_DEPRECATED<
   +id: ?string,
   +name: string,
   +source: ?Observable<GraphQLResponse>,
-  +variables: TQuery['variables'],
+  +variables: $PropertyType<TQuery, 'variables'>,
   +status: PreloadQueryStatus,
 |};
 
@@ -100,7 +100,7 @@ export type PreloadedQueryInner<
   +networkCacheConfig: ?CacheConfig,
   +source: ?Observable<GraphQLResponse>,
   +kind: 'PreloadedQuery',
-  +variables: TQuery['variables'],
+  +variables: $PropertyType<TQuery, 'variables'>,
 |};
 
 export type PreloadQueryStatus = {|
@@ -203,11 +203,14 @@ export type PreloadProps<
 // Return type of `loadEntryPoint(...)`
 export type PreloadedEntryPoint<TEntryPointComponent> = $ReadOnly<{|
   dispose: () => void,
-  entryPoints: ElementConfig<TEntryPointComponent>['entryPoints'],
-  extraProps: ElementConfig<TEntryPointComponent>['extraProps'],
+  entryPoints: $PropertyType<
+    ElementConfig<TEntryPointComponent>,
+    'entryPoints',
+  >,
+  extraProps: $PropertyType<ElementConfig<TEntryPointComponent>, 'extraProps'>,
   getComponent: () => TEntryPointComponent,
   isDisposed: boolean,
-  queries: ElementConfig<TEntryPointComponent>['queries'],
+  queries: $PropertyType<ElementConfig<TEntryPointComponent>, 'queries'>,
   rootModuleID: string,
 |}>;
 
@@ -224,9 +227,10 @@ type ComponentFromEntryPoint<+TEntryPoint> = $Call<
   TEntryPoint,
 >;
 
-export type EntryPointElementConfig<+TEntryPoint> = ElementConfig<
-  ComponentFromEntryPoint<TEntryPoint>,
->['props'];
+export type EntryPointElementConfig<+TEntryPoint> = $PropertyType<
+  ElementConfig<ComponentFromEntryPoint<TEntryPoint>>,
+  'props',
+>;
 
 export type ThinQueryParams<
   TQuery: OperationType,
@@ -235,7 +239,7 @@ export type ThinQueryParams<
   environmentProviderOptions?: ?TEnvironmentProviderOptions,
   options?: ?PreloadOptions,
   parameters: PreloadableConcreteRequest<TQuery>,
-  variables: TQuery['variables'],
+  variables: $PropertyType<TQuery, 'variables'>,
 |}>;
 
 type ThinNestedEntryPointParams<TEntryPointParams, TEntryPoint> = $ReadOnly<{|
@@ -260,14 +264,14 @@ export type ExtractEntryPointTypeHelper = <
 export type EntryPoint<TEntryPointParams, +TEntryPointComponent> =
   InternalEntryPointRepresentation<
     TEntryPointParams,
-    ElementConfig<TEntryPointComponent>['queries'],
-    ElementConfig<TEntryPointComponent>['entryPoints'],
-    ElementConfig<TEntryPointComponent>['props'],
-    ElementConfig<TEntryPointComponent>['extraProps'],
+    $PropertyType<ElementConfig<TEntryPointComponent>, 'queries'>,
+    $PropertyType<ElementConfig<TEntryPointComponent>, 'entryPoints'>,
+    $PropertyType<ElementConfig<TEntryPointComponent>, 'props'>,
+    $PropertyType<ElementConfig<TEntryPointComponent>, 'extraProps'>,
   >;
 
 type ExtractFirstParam = <P, R>((P) => R) => P;
-type GetPreloadPropsType<T> = T['getPreloadProps'];
+type GetPreloadPropsType<T> = $PropertyType<T, 'getPreloadProps'>;
 export type PreloadParamsOf<T> = $Call<
   ExtractFirstParam,
   GetPreloadPropsType<T>,

--- a/packages/react-relay/relay-hooks/LazyLoadEntryPointContainer_DEPRECATED.react.js
+++ b/packages/react-relay/relay-hooks/LazyLoadEntryPointContainer_DEPRECATED.react.js
@@ -28,10 +28,16 @@ const {useContext, useEffect, useMemo} = require('react');
 const {stableCopy} = require('relay-runtime');
 
 type PreloadedEntryPoint<TEntryPointComponent> = $ReadOnly<{|
-  entryPoints: React.ElementConfig<TEntryPointComponent>['entryPoints'],
-  extraProps: React.ElementConfig<TEntryPointComponent>['extraProps'],
+  entryPoints: $PropertyType<
+    React.ElementConfig<TEntryPointComponent>,
+    'entryPoints',
+  >,
+  extraProps: $PropertyType<
+    React.ElementConfig<TEntryPointComponent>,
+    'extraProps',
+  >,
   getComponent: () => TEntryPointComponent,
-  queries: React.ElementConfig<TEntryPointComponent>['queries'],
+  queries: $PropertyType<React.ElementConfig<TEntryPointComponent>, 'queries'>,
   rootModuleID: string,
 |}>;
 
@@ -91,7 +97,7 @@ function prepareEntryPoint<
   const preloadedEntryPoints: $Shape<TPreloadedEntryPoints> = {};
   if (queries != null) {
     const queriesPropNames = Object.keys(queries);
-    queriesPropNames.forEach(queryPropName => {
+    queriesPropNames.forEach((queryPropName) => {
       const {environmentProviderOptions, options, parameters, variables} =
         queries[queryPropName];
 
@@ -111,7 +117,7 @@ function prepareEntryPoint<
 
   if (entryPoints != null) {
     const entryPointPropNames = Object.keys(entryPoints);
-    entryPointPropNames.forEach(entryPointPropName => {
+    entryPointPropNames.forEach((entryPointPropName) => {
       const entryPointDescription = entryPoints[entryPointPropName];
       if (entryPointDescription == null) {
         return;

--- a/packages/react-relay/relay-hooks/loadQuery.js
+++ b/packages/react-relay/relay-hooks/loadQuery.js
@@ -57,7 +57,7 @@ function useTrackLoadQueryInRender() {
 function loadQuery<TQuery: OperationType, TEnvironmentProviderOptions>(
   environment: IEnvironment,
   preloadableRequest: GraphQLTaggedNode | PreloadableConcreteRequest<TQuery>,
-  variables: TQuery['variables'],
+  variables: $PropertyType<TQuery, 'variables'>,
   options?: ?LoadQueryOptions,
   environmentProviderOptions?: ?TEnvironmentProviderOptions,
 ): PreloadedQueryInner<TQuery, TEnvironmentProviderOptions> {
@@ -115,7 +115,7 @@ function loadQuery<TQuery: OperationType, TEnvironmentProviderOptions>(
   // of the operation, and then replay them to the Observable we
   // ultimately return.
   const executionSubject = new ReplaySubject();
-  const returnedObservable = Observable.create(sink =>
+  const returnedObservable = Observable.create((sink) =>
     executionSubject.subscribe(sink),
   );
 
@@ -179,7 +179,7 @@ function loadQuery<TQuery: OperationType, TEnvironmentProviderOptions>(
       },
     });
     unsubscribeFromNetworkRequest = unsubscribe;
-    return Observable.create(sink => {
+    return Observable.create((sink) => {
       const subjectSubscription = subject.subscribe(sink);
       return () => {
         subjectSubscription.unsubscribe();
@@ -236,7 +236,7 @@ function loadQuery<TQuery: OperationType, TEnvironmentProviderOptions>(
     }));
   };
 
-  const checkAvailabilityAndExecute = concreteRequest => {
+  const checkAvailabilityAndExecute = (concreteRequest) => {
     const operation = createOperationDescriptor(
       concreteRequest,
       variables,
@@ -300,7 +300,7 @@ function loadQuery<TQuery: OperationType, TEnvironmentProviderOptions>(
       // $FlowFixMe[method-unbinding] added when improving typing for this parameters
       ({dispose: cancelOnLoadCallback} = PreloadableQueryRegistry.onLoad(
         queryId,
-        preloadedModule => {
+        (preloadedModule) => {
           cancelOnLoadCallback();
           const operation = createOperationDescriptor(
             preloadedModule,

--- a/packages/react-relay/relay-hooks/useLazyLoadQueryNode.js
+++ b/packages/react-relay/relay-hooks/useLazyLoadQueryNode.js
@@ -48,7 +48,7 @@ function useLazyLoadQueryNode<TQuery: OperationType>({
   fetchPolicy?: ?FetchPolicy,
   fetchKey?: ?string | ?number,
   renderPolicy?: ?RenderPolicy,
-|}): TQuery['response'] {
+|}): $PropertyType<TQuery, 'response'> {
   const environment = useRelayEnvironment();
   const profilerContext = useContext(ProfilerContext);
   const QueryResource = getQueryResourceForEnvironment(environment);
@@ -101,7 +101,7 @@ function useLazyLoadQueryNode<TQuery: OperationType>({
       // a re-render so that the cache entry for this query is re-intiliazed and
       // and re-evaluated (and potentially cause a refetch).
       maybeHiddenOrFastRefresh.current = false;
-      forceUpdate(n => n + 1);
+      forceUpdate((n) => n + 1);
       return;
     }
 

--- a/packages/react-relay/relay-hooks/useMutation.js
+++ b/packages/react-relay/relay-hooks/useMutation.js
@@ -36,20 +36,25 @@ export type UseMutationConfig<TMutation: MutationParameters> = {|
   configs?: Array<DeclarativeMutationConfig>,
   onError?: ?(error: Error) => void,
   onCompleted?: ?(
-    response: TMutation['response'],
+    response: $PropertyType<TMutation, 'response'>,
     errors: ?Array<PayloadError>,
   ) => void,
   onNext?: ?() => void,
   onUnsubscribe?: ?() => void,
-  optimisticResponse?: {
-    +rawResponse?: {...},
-    ...TMutation,
-    ...
-  }['rawResponse'],
-  optimisticUpdater?: ?SelectorStoreUpdater<TMutation['response']>,
-  updater?: ?SelectorStoreUpdater<TMutation['response']>,
+  optimisticResponse?: $PropertyType<
+    {
+      +rawResponse?: {...},
+      ...TMutation,
+      ...
+    },
+    'rawResponse',
+  >,
+  optimisticUpdater?: ?SelectorStoreUpdater<
+    $PropertyType<TMutation, 'response'>,
+  >,
+  updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   uploadables?: UploadableMap,
-  variables: TMutation['variables'],
+  variables: $PropertyType<TMutation, 'variables'>,
 |};
 
 function useMutation<TMutation: MutationParameters>(
@@ -67,7 +72,7 @@ function useMutation<TMutation: MutationParameters>(
   const [isMutationInFlight, setMutationInFlight] = useState(false);
 
   const cleanup = useCallback(
-    disposable => {
+    (disposable) => {
       if (
         environmentRef.current === environment &&
         mutationRef.current === mutation
@@ -104,7 +109,7 @@ function useMutation<TMutation: MutationParameters>(
           cleanup(disposable);
           config.onCompleted?.(response, errors);
         },
-        onError: error => {
+        onError: (error) => {
           cleanup(disposable);
           config.onError?.(error);
         },

--- a/packages/react-relay/relay-hooks/usePreloadedQuery.js
+++ b/packages/react-relay/relay-hooks/usePreloadedQuery.js
@@ -37,7 +37,7 @@ function usePreloadedQuery<TQuery: OperationType>(
   options?: {|
     UNSTABLE_renderPolicy?: RenderPolicy,
   |},
-): TQuery['response'] {
+): $PropertyType<TQuery, 'response'> {
   // We need to use this hook in order to be able to track if
   // loadQuery was called during render
   useTrackLoadQueryInRender();

--- a/packages/react-relay/relay-hooks/useQueryLoader.js
+++ b/packages/react-relay/relay-hooks/useQueryLoader.js
@@ -31,7 +31,7 @@ const {useCallback, useEffect, useRef, useState} = require('react');
 const {getRequest} = require('relay-runtime');
 
 export type LoaderFn<TQuery: OperationType> = (
-  variables: TQuery['variables'],
+  variables: $PropertyType<TQuery, 'variables'>,
   options?: UseQueryLoaderLoadQueryOptions,
 ) => void;
 
@@ -128,7 +128,7 @@ function useQueryLoader<TQuery: OperationType>(
 
   const queryLoaderCallback = useCallback(
     (
-      variables: TQuery['variables'],
+      variables: $PropertyType<TQuery, 'variables'>,
       options?: ?UseQueryLoaderLoadQueryOptions,
     ) => {
       const mergedOptions: ?UseQueryLoaderLoadQueryOptions =

--- a/packages/relay-runtime/multi-actor-environment/ActorSpecificEnvironment.js
+++ b/packages/relay-runtime/multi-actor-environment/ActorSpecificEnvironment.js
@@ -195,7 +195,7 @@ class ActorSpecificEnvironment implements IActorEnvironment {
 
   executeSubscription<TMutation: MutationParameters>(config: {
     operation: OperationDescriptor,
-    updater?: ?SelectorStoreUpdater<TMutation['response']>,
+    updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   }): RelayObservable<GraphQLResponse> {
     return this.multiActorEnvironment.executeSubscription(this, config);
   }

--- a/packages/relay-runtime/multi-actor-environment/MultiActorEnvironment.js
+++ b/packages/relay-runtime/multi-actor-environment/MultiActorEnvironment.js
@@ -160,7 +160,7 @@ class MultiActorEnvironment implements IMultiActorEnvironment {
       return actorEnvironment.getStore().check(operation, {
         handlers: [],
         defaultActorIdentifier: actorEnvironment.actorIdentifier,
-        getSourceForActor: actorIdentifier => {
+        getSourceForActor: (actorIdentifier) => {
           return this.forActor(actorIdentifier).getStore().getSource();
         },
         getTargetForActor: () => {
@@ -186,10 +186,10 @@ class MultiActorEnvironment implements IMultiActorEnvironment {
     const result = actorEnvironment.getStore().check(operation, {
       handlers,
       defaultActorIdentifier: actorEnvironment.actorIdentifier,
-      getSourceForActor: actorIdentifier => {
+      getSourceForActor: (actorIdentifier) => {
         return this.forActor(actorIdentifier).getStore().getSource();
       },
-      getTargetForActor: actorIdentifier => {
+      getTargetForActor: (actorIdentifier) => {
         let target = targets.get(actorIdentifier);
         if (target == null) {
           target = RelayRecordSource.create();
@@ -275,7 +275,7 @@ class MultiActorEnvironment implements IMultiActorEnvironment {
     optimisticConfig: OptimisticResponseConfig<TMutation>,
   ): Disposable {
     const subscription = this._execute(actorEnvironment, {
-      createSource: () => RelayObservable.create(_sink => {}),
+      createSource: () => RelayObservable.create((_sink) => {}),
       isClientPayload: false,
       operation: optimisticConfig.operation,
       optimisticConfig,
@@ -351,7 +351,7 @@ class MultiActorEnvironment implements IMultiActorEnvironment {
       updater,
     }: {
       operation: OperationDescriptor,
-      updater?: ?SelectorStoreUpdater<TMutation['response']>,
+      updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
     },
   ): RelayObservable<GraphQLResponse> {
     return this._execute(actorEnvironment, {
@@ -448,10 +448,10 @@ class MultiActorEnvironment implements IMultiActorEnvironment {
       isClientPayload: boolean,
       operation: OperationDescriptor,
       optimisticConfig: ?OptimisticResponseConfig<TMutation>,
-      updater: ?SelectorStoreUpdater<TMutation['response']>,
+      updater: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
     |},
   ): RelayObservable<GraphQLResponse> {
-    return RelayObservable.create(sink => {
+    return RelayObservable.create((sink) => {
       const executor = OperationExecutor.execute({
         actorIdentifier: actorEnvironment.actorIdentifier,
         getDataID: this._getDataID,
@@ -494,7 +494,7 @@ class MultiActorEnvironment implements IMultiActorEnvironment {
 
   commitMultiActorUpdate(updater: MultiActorStoreUpdater): void {
     for (const [actorIdentifier, environment] of this._actorEnvironments) {
-      environment.commitUpdate(storeProxy => {
+      environment.commitUpdate((storeProxy) => {
         updater(actorIdentifier, environment, storeProxy);
       });
     }

--- a/packages/relay-runtime/multi-actor-environment/MultiActorEnvironmentTypes.js
+++ b/packages/relay-runtime/multi-actor-environment/MultiActorEnvironmentTypes.js
@@ -206,7 +206,7 @@ export interface IMultiActorEnvironment {
     actorEnvironment: IActorEnvironment,
     config: {
       operation: OperationDescriptor,
-      updater?: ?SelectorStoreUpdater<TMutation['response']>,
+      updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
     },
   ): RelayObservable<GraphQLResponse>;
 

--- a/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
+++ b/packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js
@@ -86,19 +86,22 @@ export type DeclarativeMutationConfig =
 function convert<TMutation: MutationParameters>(
   configs: Array<DeclarativeMutationConfig>,
   request: ConcreteRequest,
-  optimisticUpdater?: ?SelectorStoreUpdater<TMutation['response']>,
-  updater?: ?SelectorStoreUpdater<TMutation['response']>,
+  optimisticUpdater?: ?SelectorStoreUpdater<
+    $PropertyType<TMutation, 'response'>,
+  >,
+  updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
 ): {
-  optimisticUpdater: SelectorStoreUpdater<TMutation['response']>,
-  updater: SelectorStoreUpdater<TMutation['response']>,
+  optimisticUpdater: SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
+  updater: SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   ...
 } {
   const configOptimisticUpdates: Array<
-    SelectorStoreUpdater<TMutation['response']>,
+    SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   > = optimisticUpdater ? [optimisticUpdater] : [];
-  const configUpdates: Array<SelectorStoreUpdater<TMutation['response']>> =
-    updater ? [updater] : [];
-  configs.forEach(config => {
+  const configUpdates: Array<
+    SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
+  > = updater ? [updater] : [];
+  configs.forEach((config) => {
     switch (config.type) {
       case 'NODE_DELETE':
         const nodeDeleteResult = nodeDelete(config, request);
@@ -126,17 +129,17 @@ function convert<TMutation: MutationParameters>(
   return {
     optimisticUpdater: (
       store: RecordSourceSelectorProxy,
-      data: ?TMutation['response'],
+      data: ?$PropertyType<TMutation, 'response'>,
     ) => {
-      configOptimisticUpdates.forEach(eachOptimisticUpdater => {
+      configOptimisticUpdates.forEach((eachOptimisticUpdater) => {
         eachOptimisticUpdater(store, data);
       });
     },
     updater: (
       store: RecordSourceSelectorProxy,
-      data: ?TMutation['response'],
+      data: ?$PropertyType<TMutation, 'response'>,
     ) => {
-      configUpdates.forEach(eachUpdater => {
+      configUpdates.forEach((eachUpdater) => {
         eachUpdater(store, data);
       });
     },
@@ -159,7 +162,7 @@ function nodeDelete(
     }
     const deleteID = payload.getValue(deletedIDFieldName);
     const deleteIDs = Array.isArray(deleteID) ? deleteID : [deleteID];
-    deleteIDs.forEach(id => {
+    deleteIDs.forEach((id) => {
       if (id && typeof id === 'string') {
         store.delete(id);
       }
@@ -270,7 +273,7 @@ function rangeDelete(
         }
       }
       if (Array.isArray(deletedIDField)) {
-        deletedIDField.forEach(idObject => {
+        deletedIDField.forEach((idObject) => {
           if (
             idObject &&
             idObject.id &&
@@ -296,7 +299,7 @@ function rangeDelete(
       if (typeof deletedIDField === 'string') {
         deleteIDs.push(deletedIDField);
       } else if (Array.isArray(deletedIDField)) {
-        deletedIDField.forEach(id => {
+        deletedIDField.forEach((id) => {
           if (typeof id === 'string') {
             deleteIDs.push(id);
           }
@@ -359,7 +362,7 @@ function deleteNode(
       key.filters,
     );
     if (connection) {
-      deleteIDs.forEach(deleteID => {
+      deleteIDs.forEach((deleteID) => {
         ConnectionHandler.deleteNode(connection, deleteID);
       });
     }

--- a/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceProxy.js
@@ -65,7 +65,7 @@ class RelayRecordSourceProxy implements RecordSourceProxy {
     fieldPayloads?: ?Array<HandleFieldPayload>,
   ): void {
     const dataIDs = source.getRecordIDs();
-    dataIDs.forEach(dataID => {
+    dataIDs.forEach((dataID) => {
       const status = source.getStatus(dataID);
       if (status === EXISTENT) {
         const sourceRecord = source.get(dataID);
@@ -81,7 +81,7 @@ class RelayRecordSourceProxy implements RecordSourceProxy {
     });
 
     if (fieldPayloads && fieldPayloads.length) {
-      fieldPayloads.forEach(fieldPayload => {
+      fieldPayloads.forEach((fieldPayload) => {
         const handler =
           this._handlerProvider && this._handlerProvider(fieldPayload.handle);
         invariant(
@@ -165,8 +165,8 @@ class RelayRecordSourceProxy implements RecordSourceProxy {
 
   readUpdatableQuery_EXPERIMENTAL<TQuery: OperationType>(
     query: GraphQLTaggedNode,
-    variables: TQuery['variables'],
-  ): TQuery['response'] {
+    variables: $PropertyType<TQuery, 'variables'>,
+  ): $PropertyType<TQuery, 'response'> {
     return readUpdatableQuery_EXPERIMENTAL(query, variables, this);
   }
 }

--- a/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
+++ b/packages/relay-runtime/mutations/RelayRecordSourceSelectorProxy.js
@@ -82,7 +82,7 @@ class RelayRecordSourceSelectorProxy implements RecordSourceSelectorProxy {
     plural: boolean,
   ): ReaderLinkedField {
     let field = selector.node.selections.find(
-      selection =>
+      (selection) =>
         (selection.kind === 'LinkedField' && selection.name === fieldName) ||
         (selection.kind === 'RequiredField' &&
           selection.field.name === fieldName),
@@ -125,8 +125,8 @@ class RelayRecordSourceSelectorProxy implements RecordSourceSelectorProxy {
 
   readUpdatableQuery_EXPERIMENTAL<TQuery: OperationType>(
     query: GraphQLTaggedNode,
-    variables: TQuery['variables'],
-  ): TQuery['response'] {
+    variables: $PropertyType<TQuery, 'variables'>,
+  ): $PropertyType<TQuery, 'response'> {
     return readUpdatableQuery_EXPERIMENTAL(query, variables, this);
   }
 }

--- a/packages/relay-runtime/mutations/applyOptimisticMutation.js
+++ b/packages/relay-runtime/mutations/applyOptimisticMutation.js
@@ -33,7 +33,9 @@ export type OptimisticMutationConfig<TMutation: MutationParameters> = {|
   configs?: ?Array<DeclarativeMutationConfig>,
   mutation: GraphQLTaggedNode,
   variables: Variables,
-  optimisticUpdater?: ?SelectorStoreUpdater<TMutation['response']>,
+  optimisticUpdater?: ?SelectorStoreUpdater<
+    $PropertyType<TMutation, 'response'>,
+  >,
   optimisticResponse?: Object,
 |};
 

--- a/packages/relay-runtime/mutations/commitMutation.js
+++ b/packages/relay-runtime/mutations/commitMutation.js
@@ -42,21 +42,26 @@ export type MutationConfig<TMutation: MutationParameters> = {|
   configs?: Array<DeclarativeMutationConfig>,
   mutation: GraphQLTaggedNode,
   onCompleted?: ?(
-    response: TMutation['response'],
+    response: $PropertyType<TMutation, 'response'>,
     errors: ?Array<PayloadError>,
   ) => void,
   onError?: ?(error: Error) => void,
   onNext?: ?() => void,
   onUnsubscribe?: ?() => void,
-  optimisticResponse?: {
-    +rawResponse?: {...},
-    ...TMutation,
-    ...
-  }['rawResponse'],
-  optimisticUpdater?: ?SelectorStoreUpdater<TMutation['response']>,
-  updater?: ?SelectorStoreUpdater<TMutation['response']>,
+  optimisticResponse?: $PropertyType<
+    {
+      +rawResponse?: {...},
+      ...TMutation,
+      ...
+    },
+    'rawResponse',
+  >,
+  optimisticUpdater?: ?SelectorStoreUpdater<
+    $PropertyType<TMutation, 'response'>,
+  >,
+  updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   uploadables?: UploadableMap,
-  variables: TMutation['variables'],
+  variables: $PropertyType<TMutation, 'variables'>,
 |};
 
 export type DEPRECATED_MutationConfig<TMutationResponse> = MutationConfig<{|
@@ -126,9 +131,9 @@ function commitMutation<TMutation: MutationParameters>(
       uploadables,
     })
     .subscribe({
-      next: payload => {
+      next: (payload) => {
         if (Array.isArray(payload)) {
-          payload.forEach(item => {
+          payload.forEach((item) => {
             if (item.errors) {
               errors.push(...item.errors);
             }

--- a/packages/relay-runtime/mutations/readUpdatableQuery_EXPERIMENTAL.js
+++ b/packages/relay-runtime/mutations/readUpdatableQuery_EXPERIMENTAL.js
@@ -25,9 +25,9 @@ const nonUpdatableKeys = ['id', '__id', '__typename', 'js'];
 
 function readUpdatableQuery_EXPERIMENTAL<TQuery: OperationType>(
   query: GraphQLTaggedNode,
-  variables: TQuery['variables'],
+  variables: $PropertyType<TQuery, 'variables'>,
   proxy: RecordSourceProxy,
-): TQuery['response'] {
+): $PropertyType<TQuery, 'response'> {
   // TODO assert that the concrete request is an updatable query
   const request = getRequest(query);
 
@@ -46,9 +46,9 @@ function readUpdatableQuery_EXPERIMENTAL<TQuery: OperationType>(
 }
 
 function updateProxyFromSelections<TQuery: OperationType>(
-  mutableUpdatableProxy: TQuery['response'],
+  mutableUpdatableProxy: $PropertyType<TQuery, 'response'>,
   recordProxy: RecordProxy,
-  queryVariables: TQuery['variables'],
+  queryVariables: $PropertyType<TQuery, 'variables'>,
   selections: $ReadOnlyArray<ReaderSelection>,
   root: RecordSourceProxy,
 ) {
@@ -163,7 +163,7 @@ function updateProxyFromSelections<TQuery: OperationType>(
 
 function createSetterForPluralLinkedField<TQuery: OperationType>(
   selection: ReaderLinkedField,
-  queryVariables: TQuery['variables'],
+  queryVariables: $PropertyType<TQuery, 'variables'>,
   recordProxy: RecordProxy,
   root: RecordSourceProxy,
 ) {
@@ -174,7 +174,7 @@ function createSetterForPluralLinkedField<TQuery: OperationType>(
         'Do not assign null to plural linked fields; assign an empty array instead.',
       );
     } else {
-      const recordProxies = newValue.map(item => {
+      const recordProxies = newValue.map((item) => {
         if (item == null) {
           throw new Error(
             'When assigning an array of items, none of the items should be null or undefined.',
@@ -206,7 +206,7 @@ function createSetterForPluralLinkedField<TQuery: OperationType>(
 
 function createSetterForSingularLinkedField<TQuery: OperationType>(
   selection: ReaderLinkedField,
-  queryVariables: TQuery['variables'],
+  queryVariables: $PropertyType<TQuery, 'variables'>,
   recordProxy: RecordProxy,
   root: RecordSourceProxy,
 ) {
@@ -238,7 +238,7 @@ function createSetterForSingularLinkedField<TQuery: OperationType>(
 
 function createGetterForPluralLinkedField<TQuery: OperationType>(
   selection: ReaderLinkedField,
-  queryVariables: TQuery['variables'],
+  queryVariables: $PropertyType<TQuery, 'variables'>,
   recordProxy: RecordProxy,
   root: RecordSourceProxy,
 ) {
@@ -250,7 +250,7 @@ function createGetterForPluralLinkedField<TQuery: OperationType>(
       (variables: any),
     );
     if (linkedRecords != null) {
-      return (linkedRecords.map(linkedRecord => {
+      return (linkedRecords.map((linkedRecord) => {
         if (linkedRecord != null) {
           const updatableProxy = {};
           updateProxyFromSelections(
@@ -280,7 +280,7 @@ function createGetterForPluralLinkedField<TQuery: OperationType>(
 
 function createGetterForSingularLinkedField<TQuery: OperationType>(
   selection: ReaderLinkedField,
-  queryVariables: TQuery['variables'],
+  queryVariables: $PropertyType<TQuery, 'variables'>,
   recordProxy: RecordProxy,
   root: RecordSourceProxy,
 ) {

--- a/packages/relay-runtime/query/fetchQuery.js
+++ b/packages/relay-runtime/query/fetchQuery.js
@@ -167,7 +167,7 @@ function fetchQuery<TVariables: Variables, TData, TRawResponse>(
 function getNetworkObservable<TQuery: OperationType>(
   environment: IEnvironment,
   operation: OperationDescriptor,
-): RelayObservable<TQuery['response']> {
+): RelayObservable<$PropertyType<TQuery, 'response'>> {
   return fetchQueryInternal
     .fetchQuery(environment, operation)
     .map(() => environment.lookup(operation.fragment));

--- a/packages/relay-runtime/query/fetchQuery_DEPRECATED.js
+++ b/packages/relay-runtime/query/fetchQuery_DEPRECATED.js
@@ -30,9 +30,9 @@ const {getRequest} = require('./GraphQLTag');
 function fetchQuery_DEPRECATED<T: OperationType>(
   environment: IEnvironment,
   taggedNode: GraphQLTaggedNode,
-  variables: T['variables'],
+  variables: $PropertyType<T, 'variables'>,
   cacheConfig?: ?CacheConfig,
-): Promise<T['response']> {
+): Promise<$PropertyType<T, 'response'>> {
   const query = getRequest(taggedNode);
   if (query.params.operationKind !== 'query') {
     throw new Error('fetchQuery: Expected query operation');

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -154,7 +154,7 @@ class RelayModernEnvironment implements IEnvironment {
     this.options = config.options;
     this._isServer = config.isServer ?? false;
 
-    (this: any).__setNet = newNet =>
+    (this: any).__setNet = (newNet) =>
       (this._network = wrapNetworkWithLogObserver(this, newNet));
 
     if (__DEV__) {
@@ -231,7 +231,7 @@ class RelayModernEnvironment implements IEnvironment {
     optimisticConfig: OptimisticResponseConfig<TMutation>,
   ): Disposable {
     const subscription = this._execute({
-      createSource: () => RelayObservable.create(_sink => {}),
+      createSource: () => RelayObservable.create((_sink) => {}),
       isClientPayload: false,
       operation: optimisticConfig.operation,
       optimisticConfig,
@@ -368,7 +368,7 @@ class RelayModernEnvironment implements IEnvironment {
     updater,
   }: {|
     operation: OperationDescriptor,
-    updater?: ?SelectorStoreUpdater<TMutation['response']>,
+    updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   |}): RelayObservable<GraphQLResponse> {
     return this._execute({
       createSource: () =>
@@ -468,11 +468,11 @@ class RelayModernEnvironment implements IEnvironment {
     isClientPayload: boolean,
     operation: OperationDescriptor,
     optimisticConfig: ?OptimisticResponseConfig<TMutation>,
-    updater: ?SelectorStoreUpdater<TMutation['response']>,
+    updater: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   |}): RelayObservable<GraphQLResponse> {
     const publishQueue = this._publishQueue;
     const store = this._store;
-    return RelayObservable.create(sink => {
+    return RelayObservable.create((sink) => {
       const executor = OperationExecutor.execute({
         actorIdentifier: INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         getDataID: this._getDataID,

--- a/packages/relay-runtime/store/RelayPublishQueue.js
+++ b/packages/relay-runtime/store/RelayPublishQueue.js
@@ -46,7 +46,7 @@ type PendingRelayPayload<TMutation: MutationParameters> = {|
   +kind: 'payload',
   +operation: OperationDescriptor,
   +payload: RelayResponsePayload,
-  +updater: ?SelectorStoreUpdater<TMutation['response']>,
+  +updater: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
 |};
 type PendingRecordSource = {|
   +kind: 'source',
@@ -160,7 +160,7 @@ class RelayPublishQueue implements PublishQueue {
   commitPayload<TMutation: MutationParameters>(
     operation: OperationDescriptor,
     payload: RelayResponsePayload,
-    updater?: ?SelectorStoreUpdater<TMutation['response']>,
+    updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   ): void {
     this._pendingBackupRebase = true;
     this._pendingData.add({
@@ -281,7 +281,7 @@ class RelayPublishQueue implements PublishQueue {
       this._getDataID,
     );
     if (fieldPayloads && fieldPayloads.length) {
-      fieldPayloads.forEach(fieldPayload => {
+      fieldPayloads.forEach((fieldPayload) => {
         const handler =
           this._handlerProvider && this._handlerProvider(fieldPayload.handle);
         invariant(
@@ -322,7 +322,7 @@ class RelayPublishQueue implements PublishQueue {
       return false;
     }
     let invalidatedStore = false;
-    this._pendingData.forEach(data => {
+    this._pendingData.forEach((data) => {
       if (data.kind === 'payload') {
         const payloadInvalidatedStore = this._publishSourceFromPayload(data);
         invalidatedStore = invalidatedStore || payloadInvalidatedStore;
@@ -418,7 +418,7 @@ class RelayPublishQueue implements PublishQueue {
 
     // apply any new updaters
     if (this._pendingOptimisticUpdates.size) {
-      this._pendingOptimisticUpdates.forEach(optimisticUpdate => {
+      this._pendingOptimisticUpdates.forEach((optimisticUpdate) => {
         processUpdate(optimisticUpdate);
         this._appliedOptimisticUpdates.add(optimisticUpdate);
       });

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -467,8 +467,8 @@ export interface RecordSourceProxy {
   invalidateStore(): void;
   readUpdatableQuery_EXPERIMENTAL<TQuery: OperationType>(
     query: GraphQLTaggedNode,
-    variables: TQuery['variables'],
-  ): TQuery['response'];
+    variables: $PropertyType<TQuery, 'variables'>,
+  ): $PropertyType<TQuery, 'response'>;
 }
 
 export interface ReadOnlyRecordSourceProxy {
@@ -626,8 +626,8 @@ export type LogEvent =
       +rootModuleID: string,
     |};
 
-export type LogFunction = LogEvent => void;
-export type LogRequestInfoFunction = mixed => void;
+export type LogFunction = (LogEvent) => void;
+export type LogRequestInfoFunction = (mixed) => void;
 
 /**
  * The public API of Relay core. Represents an encapsulated environment with its
@@ -765,7 +765,7 @@ export interface IEnvironment {
    */
   executeSubscription<TMutation: MutationParameters>(config: {|
     operation: OperationDescriptor,
-    updater?: ?SelectorStoreUpdater<TMutation['response']>,
+    updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   |}): RelayObservable<GraphQLResponse>;
 
   /**
@@ -1015,13 +1015,13 @@ export type OptimisticUpdateFunction = {|
 export type OptimisticUpdateRelayPayload<TMutation: MutationParameters> = {|
   +operation: OperationDescriptor,
   +payload: RelayResponsePayload,
-  +updater: ?SelectorStoreUpdater<TMutation['response']>,
+  +updater: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
 |};
 
 export type OptimisticResponseConfig<TMutation: MutationParameters> = {|
   +operation: OperationDescriptor,
   +response: ?PayloadData,
-  +updater: ?SelectorStoreUpdater<TMutation['response']>,
+  +updater: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
 |};
 
 /**
@@ -1091,9 +1091,11 @@ export type RelayResponsePayload = {|
  */
 export type ExecuteMutationConfig<TMutation: MutationParameters> = {|
   operation: OperationDescriptor,
-  optimisticUpdater?: ?SelectorStoreUpdater<TMutation['response']>,
+  optimisticUpdater?: ?SelectorStoreUpdater<
+    $PropertyType<TMutation, 'response'>,
+  >,
   optimisticResponse?: ?Object,
-  updater?: ?SelectorStoreUpdater<TMutation['response']>,
+  updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   uploadables?: ?UploadableMap,
 |};
 
@@ -1126,7 +1128,7 @@ export interface PublishQueue {
   commitPayload<TMutation: MutationParameters>(
     operation: OperationDescriptor,
     payload: RelayResponsePayload,
-    updater?: ?SelectorStoreUpdater<TMutation['response']>,
+    updater?: ?SelectorStoreUpdater<$PropertyType<TMutation, 'response'>>,
   ): void;
 
   /**

--- a/packages/relay-runtime/subscription/requestSubscription.js
+++ b/packages/relay-runtime/subscription/requestSubscription.js
@@ -42,11 +42,11 @@ export type GraphQLSubscriptionConfig<T: SubscriptionParameters> = {|
   configs?: Array<DeclarativeMutationConfig>,
   cacheConfig?: CacheConfig,
   subscription: GraphQLTaggedNode,
-  variables: T['variables'],
+  variables: $PropertyType<T, 'variables'>,
   onCompleted?: ?() => void,
   onError?: ?(error: Error) => void,
-  onNext?: ?(response: ?T['response']) => void,
-  updater?: ?SelectorStoreUpdater<T['response']>,
+  onNext?: ?(response: ?$PropertyType<T, 'response'>) => void,
+  updater?: ?SelectorStoreUpdater<$PropertyType<T, 'response'>>,
 |};
 
 export type DEPRECATED_GraphQLSubscriptionConfig<TSubscriptionPayload: {...}> =
@@ -91,7 +91,7 @@ function requestSubscription<TSubscriptionPayload: {...}>(
       updater,
     })
     .subscribe({
-      next: responses => {
+      next: (responses) => {
         if (onNext != null) {
           let selector = operation.fragment;
           let nextID;

--- a/packages/relay-runtime/util/RelayRuntimeTypes.js
+++ b/packages/relay-runtime/util/RelayRuntimeTypes.js
@@ -41,7 +41,7 @@ export type OperationType = {|
   +rawResponse?: {...},
 |};
 
-export type VariablesOf<T: OperationType> = T['variables'];
+export type VariablesOf<T: OperationType> = $PropertyType<T, 'variables'>;
 
 /**
  * Settings for how a query response may be cached.


### PR DESCRIPTION
There are some Flow type declarations that make use of [indexed access](https://flow.org/en/docs/types/indexed-access/), but that's only available from Flow 0.155 and older versions can't parse the syntax.

`$PropertyType` works in the same way and it's supported in older versions, so updating usages of indexed access for this so that Relay can be used with older versions of Flow.