### PR TITLE
Update CodeSandbox link

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,8 +10,8 @@ If you have a question on how to use Relay, please get in touch with community m
 
 We will be using GitHub Issues for our public bugs. We will keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new issue, make sure an issue for your problem doesn't already exist.
 
-The best way to get your bug fixed is to provide a reduced test case. To make reproduction simple for you, and set-up simple for Relay's maintainers, you can use Glitch:
-https://glitch.com/edit/#!/remix/relay-starter-kit
+The best way to get your bug fixed is to provide a reduced test case. To make reproduction simple for you, and set-up simple for Relay's maintainers, you can use CodeSandbox:
+https://codesandbox.io/s/relay-sandbox-2qfy9
 
 You can also provide a public repository with a runnable example.
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -68,7 +68,7 @@ const HomeSplash = () => {
               <h3>
                 <a
                   className="button"
-                  href="https://codesandbox.io/s/relay-sandbox-nxl7i?file=/src/TodoApp.tsx"
+                  href="https://codesandbox.io/s/relay-sandbox-2qfy9?file=/src/TodoApp.tsx"
                   target="_blank">
                   Explore an example
                 </a>
@@ -584,7 +584,7 @@ export default function ArtistCard(props) {
             id="iframe-wrapper"
             style={{height: 500, width: '100%', marginTop: 40}}>
             <iframe
-              src={`https://codesandbox.io/embed/relay-sandbox-nxl7i?&module=%2Fsrc%2FTodoApp.tsx&fontsize=14&hidenavigation=1&hidedevtools=1&theme=${
+              src={`https://codesandbox.io/embed/relay-sandbox-2qfy9?&module=%2Fsrc%2FTodoApp.tsx&fontsize=14&hidenavigation=1&hidedevtools=1&theme=${
                 isDarkTheme ? 'dark' : 'light'
               }`}
               style={{


### PR DESCRIPTION
Fixes #3775

I've updated CodeSandbox example to the latest relay version and webpack 5. Tried to keep everything as it was in the previous version.

Also links from the main page have been updated and tested using a local build of the website package.

If you want to keep ownership, here is the repo and the template
https://github.com/ch1ffa/relay-sandbox
https://codesandbox.io/s/relay-sandbox-2qfy9