### PR TITLE
add validation option

### DIFF
--- a/compiler/crates/relay-compiler/src/errors.rs
+++ b/compiler/crates/relay-compiler/src/errors.rs
@@ -112,6 +112,9 @@ pub enum Error {
     #[error("A thread that the Relay compiler spun up did not shut down gracefully: {error}")]
     JoinError { error: String },
 
+    #[error("Artifacts validation failed: {error}")]
+    OutOfDateError { error: String },
+
     #[error("Error in post artifact writer: {error}")]
     PostArtifactsError {
         error: Box<dyn std::error::Error + Sync + Send>,

--- a/compiler/crates/relay-compiler/src/lib.rs
+++ b/compiler/crates/relay-compiler/src/lib.rs
@@ -10,7 +10,7 @@
 #![deny(clippy::all)]
 
 mod artifact_map;
-mod build_project;
+pub mod build_project;
 pub mod compiler;
 pub mod compiler_state;
 pub mod config;
@@ -26,6 +26,7 @@ pub use build_project::{
     add_to_mercurial,
     artifact_writer::{
         ArtifactDifferenceWriter, ArtifactFileWriter, ArtifactWriter, NoopArtifactWriter,
+        ArtifactValidationWriter,
     },
     build_programs, build_raw_program, build_schema, create_path_for_artifact, generate_artifacts,
     generate_extra_artifacts::GenerateExtraArtifactsFn,

--- a/compiler/crates/relay-compiler/src/main.rs
+++ b/compiler/crates/relay-compiler/src/main.rs
@@ -50,7 +50,8 @@ struct Opt {
     #[structopt(long, possible_values = &OutputKind::variants(), case_insensitive = true, default_value = "verbose")]
     output: OutputKind,
 
-    /// Do not write artifacts to disk and check for changes only
+    /// Looks for pending changes and exits with non-zero code instead of
+    /// writing to disk
     #[structopt(long)]
     validate: bool,
 }

--- a/packages/relay-compiler/README.md
+++ b/packages/relay-compiler/README.md
@@ -115,3 +115,5 @@ when you need to run the compiler.
 - `--output`            Output format of the compiler. Supported options:
                         `debug` | `verbose` | `quiet` | `quietWithErrors`.
                         The default value is `verbose`.
+- `--validate`          Looks for pending changes and exits with non-zero code
+                        instead of writing to disk.


### PR DESCRIPTION
Attempts to fix #3738

I've ended up with adding new implementation of `ArtifactWriter` which allows to collect added, updated and removed artefacts and then print a result in the `finalize` method.

I'm not sure about the proper output and error naming. Also don't like that returning a result as an error leads to print it two times: in status_reporter and in macro after compile method. I would be happy to get a piece of advice about that.

**Test Plan:**
Tested on macOS using relay-examples/issue-tracker project.
After the first run with the `--validate` option:
```
[INFO] [default] compiling...
[INFO] [default] compiled documents: 12 reader, 8 normalization, 14 operation text
[ERROR] Artifacts validation failed: 
Missing:
 - IssueActions_issue.graphql.js
 - IssueDetailRootQuery.graphql.js
 - IssueActionsCloseIssueMutation.graphql.js
 - IssueDetailCommentsQuery.graphql.js
 - IssuesPaginationQuery.graphql.js
 - HomeRootIssuesQuery.graphql.js
 - IssuesListItem_issue.graphql.js
 - RootQuery.graphql.js
 - Issues_repository.graphql.js
 - IssueDetailComments_issue.graphql.js
 - IssueActionsAddCommentMutation.graphql.js
 - IssueActionsReopenIssueMutation.graphql.js
[ERROR] Compilation failed.
```
No artefacts have been generated.

After running without the `--validate` option:
```
[INFO] [default] compiling...
[INFO] [default] compiled documents: 12 reader, 8 normalization, 14 operation text
[INFO] Done
```
New artefacts in `__generated__` folder appeared

After changing some files (adding, removing and editing) and running with the `--validate` option:
```
[INFO] [default] compiling...
[INFO] [default] compiled documents: 12 reader, 8 normalization, 14 operation text
[ERROR] Artifacts validation failed: 
Out of date:
 - IssueActionsCloseIssueMutation.graphql.js
Missing:
 - Root2Query.graphql.js
Extra:
 - IssueActionsReopenIssueMutation.graphql.js
[ERROR] Compilation failed.
```
To detect `Extra` artefacts, which are about to be deleted, you need to add `exclude` to the project config without `**/__generated__/**` value.