### PR TITLE
Restore live query in non fb_only

### DIFF
--- a/compiler/crates/relay-transforms/src/apply_transforms.rs
+++ b/compiler/crates/relay-transforms/src/apply_transforms.rs
@@ -316,6 +316,10 @@ fn apply_operation_transforms(
     program =
         apply_internal_fb_operation_transforms(project_config, &program, Arc::clone(&perf_logger))?;
 
+    program = log_event.time("generate_live_query_metadata", || {
+        generate_live_query_metadata(&program)
+    })?;
+
     program = apply_after_custom_transforms(
         &program,
         custom_transforms,
@@ -339,11 +343,8 @@ fn apply_internal_fb_operation_transforms(
     let log_event = perf_logger.create_event("apply_internal_fb_operation_transforms");
     log_event.string("project", project_config.name.to_string());
 
-    let mut next_program = log_event.time("generate_subscription_name_metadata", || {
+    let next_program = log_event.time("generate_subscription_name_metadata", || {
         generate_subscription_name_metadata(program)
-    })?;
-    next_program = log_event.time("generate_live_query_metadata", || {
-        generate_live_query_metadata(&next_program)
     })?;
 
     log_event.complete();


### PR DESCRIPTION
A combination of these two commits removed support for `@live_query()` support in non-FB builds:
* https://github.com/facebook/relay/commit/18305a101acc988c80291328e714f8a1fb07a151
* https://github.com/facebook/relay/commit/9dab3ffd344ced209eb54a315eaa57f21e16c536

The reasoning given in the first commit is incorrect, `live_query` can absolutely be used in non-FB environments.

I have support in my network layer like this: (error checking/types removed for brevity)

```js
export function graphqlRawFetchQuery(
    request,
    variables,
    cacheConfig,
    uploadables,
) {
    let observable = Observable.create((sink) => {
        fetch(...)
            .then((response) => response.json())
            .then((json) => {
                sink.next(json);
                sink.complete();
            });
    });

    if (request.metadata.live != null) {
        observable = observable.poll(request.metadata.live.polling_interval);
    }

    return observable;
}
```

This works exactly like I would expect in 13.0.1, however when I upgraded to 13.0.3 today (sorry, I missed 13.0.2) the metadata is missing in the `.graphql.js` files generated by the compiler, which means the above network fails to perform an actual live query.

If we want this to be put behind a feature flag instead I'm happy to do so, but this doesn't really seem like it needs it to me. Perhaps the `config_id` version should be put behind a feature flag, but the `polling_interval` version works client-side-only just fine for me.