### PR TITLE
Sort object members in typegen

### DIFF
--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -217,7 +217,7 @@ impl FlowPrinter {
         }
         self.indentation += 1;
 
-        for prop in props {
+        for prop in self.sort_props(props) {
             self.write_indentation()?;
             match prop {
                 Prop::Spread(spread) => {

--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -399,8 +399,8 @@ mod tests {
                 }),
             ])),
             r"{|
-  foo?: string,
   +bar: number,
+  foo?: string,
 |}"
             .to_string()
         );
@@ -437,11 +437,11 @@ mod tests {
                 }),
             ])),
             r"{|
+  +bar: number,
   foo?: {|
     nested_foo?: string,
     +nested_foo2: number,
   |},
-  +bar: number,
 |}"
             .to_string()
         );
@@ -489,8 +489,8 @@ mod tests {
                 })
             ])),
             r"{
-  foo: string,
   +bar?: number,
+  foo: string,
   ...
 }"
             .to_string()

--- a/compiler/crates/relay-typegen/src/lib.rs
+++ b/compiler/crates/relay-typegen/src/lib.rs
@@ -629,7 +629,6 @@ impl<'a> TypeGenerator<'a> {
             .entry(haste_import_name)
             .or_insert(local_resolver_name);
 
-
         let inner_value = Box::new(AST::ReturnTypeOfFunctionWithName(local_resolver_name));
 
         let value = if required {
@@ -637,7 +636,6 @@ impl<'a> TypeGenerator<'a> {
         } else {
             AST::Nullable(inner_value)
         };
-
 
         type_selections.push(TypeSelection::ScalarField(TypeSelectionScalarField {
             field_name_or_alias: key,

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -48,8 +48,7 @@ impl Writer for TypeScriptPrinter {
             AST::ReadOnlyArray(of_type) => self.write_read_only_array(of_type),
             AST::Nullable(of_type) => self.write_nullable(of_type),
             AST::NonNullable(of_type) => self.write_non_nullable(of_type),
-            AST::ExactObject(props) => self.write_object(props),
-            AST::InexactObject(props) => self.write_object(props),
+            AST::ExactObject(props) | AST::InexactObject(props) => self.write_object(props),
             AST::Local3DPayload(document_name, selections) => {
                 self.write_local_3d_payload(*document_name, selections)
             }
@@ -192,7 +191,7 @@ impl TypeScriptPrinter {
         writeln!(&mut self.result, "{{")?;
         self.indentation += 1;
 
-        for prop in props {
+        for prop in self.sort_props(props) {
             match prop {
                 Prop::Spread(_) => continue,
                 Prop::KeyValuePair(key_value_pair) => {

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -361,8 +361,8 @@ mod tests {
                 }),
             ])),
             r"{
-  foo?: string;
   readonly bar: number;
+  foo?: string;
 }"
             .to_string()
         );
@@ -399,11 +399,11 @@ mod tests {
                 }),
             ])),
             r"{
+  readonly bar: number;
   foo?: {
     nested_foo?: string;
     readonly nested_foo2: number;
   };
-  readonly bar: number;
 }"
             .to_string()
         );
@@ -447,8 +447,8 @@ mod tests {
                 })
             ])),
             r"{
-  foo: string;
   readonly bar?: number;
