### PR TITLE
Fix null comparison for skip_printing_nulls

### DIFF
--- a/packages/relay-test-utils/RelayMockPayloadGenerator.js
+++ b/packages/relay-test-utils/RelayMockPayloadGenerator.js
@@ -699,7 +699,7 @@ class RelayMockPayloadGenerator {
     // information came from mock resolver __typename value and it was
     // an intentional selection of the specific type
     const isAbstractType =
-      field.concreteType === null && typeName === typeFromSelection.type;
+      field.concreteType == null && typeName === typeFromSelection.type;
 
     const generateDataForField = possibleDefaultValue => {
       const fieldDefaultValue =


### PR DESCRIPTION
In `skip_printing_nulls` (https://github.com/facebook/relay/pull/3626) we change some `null` values to be undefined by skipping them in the output.

Generally, the js code uses loose equality, either as
 * `field.X != null`
 * `field.X ?? default`
 * `if (field.X) {`

which allows us to do this safely.

The comparison this commit fixes was a rare exception to that showing up when using `@required`, mocking data and `skip_printing_nulls` is enabled.