### PR TITLE
Allow using native flow/typescript enums.

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1421,6 +1421,7 @@ dependencies = [
  "common-path",
  "dashmap",
  "dependency-analyzer",
+ "docblock-syntax",
  "errors",
  "extract-graphql",
  "fixture-tests",

--- a/compiler/crates/relay-config/src/typegen_config.rs
+++ b/compiler/crates/relay-config/src/typegen_config.rs
@@ -7,12 +7,11 @@
 
 use common::Rollout;
 use fnv::FnvBuildHasher;
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 use intern::string_key::StringKey;
 use serde::{Deserialize, Serialize};
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
-type FnvIndexSet<T> = IndexSet<T, FnvBuildHasher>;
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
@@ -43,14 +42,6 @@ pub struct TypegenConfig {
     pub enum_module_suffix: Option<String>,
 
     /// # For Flow type generation
-    /// Generate enum files using Flow Enums instead of string unions for the
-    /// given GraphQL enum names.
-    /// Enums with names that start with lowercase are invalid Flow Enum values
-    /// and always generate legacy enums.
-    #[serde(default)]
-    pub flow_enums: FnvIndexSet<StringKey>,
-
-    /// # For Flow type generation
     /// When set, generated input types will have the listed fields optional
     /// even if the schema defines them as required.
     #[serde(default)]
@@ -61,6 +52,14 @@ pub struct TypegenConfig {
     /// version 3.8. This will prevent warnings from `importsNotUsedAsValues`.
     #[serde(default)]
     pub use_import_type_syntax: bool,
+
+    /// # For Typescript type generation
+    /// If `useNativeEnums` is enabled, and the typegen language is "typescript",
+    /// this option sets whether enums are generated as `const enums` or not.
+    /// On paper, const enums are better, but depending on the compilation
+    /// configuration, they may require additional setup.
+    #[serde(default)]
+    pub use_typescript_const_enums: bool,
 
     /// A map from GraphQL scalar types to a custom JS type, example:
     /// { "Url": "String" }
@@ -75,6 +74,10 @@ pub struct TypegenConfig {
     /// Work in progress new Flow type definitions
     #[serde(default)]
     pub flow_typegen: FlowTypegenConfig,
+
+    /// Use native Typescript/Flow enums when possible, instead of a string union.
+    #[serde(default)]
+    pub use_native_enums: bool,
 
     /// This option enables emitting es modules artifacts.
     #[serde(default)]

--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -71,6 +71,25 @@ impl Writer for FlowPrinter {
         writeln!(&mut self.result, ";")
     }
 
+    fn write_export_enum(
+        &mut self,
+        name: &str,
+        values: &[StringKey],
+        incomplete: bool,
+    ) -> FmtResult {
+        writeln!(&mut self.result, "export const enum {} {{", name)?;
+        for value in values {
+            let enum_key = self.to_title_case(value.lookup());
+            write!(&mut self.result, "  {} = ", enum_key)?;
+            self.write_string_literal(*value)?;
+            writeln!(&mut self.result, ",")?;
+        }
+        if incomplete {
+            writeln!(&mut self.result, "  ...")?;
+        }
+        writeln!(&mut self.result, "}}")
+    }
+
     fn write_export_type(&mut self, name: &str, value: &AST) -> FmtResult {
         write!(&mut self.result, "export type {} = ", name)?;
         self.write(value)?;

--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -629,7 +629,6 @@ impl<'a> TypeGenerator<'a> {
             .entry(haste_import_name)
             .or_insert(local_resolver_name);
 
-
         let inner_value = Box::new(AST::ReturnTypeOfFunctionWithName(local_resolver_name));
 
         let value = if required {
@@ -637,7 +636,6 @@ impl<'a> TypeGenerator<'a> {
         } else {
             AST::Nullable(inner_value)
         };
-
 
         type_selections.push(TypeSelection::ScalarField(TypeSelectionScalarField {
             field_name_or_alias: key,
@@ -1456,6 +1454,16 @@ impl<'a> TypeGenerator<'a> {
                 self.writer.write_import_type(
                     &[enum_type.name.lookup()],
                     &format!("{}{}", enum_type.name, enum_module_suffix),
+                )?;
+            } else if self.typegen_config.use_native_enums {
+                self.writer.write_export_enum(
+                    enum_type.name.lookup(),
+                    &enum_type
+                        .values
+                        .iter()
+                        .map(|enum_value| enum_value.value)
+                        .collect::<Vec<_>>(),
+                    !self.typegen_config.flow_typegen.no_future_proof_enums,
                 )?;
             } else {
                 let mut members: Vec<AST> = enum_type

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -70,6 +70,13 @@ pub trait Writer: Write {
 
     fn write_local_type(&mut self, name: &str, ast: &AST) -> FmtResult;
 
+    fn write_export_enum(
+        &mut self,
+        name: &str,
+        values: &[StringKey],
+        incomplete: bool,
+    ) -> FmtResult;
+
     fn write_export_type(&mut self, name: &str, ast: &AST) -> FmtResult;
 
     fn write_import_module_default(&mut self, name: &str, from: &str) -> FmtResult;
@@ -87,4 +94,25 @@ pub trait Writer: Write {
     ) -> FmtResult;
 
     fn write_any_type_definition(&mut self, name: &str) -> FmtResult;
+
+    fn to_title_case(&self, value: &str) -> String {
+        let mut result = String::with_capacity(value.len());
+        let mut first = true;
+        for c in value.chars() {
+            if first {
+                for u in c.to_uppercase() {
+                    result.push(u);
+                }
+                first = false
+            } else if c == '_' {
+                first = true
+            } else {
+                for l in c.to_lowercase() {
+                    result.push(l);
+                }
+            }
+        }
+
+        result
+    }
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-enums-on-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-enums-on-fragment.expected
@@ -28,7 +28,11 @@ fragment FriendFragment on User {
 }
 ==================================== OUTPUT ===================================
 import type { FriendFragment$fragmentType } from "FriendFragment.graphql";
-export type TestEnums = "mark" | "zuck" | "%future added value";
+export const enum TestEnums {
+  Mark = "mark",
+  Zuck = "zuck",
+  ...
+}
 export type CommentCreateInput = {|
   clientMutationId?: ?string,
   feedbackId?: ?string,
@@ -86,7 +90,11 @@ export type CommentCreateMutation = {|
   rawResponse: CommentCreateMutation$rawResponse,
 |};
 -------------------------------------------------------------------------------
-export type TestEnums = "mark" | "zuck" | "%future added value";
+export const enum TestEnums {
+  Mark = "mark",
+  Zuck = "zuck",
+  ...
+}
 import type { FragmentType } from "relay-runtime";
 declare export opaque type FriendFragment$fragmentType: FragmentType;
 export type FriendFragment$data = {|

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/scalar-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/scalar-field.expected
@@ -13,7 +13,13 @@ fragment ScalarField on User {
   }
 }
 ==================================== OUTPUT ===================================
-export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value";
+export const enum PersonalityTraits {
+  Cheerful = "CHEERFUL",
+  Derisive = "DERISIVE",
+  Helpful = "HELPFUL",
+  Snarky = "SNARKY",
+  ...
+}
 import type { FragmentType } from "relay-runtime";
 declare export opaque type ScalarField$fragmentType: FragmentType;
 export type ScalarField$data = {|

--- a/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
@@ -67,6 +67,8 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         typegen_config: TypegenConfig {
             language: TypegenLanguage::Flow,
             custom_scalar_types,
+            use_native_enums: true,
+            use_typescript_const_enums: true,
             flow_typegen: FlowTypegenConfig {
                 phase: FlowTypegenPhase::Final,
                 ..Default::default()

--- a/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
@@ -46,6 +46,8 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
                 phase: FlowTypegenPhase::Final,
                 ..Default::default()
             },
+            use_native_enums: true,
+            use_typescript_const_enums: true,
             ..Default::default()
         },
         ..Default::default()


### PR DESCRIPTION
Fixes #3596

Basically, allow using native [Flow enums](https://flow.org/en/docs/enums/) or [Typescript enums](https://www.typescriptlang.org/docs/handbook/enums.html). I removed the `flow_enums` config key, as it seems to be unused. That one was a set, rather than a boolean. I think this was only because of Flow enums not being allowed to have values starting with a lowercase letter, but instead I just transform all enum values to title case (aka pascal case), which I believe eliminates the need for a set.

@alunyov @mrtnzlml