+  foo: string;
 }"
             .to_string()
         );

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/actor-change-with-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/actor-change-with-query.expected
@@ -28,8 +28,8 @@ export type Viewer$data = {|
   |},
 |};
 export type Viewer = {|
-  variables: Viewer$variables,
   response: Viewer$data,
+  variables: Viewer$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
@@ -37,9 +37,9 @@ declare export opaque type ActorFragment$fragmentType: FragmentType;
 export type ActorFragment$data = {|
   +name: ?string,
   +profilePicture: ?{|
+    +height: ?number,
     +uri: ?string,
     +width: ?number,
-    +height: ?number,
   |},
   +$fragmentType: ActorFragment$fragmentType,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/actor-change.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/actor-change.expected
@@ -19,9 +19,9 @@ declare export opaque type ActorFragment$fragmentType: FragmentType;
 export type ActorFragment$data = {|
   +name: ?string,
   +profilePicture: ?{|
+    +height: ?number,
     +uri: ?string,
     +width: ?number,
-    +height: ?number,
   |},
   +$fragmentType: ActorFragment$fragmentType,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/fragment-spread.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/fragment-spread.expected
@@ -79,12 +79,12 @@ import type { UserFrag2$fragmentType } from "UserFrag2.graphql";
 import type { FragmentType } from "relay-runtime";
 declare export opaque type FragmentSpread$fragmentType: FragmentType;
 export type FragmentSpread$data = {|
-  +id: string,
-  +justFrag: ?{|
-    +$fragmentSpreads: PictureFragment$fragmentType,
-  |},
   +fragAndField: ?{|
     +uri: ?string,
+    +$fragmentSpreads: PictureFragment$fragmentType,
+  |},
+  +id: string,
+  +justFrag: ?{|
     +$fragmentSpreads: PictureFragment$fragmentType,
   |},
   +$fragmentSpreads: OtherFragment$fragmentType & UserFrag1$fragmentType & UserFrag2$fragmentType,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/inline-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/inline-fragment.expected
@@ -68,10 +68,10 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type InlineFragment$fragmentType: FragmentType;
 export type InlineFragment$data = {|
   +id: string,
-  +name?: ?string,
   +message?: ?{|
     +text: ?string,
   |},
+  +name?: ?string,
   +$fragmentType: InlineFragment$fragmentType,
 |};
 export type InlineFragment$key = {
@@ -99,12 +99,12 @@ declare export opaque type InlineFragmentKitchenSink$fragmentType: FragmentType;
 export type InlineFragmentKitchenSink$data = {|
   +actor: ?{|
     +id: string,
+    +name?: ?string,
     +profilePicture: ?{|
+      +height?: ?number,
       +uri: ?string,
       +width?: ?number,
-      +height?: ?number,
     |},
-    +name?: ?string,
     +$fragmentSpreads: SomeFragment$fragmentType,
   |},
   +$fragmentType: InlineFragmentKitchenSink$fragmentType,
@@ -120,10 +120,10 @@ declare export opaque type InlineFragmentWithOverlappingFields$fragmentType: Fra
 export type InlineFragmentWithOverlappingFields$data = {|
   +hometown?: ?{|
     +id: string,
-    +name: ?string,
     +message?: ?{|
       +text: ?string,
     |},
+    +name: ?string,
   |},
   +name?: ?string,
   +$fragmentType: InlineFragmentWithOverlappingFields$fragmentType,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/linked-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/linked-field.expected
@@ -39,17 +39,15 @@ export type UnionTypeTest$data = {|
   |}),
 |};
 export type UnionTypeTest = {|
-  variables: UnionTypeTest$variables,
   response: UnionTypeTest$data,
+  variables: UnionTypeTest$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type LinkedField$fragmentType: FragmentType;
 export type LinkedField$data = {|
-  +profilePicture: ?{|
-    +uri: ?string,
-    +width: ?number,
-    +height: ?number,
+  +actor: ?{|
+    +id: string,
   |},
   +hometown: ?{|
     +id: string,
@@ -57,8 +55,10 @@ export type LinkedField$data = {|
       +uri: ?string,
     |},
   |},
-  +actor: ?{|
-    +id: string,
+  +profilePicture: ?{|
+    +height: ?number,
+    +uri: ?string,
+    +width: ?number,
   |},
   +$fragmentType: LinkedField$fragmentType,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/match-field-in-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/match-field-in-query.expected
@@ -36,17 +36,17 @@ export type NameRendererQuery$data = {|
   |},
 |};
 export type NameRendererQuery = {|
-  variables: NameRendererQuery$variables,
   response: NameRendererQuery$data,
+  variables: NameRendererQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type MarkdownUserNameRenderer_name$fragmentType: FragmentType;
 export type MarkdownUserNameRenderer_name$data = {|
-  +markdown: ?string,
   +data: ?{|
     +markup: ?string,
   |},
+  +markdown: ?string,
   +$fragmentType: MarkdownUserNameRenderer_name$fragmentType,
 |};
 export type MarkdownUserNameRenderer_name$key = {
@@ -58,10 +58,10 @@ export type MarkdownUserNameRenderer_name$key = {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type PlainUserNameRenderer_name$fragmentType: FragmentType;
 export type PlainUserNameRenderer_name$data = {|
-  +plaintext: ?string,
   +data: ?{|
     +text: ?string,
   |},
+  +plaintext: ?string,
   +$fragmentType: PlainUserNameRenderer_name$fragmentType,
 |};
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/match-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/match-field.expected
@@ -25,10 +25,10 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type MarkdownUserNameRenderer_name$fragmentType: FragmentType;
 export type MarkdownUserNameRenderer_name$data = {|
-  +markdown: ?string,
   +data: ?{|
     +markup: ?string,
   |},
+  +markdown: ?string,
   +$fragmentType: MarkdownUserNameRenderer_name$fragmentType,
 |};
 export type MarkdownUserNameRenderer_name$key = {
@@ -59,10 +59,10 @@ export type NameRendererFragment$key = {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type PlainUserNameRenderer_name$fragmentType: FragmentType;
 export type PlainUserNameRenderer_name$data = {|
-  +plaintext: ?string,
   +data: ?{|
     +text: ?string,
   |},
+  +plaintext: ?string,
   +$fragmentType: PlainUserNameRenderer_name$fragmentType,
 |};
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-input-has-array.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-input-has-array.expected
@@ -30,7 +30,7 @@ export type InputHasArray$rawResponse = {|
   |},
 |};
 export type InputHasArray = {|
-  variables: InputHasArray$variables,
-  response: InputHasArray$data,
   rawResponse: InputHasArray$rawResponse,
+  response: InputHasArray$data,
+  variables: InputHasArray$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-client-extension.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-client-extension.expected
@@ -38,15 +38,15 @@ export type Test$data = {|
 export type Test$rawResponse = {|
   +viewerNotificationsUpdateAllSeenState: ?{|
     +stories: ?$ReadOnlyArray<?{|
-      +id: string,
       +foos?: ?$ReadOnlyArray<?{|
         +bar: ?string,
       |}>,
+      +id: string,
     |}>,
   |},
 |};
 export type Test = {|
-  variables: Test$variables,
-  response: Test$data,
   rawResponse: Test$rawResponse,
+  response: Test$data,
+  variables: Test$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-enums-on-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-enums-on-fragment.expected
@@ -31,8 +31,8 @@ import type { FriendFragment$fragmentType } from "FriendFragment.graphql";
 export type TestEnums = "mark" | "zuck" | "%future added value";
 export type CommentCreateInput = {|
   clientMutationId?: ?string,
-  feedbackId?: ?string,
   feedback?: ?CommentfeedbackFeedback,
+  feedbackId?: ?string,
 |};
 export type CommentfeedbackFeedback = {|
   comment?: ?FeedbackcommentComment,
@@ -41,8 +41,8 @@ export type FeedbackcommentComment = {|
   feedback?: ?CommentfeedbackFeedback,
 |};
 export type CommentCreateMutation$variables = {|
-  input: CommentCreateInput,
   first?: ?number,
+  input: CommentCreateInput,
   orderBy?: ?$ReadOnlyArray<string>,
 |};
 export type CommentCreateMutation$data = {|
@@ -51,8 +51,8 @@ export type CommentCreateMutation$data = {|
       +friends: ?{|
         +edges: ?$ReadOnlyArray<?{|
           +node: ?{|
-            +id: string,
             +__typename: string,
+            +id: string,
             +$fragmentSpreads: FriendFragment$fragmentType,
           |},
         |}>,
@@ -66,10 +66,10 @@ export type CommentCreateMutation$rawResponse = {|
       +friends: ?{|
         +edges: ?$ReadOnlyArray<?{|
           +node: ?{|
-            +id: string,
             +__typename: "User",
-            +name: ?string,
+            +id: string,
             +lastName: ?string,
+            +name: ?string,
             +profilePicture2: ?{|
               +test_enums: ?TestEnums,
             |},
@@ -81,17 +81,17 @@ export type CommentCreateMutation$rawResponse = {|
   |},
 |};
 export type CommentCreateMutation = {|
-  variables: CommentCreateMutation$variables,
-  response: CommentCreateMutation$data,
   rawResponse: CommentCreateMutation$rawResponse,
+  response: CommentCreateMutation$data,
+  variables: CommentCreateMutation$variables,
 |};
 -------------------------------------------------------------------------------
 export type TestEnums = "mark" | "zuck" | "%future added value";
 import type { FragmentType } from "relay-runtime";
 declare export opaque type FriendFragment$fragmentType: FragmentType;
 export type FriendFragment$data = {|
-  +name: ?string,
   +lastName: ?string,
+  +name: ?string,
   +profilePicture2: ?{|
     +test_enums: ?TestEnums,
   |},

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-nested-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-nested-fragments.expected
@@ -34,8 +34,8 @@ fragment FeedbackFragment on Feedback {
 import type { FriendFragment$fragmentType } from "FriendFragment.graphql";
 export type CommentCreateInput = {|
   clientMutationId?: ?string,
-  feedbackId?: ?string,
   feedback?: ?CommentfeedbackFeedback,
+  feedbackId?: ?string,
 |};
 export type CommentfeedbackFeedback = {|
   comment?: ?FeedbackcommentComment,
@@ -44,8 +44,8 @@ export type FeedbackcommentComment = {|
   feedback?: ?CommentfeedbackFeedback,
 |};
 export type CommentCreateMutation$variables = {|
-  input: CommentCreateInput,
   first?: ?number,
+  input: CommentCreateInput,
   orderBy?: ?$ReadOnlyArray<string>,
 |};
 export type CommentCreateMutation$data = {|
@@ -68,13 +68,13 @@ export type CommentCreateMutation$rawResponse = {|
       +friends: ?{|
         +edges: ?$ReadOnlyArray<?{|
           +node: ?{|
-            +lastName: ?string,
-            +name: ?string,
             +feedback: ?{|
               +id: string,
               +name: ?string,
             |},
             +id: string,
+            +lastName: ?string,
+            +name: ?string,
           |},
         |}>,
       |},
@@ -83,9 +83,9 @@ export type CommentCreateMutation$rawResponse = {|
   |},
 |};
 export type CommentCreateMutation = {|
-  variables: CommentCreateMutation$variables,
-  response: CommentCreateMutation$data,
   rawResponse: CommentCreateMutation$rawResponse,
+  response: CommentCreateMutation$data,
+  variables: CommentCreateMutation$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
@@ -105,11 +105,11 @@ import type { FeedbackFragment$fragmentType } from "FeedbackFragment.graphql";
 import type { FragmentType } from "relay-runtime";
 declare export opaque type FriendFragment$fragmentType: FragmentType;
 export type FriendFragment$data = {|
-  +name: ?string,
-  +lastName: ?string,
   +feedback: ?{|
     +$fragmentSpreads: FeedbackFragment$fragmentType,
   |},
+  +lastName: ?string,
+  +name: ?string,
   +$fragmentType: FriendFragment$fragmentType,
 |};
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-response-on-inline-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-response-on-inline-fragments.expected
@@ -30,8 +30,8 @@ fragment InlineFragmentWithOverlappingFields on Actor {
 import type { InlineFragmentWithOverlappingFields$fragmentType } from "InlineFragmentWithOverlappingFields.graphql";
 export type CommentCreateInput = {|
   clientMutationId?: ?string,
-  feedbackId?: ?string,
   feedback?: ?CommentfeedbackFeedback,
+  feedbackId?: ?string,
 |};
 export type CommentfeedbackFeedback = {|
   comment?: ?FeedbackcommentComment,
@@ -55,36 +55,36 @@ export type TestMutation$rawResponse = {|
   +commentCreate: ?{|
     +viewer: ?{|
       +actor: ?({|
-        +__typename: "User",
         +__isActor: "User",
-        +id: string,
+        +__typename: "User",
         +hometown: ?{|
           +id: string,
           +name: ?string,
         |},
-      |} | {|
-        +__typename: "Page",
-        +__isActor: "Page",
         +id: string,
-        +name: ?string,
+      |} | {|
+        +__isActor: "Page",
+        +__typename: "Page",
         +hometown: ?{|
           +id: string,
           +message: ?{|
             +text: ?string,
           |},
         |},
+        +id: string,
+        +name: ?string,
       |} | {|
-        +__typename: string,
         +__isActor: string,
+        +__typename: string,
         +id: string,
       |}),
     |},
   |},
 |};
 export type TestMutation = {|
-  variables: TestMutation$variables,
-  response: TestMutation$data,
   rawResponse: TestMutation$rawResponse,
+  response: TestMutation$data,
+  variables: TestMutation$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
@@ -92,10 +92,10 @@ declare export opaque type InlineFragmentWithOverlappingFields$fragmentType: Fra
 export type InlineFragmentWithOverlappingFields$data = {|
   +hometown?: ?{|
     +id: string,
-    +name: ?string,
     +message?: ?{|
       +text: ?string,
     |},
+    +name: ?string,
   |},
   +name?: ?string,
   +$fragmentType: InlineFragmentWithOverlappingFields$fragmentType,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation.expected
@@ -17,8 +17,8 @@ mutation CommentCreateMutation(
 ==================================== OUTPUT ===================================
 export type CommentCreateInput = {|
   clientMutationId?: ?string,
-  feedbackId?: ?string,
   feedback?: ?CommentfeedbackFeedback,
+  feedbackId?: ?string,
 |};
 export type CommentfeedbackFeedback = {|
   comment?: ?FeedbackcommentComment,
@@ -27,22 +27,22 @@ export type FeedbackcommentComment = {|
   feedback?: ?CommentfeedbackFeedback,
 |};
 export type CommentCreateMutation$variables = {|
-  input: CommentCreateInput,
   first?: ?number,
+  input: CommentCreateInput,
   orderBy?: ?$ReadOnlyArray<string>,
 |};
 export type CommentCreateMutation$data = {|
   +commentCreate: ?{|
     +comment: ?{|
-      +id: string,
-      +name: ?string,
       +friends: ?{|
         +count: ?number,
       |},
+      +id: string,
+      +name: ?string,
     |},
   |},
 |};
 export type CommentCreateMutation = {|
-  variables: CommentCreateMutation$variables,
   response: CommentCreateMutation$data,
+  variables: CommentCreateMutation$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/no-inline-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/no-inline-fragment.expected
@@ -29,8 +29,8 @@ import type { noInlineFragment_address$normalization } from "noInlineFragment_ad
 import type { noInlineFragment_user$normalization } from "noInlineFragment_user$normalization.graphql";
 export type noInlineFragmentQuery$variables = {|
   global?: ?number,
-  shadowed_global?: ?number,
   global_from_parent?: ?number,
+  shadowed_global?: ?number,
 |};
 export type noInlineFragmentQuery$data = {|
   +me: ?{|
@@ -42,17 +42,17 @@ export type noInlineFragmentQuery$data = {|
 |};
 export type noInlineFragmentQuery$rawResponse = {|
   +me: ?{|
-    ...noInlineFragment_user$normalization,
     +address: ?{|
       ...noInlineFragment_address$normalization,
     |},
     +id: string,
+    ...noInlineFragment_user$normalization,
   |},
 |};
 export type noInlineFragmentQuery = {|
-  variables: noInlineFragmentQuery$variables,
-  response: noInlineFragmentQuery$data,
   rawResponse: noInlineFragmentQuery$rawResponse,
+  response: noInlineFragmentQuery$data,
+  variables: noInlineFragmentQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-mixed-provided-variables.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-mixed-provided-variables.expected
@@ -60,8 +60,8 @@ export type queryMixedProvidedVar_MultiFragment$data = {|
   |},
 |};
 export type queryMixedProvidedVar_MultiFragment = {|
-  variables: queryMixedProvidedVar_MultiFragment$variables,
   response: queryMixedProvidedVar_MultiFragment$data,
+  variables: queryMixedProvidedVar_MultiFragment$variables,
 |};
 type ProvidedVariablesType = {|
   +__relay_internal__pv__includeNameProvider: {|
@@ -85,8 +85,8 @@ export type queryMixedProvidedVar_OneFragment$data = {|
   |},
 |};
 export type queryMixedProvidedVar_OneFragment = {|
-  variables: queryMixedProvidedVar_OneFragment$variables,
   response: queryMixedProvidedVar_OneFragment$data,
+  variables: queryMixedProvidedVar_OneFragment$variables,
 |};
 type ProvidedVariablesType = {|
   +__relay_internal__pv__includeNameProvider: {|
@@ -101,8 +101,8 @@ export type FragmentMultiProvidedVar$data = {|
     +count: ?number,
     +edges: ?$ReadOnlyArray<?{|
       +node: ?{|
-        +name?: ?string,
         +alternate_name?: ?string,
+        +name?: ?string,
       |},
     |}>,
   |},
@@ -117,8 +117,8 @@ export type FragmentMultiProvidedVar$key = {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type FragmentOneProvidedVar$fragmentType: FragmentType;
 export type FragmentOneProvidedVar$data = {|
-  +name?: ?string,
   +alternate_name?: ?string,
+  +name?: ?string,
   +$fragmentType: FragmentOneProvidedVar$fragmentType,
 |};
 export type FragmentOneProvidedVar$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-only-provided-variables.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-only-provided-variables.expected
@@ -43,8 +43,8 @@ export type queryOnlyProvidedVar_MultiFragment$data = {|
   |},
 |};
 export type queryOnlyProvidedVar_MultiFragment = {|
-  variables: queryOnlyProvidedVar_MultiFragment$variables,
   response: queryOnlyProvidedVar_MultiFragment$data,
+  variables: queryOnlyProvidedVar_MultiFragment$variables,
 |};
 type ProvidedVariablesType = {|
   +__relay_internal__pv__includeNameProvider: {|
@@ -63,8 +63,8 @@ export type queryOnlyProvidedVar_OneFragment$data = {|
   |},
 |};
 export type queryOnlyProvidedVar_OneFragment = {|
-  variables: queryOnlyProvidedVar_OneFragment$variables,
   response: queryOnlyProvidedVar_OneFragment$data,
+  variables: queryOnlyProvidedVar_OneFragment$variables,
 |};
 type ProvidedVariablesType = {|
   +__relay_internal__pv__includeNameProvider: {|

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-handles.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-handles.expected
@@ -30,19 +30,19 @@ export type LinkedHandleField$data = {|
 export type LinkedHandleField$rawResponse = {|
   +node: ?({|
     +__typename: "User",
-    +id: string,
     +friends: ?{|
       +count: ?number,
     |},
+    +id: string,
   |} | {|
     +__typename: string,
     +id: string,
   |}),
 |};
 export type LinkedHandleField = {|
-  variables: LinkedHandleField$variables,
-  response: LinkedHandleField$data,
   rawResponse: LinkedHandleField$rawResponse,
+  response: LinkedHandleField$data,
+  variables: LinkedHandleField$variables,
 |};
 -------------------------------------------------------------------------------
 export type ScalarHandleField$variables = {|
@@ -64,7 +64,7 @@ export type ScalarHandleField$rawResponse = {|
   |}),
 |};
 export type ScalarHandleField = {|
-  variables: ScalarHandleField$variables,
-  response: ScalarHandleField$data,
   rawResponse: ScalarHandleField$rawResponse,
+  response: ScalarHandleField$data,
+  variables: ScalarHandleField$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-match-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-match-fields.expected
@@ -49,17 +49,17 @@ export type Test$rawResponse = {|
     +__typename: "User",
     +id: string,
     +nameRenderer: ?({|
-      +__typename: "PlainUserNameRenderer",
-      +__module_operation_NameRendererFragment: ?any,
       +__module_component_NameRendererFragment: ?any,
+      +__module_operation_NameRendererFragment: ?any,
+      +__typename: "PlainUserNameRenderer",
       ...PlainUserNameRenderer_name,
     |} | Local3DPayload<"NameRendererFragment", {|
       +__typename: "PlainUserNameRenderer",
       ...PlainUserNameRenderer_name,
     |}> | {|
-      +__typename: "MarkdownUserNameRenderer",
-      +__module_operation_NameRendererFragment: ?any,
       +__module_component_NameRendererFragment: ?any,
+      +__module_operation_NameRendererFragment: ?any,
+      +__typename: "MarkdownUserNameRenderer",
       ...MarkdownUserNameRenderer_name,
     |} | Local3DPayload<"NameRendererFragment", {|
       +__typename: "MarkdownUserNameRenderer",
@@ -73,18 +73,18 @@ export type Test$rawResponse = {|
   |}),
 |};
 export type Test = {|
-  variables: Test$variables,
-  response: Test$data,
   rawResponse: Test$rawResponse,
+  response: Test$data,
+  variables: Test$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type MarkdownUserNameRenderer_name$fragmentType: FragmentType;
 export type MarkdownUserNameRenderer_name$data = {|
-  +markdown: ?string,
   +data: ?{|
     +markup: ?string,
   |},
+  +markdown: ?string,
   +$fragmentType: MarkdownUserNameRenderer_name$fragmentType,
 |};
 export type MarkdownUserNameRenderer_name$key = {
@@ -115,10 +115,10 @@ export type NameRendererFragment$key = {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type PlainUserNameRenderer_name$fragmentType: FragmentType;
 export type PlainUserNameRenderer_name$data = {|
-  +plaintext: ?string,
   +data: ?{|
     +text: ?string,
   |},
+  +plaintext: ?string,
   +$fragmentType: PlainUserNameRenderer_name$fragmentType,
 |};
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-module-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-module-field.expected
@@ -34,8 +34,8 @@ export type Test$rawResponse = {|
     +__typename: "User",
     +id: string,
     +plainUserRenderer: ?({|
-      +__module_operation_Test_user: ?any,
       +__module_component_Test_user: ?any,
+      +__module_operation_Test_user: ?any,
       ...Test_userRenderer,
     |} | Local3DPayload<"Test_user", {|
       ...Test_userRenderer,
@@ -46,9 +46,9 @@ export type Test$rawResponse = {|
   |}),
 |};
 export type Test = {|
-  variables: Test$variables,
-  response: Test$data,
   rawResponse: Test$rawResponse,
+  response: Test$data,
+  variables: Test$variables,
 |};
 -------------------------------------------------------------------------------
 import type { Test_userRenderer$fragmentType } from "Test_userRenderer.graphql";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-multiple-match-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-multiple-match-fields.expected
@@ -76,19 +76,18 @@ export type Test$rawResponse = {|
   +node: ?({|
     +__typename: "User",
     +id: string,
-    +username: ?string,
     +nameRenderer: ?({|
-      +__typename: "PlainUserNameRenderer",
-      +__module_operation_NameRendererFragment: ?any,
       +__module_component_NameRendererFragment: ?any,
+      +__module_operation_NameRendererFragment: ?any,
+      +__typename: "PlainUserNameRenderer",
       ...PlainUserNameRenderer_name,
     |} | Local3DPayload<"NameRendererFragment", {|
       +__typename: "PlainUserNameRenderer",
       ...PlainUserNameRenderer_name,
     |}> | {|
-      +__typename: "MarkdownUserNameRenderer",
-      +__module_operation_NameRendererFragment: ?any,
       +__module_component_NameRendererFragment: ?any,
+      +__module_operation_NameRendererFragment: ?any,
+      +__typename: "MarkdownUserNameRenderer",
       ...MarkdownUserNameRenderer_name,
     |} | Local3DPayload<"NameRendererFragment", {|
       +__typename: "MarkdownUserNameRenderer",
@@ -96,6 +95,7 @@ export type Test$rawResponse = {|
     |}> | {|
       +__typename: string,
     |}),
+    +username: ?string,
   |} | {|
     +__typename: string,
     +id: string,
@@ -106,17 +106,17 @@ export type Test$rawResponse = {|
       +id: string,
       +name: ?string,
       +nameRenderer: ?({|
-        +__typename: "PlainUserNameRenderer",
-        +__module_operation_AnotherNameRendererFragment: ?any,
         +__module_component_AnotherNameRendererFragment: ?any,
+        +__module_operation_AnotherNameRendererFragment: ?any,
+        +__typename: "PlainUserNameRenderer",
         ...PlainUserNameRenderer_name,
       |} | Local3DPayload<"AnotherNameRendererFragment", {|
         +__typename: "PlainUserNameRenderer",
         ...PlainUserNameRenderer_name,
       |}> | {|
-        +__typename: "MarkdownUserNameRenderer",
-        +__module_operation_AnotherNameRendererFragment: ?any,
         +__module_component_AnotherNameRendererFragment: ?any,
+        +__module_operation_AnotherNameRendererFragment: ?any,
+        +__typename: "MarkdownUserNameRenderer",
         ...MarkdownUserNameRenderer_name,
       |} | Local3DPayload<"AnotherNameRendererFragment", {|
         +__typename: "MarkdownUserNameRenderer",
@@ -131,9 +131,9 @@ export type Test$rawResponse = {|
   |},
 |};
 export type Test = {|
-  variables: Test$variables,
-  response: Test$data,
   rawResponse: Test$rawResponse,
+  response: Test$data,
+  variables: Test$variables,
 |};
 -------------------------------------------------------------------------------
 import type { MarkdownUserNameRenderer_name$fragmentType } from "MarkdownUserNameRenderer_name.graphql";
@@ -158,10 +158,10 @@ export type AnotherNameRendererFragment$key = {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type MarkdownUserNameRenderer_name$fragmentType: FragmentType;
 export type MarkdownUserNameRenderer_name$data = {|
-  +markdown: ?string,
   +data: ?{|
     +markup: ?string,
   |},
+  +markdown: ?string,
   +$fragmentType: MarkdownUserNameRenderer_name$fragmentType,
 |};
 export type MarkdownUserNameRenderer_name$key = {
@@ -192,10 +192,10 @@ export type NameRendererFragment$key = {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type PlainUserNameRenderer_name$fragmentType: FragmentType;
 export type PlainUserNameRenderer_name$data = {|
-  +plaintext: ?string,
   +data: ?{|
     +text: ?string,
   |},
+  +plaintext: ?string,
   +$fragmentType: PlainUserNameRenderer_name$fragmentType,
 |};
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-raw-response-on-conditional.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-raw-response-on-conditional.expected
@@ -18,8 +18,8 @@ fragment FriendFragment on User {
 ==================================== OUTPUT ===================================
 import type { FriendFragment$fragmentType } from "FriendFragment.graphql";
 export type ExampleQuery$variables = {|
-  id: string,
   condition: CustomBoolean,
+  id: string,
 |};
 export type ExampleQuery$data = {|
   +node: ?{|
@@ -29,33 +29,33 @@ export type ExampleQuery$data = {|
 export type ExampleQuery$rawResponse = {|
   +node: ?({|
     +__typename: "User",
-    +id: string,
-    +name: ?string,
-    +lastName: ?string,
     +feedback: ?{|
       +id: string,
       +name: ?string,
     |},
+    +id: string,
+    +lastName: ?string,
+    +name: ?string,
   |} | {|
     +__typename: string,
     +id: string,
   |}),
 |};
 export type ExampleQuery = {|
-  variables: ExampleQuery$variables,
-  response: ExampleQuery$data,
   rawResponse: ExampleQuery$rawResponse,
+  response: ExampleQuery$data,
+  variables: ExampleQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type FriendFragment$fragmentType: FragmentType;
 export type FriendFragment$data = {|
-  +name?: ?string,
-  +lastName?: ?string,
   +feedback?: ?{|
     +id: string,
     +name: ?string,
   |},
+  +lastName?: ?string,
+  +name?: ?string,
   +$fragmentType: FriendFragment$fragmentType,
 |};
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-raw-response-on-literal-conditional.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-raw-response-on-literal-conditional.expected
@@ -28,35 +28,35 @@ export type ExampleQuery$variables = {|
 |};
 export type ExampleQuery$data = {|
   +node: ?{|
-    +username: ?string,
     +friends?: ?{|
       +count: ?number,
     |},
+    +username: ?string,
     +$fragmentSpreads: FriendFragment$fragmentType,
   |},
 |};
 export type ExampleQuery$rawResponse = {|
   +node: ?{|
     +__typename: string,
-    +username: ?string,
     +id: string,
+    +username: ?string,
   |},
 |};
 export type ExampleQuery = {|
-  variables: ExampleQuery$variables,
-  response: ExampleQuery$data,
   rawResponse: ExampleQuery$rawResponse,
+  response: ExampleQuery$data,
+  variables: ExampleQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type FriendFragment$fragmentType: FragmentType;
 export type FriendFragment$data = {|
-  +name?: ?string,
-  +lastName?: ?string,
   +feedback?: ?{|
     +id: string,
     +name: ?string,
   |},
+  +lastName?: ?string,
+  +name?: ?string,
   +$fragmentType: FriendFragment$fragmentType,
 |};
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream-connection.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream-connection.expected
@@ -20,7 +20,6 @@ query TestDefer @raw_response_type {
 export type TestDefer$variables = {||};
 export type TestDefer$data = {|
   +node: ?{|
-    +name?: ?string,
     +friends?: ?{|
       +edges: ?$ReadOnlyArray<?{|
         +node: ?{|
@@ -30,38 +29,39 @@ export type TestDefer$data = {|
         |},
       |}>,
     |},
+    +name?: ?string,
   |},
 |};
 export type TestDefer$rawResponse = {|
   +node: ?({|
     +__typename: "User",
-    +id: string,
-    +name: ?string,
     +friends: ?{|
       +edges: ?$ReadOnlyArray<?{|
+        +cursor: ?string,
         +node: ?{|
+          +__typename: "User",
           +actor: ?{|
             +__typename: string,
-            +name: ?string,
             +id: string,
+            +name: ?string,
           |},
           +id: string,
-          +__typename: "User",
         |},
-        +cursor: ?string,
       |}>,
       +pageInfo: ?{|
         +endCursor: ?string,
         +hasNextPage: ?CustomBoolean,
       |},
     |},
+    +id: string,
+    +name: ?string,
   |} | {|
     +__typename: string,
     +id: string,
   |}),
 |};
 export type TestDefer = {|
-  variables: TestDefer$variables,
-  response: TestDefer$data,
   rawResponse: TestDefer$rawResponse,
+  response: TestDefer$data,
+  variables: TestDefer$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-stream.expected
@@ -21,7 +21,6 @@ query TestStream @raw_response_type {
 export type TestStream$variables = {||};
 export type TestStream$data = {|
   +node: ?{|
-    +name?: ?string,
     +friends?: ?{|
       +edges: ?$ReadOnlyArray<?{|
         +node: ?{|
@@ -29,33 +28,34 @@ export type TestStream$data = {|
         |},
       |}>,
     |},
+    +name?: ?string,
   |},
 |};
 export type TestStream$rawResponse = {|
   +node: ?({|
     +__typename: "User",
-    +id: string,
-    +name: ?string,
     +friends: ?{|
       +edges: ?$ReadOnlyArray<?{|
-        +node: ?{|
-          +id: string,
-          +__typename: "User",
-        |},
         +cursor: ?string,
+        +node: ?{|
+          +__typename: "User",
+          +id: string,
+        |},
       |}>,
       +pageInfo: ?{|
         +endCursor: ?string,
         +hasNextPage: ?CustomBoolean,
       |},
     |},
+    +id: string,
+    +name: ?string,
   |} | {|
     +__typename: string,
     +id: string,
   |}),
 |};
 export type TestStream = {|
-  variables: TestStream$variables,
-  response: TestStream$data,
   rawResponse: TestStream$rawResponse,
+  response: TestStream$data,
+  variables: TestStream$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query_with_raw_response_and_client_components.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query_with_raw_response_and_client_components.expected
@@ -26,9 +26,9 @@ export type queryWithRelayClientComponentQuery$rawResponse = {|
   +viewer: ?{||},
 |};
 export type queryWithRelayClientComponentQuery = {|
-  variables: queryWithRelayClientComponentQuery$variables,
-  response: queryWithRelayClientComponentQuery$data,
   rawResponse: queryWithRelayClientComponentQuery$rawResponse,
+  response: queryWithRelayClientComponentQuery$data,
+  variables: queryWithRelayClientComponentQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/refetchable-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/refetchable-fragment.expected
@@ -18,18 +18,18 @@ export type RefetchableFragmentQuery$data = {|
   |},
 |};
 export type RefetchableFragmentQuery = {|
-  variables: RefetchableFragmentQuery$variables,
   response: RefetchableFragmentQuery$data,
+  variables: RefetchableFragmentQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type RefetchableFragment$fragmentType: FragmentType;
 import type { RefetchableFragmentQuery$variables } from "RefetchableFragmentQuery.graphql";
 export type RefetchableFragment$data = {|
-  +id: string,
   +fragAndField: ?{|
     +uri: ?string,
   |},
+  +id: string,
   +$fragmentType: RefetchableFragment$fragmentType,
 |};
 export type RefetchableFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/refetchable.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/refetchable.expected
@@ -18,8 +18,8 @@ export type FlowRefetchableFragmentQuery$data = {|
   |},
 |};
 export type FlowRefetchableFragmentQuery = {|
-  variables: FlowRefetchableFragmentQuery$variables,
   response: FlowRefetchableFragmentQuery$data,
+  variables: FlowRefetchableFragmentQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-client-id-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-client-id-field.expected
@@ -40,7 +40,6 @@ export type RelayClientIDFieldQuery$data = {|
   +node: ?{|
     +__id: string,
     +__typename: string,
-    +id: string,
     +commentBody?: ?{|
       +__id: string,
       +__typename: string,
@@ -50,9 +49,10 @@ export type RelayClientIDFieldQuery$data = {|
         +text: ?string,
       |},
     |},
+    +id: string,
   |},
 |};
 export type RelayClientIDFieldQuery = {|
-  variables: RelayClientIDFieldQuery$variables,
   response: RelayClientIDFieldQuery$data,
+  variables: RelayClientIDFieldQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-client-edge-required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-client-edge-required.expected
@@ -27,8 +27,8 @@ export type ClientEdgeQuery_relayResolver_Query_me__best_friend$data = {|
   |},
 |};
 export type ClientEdgeQuery_relayResolver_Query_me__best_friend = {|
-  variables: ClientEdgeQuery_relayResolver_Query_me__best_friend$variables,
   response: ClientEdgeQuery_relayResolver_Query_me__best_friend$data,
+  variables: ClientEdgeQuery_relayResolver_Query_me__best_friend$variables,
 |};
 -------------------------------------------------------------------------------
 export type relayResolver_Query$variables = {||};
@@ -40,16 +40,16 @@ export type relayResolver_Query$data = {|
   |},
 |};
 export type relayResolver_Query = {|
-  variables: relayResolver_Query$variables,
   response: relayResolver_Query$data,
+  variables: relayResolver_Query$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type RefetchableClientEdgeQuery_relayResolver_Query_me__best_friend$fragmentType: FragmentType;
 import type { ClientEdgeQuery_relayResolver_Query_me__best_friend$variables } from "ClientEdgeQuery_relayResolver_Query_me__best_friend.graphql";
 export type RefetchableClientEdgeQuery_relayResolver_Query_me__best_friend$data = {|
-  +name: ?string,
   +id: string,
+  +name: ?string,
   +$fragmentType: RefetchableClientEdgeQuery_relayResolver_Query_me__best_friend$fragmentType,
 |};
 export type RefetchableClientEdgeQuery_relayResolver_Query_me__best_friend$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-client-edge.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-client-edge.expected
@@ -27,8 +27,8 @@ export type ClientEdgeQuery_relayResolver_Query_me__best_friend$data = {|
   |},
 |};
 export type ClientEdgeQuery_relayResolver_Query_me__best_friend = {|
-  variables: ClientEdgeQuery_relayResolver_Query_me__best_friend$variables,
   response: ClientEdgeQuery_relayResolver_Query_me__best_friend$data,
+  variables: ClientEdgeQuery_relayResolver_Query_me__best_friend$variables,
 |};
 -------------------------------------------------------------------------------
 export type relayResolver_Query$variables = {||};
@@ -40,16 +40,16 @@ export type relayResolver_Query$data = {|
   |},
 |};
 export type relayResolver_Query = {|
-  variables: relayResolver_Query$variables,
   response: relayResolver_Query$data,
+  variables: relayResolver_Query$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type RefetchableClientEdgeQuery_relayResolver_Query_me__best_friend$fragmentType: FragmentType;
 import type { ClientEdgeQuery_relayResolver_Query_me__best_friend$variables } from "ClientEdgeQuery_relayResolver_Query_me__best_friend.graphql";
 export type RefetchableClientEdgeQuery_relayResolver_Query_me__best_friend$data = {|
-  +name: ?string,
   +id: string,
+  +name: ?string,
   +$fragmentType: RefetchableClientEdgeQuery_relayResolver_Query_me__best_friend$fragmentType,
 |};
 export type RefetchableClientEdgeQuery_relayResolver_Query_me__best_friend$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-multiple-consumers.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-multiple-consumers.expected
@@ -22,15 +22,15 @@ import userPopStarNameResolver from "PopStarNameResolver";
 export type relayResolver_Query$variables = {||};
 export type relayResolver_Query$data = {|
   +me: ?{|
-    +pop_star_name: ?$Call<<R>((...empty[]) => R) => R, typeof userPopStarNameResolver>,
     +parents: $ReadOnlyArray<{|
       +pop_star_name: ?$Call<<R>((...empty[]) => R) => R, typeof userPopStarNameResolver>,
     |}>,
+    +pop_star_name: ?$Call<<R>((...empty[]) => R) => R, typeof userPopStarNameResolver>,
   |},
 |};
 export type relayResolver_Query = {|
-  variables: relayResolver_Query$variables,
   response: relayResolver_Query$data,
+  variables: relayResolver_Query$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-raw-response.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-raw-response.expected
@@ -28,14 +28,14 @@ export type relayResolver_Query$data = {|
 |};
 export type relayResolver_Query$rawResponse = {|
   +me: ?{|
-    +name: ?string,
     +id: string,
+    +name: ?string,
   |},
 |};
 export type relayResolver_Query = {|
-  variables: relayResolver_Query$variables,
-  response: relayResolver_Query$data,
   rawResponse: relayResolver_Query$rawResponse,
+  response: relayResolver_Query$data,
+  variables: relayResolver_Query$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-required.expected
@@ -23,8 +23,8 @@ export type relayResolver_Query$data = {|
   |},
 |};
 export type relayResolver_Query = {|
-  variables: relayResolver_Query$variables,
   response: relayResolver_Query$data,
+  variables: relayResolver_Query$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver.expected
@@ -23,8 +23,8 @@ export type relayResolver_Query$data = {|
   |},
 |};
 export type relayResolver_Query = {|
-  variables: relayResolver_Query$variables,
   response: relayResolver_Query$data,
+  variables: relayResolver_Query$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-bubbles-to-item-in-required-plural-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-bubbles-to-item-in-required-plural-field.expected
@@ -16,6 +16,6 @@ export type TestQuery$data = {|
   |},
 |};
 export type TestQuery = {|
-  variables: TestQuery$variables,
   response: TestQuery$data,
+  variables: TestQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-bubbles-to-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-bubbles-to-query.expected
@@ -14,6 +14,6 @@ export type FooQuery$data = ?{|
   |},
 |};
 export type FooQuery = {|
-  variables: FooQuery$variables,
   response: FooQuery$data,
+  variables: FooQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-bubbles-up-to-mutation-response.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-bubbles-up-to-mutation-response.expected
@@ -9,8 +9,8 @@ mutation CommentCreateMutation($input: CommentCreateInput!) {
 ==================================== OUTPUT ===================================
 export type CommentCreateInput = {|
   clientMutationId?: ?string,
-  feedbackId?: ?string,
   feedback?: ?CommentfeedbackFeedback,
+  feedbackId?: ?string,
 |};
 export type CommentfeedbackFeedback = {|
   comment?: ?FeedbackcommentComment,
@@ -29,6 +29,6 @@ export type CommentCreateMutation$data = ?{|
   |},
 |};
 export type CommentCreateMutation = {|
-  variables: CommentCreateMutation$variables,
   response: CommentCreateMutation$data,
+  variables: CommentCreateMutation$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-isolates-concrete-inline-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-isolates-concrete-inline-fragments.expected
@@ -31,10 +31,10 @@ fragment Foo on Node {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type Bar$fragmentType: FragmentType;
 export type Bar$data = ?{|
-  +name?: string,
   +body?: ?{|
     +text: ?string,
   |},
+  +name?: string,
   +$fragmentType: Bar$fragmentType,
 |};
 export type Bar$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-raw-response-type.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-raw-response-type.expected
@@ -20,7 +20,7 @@ export type MyQuery$rawResponse = {|
   |},
 |};
 export type MyQuery = {|
-  variables: MyQuery$variables,
-  response: MyQuery$data,
   rawResponse: MyQuery$rawResponse,
+  response: MyQuery$data,
+  variables: MyQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-throw-doesnt-bubbles-to-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-throw-doesnt-bubbles-to-query.expected
@@ -14,6 +14,6 @@ export type FooQuery$data = {|
   |},
 |};
 export type FooQuery = {|
-  variables: FooQuery$variables,
   response: FooQuery$data,
+  variables: FooQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-throws-nested.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required-throws-nested.expected
@@ -14,6 +14,6 @@ export type FooQuery$data = {|
   |},
 |};
 export type FooQuery = {|
-  variables: FooQuery$variables,
   response: FooQuery$data,
+  variables: FooQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/required.expected
@@ -14,6 +14,6 @@ export type FooQuery$data = {|
   |},
 |};
 export type FooQuery = {|
-  variables: FooQuery$variables,
   response: FooQuery$data,
+  variables: FooQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/roots.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/roots.expected
@@ -34,14 +34,14 @@ export type ExampleQuery$data = {|
   |},
 |};
 export type ExampleQuery = {|
-  variables: ExampleQuery$variables,
   response: ExampleQuery$data,
+  variables: ExampleQuery$variables,
 |};
 -------------------------------------------------------------------------------
 export type CommentCreateInput = {|
   clientMutationId?: ?string,
-  feedbackId?: ?string,
   feedback?: ?CommentfeedbackFeedback,
+  feedbackId?: ?string,
 |};
 export type CommentfeedbackFeedback = {|
   comment?: ?FeedbackcommentComment,
@@ -60,8 +60,8 @@ export type TestMutation$data = {|
   |},
 |};
 export type TestMutation = {|
-  variables: TestMutation$variables,
   response: TestMutation$data,
+  variables: TestMutation$variables,
 |};
 -------------------------------------------------------------------------------
 export type FeedbackLikeInput = {|
@@ -79,8 +79,8 @@ export type TestSubscription$data = {|
   |},
 |};
 export type TestSubscription = {|
-  variables: TestSubscription$variables,
   response: TestSubscription$data,
+  variables: TestSubscription$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/scalar-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/scalar-field.expected
@@ -17,17 +17,17 @@ export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" |
 import type { FragmentType } from "relay-runtime";
 declare export opaque type ScalarField$fragmentType: FragmentType;
 export type ScalarField$data = {|
-  +id: string,
-  +name: ?string,
-  +websites: ?$ReadOnlyArray<?string>,
-  +traits: ?$ReadOnlyArray<?PersonalityTraits>,
   +aliasedLinkedField: ?{|
     +aliasedField: ?number,
   |},
+  +id: string,
+  +name: ?string,
   +screennames: ?$ReadOnlyArray<?{|
     +name: ?string,
     +service: ?string,
   |}>,
+  +traits: ?$ReadOnlyArray<?PersonalityTraits>,
+  +websites: ?$ReadOnlyArray<?string>,
   +$fragmentType: ScalarField$fragmentType,
 |};
 export type ScalarField$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/simple.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/simple.expected
@@ -13,9 +13,9 @@ declare export opaque type LinkedField$fragmentType: FragmentType;
 export type LinkedField$data = {|
   +name: ?string,
   +profilePicture: ?{|
+    +height: ?number,
     +uri: ?string,
     +width: ?number,
-    +height: ?number,
   |},
   +$fragmentType: LinkedField$fragmentType,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/typename-on-union.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/typename-on-union.expected
@@ -177,13 +177,13 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type TypenameOutsideWithAbstractType$fragmentType: FragmentType;
 export type TypenameOutsideWithAbstractType$data = {|
   +__typename: string,
-  +username?: ?string,
   +address?: ?{|
     +city: ?string,
     +country: ?string,
     +street?: ?string,
   |},
   +firstName?: ?string,
+  +username?: ?string,
   +$fragmentType: TypenameOutsideWithAbstractType$fragmentType,
 |};
 export type TypenameOutsideWithAbstractType$key = {
@@ -196,8 +196,8 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type TypenameWithCommonSelections$fragmentType: FragmentType;
 export type TypenameWithCommonSelections$data = {|
   +__typename: string,
-  +name: ?string,
   +firstName?: ?string,
+  +name: ?string,
   +username?: ?string,
   +$fragmentType: TypenameWithCommonSelections$fragmentType,
 |};
@@ -210,8 +210,8 @@ export type TypenameWithCommonSelections$key = {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type TypenameWithoutSpreads$fragmentType: FragmentType;
 export type TypenameWithoutSpreads$data = {|
-  +firstName: ?string,
   +__typename: "User",
+  +firstName: ?string,
   +$fragmentType: TypenameWithoutSpreads$fragmentType,
 |};
 export type TypenameWithoutSpreads$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/unmasked-fragment-spreads.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/unmasked-fragment-spreads.expected
@@ -29,8 +29,8 @@ fragment AnotherRecursiveFragment on Image {
 import type { FragmentType } from "relay-runtime";
 declare export opaque type AnotherRecursiveFragment$fragmentType: FragmentType;
 export type AnotherRecursiveFragment$data = {|
-  +uri: ?string,
   +height: ?number,
+  +uri: ?string,
   +$fragmentType: AnotherRecursiveFragment$fragmentType,
 |};
 export type AnotherRecursiveFragment$key = {
@@ -70,9 +70,9 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type UserProfile$fragmentType: FragmentType;
 export type UserProfile$data = {|
   +profilePicture: ?{|
+    +height: ?number,
     +uri: ?string,
     +width: ?number,
-    +height: ?number,
     +$fragmentSpreads: PhotoFragment$fragmentType,
   |},
   +$fragmentType: UserProfile$fragmentType,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-assignable-fragment-plural.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-assignable-fragment-plural.expected
@@ -21,9 +21,9 @@ export type UpdatableQuery$data = {|
     +__typename: "User",
     get parents(): $ReadOnlyArray<{||}>,
     set parents(value: $ReadOnlyArray<{
-      +$fragmentSpreads: Assignable_user$fragmentType,
-      +__typename: "User",
       +__id: string,
+      +__typename: "User",
+      +$fragmentSpreads: Assignable_user$fragmentType,
       ...
     }>): void,
   |} | {|
@@ -34,8 +34,8 @@ export type UpdatableQuery$data = {|
   set node(value: null | void): void,
 |};
 export type UpdatableQuery = {|
-  variables: UpdatableQuery$variables,
   response: UpdatableQuery$data,
+  variables: UpdatableQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-assignable-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-assignable-fragment.expected
@@ -14,15 +14,15 @@ export type UpdatableQuery$variables = {||};
 export type UpdatableQuery$data = {|
   get viewer(): ?{||},
   set viewer(value: ?{
-    +$fragmentSpreads: Assignable_viewer$fragmentType,
-    +__typename: "Viewer",
     +__id: string,
+    +__typename: "Viewer",
+    +$fragmentSpreads: Assignable_viewer$fragmentType,
     ...
   }): void,
 |};
 export type UpdatableQuery = {|
-  variables: UpdatableQuery$variables,
   response: UpdatableQuery$data,
+  variables: UpdatableQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-assignable-fragments-within-narrowing.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-assignable-fragments-within-narrowing.expected
@@ -37,22 +37,22 @@ export type UpdatableQuery$data = {|
       +__typename: "%other",
     |}),
     set actor(value: ?({
-      +$fragmentSpreads: Assignable_user$fragmentType,
-      +__typename: "User",
       +__id: string,
+      +__typename: "User",
+      +$fragmentSpreads: Assignable_user$fragmentType,
       ...
     } | {
-      +$fragmentSpreads: Assignable_page$fragmentType,
-      +__typename: "Page",
       +__id: string,
+      +__typename: "Page",
+      +$fragmentSpreads: Assignable_page$fragmentType,
       ...
     })): void,
   |},
   set me(value: null | void): void,
 |};
 export type UpdatableQuery = {|
-  variables: UpdatableQuery$variables,
   response: UpdatableQuery$data,
+  variables: UpdatableQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-multiple-assignable-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-multiple-assignable-fragments.expected
@@ -28,22 +28,22 @@ export type UpdatableQuery$data = {|
       name: ?string,
     |},
     set actor(value: ?({
-      +$fragmentSpreads: Assignable_page$fragmentType,
-      +__typename: "Page",
       +__id: string,
+      +__typename: "Page",
+      +$fragmentSpreads: Assignable_page$fragmentType,
       ...
     } | {
-      +$fragmentSpreads: Assignable_node$fragmentType,
-      +__isAssignable_node: string,
       +__id: string,
+      +__isAssignable_node: string,
+      +$fragmentSpreads: Assignable_node$fragmentType,
       ...
     })): void,
   |},
   set me(value: null | void): void,
 |};
 export type UpdatableQuery = {|
-  variables: UpdatableQuery$variables,
   response: UpdatableQuery$data,
+  variables: UpdatableQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-plural-field-no-spreads.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-plural-field-no-spreads.expected
@@ -13,6 +13,6 @@ export type UpdatableQuery$data = {|
   set nodes(value: []): void,
 |};
 export type UpdatableQuery = {|
-  variables: UpdatableQuery$variables,
   response: UpdatableQuery$data,
+  variables: UpdatableQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-plural-field-with-spreads.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-plural-field-with-spreads.expected
@@ -14,15 +14,15 @@ export type UpdatableQuery$variables = {||};
 export type UpdatableQuery$data = {|
   get nodes(): ?$ReadOnlyArray<?{||}>,
   set nodes(value: $ReadOnlyArray<{
-    +$fragmentSpreads: Updatable_user$fragmentType,
-    +__typename: "User",
     +__id: string,
+    +__typename: "User",
+    +$fragmentSpreads: Updatable_user$fragmentType,
     ...
   }>): void,
 |};
 export type UpdatableQuery = {|
-  variables: UpdatableQuery$variables,
   response: UpdatableQuery$data,
+  variables: UpdatableQuery$variables,
 |};
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-special-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-special-fields.expected
@@ -13,16 +13,16 @@ query UpdatableQuery @updatable {
 export type UpdatableQuery$variables = {||};
 export type UpdatableQuery$data = {|
   get me(): ?{|
-    +id: string,
-    +aliased_id: string,
-    +__typename: string,
-    +aliased_typename: string,
     +__id: string,
+    +__typename: string,
     +aliased_double_under_id: string,
+    +aliased_id: string,
+    +aliased_typename: string,
+    +id: string,
   |},
   set me(value: null | void): void,
 |};
 export type UpdatableQuery = {|
-  variables: UpdatableQuery$variables,
   response: UpdatableQuery$data,
+  variables: UpdatableQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-type-refinement.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation-type-refinement.expected
@@ -35,6 +35,6 @@ export type UpdatableQuery$data = {|
   set maybeNodeInterface(value: null | void): void,
 |};
 export type UpdatableQuery = {|
-  variables: UpdatableQuery$variables,
   response: UpdatableQuery$data,
+  variables: UpdatableQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/updatable-operation.expected
@@ -15,6 +15,6 @@ export type UpdatableQuery$data = {|
   set me(value: null | void): void,
 |};
 export type UpdatableQuery = {|
-  variables: UpdatableQuery$variables,
   response: UpdatableQuery$data,
+  variables: UpdatableQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/fixtures/relay-client-id-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/fixtures/relay-client-id-field.expected
@@ -40,7 +40,6 @@ export type RelayClientIDFieldQuery$data = {|
   +node: ?{|
     +__id: string,
     +__typename: string,
-    +global_id: string,
     +commentBody?: ?{|
       +__id: string,
       +__typename: string,
@@ -50,9 +49,10 @@ export type RelayClientIDFieldQuery$data = {|
         +text: ?string,
       |},
     |},
+    +global_id: string,
   |},
 |};
 export type RelayClientIDFieldQuery = {|
-  variables: RelayClientIDFieldQuery$variables,
   response: RelayClientIDFieldQuery$data,
+  variables: RelayClientIDFieldQuery$variables,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/fixtures/simple.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/fixtures/simple.expected
@@ -15,9 +15,9 @@ export type LinkedField$data = {|
   +global_id: string,
   +name: ?string,
   +profilePicture: ?{|
+    +height: ?number,
     +uri: ?string,
     +width: ?number,
-    +height: ?number,
   |},
   +$fragmentType: LinkedField$fragmentType,
 |};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/fragment-spread.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/fragment-spread.expected
@@ -71,12 +71,12 @@ export type ConcreateTypes$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type FragmentSpread$data = {
-  readonly id: string;
-  readonly justFrag: {
-    readonly " $fragmentSpreads": FragmentRefs<"PictureFragment">;
-  } | null;
   readonly fragAndField: {
     readonly uri: string | null;
+    readonly " $fragmentSpreads": FragmentRefs<"PictureFragment">;
+  } | null;
+  readonly id: string;
+  readonly justFrag: {
     readonly " $fragmentSpreads": FragmentRefs<"PictureFragment">;
   } | null;
   readonly " $fragmentSpreads": FragmentRefs<"OtherFragment" | "UserFrag1" | "UserFrag2">;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/inline-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/inline-fragment.expected
@@ -67,10 +67,10 @@ fragment SomeFragment on User {
 import { FragmentRefs } from "relay-runtime";
 export type InlineFragment$data = {
   readonly id: string;
-  readonly name?: string | null;
   readonly message?: {
     readonly text: string | null;
   } | null;
+  readonly name?: string | null;
   readonly " $fragmentType": "InlineFragment";
 };
 export type InlineFragment$key = {
@@ -93,12 +93,12 @@ import { FragmentRefs } from "relay-runtime";
 export type InlineFragmentKitchenSink$data = {
   readonly actor: {
     readonly id: string;
+    readonly name?: string | null;
     readonly profilePicture: {
+      readonly height?: number | null;
       readonly uri: string | null;
       readonly width?: number | null;
-      readonly height?: number | null;
     } | null;
-    readonly name?: string | null;
     readonly " $fragmentSpreads": FragmentRefs<"SomeFragment">;
   } | null;
   readonly " $fragmentType": "InlineFragmentKitchenSink";
@@ -112,10 +112,10 @@ import { FragmentRefs } from "relay-runtime";
 export type InlineFragmentWithOverlappingFields$data = {
   readonly hometown?: {
     readonly id: string;
-    readonly name: string | null;
     readonly message?: {
       readonly text: string | null;
     } | null;
+    readonly name: string | null;
   } | null;
   readonly name?: string | null;
   readonly " $fragmentType": "InlineFragmentWithOverlappingFields";

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-field.expected
@@ -39,16 +39,14 @@ export type UnionTypeTest$data = {
   } | null;
 };
 export type UnionTypeTest = {
-  variables: UnionTypeTest$variables;
   response: UnionTypeTest$data;
+  variables: UnionTypeTest$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type LinkedField$data = {
-  readonly profilePicture: {
-    readonly uri: string | null;
-    readonly width: number | null;
-    readonly height: number | null;
+  readonly actor: {
+    readonly id: string;
   } | null;
   readonly hometown: {
     readonly id: string;
@@ -56,8 +54,10 @@ export type LinkedField$data = {
       readonly uri: string | null;
     } | null;
   } | null;
-  readonly actor: {
-    readonly id: string;
+  readonly profilePicture: {
+    readonly height: number | null;
+    readonly uri: string | null;
+    readonly width: number | null;
   } | null;
   readonly " $fragmentType": "LinkedField";
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field-in-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field-in-query.expected
@@ -35,16 +35,16 @@ export type NameRendererQuery$data = {
   } | null;
 };
 export type NameRendererQuery = {
-  variables: NameRendererQuery$variables;
   response: NameRendererQuery$data;
+  variables: NameRendererQuery$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type MarkdownUserNameRenderer_name$data = {
-  readonly markdown: string | null;
   readonly data: {
     readonly markup: string | null;
   } | null;
+  readonly markdown: string | null;
   readonly " $fragmentType": "MarkdownUserNameRenderer_name";
 };
 export type MarkdownUserNameRenderer_name$key = {
@@ -54,10 +54,10 @@ export type MarkdownUserNameRenderer_name$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type PlainUserNameRenderer_name$data = {
-  readonly plaintext: string | null;
   readonly data: {
     readonly text: string | null;
   } | null;
+  readonly plaintext: string | null;
   readonly " $fragmentType": "PlainUserNameRenderer_name";
 };
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field.expected
@@ -24,10 +24,10 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type MarkdownUserNameRenderer_name$data = {
-  readonly markdown: string | null;
   readonly data: {
     readonly markup: string | null;
   } | null;
+  readonly markdown: string | null;
   readonly " $fragmentType": "MarkdownUserNameRenderer_name";
 };
 export type MarkdownUserNameRenderer_name$key = {
@@ -52,10 +52,10 @@ export type NameRendererFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type PlainUserNameRenderer_name$data = {
-  readonly plaintext: string | null;
   readonly data: {
     readonly text: string | null;
   } | null;
+  readonly plaintext: string | null;
   readonly " $fragmentType": "PlainUserNameRenderer_name";
 };
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-input-has-array.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-input-has-array.expected
@@ -30,7 +30,7 @@ export type InputHasArray$rawResponse = {
   } | null;
 };
 export type InputHasArray = {
-  variables: InputHasArray$variables;
-  response: InputHasArray$data;
   rawResponse: InputHasArray$rawResponse;
+  response: InputHasArray$data;
+  variables: InputHasArray$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-client-extension.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-client-extension.expected
@@ -38,15 +38,15 @@ export type Test$data = {
 export type Test$rawResponse = {
   readonly viewerNotificationsUpdateAllSeenState: {
     readonly stories: ReadonlyArray<{
-      readonly id: string;
       readonly foos?: ReadonlyArray<{
         readonly bar: string | null;
       } | null> | null;
+      readonly id: string;
     } | null> | null;
   } | null;
 };
 export type Test = {
-  variables: Test$variables;
-  response: Test$data;
   rawResponse: Test$rawResponse;
+  response: Test$data;
+  variables: Test$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-enums-on-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-enums-on-fragment.expected
@@ -31,8 +31,8 @@ import { FragmentRefs } from "relay-runtime";
 export type TestEnums = "mark" | "zuck" | "%future added value";
 export type CommentCreateInput = {
   clientMutationId?: string | null;
-  feedbackId?: string | null;
   feedback?: CommentfeedbackFeedback | null;
+  feedbackId?: string | null;
 };
 export type CommentfeedbackFeedback = {
   comment?: FeedbackcommentComment | null;
@@ -41,8 +41,8 @@ export type FeedbackcommentComment = {
   feedback?: CommentfeedbackFeedback | null;
 };
 export type CommentCreateMutation$variables = {
-  input: CommentCreateInput;
   first?: number | null;
+  input: CommentCreateInput;
   orderBy?: ReadonlyArray<string> | null;
 };
 export type CommentCreateMutation$data = {
@@ -51,8 +51,8 @@ export type CommentCreateMutation$data = {
       readonly friends: {
         readonly edges: ReadonlyArray<{
           readonly node: {
-            readonly id: string;
             readonly __typename: string;
+            readonly id: string;
             readonly " $fragmentSpreads": FragmentRefs<"FriendFragment">;
           } | null;
         } | null> | null;
@@ -66,10 +66,10 @@ export type CommentCreateMutation$rawResponse = {
       readonly friends: {
         readonly edges: ReadonlyArray<{
           readonly node: {
-            readonly id: string;
             readonly __typename: "User";
-            readonly name: string | null;
+            readonly id: string;
             readonly lastName: string | null;
+            readonly name: string | null;
             readonly profilePicture2: {
               readonly test_enums: TestEnums | null;
             } | null;
@@ -81,16 +81,16 @@ export type CommentCreateMutation$rawResponse = {
   } | null;
 };
 export type CommentCreateMutation = {
-  variables: CommentCreateMutation$variables;
-  response: CommentCreateMutation$data;
   rawResponse: CommentCreateMutation$rawResponse;
+  response: CommentCreateMutation$data;
+  variables: CommentCreateMutation$variables;
 };
 -------------------------------------------------------------------------------
 export type TestEnums = "mark" | "zuck" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type FriendFragment$data = {
-  readonly name: string | null;
   readonly lastName: string | null;
+  readonly name: string | null;
   readonly profilePicture2: {
     readonly test_enums: TestEnums | null;
   } | null;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-nested-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-nested-fragments.expected
@@ -34,8 +34,8 @@ fragment FeedbackFragment on Feedback {
 import { FragmentRefs } from "relay-runtime";
 export type CommentCreateInput = {
   clientMutationId?: string | null;
-  feedbackId?: string | null;
   feedback?: CommentfeedbackFeedback | null;
+  feedbackId?: string | null;
 };
 export type CommentfeedbackFeedback = {
   comment?: FeedbackcommentComment | null;
@@ -44,8 +44,8 @@ export type FeedbackcommentComment = {
   feedback?: CommentfeedbackFeedback | null;
 };
 export type CommentCreateMutation$variables = {
-  input: CommentCreateInput;
   first?: number | null;
+  input: CommentCreateInput;
   orderBy?: ReadonlyArray<string> | null;
 };
 export type CommentCreateMutation$data = {
@@ -68,13 +68,13 @@ export type CommentCreateMutation$rawResponse = {
       readonly friends: {
         readonly edges: ReadonlyArray<{
           readonly node: {
-            readonly lastName: string | null;
-            readonly name: string | null;
             readonly feedback: {
               readonly id: string;
               readonly name: string | null;
             } | null;
             readonly id: string;
+            readonly lastName: string | null;
+            readonly name: string | null;
           } | null;
         } | null> | null;
       } | null;
@@ -83,9 +83,9 @@ export type CommentCreateMutation$rawResponse = {
   } | null;
 };
 export type CommentCreateMutation = {
-  variables: CommentCreateMutation$variables;
-  response: CommentCreateMutation$data;
   rawResponse: CommentCreateMutation$rawResponse;
+  response: CommentCreateMutation$data;
+  variables: CommentCreateMutation$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
@@ -101,11 +101,11 @@ export type FeedbackFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type FriendFragment$data = {
-  readonly name: string | null;
-  readonly lastName: string | null;
   readonly feedback: {
     readonly " $fragmentSpreads": FragmentRefs<"FeedbackFragment">;
   } | null;
+  readonly lastName: string | null;
+  readonly name: string | null;
   readonly " $fragmentType": "FriendFragment";
 };
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-response-on-inline-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-response-on-inline-fragments.expected
@@ -30,8 +30,8 @@ fragment InlineFragmentWithOverlappingFields on Actor {
 import { FragmentRefs } from "relay-runtime";
 export type CommentCreateInput = {
   clientMutationId?: string | null;
-  feedbackId?: string | null;
   feedback?: CommentfeedbackFeedback | null;
+  feedbackId?: string | null;
 };
 export type CommentfeedbackFeedback = {
   comment?: FeedbackcommentComment | null;
@@ -55,46 +55,46 @@ export type TestMutation$rawResponse = {
   readonly commentCreate: {
     readonly viewer: {
       readonly actor: {
-        readonly __typename: "User";
         readonly __isActor: "User";
-        readonly id: string;
+        readonly __typename: "User";
         readonly hometown: {
           readonly id: string;
           readonly name: string | null;
         } | null;
-      } | {
-        readonly __typename: "Page";
-        readonly __isActor: "Page";
         readonly id: string;
-        readonly name: string | null;
+      } | {
+        readonly __isActor: "Page";
+        readonly __typename: "Page";
         readonly hometown: {
           readonly id: string;
           readonly message: {
             readonly text: string | null;
           } | null;
         } | null;
+        readonly id: string;
+        readonly name: string | null;
       } | {
-        readonly __typename: string;
         readonly __isActor: string;
+        readonly __typename: string;
         readonly id: string;
       } | null;
     } | null;
   } | null;
 };
 export type TestMutation = {
-  variables: TestMutation$variables;
-  response: TestMutation$data;
   rawResponse: TestMutation$rawResponse;
+  response: TestMutation$data;
+  variables: TestMutation$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type InlineFragmentWithOverlappingFields$data = {
   readonly hometown?: {
     readonly id: string;
-    readonly name: string | null;
     readonly message?: {
       readonly text: string | null;
     } | null;
+    readonly name: string | null;
   } | null;
   readonly name?: string | null;
   readonly " $fragmentType": "InlineFragmentWithOverlappingFields";

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation.expected
@@ -17,8 +17,8 @@ mutation CommentCreateMutation(
 ==================================== OUTPUT ===================================
 export type CommentCreateInput = {
   clientMutationId?: string | null;
-  feedbackId?: string | null;
   feedback?: CommentfeedbackFeedback | null;
+  feedbackId?: string | null;
 };
 export type CommentfeedbackFeedback = {
   comment?: FeedbackcommentComment | null;
@@ -27,22 +27,22 @@ export type FeedbackcommentComment = {
   feedback?: CommentfeedbackFeedback | null;
 };
 export type CommentCreateMutation$variables = {
-  input: CommentCreateInput;
   first?: number | null;
+  input: CommentCreateInput;
   orderBy?: ReadonlyArray<string> | null;
 };
 export type CommentCreateMutation$data = {
   readonly commentCreate: {
     readonly comment: {
-      readonly id: string;
-      readonly name: string | null;
       readonly friends: {
         readonly count: number | null;
       } | null;
+      readonly id: string;
+      readonly name: string | null;
     } | null;
   } | null;
 };
 export type CommentCreateMutation = {
-  variables: CommentCreateMutation$variables;
   response: CommentCreateMutation$data;
+  variables: CommentCreateMutation$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-handles.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-handles.expected
@@ -30,19 +30,19 @@ export type LinkedHandleField$data = {
 export type LinkedHandleField$rawResponse = {
   readonly node: {
     readonly __typename: "User";
-    readonly id: string;
     readonly friends: {
       readonly count: number | null;
     } | null;
+    readonly id: string;
   } | {
     readonly __typename: string;
     readonly id: string;
   } | null;
 };
 export type LinkedHandleField = {
-  variables: LinkedHandleField$variables;
-  response: LinkedHandleField$data;
   rawResponse: LinkedHandleField$rawResponse;
+  response: LinkedHandleField$data;
+  variables: LinkedHandleField$variables;
 };
 -------------------------------------------------------------------------------
 export type ScalarHandleField$variables = {
@@ -64,7 +64,7 @@ export type ScalarHandleField$rawResponse = {
   } | null;
 };
 export type ScalarHandleField = {
-  variables: ScalarHandleField$variables;
-  response: ScalarHandleField$data;
   rawResponse: ScalarHandleField$rawResponse;
+  response: ScalarHandleField$data;
+  variables: ScalarHandleField$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-match-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-match-fields.expected
@@ -36,33 +36,33 @@ export type Test$data = {
   } | null;
 };
 export type PlainUserNameRenderer_name = {
-  readonly plaintext: string | null;
   readonly data: {
-    readonly text: string | null;
     readonly id: string | null;
+    readonly text: string | null;
   } | null;
+  readonly plaintext: string | null;
 };
 export type MarkdownUserNameRenderer_name = {
-  readonly markdown: string | null;
   readonly data: {
-    readonly markup: string | null;
     readonly id: string | null;
+    readonly markup: string | null;
   } | null;
+  readonly markdown: string | null;
 };
 export type Test$rawResponse = {
   readonly node: {
     readonly __typename: "User";
     readonly id: string;
     readonly nameRenderer: {
-      readonly __typename: "PlainUserNameRenderer";
-      readonly __module_operation_NameRendererFragment: any | null;
       readonly __module_component_NameRendererFragment: any | null;
+      readonly __module_operation_NameRendererFragment: any | null;
+      readonly __typename: "PlainUserNameRenderer";
     } | Local3DPayload<"NameRendererFragment", {
       readonly __typename: "PlainUserNameRenderer";
     }> | {
-      readonly __typename: "MarkdownUserNameRenderer";
-      readonly __module_operation_NameRendererFragment: any | null;
       readonly __module_component_NameRendererFragment: any | null;
+      readonly __module_operation_NameRendererFragment: any | null;
+      readonly __typename: "MarkdownUserNameRenderer";
     } | Local3DPayload<"NameRendererFragment", {
       readonly __typename: "MarkdownUserNameRenderer";
     }> | {
@@ -74,17 +74,17 @@ export type Test$rawResponse = {
   } | null;
 };
 export type Test = {
-  variables: Test$variables;
-  response: Test$data;
   rawResponse: Test$rawResponse;
+  response: Test$data;
+  variables: Test$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type MarkdownUserNameRenderer_name$data = {
-  readonly markdown: string | null;
   readonly data: {
     readonly markup: string | null;
   } | null;
+  readonly markdown: string | null;
   readonly " $fragmentType": "MarkdownUserNameRenderer_name";
 };
 export type MarkdownUserNameRenderer_name$key = {
@@ -109,10 +109,10 @@ export type NameRendererFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type PlainUserNameRenderer_name$data = {
-  readonly plaintext: string | null;
   readonly data: {
     readonly text: string | null;
   } | null;
+  readonly plaintext: string | null;
   readonly " $fragmentType": "PlainUserNameRenderer_name";
 };
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-module-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-module-field.expected
@@ -26,8 +26,8 @@ export type Test$data = {
 };
 export type Test_userRenderer = {
   readonly user: {
-    readonly username: string | null;
     readonly id: string;
+    readonly username: string | null;
   } | null;
 };
 export type Test$rawResponse = {
@@ -35,8 +35,8 @@ export type Test$rawResponse = {
     readonly __typename: "User";
     readonly id: string;
     readonly plainUserRenderer: {
-      readonly __module_operation_Test_user: any | null;
       readonly __module_component_Test_user: any | null;
+      readonly __module_operation_Test_user: any | null;
     } | Local3DPayload<"Test_user", {}> | null;
   } | {
     readonly __typename: string;
@@ -44,9 +44,9 @@ export type Test$rawResponse = {
   } | null;
 };
 export type Test = {
-  variables: Test$variables;
-  response: Test$data;
   rawResponse: Test$rawResponse;
+  response: Test$data;
+  variables: Test$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-multiple-match-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-multiple-match-fields.expected
@@ -63,39 +63,39 @@ export type Test$data = {
   } | null;
 };
 export type PlainUserNameRenderer_name = {
-  readonly plaintext: string | null;
   readonly data: {
-    readonly text: string | null;
     readonly id: string | null;
+    readonly text: string | null;
   } | null;
+  readonly plaintext: string | null;
 };
 export type MarkdownUserNameRenderer_name = {
-  readonly markdown: string | null;
   readonly data: {
-    readonly markup: string | null;
     readonly id: string | null;
+    readonly markup: string | null;
   } | null;
+  readonly markdown: string | null;
 };
 export type Test$rawResponse = {
   readonly node: {
     readonly __typename: "User";
     readonly id: string;
-    readonly username: string | null;
     readonly nameRenderer: {
-      readonly __typename: "PlainUserNameRenderer";
-      readonly __module_operation_NameRendererFragment: any | null;
       readonly __module_component_NameRendererFragment: any | null;
+      readonly __module_operation_NameRendererFragment: any | null;
+      readonly __typename: "PlainUserNameRenderer";
     } | Local3DPayload<"NameRendererFragment", {
       readonly __typename: "PlainUserNameRenderer";
     }> | {
-      readonly __typename: "MarkdownUserNameRenderer";
-      readonly __module_operation_NameRendererFragment: any | null;
       readonly __module_component_NameRendererFragment: any | null;
+      readonly __module_operation_NameRendererFragment: any | null;
+      readonly __typename: "MarkdownUserNameRenderer";
     } | Local3DPayload<"NameRendererFragment", {
       readonly __typename: "MarkdownUserNameRenderer";
     }> | {
       readonly __typename: string;
     } | null;
+    readonly username: string | null;
   } | {
     readonly __typename: string;
     readonly id: string;
@@ -106,15 +106,15 @@ export type Test$rawResponse = {
       readonly id: string;
       readonly name: string | null;
       readonly nameRenderer: {
-        readonly __typename: "PlainUserNameRenderer";
-        readonly __module_operation_AnotherNameRendererFragment: any | null;
         readonly __module_component_AnotherNameRendererFragment: any | null;
+        readonly __module_operation_AnotherNameRendererFragment: any | null;
+        readonly __typename: "PlainUserNameRenderer";
       } | Local3DPayload<"AnotherNameRendererFragment", {
         readonly __typename: "PlainUserNameRenderer";
       }> | {
-        readonly __typename: "MarkdownUserNameRenderer";
-        readonly __module_operation_AnotherNameRendererFragment: any | null;
         readonly __module_component_AnotherNameRendererFragment: any | null;
+        readonly __module_operation_AnotherNameRendererFragment: any | null;
+        readonly __typename: "MarkdownUserNameRenderer";
       } | Local3DPayload<"AnotherNameRendererFragment", {
         readonly __typename: "MarkdownUserNameRenderer";
       }> | {
@@ -127,9 +127,9 @@ export type Test$rawResponse = {
   } | null;
 };
 export type Test = {
-  variables: Test$variables;
-  response: Test$data;
   rawResponse: Test$rawResponse;
+  response: Test$data;
+  variables: Test$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
@@ -149,10 +149,10 @@ export type AnotherNameRendererFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type MarkdownUserNameRenderer_name$data = {
-  readonly markdown: string | null;
   readonly data: {
     readonly markup: string | null;
   } | null;
+  readonly markdown: string | null;
   readonly " $fragmentType": "MarkdownUserNameRenderer_name";
 };
 export type MarkdownUserNameRenderer_name$key = {
@@ -177,10 +177,10 @@ export type NameRendererFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type PlainUserNameRenderer_name$data = {
-  readonly plaintext: string | null;
   readonly data: {
     readonly text: string | null;
   } | null;
+  readonly plaintext: string | null;
   readonly " $fragmentType": "PlainUserNameRenderer_name";
 };
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-conditional.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-conditional.expected
@@ -18,8 +18,8 @@ fragment FriendFragment on User {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type ExampleQuery$variables = {
-  id: string;
   condition: boolean;
+  id: string;
 };
 export type ExampleQuery$data = {
   readonly node: {
@@ -29,32 +29,32 @@ export type ExampleQuery$data = {
 export type ExampleQuery$rawResponse = {
   readonly node: {
     readonly __typename: "User";
-    readonly id: string;
-    readonly name: string | null;
-    readonly lastName: string | null;
     readonly feedback: {
       readonly id: string;
       readonly name: string | null;
     } | null;
+    readonly id: string;
+    readonly lastName: string | null;
+    readonly name: string | null;
   } | {
     readonly __typename: string;
     readonly id: string;
   } | null;
 };
 export type ExampleQuery = {
-  variables: ExampleQuery$variables;
-  response: ExampleQuery$data;
   rawResponse: ExampleQuery$rawResponse;
+  response: ExampleQuery$data;
+  variables: ExampleQuery$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type FriendFragment$data = {
-  readonly name?: string | null;
-  readonly lastName?: string | null;
   readonly feedback?: {
     readonly id: string;
     readonly name: string | null;
   } | null;
+  readonly lastName?: string | null;
+  readonly name?: string | null;
   readonly " $fragmentType": "FriendFragment";
 };
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-literal-conditional.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-literal-conditional.expected
@@ -28,34 +28,34 @@ export type ExampleQuery$variables = {
 };
 export type ExampleQuery$data = {
   readonly node: {
-    readonly username: string | null;
     readonly friends?: {
       readonly count: number | null;
     } | null;
+    readonly username: string | null;
     readonly " $fragmentSpreads": FragmentRefs<"FriendFragment">;
   } | null;
 };
 export type ExampleQuery$rawResponse = {
   readonly node: {
     readonly __typename: string;
-    readonly username: string | null;
     readonly id: string;
+    readonly username: string | null;
   } | null;
 };
 export type ExampleQuery = {
-  variables: ExampleQuery$variables;
-  response: ExampleQuery$data;
   rawResponse: ExampleQuery$rawResponse;
+  response: ExampleQuery$data;
+  variables: ExampleQuery$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type FriendFragment$data = {
-  readonly name?: string | null;
-  readonly lastName?: string | null;
   readonly feedback?: {
     readonly id: string;
     readonly name: string | null;
   } | null;
+  readonly lastName?: string | null;
+  readonly name?: string | null;
   readonly " $fragmentType": "FriendFragment";
 };
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.expected
@@ -20,7 +20,6 @@ query TestDefer @raw_response_type {
 export type TestDefer$variables = {};
 export type TestDefer$data = {
   readonly node: {
-    readonly name?: string | null;
     readonly friends?: {
       readonly edges: ReadonlyArray<{
         readonly node: {
@@ -30,38 +29,39 @@ export type TestDefer$data = {
         } | null;
       } | null> | null;
     } | null;
+    readonly name?: string | null;
   } | null;
 };
 export type TestDefer$rawResponse = {
   readonly node: {
     readonly __typename: "User";
-    readonly id: string;
-    readonly name: string | null;
     readonly friends: {
       readonly edges: ReadonlyArray<{
+        readonly cursor: string | null;
         readonly node: {
+          readonly __typename: "User";
           readonly actor: {
             readonly __typename: string;
-            readonly name: string | null;
             readonly id: string;
+            readonly name: string | null;
           } | null;
           readonly id: string;
-          readonly __typename: "User";
         } | null;
-        readonly cursor: string | null;
       } | null> | null;
       readonly pageInfo: {
         readonly endCursor: string | null;
         readonly hasNextPage: boolean | null;
       } | null;
     } | null;
+    readonly id: string;
+    readonly name: string | null;
   } | {
     readonly __typename: string;
     readonly id: string;
   } | null;
 };
 export type TestDefer = {
-  variables: TestDefer$variables;
-  response: TestDefer$data;
   rawResponse: TestDefer$rawResponse;
+  response: TestDefer$data;
+  variables: TestDefer$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.expected
@@ -21,7 +21,6 @@ query TestStream @raw_response_type {
 export type TestStream$variables = {};
 export type TestStream$data = {
   readonly node: {
-    readonly name?: string | null;
     readonly friends?: {
       readonly edges: ReadonlyArray<{
         readonly node: {
@@ -29,33 +28,34 @@ export type TestStream$data = {
         } | null;
       } | null> | null;
     } | null;
+    readonly name?: string | null;
   } | null;
 };
 export type TestStream$rawResponse = {
   readonly node: {
     readonly __typename: "User";
-    readonly id: string;
-    readonly name: string | null;
     readonly friends: {
       readonly edges: ReadonlyArray<{
-        readonly node: {
-          readonly id: string;
-          readonly __typename: "User";
-        } | null;
         readonly cursor: string | null;
+        readonly node: {
+          readonly __typename: "User";
+          readonly id: string;
+        } | null;
       } | null> | null;
       readonly pageInfo: {
         readonly endCursor: string | null;
         readonly hasNextPage: boolean | null;
       } | null;
     } | null;
+    readonly id: string;
+    readonly name: string | null;
   } | {
     readonly __typename: string;
     readonly id: string;
   } | null;
 };
 export type TestStream = {
-  variables: TestStream$variables;
-  response: TestStream$data;
   rawResponse: TestStream$rawResponse;
+  response: TestStream$data;
+  variables: TestStream$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/refetchable-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/refetchable-fragment.expected
@@ -17,16 +17,16 @@ export type RefetchableFragmentQuery$data = {
   } | null;
 };
 export type RefetchableFragmentQuery = {
-  variables: RefetchableFragmentQuery$variables;
   response: RefetchableFragmentQuery$data;
+  variables: RefetchableFragmentQuery$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type RefetchableFragment$data = {
-  readonly id: string;
   readonly fragAndField: {
     readonly uri: string | null;
   } | null;
+  readonly id: string;
   readonly " $fragmentType": "RefetchableFragment";
 };
 export type RefetchableFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/refetchable.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/refetchable.expected
@@ -17,8 +17,8 @@ export type FlowRefetchableFragmentQuery$data = {
   } | null;
 };
 export type FlowRefetchableFragmentQuery = {
-  variables: FlowRefetchableFragmentQuery$variables;
   response: FlowRefetchableFragmentQuery$data;
+  variables: FlowRefetchableFragmentQuery$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/relay-client-id-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/relay-client-id-field.expected
@@ -40,7 +40,6 @@ export type RelayClientIDFieldQuery$data = {
   readonly node: {
     readonly __id: string;
     readonly __typename: string;
-    readonly id: string;
     readonly commentBody?: {
       readonly __id: string;
       readonly __typename: string;
@@ -50,9 +49,10 @@ export type RelayClientIDFieldQuery$data = {
         readonly text: string | null;
       } | null;
     } | null;
+    readonly id: string;
   } | null;
 };
 export type RelayClientIDFieldQuery = {
-  variables: RelayClientIDFieldQuery$variables;
   response: RelayClientIDFieldQuery$data;
+  variables: RelayClientIDFieldQuery$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-query.expected
@@ -14,6 +14,6 @@ export type FooQuery$data = {
   };
 } | null;
 export type FooQuery = {
-  variables: FooQuery$variables;
   response: FooQuery$data;
+  variables: FooQuery$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-up-to-mutation-response.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-up-to-mutation-response.expected
@@ -9,8 +9,8 @@ mutation CommentCreateMutation($input: CommentCreateInput!) {
 ==================================== OUTPUT ===================================
 export type CommentCreateInput = {
   clientMutationId?: string | null;
-  feedbackId?: string | null;
   feedback?: CommentfeedbackFeedback | null;
+  feedbackId?: string | null;
 };
 export type CommentfeedbackFeedback = {
   comment?: FeedbackcommentComment | null;
@@ -29,6 +29,6 @@ export type CommentCreateMutation$data = {
   };
 } | null;
 export type CommentCreateMutation = {
-  variables: CommentCreateMutation$variables;
   response: CommentCreateMutation$data;
+  variables: CommentCreateMutation$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-isolates-concrete-inline-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-isolates-concrete-inline-fragments.expected
@@ -30,10 +30,10 @@ fragment Foo on Node {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type Bar$data = {
-  readonly name?: string;
   readonly body?: {
     readonly text: string | null;
   } | null;
+  readonly name?: string;
   readonly " $fragmentType": "Bar";
 } | null;
 export type Bar$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-raw-response-type.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-raw-response-type.expected
@@ -20,7 +20,7 @@ export type MyQuery$rawResponse = {
   } | null;
 };
 export type MyQuery = {
-  variables: MyQuery$variables;
-  response: MyQuery$data;
   rawResponse: MyQuery$rawResponse;
+  response: MyQuery$data;
+  variables: MyQuery$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.expected
@@ -14,6 +14,6 @@ export type FooQuery$data = {
   };
 };
 export type FooQuery = {
-  variables: FooQuery$variables;
   response: FooQuery$data;
+  variables: FooQuery$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throws-nested.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throws-nested.expected
@@ -14,6 +14,6 @@ export type FooQuery$data = {
   } | null;
 };
 export type FooQuery = {
-  variables: FooQuery$variables;
   response: FooQuery$data;
+  variables: FooQuery$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required.expected
@@ -14,6 +14,6 @@ export type FooQuery$data = {
   } | null;
 };
 export type FooQuery = {
-  variables: FooQuery$variables;
   response: FooQuery$data;
+  variables: FooQuery$variables;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/roots.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/roots.expected
@@ -34,14 +34,14 @@ export type ExampleQuery$data = {
   } | null;
 };
 export type ExampleQuery = {
-  variables: ExampleQuery$variables;
   response: ExampleQuery$data;
+  variables: ExampleQuery$variables;
 };
 -------------------------------------------------------------------------------
 export type CommentCreateInput = {
   clientMutationId?: string | null;
-  feedbackId?: string | null;
   feedback?: CommentfeedbackFeedback | null;
+  feedbackId?: string | null;
 };
 export type CommentfeedbackFeedback = {
   comment?: FeedbackcommentComment | null;
@@ -60,8 +60,8 @@ export type TestMutation$data = {
   } | null;
 };
 export type TestMutation = {
-  variables: TestMutation$variables;
   response: TestMutation$data;
+  variables: TestMutation$variables;
 };
 -------------------------------------------------------------------------------
 export type FeedbackLikeInput = {
@@ -79,8 +79,8 @@ export type TestSubscription$data = {
   } | null;
 };
 export type TestSubscription = {
-  variables: TestSubscription$variables;
   response: TestSubscription$data;
+  variables: TestSubscription$variables;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/scalar-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/scalar-field.expected
@@ -16,17 +16,17 @@ fragment ScalarField on User {
 export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ScalarField$data = {
-  readonly id: string;
-  readonly name: string | null;
-  readonly websites: ReadonlyArray<string | null> | null;
-  readonly traits: ReadonlyArray<PersonalityTraits | null> | null;
   readonly aliasedLinkedField: {
     readonly aliasedField: number | null;
   } | null;
+  readonly id: string;
+  readonly name: string | null;
   readonly screennames: ReadonlyArray<{
     readonly name: string | null;
     readonly service: string | null;
   } | null> | null;
+  readonly traits: ReadonlyArray<PersonalityTraits | null> | null;
+  readonly websites: ReadonlyArray<string | null> | null;
   readonly " $fragmentType": "ScalarField";
 };
 export type ScalarField$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/simple.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/simple.expected
@@ -12,9 +12,9 @@ import { FragmentRefs } from "relay-runtime";
 export type LinkedField$data = {
   readonly name: string | null;
   readonly profilePicture: {
+    readonly height: number | null;
     readonly uri: string | null;
     readonly width: number | null;
-    readonly height: number | null;
   } | null;
   readonly " $fragmentType": "LinkedField";
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/typename-on-union.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/typename-on-union.expected
@@ -168,13 +168,13 @@ export type TypenameOutside$key = {
 import { FragmentRefs } from "relay-runtime";
 export type TypenameOutsideWithAbstractType$data = {
   readonly __typename: string;
-  readonly username?: string | null;
   readonly address?: {
     readonly city: string | null;
     readonly country: string | null;
     readonly street?: string | null;
   } | null;
   readonly firstName?: string | null;
+  readonly username?: string | null;
   readonly " $fragmentType": "TypenameOutsideWithAbstractType";
 };
 export type TypenameOutsideWithAbstractType$key = {
@@ -185,8 +185,8 @@ export type TypenameOutsideWithAbstractType$key = {
 import { FragmentRefs } from "relay-runtime";
 export type TypenameWithCommonSelections$data = {
   readonly __typename: string;
-  readonly name: string | null;
   readonly firstName?: string | null;
+  readonly name: string | null;
   readonly username?: string | null;
   readonly " $fragmentType": "TypenameWithCommonSelections";
 };
@@ -197,8 +197,8 @@ export type TypenameWithCommonSelections$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type TypenameWithoutSpreads$data = {
-  readonly firstName: string | null;
   readonly __typename: "User";
+  readonly firstName: string | null;
   readonly " $fragmentType": "TypenameWithoutSpreads";
 };
 export type TypenameWithoutSpreads$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/unmasked-fragment-spreads.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/unmasked-fragment-spreads.expected
@@ -28,8 +28,8 @@ fragment AnotherRecursiveFragment on Image {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type AnotherRecursiveFragment$data = {
-  readonly uri: string | null;
   readonly height: number | null;
+  readonly uri: string | null;
   readonly " $fragmentType": "AnotherRecursiveFragment";
 };
 export type AnotherRecursiveFragment$key = {
@@ -61,9 +61,9 @@ export type RecursiveFragment$key = {
 import { FragmentRefs } from "relay-runtime";
 export type UserProfile$data = {
   readonly profilePicture: {
+    readonly height: number | null;
     readonly uri: string | null;
     readonly width: number | null;
-    readonly height: number | null;
     readonly " $fragmentSpreads": FragmentRefs<"PhotoFragment">;
   } | null;
   readonly " $fragmentType": "UserProfile";


### PR DESCRIPTION
Trying to start split #3280 into smaller parts. When writing objects (whether exact or inexact) in typegen, sort the object's members by name. The used sorting is a bit subjective, so I'm open to suggestions.

@rbalicki2 