### PR TITLE
Typegen: Add intersection variant, and wrap unions and intersections in parentheses when they have more than one member

### DIFF
--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -11,6 +11,10 @@ use std::fmt::{Result as FmtResult, Write};
 #[derive(Debug, Clone)]
 pub enum AST {
     Union(Vec<AST>),
+    // Intersection variant added in preparation for better support for abstract types.
+    // See https://github.com/facebook/relay/pull/3280
+    #[allow(dead_code)]
+    Intersection(Vec<AST>),
     ReadOnlyArray(Box<AST>),
     Nullable(Box<AST>),
     NonNullable(Box<AST>),

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/fragment-spread.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/fragment-spread.expected
@@ -110,7 +110,7 @@ export type OtherFragment$key = {
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type PageFragment$fragmentType: FragmentType;
-export type PageFragment$data = {|
+export type PageFragment$data = ({|
   +__typename: "Page",
   +$fragmentType: PageFragment$fragmentType,
 |} | {|
@@ -118,7 +118,7 @@ export type PageFragment$data = {|
   // value in case none of the concrete values match.
   +__typename: "%other",
   +$fragmentType: PageFragment$fragmentType,
-|};
+|});
 export type PageFragment$key = {
   +$data?: PageFragment$data,
   +$fragmentSpreads: PageFragment$fragmentType,
@@ -127,7 +127,7 @@ export type PageFragment$key = {
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type PictureFragment$fragmentType: FragmentType;
-export type PictureFragment$data = {|
+export type PictureFragment$data = ({|
   +__typename: "Image",
   +$fragmentType: PictureFragment$fragmentType,
 |} | {|
@@ -135,7 +135,7 @@ export type PictureFragment$data = {|
   // value in case none of the concrete values match.
   +__typename: "%other",
   +$fragmentType: PictureFragment$fragmentType,
-|};
+|});
 export type PictureFragment$key = {
   +$data?: PictureFragment$data,
   +$fragmentSpreads: PictureFragment$fragmentType,
@@ -144,7 +144,7 @@ export type PictureFragment$key = {
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type UserFrag1$fragmentType: FragmentType;
-export type UserFrag1$data = {|
+export type UserFrag1$data = ({|
   +__typename: "User",
   +$fragmentType: UserFrag1$fragmentType,
 |} | {|
@@ -152,7 +152,7 @@ export type UserFrag1$data = {|
   // value in case none of the concrete values match.
   +__typename: "%other",
   +$fragmentType: UserFrag1$fragmentType,
-|};
+|});
 export type UserFrag1$key = {
   +$data?: UserFrag1$data,
   +$fragmentSpreads: UserFrag1$fragmentType,
@@ -161,7 +161,7 @@ export type UserFrag1$key = {
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type UserFrag2$fragmentType: FragmentType;
-export type UserFrag2$data = {|
+export type UserFrag2$data = ({|
   +__typename: "User",
   +$fragmentType: UserFrag2$fragmentType,
 |} | {|
@@ -169,7 +169,7 @@ export type UserFrag2$data = {|
   // value in case none of the concrete values match.
   +__typename: "%other",
   +$fragmentType: UserFrag2$fragmentType,
-|};
+|});
 export type UserFrag2$key = {
   +$data?: UserFrag2$data,
   +$fragmentSpreads: UserFrag2$fragmentType,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/inline-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/inline-fragment.expected
@@ -136,7 +136,7 @@ export type InlineFragmentWithOverlappingFields$key = {
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type SomeFragment$fragmentType: FragmentType;
-export type SomeFragment$data = {|
+export type SomeFragment$data = ({|
   +__typename: "User",
   +$fragmentType: SomeFragment$fragmentType,
 |} | {|
@@ -144,7 +144,7 @@ export type SomeFragment$data = {|
   // value in case none of the concrete values match.
   +__typename: "%other",
   +$fragmentType: SomeFragment$fragmentType,
-|};
+|});
 export type SomeFragment$key = {
   +$data?: SomeFragment$data,
   +$fragmentSpreads: SomeFragment$fragmentType,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-enums-on-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/mutation-with-enums-on-fragment.expected
@@ -28,7 +28,7 @@ fragment FriendFragment on User {
 }
 ==================================== OUTPUT ===================================
 import type { FriendFragment$fragmentType } from "FriendFragment.graphql";
-export type TestEnums = "mark" | "zuck" | "%future added value";
+export type TestEnums = ("mark" | "zuck" | "%future added value");
 export type CommentCreateInput = {|
   clientMutationId?: ?string,
   feedbackId?: ?string,
@@ -86,7 +86,7 @@ export type CommentCreateMutation = {|
   rawResponse: CommentCreateMutation$rawResponse,
 |};
 -------------------------------------------------------------------------------
-export type TestEnums = "mark" | "zuck" | "%future added value";
+export type TestEnums = ("mark" | "zuck" | "%future added value");
 import type { FragmentType } from "relay-runtime";
 declare export opaque type FriendFragment$fragmentType: FragmentType;
 export type FriendFragment$data = {|

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query_with_raw_response_and_client_components.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query_with_raw_response_and_client_components.expected
@@ -33,7 +33,7 @@ export type queryWithRelayClientComponentQuery = {|
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type queryWithRelayClientComponent_f1$fragmentType: FragmentType;
-export type queryWithRelayClientComponent_f1$data = {|
+export type queryWithRelayClientComponent_f1$data = ({|
   +__typename: "Viewer",
   +$fragmentType: queryWithRelayClientComponent_f1$fragmentType,
 |} | {|
@@ -41,7 +41,7 @@ export type queryWithRelayClientComponent_f1$data = {|
   // value in case none of the concrete values match.
   +__typename: "%other",
   +$fragmentType: queryWithRelayClientComponent_f1$fragmentType,
-|};
+|});
 export type queryWithRelayClientComponent_f1$key = {
   +$data?: queryWithRelayClientComponent_f1$data,
   +$fragmentSpreads: queryWithRelayClientComponent_f1$fragmentType,
@@ -50,7 +50,7 @@ export type queryWithRelayClientComponent_f1$key = {
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type queryWithRelayClientComponent_f2$fragmentType: FragmentType;
-export type queryWithRelayClientComponent_f2$data = {|
+export type queryWithRelayClientComponent_f2$data = ({|
   +__typename: "Viewer",
   +$fragmentType: queryWithRelayClientComponent_f2$fragmentType,
 |} | {|
@@ -58,7 +58,7 @@ export type queryWithRelayClientComponent_f2$data = {|
   // value in case none of the concrete values match.
   +__typename: "%other",
   +$fragmentType: queryWithRelayClientComponent_f2$fragmentType,
-|};
+|});
 export type queryWithRelayClientComponent_f2$key = {
   +$data?: queryWithRelayClientComponent_f2$data,
   +$fragmentSpreads: queryWithRelayClientComponent_f2$fragmentType,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/scalar-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/scalar-field.expected
@@ -13,7 +13,7 @@ fragment ScalarField on User {
   }
 }
 ==================================== OUTPUT ===================================
-export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value";
+export type PersonalityTraits = ("CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value");
 import type { FragmentType } from "relay-runtime";
 declare export opaque type ScalarField$fragmentType: FragmentType;
 export type ScalarField$data = {|

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/typename-on-union.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/typename-on-union.expected
@@ -82,7 +82,7 @@ fragment TypenameAliases on Actor {
 ==================================== OUTPUT ===================================
 import type { FragmentType } from "relay-runtime";
 declare export opaque type TypenameAlias$fragmentType: FragmentType;
-export type TypenameAlias$data = {|
+export type TypenameAlias$data = ({|
   +_typeAlias: "User",
   +firstName: ?string,
   +$fragmentType: TypenameAlias$fragmentType,
@@ -95,7 +95,7 @@ export type TypenameAlias$data = {|
   // value in case none of the concrete values match.
   +_typeAlias: "%other",
   +$fragmentType: TypenameAlias$fragmentType,
-|};
+|});
 export type TypenameAlias$key = {
   +$data?: TypenameAlias$data,
   +$fragmentSpreads: TypenameAlias$fragmentType,
@@ -104,7 +104,7 @@ export type TypenameAlias$key = {
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type TypenameAliases$fragmentType: FragmentType;
-export type TypenameAliases$data = {|
+export type TypenameAliases$data = ({|
   +_typeAlias1: "User",
   +_typeAlias2: "User",
   +firstName: ?string,
@@ -122,7 +122,7 @@ export type TypenameAliases$data = {|
   // value in case none of the concrete values match.
   +_typeAlias2: "%other",
   +$fragmentType: TypenameAliases$fragmentType,
-|};
+|});
 export type TypenameAliases$key = {
   +$data?: TypenameAliases$data,
   +$fragmentSpreads: TypenameAliases$fragmentType,
@@ -131,7 +131,7 @@ export type TypenameAliases$key = {
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type TypenameInside$fragmentType: FragmentType;
-export type TypenameInside$data = {|
+export type TypenameInside$data = ({|
   +__typename: "User",
   +firstName: ?string,
   +$fragmentType: TypenameInside$fragmentType,
@@ -144,7 +144,7 @@ export type TypenameInside$data = {|
   // value in case none of the concrete values match.
   +__typename: "%other",
   +$fragmentType: TypenameInside$fragmentType,
-|};
+|});
 export type TypenameInside$key = {
   +$data?: TypenameInside$data,
   +$fragmentSpreads: TypenameInside$fragmentType,
@@ -153,7 +153,7 @@ export type TypenameInside$key = {
 -------------------------------------------------------------------------------
 import type { FragmentType } from "relay-runtime";
 declare export opaque type TypenameOutside$fragmentType: FragmentType;
-export type TypenameOutside$data = {|
+export type TypenameOutside$data = ({|
   +__typename: "User",
   +firstName: ?string,
   +$fragmentType: TypenameOutside$fragmentType,
@@ -166,7 +166,7 @@ export type TypenameOutside$data = {|
   // value in case none of the concrete values match.
   +__typename: "%other",
   +$fragmentType: TypenameOutside$fragmentType,
-|};
+|});
 export type TypenameOutside$key = {
   +$data?: TypenameOutside$data,
   +$fragmentSpreads: TypenameOutside$fragmentType,

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/fragment-spread.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/fragment-spread.expected
@@ -50,18 +50,18 @@ fragment UserFrag2 on User {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type ConcreateTypes$data = {
-  readonly actor: {
+  readonly actor: ({
     readonly __typename: "Page";
     readonly id: string;
     readonly " $fragmentSpreads": FragmentRefs<"PageFragment">;
   } | {
     readonly __typename: "User";
-    readonly name: string | null;
+    readonly name: (string | null);
   } | {
     // This will never be '%other', but we need some
     // value in case none of the concrete values match.
     readonly __typename: "%other";
-  } | null;
+  } | null);
   readonly " $fragmentType": "ConcreateTypes";
 };
 export type ConcreateTypes$key = {
@@ -72,14 +72,14 @@ export type ConcreateTypes$key = {
 import { FragmentRefs } from "relay-runtime";
 export type FragmentSpread$data = {
   readonly id: string;
-  readonly justFrag: {
+  readonly justFrag: ({
     readonly " $fragmentSpreads": FragmentRefs<"PictureFragment">;
-  } | null;
-  readonly fragAndField: {
-    readonly uri: string | null;
+  } | null);
+  readonly fragAndField: ({
+    readonly uri: (string | null);
     readonly " $fragmentSpreads": FragmentRefs<"PictureFragment">;
-  } | null;
-  readonly " $fragmentSpreads": FragmentRefs<"OtherFragment" | "UserFrag1" | "UserFrag2">;
+  } | null);
+  readonly " $fragmentSpreads": FragmentRefs<("OtherFragment" | "UserFrag1" | "UserFrag2")>;
   readonly " $fragmentType": "FragmentSpread";
 };
 export type FragmentSpread$key = {
@@ -98,7 +98,7 @@ export type OtherFragment$key = {
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
-export type PageFragment$data = {
+export type PageFragment$data = ({
   readonly __typename: "Page";
   readonly " $fragmentType": "PageFragment";
 } | {
@@ -106,14 +106,14 @@ export type PageFragment$data = {
   // value in case none of the concrete values match.
   readonly __typename: "%other";
   readonly " $fragmentType": "PageFragment";
-};
+});
 export type PageFragment$key = {
   readonly " $data"?: PageFragment$data;
   readonly " $fragmentSpreads": FragmentRefs<"PageFragment">;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
-export type PictureFragment$data = {
+export type PictureFragment$data = ({
   readonly __typename: "Image";
   readonly " $fragmentType": "PictureFragment";
 } | {
@@ -121,14 +121,14 @@ export type PictureFragment$data = {
   // value in case none of the concrete values match.
   readonly __typename: "%other";
   readonly " $fragmentType": "PictureFragment";
-};
+});
 export type PictureFragment$key = {
   readonly " $data"?: PictureFragment$data;
   readonly " $fragmentSpreads": FragmentRefs<"PictureFragment">;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
-export type UserFrag1$data = {
+export type UserFrag1$data = ({
   readonly __typename: "User";
   readonly " $fragmentType": "UserFrag1";
 } | {
@@ -136,14 +136,14 @@ export type UserFrag1$data = {
   // value in case none of the concrete values match.
   readonly __typename: "%other";
   readonly " $fragmentType": "UserFrag1";
-};
+});
 export type UserFrag1$key = {
   readonly " $data"?: UserFrag1$data;
   readonly " $fragmentSpreads": FragmentRefs<"UserFrag1">;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
-export type UserFrag2$data = {
+export type UserFrag2$data = ({
   readonly __typename: "User";
   readonly " $fragmentType": "UserFrag2";
 } | {
@@ -151,7 +151,7 @@ export type UserFrag2$data = {
   // value in case none of the concrete values match.
   readonly __typename: "%other";
   readonly " $fragmentType": "UserFrag2";
-};
+});
 export type UserFrag2$key = {
   readonly " $data"?: UserFrag2$data;
   readonly " $fragmentSpreads": FragmentRefs<"UserFrag2">;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/inline-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/inline-fragment.expected
@@ -67,10 +67,10 @@ fragment SomeFragment on User {
 import { FragmentRefs } from "relay-runtime";
 export type InlineFragment$data = {
   readonly id: string;
-  readonly name?: string | null;
-  readonly message?: {
-    readonly text: string | null;
-  } | null;
+  readonly name?: (string | null);
+  readonly message?: ({
+    readonly text: (string | null);
+  } | null);
   readonly " $fragmentType": "InlineFragment";
 };
 export type InlineFragment$key = {
@@ -81,7 +81,7 @@ export type InlineFragment$key = {
 import { FragmentRefs } from "relay-runtime";
 export type InlineFragmentConditionalID$data = {
   readonly id?: string;
-  readonly name?: string | null;
+  readonly name?: (string | null);
   readonly " $fragmentType": "InlineFragmentConditionalID";
 };
 export type InlineFragmentConditionalID$key = {
@@ -91,16 +91,16 @@ export type InlineFragmentConditionalID$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type InlineFragmentKitchenSink$data = {
-  readonly actor: {
+  readonly actor: ({
     readonly id: string;
-    readonly profilePicture: {
-      readonly uri: string | null;
-      readonly width?: number | null;
-      readonly height?: number | null;
-    } | null;
-    readonly name?: string | null;
+    readonly profilePicture: ({
+      readonly uri: (string | null);
+      readonly width?: (number | null);
+      readonly height?: (number | null);
+    } | null);
+    readonly name?: (string | null);
     readonly " $fragmentSpreads": FragmentRefs<"SomeFragment">;
-  } | null;
+  } | null);
   readonly " $fragmentType": "InlineFragmentKitchenSink";
 };
 export type InlineFragmentKitchenSink$key = {
@@ -110,14 +110,14 @@ export type InlineFragmentKitchenSink$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type InlineFragmentWithOverlappingFields$data = {
-  readonly hometown?: {
+  readonly hometown?: ({
     readonly id: string;
-    readonly name: string | null;
-    readonly message?: {
-      readonly text: string | null;
-    } | null;
-  } | null;
-  readonly name?: string | null;
+    readonly name: (string | null);
+    readonly message?: ({
+      readonly text: (string | null);
+    } | null);
+  } | null);
+  readonly name?: (string | null);
   readonly " $fragmentType": "InlineFragmentWithOverlappingFields";
 };
 export type InlineFragmentWithOverlappingFields$key = {
@@ -126,7 +126,7 @@ export type InlineFragmentWithOverlappingFields$key = {
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
-export type SomeFragment$data = {
+export type SomeFragment$data = ({
   readonly __typename: "User";
   readonly " $fragmentType": "SomeFragment";
 } | {
@@ -134,7 +134,7 @@ export type SomeFragment$data = {
   // value in case none of the concrete values match.
   readonly __typename: "%other";
   readonly " $fragmentType": "SomeFragment";
-};
+});
 export type SomeFragment$key = {
   readonly " $data"?: SomeFragment$data;
   readonly " $fragmentSpreads": FragmentRefs<"SomeFragment">;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-field.expected
@@ -29,14 +29,14 @@ query UnionTypeTest {
 ==================================== OUTPUT ===================================
 export type UnionTypeTest$variables = {};
 export type UnionTypeTest$data = {
-  readonly neverNode: {
+  readonly neverNode: ({
     readonly __typename: "FakeNode";
     readonly id: string;
   } | {
     // This will never be '%other', but we need some
     // value in case none of the concrete values match.
     readonly __typename: "%other";
-  } | null;
+  } | null);
 };
 export type UnionTypeTest = {
   variables: UnionTypeTest$variables;
@@ -45,20 +45,20 @@ export type UnionTypeTest = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type LinkedField$data = {
-  readonly profilePicture: {
-    readonly uri: string | null;
-    readonly width: number | null;
-    readonly height: number | null;
-  } | null;
-  readonly hometown: {
+  readonly profilePicture: ({
+    readonly uri: (string | null);
+    readonly width: (number | null);
+    readonly height: (number | null);
+  } | null);
+  readonly hometown: ({
     readonly id: string;
-    readonly profilePicture: {
-      readonly uri: string | null;
-    } | null;
-  } | null;
-  readonly actor: {
+    readonly profilePicture: ({
+      readonly uri: (string | null);
+    } | null);
+  } | null);
+  readonly actor: ({
     readonly id: string;
-  } | null;
+  } | null);
   readonly " $fragmentType": "LinkedField";
 };
 export type LinkedField$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field-in-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field-in-query.expected
@@ -26,13 +26,13 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 import { FragmentRefs } from "relay-runtime";
 export type NameRendererQuery$variables = {};
 export type NameRendererQuery$data = {
-  readonly me: {
-    readonly nameRenderer: {
-      readonly __fragmentPropName?: string | null;
-      readonly __module_component?: string | null;
-      readonly " $fragmentSpreads": FragmentRefs<"PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name">;
-    } | null;
-  } | null;
+  readonly me: ({
+    readonly nameRenderer: ({
+      readonly __fragmentPropName?: (string | null);
+      readonly __module_component?: (string | null);
+      readonly " $fragmentSpreads": FragmentRefs<("PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name")>;
+    } | null);
+  } | null);
 };
 export type NameRendererQuery = {
   variables: NameRendererQuery$variables;
@@ -41,10 +41,10 @@ export type NameRendererQuery = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type MarkdownUserNameRenderer_name$data = {
-  readonly markdown: string | null;
-  readonly data: {
-    readonly markup: string | null;
-  } | null;
+  readonly markdown: (string | null);
+  readonly data: ({
+    readonly markup: (string | null);
+  } | null);
   readonly " $fragmentType": "MarkdownUserNameRenderer_name";
 };
 export type MarkdownUserNameRenderer_name$key = {
@@ -54,10 +54,10 @@ export type MarkdownUserNameRenderer_name$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type PlainUserNameRenderer_name$data = {
-  readonly plaintext: string | null;
-  readonly data: {
-    readonly text: string | null;
-  } | null;
+  readonly plaintext: (string | null);
+  readonly data: ({
+    readonly text: (string | null);
+  } | null);
   readonly " $fragmentType": "PlainUserNameRenderer_name";
 };
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field.expected
@@ -24,10 +24,10 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type MarkdownUserNameRenderer_name$data = {
-  readonly markdown: string | null;
-  readonly data: {
-    readonly markup: string | null;
-  } | null;
+  readonly markdown: (string | null);
+  readonly data: ({
+    readonly markup: (string | null);
+  } | null);
   readonly " $fragmentType": "MarkdownUserNameRenderer_name";
 };
 export type MarkdownUserNameRenderer_name$key = {
@@ -38,11 +38,11 @@ export type MarkdownUserNameRenderer_name$key = {
 import { FragmentRefs } from "relay-runtime";
 export type NameRendererFragment$data = {
   readonly id: string;
-  readonly nameRenderer: {
-    readonly __fragmentPropName?: string | null;
-    readonly __module_component?: string | null;
-    readonly " $fragmentSpreads": FragmentRefs<"PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name">;
-  } | null;
+  readonly nameRenderer: ({
+    readonly __fragmentPropName?: (string | null);
+    readonly __module_component?: (string | null);
+    readonly " $fragmentSpreads": FragmentRefs<("PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name")>;
+  } | null);
   readonly " $fragmentType": "NameRendererFragment";
 };
 export type NameRendererFragment$key = {
@@ -52,10 +52,10 @@ export type NameRendererFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type PlainUserNameRenderer_name$data = {
-  readonly plaintext: string | null;
-  readonly data: {
-    readonly text: string | null;
-  } | null;
+  readonly plaintext: (string | null);
+  readonly data: ({
+    readonly text: (string | null);
+  } | null);
   readonly " $fragmentType": "PlainUserNameRenderer_name";
 };
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-input-has-array.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-input-has-array.expected
@@ -8,26 +8,26 @@ mutation InputHasArray($input: UpdateAllSeenStateInput) @raw_response_type {
 }
 ==================================== OUTPUT ===================================
 export type UpdateAllSeenStateInput = {
-  clientMutationId?: string | null;
-  storyIds?: ReadonlyArray<string | null> | null;
+  clientMutationId?: (string | null);
+  storyIds?: (ReadonlyArray<(string | null)> | null);
 };
 export type InputHasArray$variables = {
-  input?: UpdateAllSeenStateInput | null;
+  input?: (UpdateAllSeenStateInput | null);
 };
 export type InputHasArray$data = {
-  readonly viewerNotificationsUpdateAllSeenState: {
-    readonly stories: ReadonlyArray<{
-      readonly actorCount: number | null;
-    } | null> | null;
-  } | null;
+  readonly viewerNotificationsUpdateAllSeenState: ({
+    readonly stories: (ReadonlyArray<({
+      readonly actorCount: (number | null);
+    } | null)> | null);
+  } | null);
 };
 export type InputHasArray$rawResponse = {
-  readonly viewerNotificationsUpdateAllSeenState: {
-    readonly stories: ReadonlyArray<{
-      readonly actorCount: number | null;
+  readonly viewerNotificationsUpdateAllSeenState: ({
+    readonly stories: (ReadonlyArray<({
+      readonly actorCount: (number | null);
       readonly id: string;
-    } | null> | null;
-  } | null;
+    } | null)> | null);
+  } | null);
 };
 export type InputHasArray = {
   variables: InputHasArray$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-client-extension.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-client-extension.expected
@@ -20,30 +20,30 @@ type Foo {
 }
 ==================================== OUTPUT ===================================
 export type UpdateAllSeenStateInput = {
-  clientMutationId?: string | null;
-  storyIds?: ReadonlyArray<string | null> | null;
+  clientMutationId?: (string | null);
+  storyIds?: (ReadonlyArray<(string | null)> | null);
 };
 export type Test$variables = {
-  input?: UpdateAllSeenStateInput | null;
+  input?: (UpdateAllSeenStateInput | null);
 };
 export type Test$data = {
-  readonly viewerNotificationsUpdateAllSeenState: {
-    readonly stories: ReadonlyArray<{
-      readonly foos: ReadonlyArray<{
-        readonly bar: string | null;
-      } | null> | null;
-    } | null> | null;
-  } | null;
+  readonly viewerNotificationsUpdateAllSeenState: ({
+    readonly stories: (ReadonlyArray<({
+      readonly foos: (ReadonlyArray<({
+        readonly bar: (string | null);
+      } | null)> | null);
+    } | null)> | null);
+  } | null);
 };
 export type Test$rawResponse = {
-  readonly viewerNotificationsUpdateAllSeenState: {
-    readonly stories: ReadonlyArray<{
+  readonly viewerNotificationsUpdateAllSeenState: ({
+    readonly stories: (ReadonlyArray<({
       readonly id: string;
-      readonly foos?: ReadonlyArray<{
-        readonly bar: string | null;
-      } | null> | null;
-    } | null> | null;
-  } | null;
+      readonly foos?: (ReadonlyArray<({
+        readonly bar: (string | null);
+      } | null)> | null);
+    } | null)> | null);
+  } | null);
 };
 export type Test = {
   variables: Test$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-enums-on-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-enums-on-fragment.expected
@@ -28,57 +28,57 @@ fragment FriendFragment on User {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
-export type TestEnums = "mark" | "zuck" | "%future added value";
+export type TestEnums = ("mark" | "zuck" | "%future added value");
 export type CommentCreateInput = {
-  clientMutationId?: string | null;
-  feedbackId?: string | null;
-  feedback?: CommentfeedbackFeedback | null;
+  clientMutationId?: (string | null);
+  feedbackId?: (string | null);
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentfeedbackFeedback = {
-  comment?: FeedbackcommentComment | null;
+  comment?: (FeedbackcommentComment | null);
 };
 export type FeedbackcommentComment = {
-  feedback?: CommentfeedbackFeedback | null;
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentCreateMutation$variables = {
   input: CommentCreateInput;
-  first?: number | null;
-  orderBy?: ReadonlyArray<string> | null;
+  first?: (number | null);
+  orderBy?: (ReadonlyArray<string> | null);
 };
 export type CommentCreateMutation$data = {
-  readonly commentCreate: {
-    readonly comment: {
-      readonly friends: {
-        readonly edges: ReadonlyArray<{
-          readonly node: {
+  readonly commentCreate: ({
+    readonly comment: ({
+      readonly friends: ({
+        readonly edges: (ReadonlyArray<({
+          readonly node: ({
             readonly id: string;
             readonly __typename: string;
             readonly " $fragmentSpreads": FragmentRefs<"FriendFragment">;
-          } | null;
-        } | null> | null;
-      } | null;
-    } | null;
-  } | null;
+          } | null);
+        } | null)> | null);
+      } | null);
+    } | null);
+  } | null);
 };
 export type CommentCreateMutation$rawResponse = {
-  readonly commentCreate: {
-    readonly comment: {
-      readonly friends: {
-        readonly edges: ReadonlyArray<{
-          readonly node: {
+  readonly commentCreate: ({
+    readonly comment: ({
+      readonly friends: ({
+        readonly edges: (ReadonlyArray<({
+          readonly node: ({
             readonly id: string;
             readonly __typename: "User";
-            readonly name: string | null;
-            readonly lastName: string | null;
-            readonly profilePicture2: {
-              readonly test_enums: TestEnums | null;
-            } | null;
-          } | null;
-        } | null> | null;
-      } | null;
+            readonly name: (string | null);
+            readonly lastName: (string | null);
+            readonly profilePicture2: ({
+              readonly test_enums: (TestEnums | null);
+            } | null);
+          } | null);
+        } | null)> | null);
+      } | null);
       readonly id: string;
-    } | null;
-  } | null;
+    } | null);
+  } | null);
 };
 export type CommentCreateMutation = {
   variables: CommentCreateMutation$variables;
@@ -86,14 +86,14 @@ export type CommentCreateMutation = {
   rawResponse: CommentCreateMutation$rawResponse;
 };
 -------------------------------------------------------------------------------
-export type TestEnums = "mark" | "zuck" | "%future added value";
+export type TestEnums = ("mark" | "zuck" | "%future added value");
 import { FragmentRefs } from "relay-runtime";
 export type FriendFragment$data = {
-  readonly name: string | null;
-  readonly lastName: string | null;
-  readonly profilePicture2: {
-    readonly test_enums: TestEnums | null;
-  } | null;
+  readonly name: (string | null);
+  readonly lastName: (string | null);
+  readonly profilePicture2: ({
+    readonly test_enums: (TestEnums | null);
+  } | null);
   readonly " $fragmentType": "FriendFragment";
 };
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-nested-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-nested-fragments.expected
@@ -33,54 +33,54 @@ fragment FeedbackFragment on Feedback {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type CommentCreateInput = {
-  clientMutationId?: string | null;
-  feedbackId?: string | null;
-  feedback?: CommentfeedbackFeedback | null;
+  clientMutationId?: (string | null);
+  feedbackId?: (string | null);
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentfeedbackFeedback = {
-  comment?: FeedbackcommentComment | null;
+  comment?: (FeedbackcommentComment | null);
 };
 export type FeedbackcommentComment = {
-  feedback?: CommentfeedbackFeedback | null;
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentCreateMutation$variables = {
   input: CommentCreateInput;
-  first?: number | null;
-  orderBy?: ReadonlyArray<string> | null;
+  first?: (number | null);
+  orderBy?: (ReadonlyArray<string> | null);
 };
 export type CommentCreateMutation$data = {
-  readonly commentCreate: {
-    readonly comment: {
-      readonly friends: {
-        readonly edges: ReadonlyArray<{
-          readonly node: {
-            readonly lastName: string | null;
+  readonly commentCreate: ({
+    readonly comment: ({
+      readonly friends: ({
+        readonly edges: (ReadonlyArray<({
+          readonly node: ({
+            readonly lastName: (string | null);
             readonly " $fragmentSpreads": FragmentRefs<"FriendFragment">;
-          } | null;
-        } | null> | null;
-      } | null;
-    } | null;
-  } | null;
+          } | null);
+        } | null)> | null);
+      } | null);
+    } | null);
+  } | null);
 };
 export type CommentCreateMutation$rawResponse = {
-  readonly commentCreate: {
-    readonly comment: {
-      readonly friends: {
-        readonly edges: ReadonlyArray<{
-          readonly node: {
-            readonly lastName: string | null;
-            readonly name: string | null;
-            readonly feedback: {
+  readonly commentCreate: ({
+    readonly comment: ({
+      readonly friends: ({
+        readonly edges: (ReadonlyArray<({
+          readonly node: ({
+            readonly lastName: (string | null);
+            readonly name: (string | null);
+            readonly feedback: ({
               readonly id: string;
-              readonly name: string | null;
-            } | null;
+              readonly name: (string | null);
+            } | null);
             readonly id: string;
-          } | null;
-        } | null> | null;
-      } | null;
+          } | null);
+        } | null)> | null);
+      } | null);
       readonly id: string;
-    } | null;
-  } | null;
+    } | null);
+  } | null);
 };
 export type CommentCreateMutation = {
   variables: CommentCreateMutation$variables;
@@ -91,7 +91,7 @@ export type CommentCreateMutation = {
 import { FragmentRefs } from "relay-runtime";
 export type FeedbackFragment$data = {
   readonly id: string;
-  readonly name: string | null;
+  readonly name: (string | null);
   readonly " $fragmentType": "FeedbackFragment";
 };
 export type FeedbackFragment$key = {
@@ -101,11 +101,11 @@ export type FeedbackFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type FriendFragment$data = {
-  readonly name: string | null;
-  readonly lastName: string | null;
-  readonly feedback: {
+  readonly name: (string | null);
+  readonly lastName: (string | null);
+  readonly feedback: ({
     readonly " $fragmentSpreads": FragmentRefs<"FeedbackFragment">;
-  } | null;
+  } | null);
   readonly " $fragmentType": "FriendFragment";
 };
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-response-on-inline-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation-with-response-on-inline-fragments.expected
@@ -29,57 +29,57 @@ fragment InlineFragmentWithOverlappingFields on Actor {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type CommentCreateInput = {
-  clientMutationId?: string | null;
-  feedbackId?: string | null;
-  feedback?: CommentfeedbackFeedback | null;
+  clientMutationId?: (string | null);
+  feedbackId?: (string | null);
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentfeedbackFeedback = {
-  comment?: FeedbackcommentComment | null;
+  comment?: (FeedbackcommentComment | null);
 };
 export type FeedbackcommentComment = {
-  feedback?: CommentfeedbackFeedback | null;
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type TestMutation$variables = {
   input: CommentCreateInput;
 };
 export type TestMutation$data = {
-  readonly commentCreate: {
-    readonly viewer: {
-      readonly actor: {
+  readonly commentCreate: ({
+    readonly viewer: ({
+      readonly actor: ({
         readonly " $fragmentSpreads": FragmentRefs<"InlineFragmentWithOverlappingFields">;
-      } | null;
-    } | null;
-  } | null;
+      } | null);
+    } | null);
+  } | null);
 };
 export type TestMutation$rawResponse = {
-  readonly commentCreate: {
-    readonly viewer: {
-      readonly actor: {
+  readonly commentCreate: ({
+    readonly viewer: ({
+      readonly actor: ({
         readonly __typename: "User";
         readonly __isActor: "User";
         readonly id: string;
-        readonly hometown: {
+        readonly hometown: ({
           readonly id: string;
-          readonly name: string | null;
-        } | null;
+          readonly name: (string | null);
+        } | null);
       } | {
         readonly __typename: "Page";
         readonly __isActor: "Page";
         readonly id: string;
-        readonly name: string | null;
-        readonly hometown: {
+        readonly name: (string | null);
+        readonly hometown: ({
           readonly id: string;
-          readonly message: {
-            readonly text: string | null;
-          } | null;
-        } | null;
+          readonly message: ({
+            readonly text: (string | null);
+          } | null);
+        } | null);
       } | {
         readonly __typename: string;
         readonly __isActor: string;
         readonly id: string;
-      } | null;
-    } | null;
-  } | null;
+      } | null);
+    } | null);
+  } | null);
 };
 export type TestMutation = {
   variables: TestMutation$variables;
@@ -89,14 +89,14 @@ export type TestMutation = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type InlineFragmentWithOverlappingFields$data = {
-  readonly hometown?: {
+  readonly hometown?: ({
     readonly id: string;
-    readonly name: string | null;
-    readonly message?: {
-      readonly text: string | null;
-    } | null;
-  } | null;
-  readonly name?: string | null;
+    readonly name: (string | null);
+    readonly message?: ({
+      readonly text: (string | null);
+    } | null);
+  } | null);
+  readonly name?: (string | null);
   readonly " $fragmentType": "InlineFragmentWithOverlappingFields";
 };
 export type InlineFragmentWithOverlappingFields$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/mutation.expected
@@ -16,31 +16,31 @@ mutation CommentCreateMutation(
 }
 ==================================== OUTPUT ===================================
 export type CommentCreateInput = {
-  clientMutationId?: string | null;
-  feedbackId?: string | null;
-  feedback?: CommentfeedbackFeedback | null;
+  clientMutationId?: (string | null);
+  feedbackId?: (string | null);
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentfeedbackFeedback = {
-  comment?: FeedbackcommentComment | null;
+  comment?: (FeedbackcommentComment | null);
 };
 export type FeedbackcommentComment = {
-  feedback?: CommentfeedbackFeedback | null;
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentCreateMutation$variables = {
   input: CommentCreateInput;
-  first?: number | null;
-  orderBy?: ReadonlyArray<string> | null;
+  first?: (number | null);
+  orderBy?: (ReadonlyArray<string> | null);
 };
 export type CommentCreateMutation$data = {
-  readonly commentCreate: {
-    readonly comment: {
+  readonly commentCreate: ({
+    readonly comment: ({
       readonly id: string;
-      readonly name: string | null;
-      readonly friends: {
-        readonly count: number | null;
-      } | null;
-    } | null;
-  } | null;
+      readonly name: (string | null);
+      readonly friends: ({
+        readonly count: (number | null);
+      } | null);
+    } | null);
+  } | null);
 };
 export type CommentCreateMutation = {
   variables: CommentCreateMutation$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-handles.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-handles.expected
@@ -21,23 +21,23 @@ export type LinkedHandleField$variables = {
   id: string;
 };
 export type LinkedHandleField$data = {
-  readonly node: {
-    readonly friends?: {
-      readonly count: number | null;
-    } | null;
-  } | null;
+  readonly node: ({
+    readonly friends?: ({
+      readonly count: (number | null);
+    } | null);
+  } | null);
 };
 export type LinkedHandleField$rawResponse = {
-  readonly node: {
+  readonly node: ({
     readonly __typename: "User";
     readonly id: string;
-    readonly friends: {
-      readonly count: number | null;
-    } | null;
+    readonly friends: ({
+      readonly count: (number | null);
+    } | null);
   } | {
     readonly __typename: string;
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type LinkedHandleField = {
   variables: LinkedHandleField$variables;
@@ -49,19 +49,19 @@ export type ScalarHandleField$variables = {
   id: string;
 };
 export type ScalarHandleField$data = {
-  readonly node: {
-    readonly name?: string | null;
-  } | null;
+  readonly node: ({
+    readonly name?: (string | null);
+  } | null);
 };
 export type ScalarHandleField$rawResponse = {
-  readonly node: {
+  readonly node: ({
     readonly __typename: "User";
     readonly id: string;
-    readonly name: string | null;
+    readonly name: (string | null);
   } | {
     readonly __typename: string;
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type ScalarHandleField = {
   variables: ScalarHandleField$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-match-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-match-fields.expected
@@ -31,47 +31,47 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 import { FragmentRefs, Local3DPayload } from "relay-runtime";
 export type Test$variables = {};
 export type Test$data = {
-  readonly node: {
+  readonly node: ({
     readonly " $fragmentSpreads": FragmentRefs<"NameRendererFragment">;
-  } | null;
+  } | null);
 };
 export type PlainUserNameRenderer_name = {
-  readonly plaintext: string | null;
-  readonly data: {
-    readonly text: string | null;
-    readonly id: string | null;
-  } | null;
+  readonly plaintext: (string | null);
+  readonly data: ({
+    readonly text: (string | null);
+    readonly id: (string | null);
+  } | null);
 };
 export type MarkdownUserNameRenderer_name = {
-  readonly markdown: string | null;
-  readonly data: {
-    readonly markup: string | null;
-    readonly id: string | null;
-  } | null;
+  readonly markdown: (string | null);
+  readonly data: ({
+    readonly markup: (string | null);
+    readonly id: (string | null);
+  } | null);
 };
 export type Test$rawResponse = {
-  readonly node: {
+  readonly node: ({
     readonly __typename: "User";
     readonly id: string;
-    readonly nameRenderer: {
+    readonly nameRenderer: ({
       readonly __typename: "PlainUserNameRenderer";
-      readonly __module_operation_NameRendererFragment: any | null;
-      readonly __module_component_NameRendererFragment: any | null;
+      readonly __module_operation_NameRendererFragment: (any | null);
+      readonly __module_component_NameRendererFragment: (any | null);
     } | Local3DPayload<"NameRendererFragment", {
       readonly __typename: "PlainUserNameRenderer";
     }> | {
       readonly __typename: "MarkdownUserNameRenderer";
-      readonly __module_operation_NameRendererFragment: any | null;
-      readonly __module_component_NameRendererFragment: any | null;
+      readonly __module_operation_NameRendererFragment: (any | null);
+      readonly __module_component_NameRendererFragment: (any | null);
     } | Local3DPayload<"NameRendererFragment", {
       readonly __typename: "MarkdownUserNameRenderer";
     }> | {
       readonly __typename: string;
-    } | null;
+    } | null);
   } | {
     readonly __typename: string;
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type Test = {
   variables: Test$variables;
@@ -81,10 +81,10 @@ export type Test = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type MarkdownUserNameRenderer_name$data = {
-  readonly markdown: string | null;
-  readonly data: {
-    readonly markup: string | null;
-  } | null;
+  readonly markdown: (string | null);
+  readonly data: ({
+    readonly markup: (string | null);
+  } | null);
   readonly " $fragmentType": "MarkdownUserNameRenderer_name";
 };
 export type MarkdownUserNameRenderer_name$key = {
@@ -95,11 +95,11 @@ export type MarkdownUserNameRenderer_name$key = {
 import { FragmentRefs } from "relay-runtime";
 export type NameRendererFragment$data = {
   readonly id: string;
-  readonly nameRenderer: {
-    readonly __fragmentPropName?: string | null;
-    readonly __module_component?: string | null;
-    readonly " $fragmentSpreads": FragmentRefs<"PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name">;
-  } | null;
+  readonly nameRenderer: ({
+    readonly __fragmentPropName?: (string | null);
+    readonly __module_component?: (string | null);
+    readonly " $fragmentSpreads": FragmentRefs<("PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name")>;
+  } | null);
   readonly " $fragmentType": "NameRendererFragment";
 };
 export type NameRendererFragment$key = {
@@ -109,10 +109,10 @@ export type NameRendererFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type PlainUserNameRenderer_name$data = {
-  readonly plaintext: string | null;
-  readonly data: {
-    readonly text: string | null;
-  } | null;
+  readonly plaintext: (string | null);
+  readonly data: ({
+    readonly text: (string | null);
+  } | null);
   readonly " $fragmentType": "PlainUserNameRenderer_name";
 };
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-module-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-module-field.expected
@@ -20,28 +20,28 @@ fragment Test_userRenderer on PlainUserRenderer {
 import { FragmentRefs, Local3DPayload } from "relay-runtime";
 export type Test$variables = {};
 export type Test$data = {
-  readonly node: {
+  readonly node: ({
     readonly " $fragmentSpreads": FragmentRefs<"Test_user">;
-  } | null;
+  } | null);
 };
 export type Test_userRenderer = {
-  readonly user: {
-    readonly username: string | null;
+  readonly user: ({
+    readonly username: (string | null);
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type Test$rawResponse = {
-  readonly node: {
+  readonly node: ({
     readonly __typename: "User";
     readonly id: string;
-    readonly plainUserRenderer: {
-      readonly __module_operation_Test_user: any | null;
-      readonly __module_component_Test_user: any | null;
-    } | Local3DPayload<"Test_user", {}> | null;
+    readonly plainUserRenderer: ({
+      readonly __module_operation_Test_user: (any | null);
+      readonly __module_component_Test_user: (any | null);
+    } | Local3DPayload<"Test_user", {}> | null);
   } | {
     readonly __typename: string;
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type Test = {
   variables: Test$variables;
@@ -51,11 +51,11 @@ export type Test = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type Test_user$data = {
-  readonly plainUserRenderer: {
-    readonly __fragmentPropName: string | null;
-    readonly __module_component: string | null;
+  readonly plainUserRenderer: ({
+    readonly __fragmentPropName: (string | null);
+    readonly __module_component: (string | null);
     readonly " $fragmentSpreads": FragmentRefs<"Test_userRenderer">;
-  } | null;
+  } | null);
   readonly " $fragmentType": "Test_user";
 };
 export type Test_user$key = {
@@ -65,9 +65,9 @@ export type Test_user$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type Test_userRenderer$data = {
-  readonly user: {
-    readonly username: string | null;
-  } | null;
+  readonly user: ({
+    readonly username: (string | null);
+  } | null);
   readonly " $fragmentType": "Test_userRenderer";
 };
 export type Test_userRenderer$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-multiple-match-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-multiple-match-fields.expected
@@ -51,80 +51,80 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 import { FragmentRefs, Local3DPayload } from "relay-runtime";
 export type Test$variables = {};
 export type Test$data = {
-  readonly node: {
-    readonly username?: string | null;
+  readonly node: ({
+    readonly username?: (string | null);
     readonly " $fragmentSpreads": FragmentRefs<"NameRendererFragment">;
-  } | null;
-  readonly viewer: {
-    readonly actor: {
-      readonly name?: string | null;
+  } | null);
+  readonly viewer: ({
+    readonly actor: ({
+      readonly name?: (string | null);
       readonly " $fragmentSpreads": FragmentRefs<"AnotherNameRendererFragment">;
-    } | null;
-  } | null;
+    } | null);
+  } | null);
 };
 export type PlainUserNameRenderer_name = {
-  readonly plaintext: string | null;
-  readonly data: {
-    readonly text: string | null;
-    readonly id: string | null;
-  } | null;
+  readonly plaintext: (string | null);
+  readonly data: ({
+    readonly text: (string | null);
+    readonly id: (string | null);
+  } | null);
 };
 export type MarkdownUserNameRenderer_name = {
-  readonly markdown: string | null;
-  readonly data: {
-    readonly markup: string | null;
-    readonly id: string | null;
-  } | null;
+  readonly markdown: (string | null);
+  readonly data: ({
+    readonly markup: (string | null);
+    readonly id: (string | null);
+  } | null);
 };
 export type Test$rawResponse = {
-  readonly node: {
+  readonly node: ({
     readonly __typename: "User";
     readonly id: string;
-    readonly username: string | null;
-    readonly nameRenderer: {
+    readonly username: (string | null);
+    readonly nameRenderer: ({
       readonly __typename: "PlainUserNameRenderer";
-      readonly __module_operation_NameRendererFragment: any | null;
-      readonly __module_component_NameRendererFragment: any | null;
+      readonly __module_operation_NameRendererFragment: (any | null);
+      readonly __module_component_NameRendererFragment: (any | null);
     } | Local3DPayload<"NameRendererFragment", {
       readonly __typename: "PlainUserNameRenderer";
     }> | {
       readonly __typename: "MarkdownUserNameRenderer";
-      readonly __module_operation_NameRendererFragment: any | null;
-      readonly __module_component_NameRendererFragment: any | null;
+      readonly __module_operation_NameRendererFragment: (any | null);
+      readonly __module_component_NameRendererFragment: (any | null);
     } | Local3DPayload<"NameRendererFragment", {
       readonly __typename: "MarkdownUserNameRenderer";
     }> | {
       readonly __typename: string;
-    } | null;
+    } | null);
   } | {
     readonly __typename: string;
     readonly id: string;
-  } | null;
-  readonly viewer: {
-    readonly actor: {
+  } | null);
+  readonly viewer: ({
+    readonly actor: ({
       readonly __typename: "User";
       readonly id: string;
-      readonly name: string | null;
-      readonly nameRenderer: {
+      readonly name: (string | null);
+      readonly nameRenderer: ({
         readonly __typename: "PlainUserNameRenderer";
-        readonly __module_operation_AnotherNameRendererFragment: any | null;
-        readonly __module_component_AnotherNameRendererFragment: any | null;
+        readonly __module_operation_AnotherNameRendererFragment: (any | null);
+        readonly __module_component_AnotherNameRendererFragment: (any | null);
       } | Local3DPayload<"AnotherNameRendererFragment", {
         readonly __typename: "PlainUserNameRenderer";
       }> | {
         readonly __typename: "MarkdownUserNameRenderer";
-        readonly __module_operation_AnotherNameRendererFragment: any | null;
-        readonly __module_component_AnotherNameRendererFragment: any | null;
+        readonly __module_operation_AnotherNameRendererFragment: (any | null);
+        readonly __module_component_AnotherNameRendererFragment: (any | null);
       } | Local3DPayload<"AnotherNameRendererFragment", {
         readonly __typename: "MarkdownUserNameRenderer";
       }> | {
         readonly __typename: string;
-      } | null;
+      } | null);
     } | {
       readonly __typename: string;
       readonly id: string;
-    } | null;
-  } | null;
+    } | null);
+  } | null);
 };
 export type Test = {
   variables: Test$variables;
@@ -134,12 +134,12 @@ export type Test = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type AnotherNameRendererFragment$data = {
-  readonly name: string | null;
-  readonly nameRenderer: {
-    readonly __fragmentPropName?: string | null;
-    readonly __module_component?: string | null;
-    readonly " $fragmentSpreads": FragmentRefs<"PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name">;
-  } | null;
+  readonly name: (string | null);
+  readonly nameRenderer: ({
+    readonly __fragmentPropName?: (string | null);
+    readonly __module_component?: (string | null);
+    readonly " $fragmentSpreads": FragmentRefs<("PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name")>;
+  } | null);
   readonly " $fragmentType": "AnotherNameRendererFragment";
 };
 export type AnotherNameRendererFragment$key = {
@@ -149,10 +149,10 @@ export type AnotherNameRendererFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type MarkdownUserNameRenderer_name$data = {
-  readonly markdown: string | null;
-  readonly data: {
-    readonly markup: string | null;
-  } | null;
+  readonly markdown: (string | null);
+  readonly data: ({
+    readonly markup: (string | null);
+  } | null);
   readonly " $fragmentType": "MarkdownUserNameRenderer_name";
 };
 export type MarkdownUserNameRenderer_name$key = {
@@ -163,11 +163,11 @@ export type MarkdownUserNameRenderer_name$key = {
 import { FragmentRefs } from "relay-runtime";
 export type NameRendererFragment$data = {
   readonly id: string;
-  readonly nameRenderer: {
-    readonly __fragmentPropName?: string | null;
-    readonly __module_component?: string | null;
-    readonly " $fragmentSpreads": FragmentRefs<"PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name">;
-  } | null;
+  readonly nameRenderer: ({
+    readonly __fragmentPropName?: (string | null);
+    readonly __module_component?: (string | null);
+    readonly " $fragmentSpreads": FragmentRefs<("PlainUserNameRenderer_name" | "MarkdownUserNameRenderer_name")>;
+  } | null);
   readonly " $fragmentType": "NameRendererFragment";
 };
 export type NameRendererFragment$key = {
@@ -177,10 +177,10 @@ export type NameRendererFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type PlainUserNameRenderer_name$data = {
-  readonly plaintext: string | null;
-  readonly data: {
-    readonly text: string | null;
-  } | null;
+  readonly plaintext: (string | null);
+  readonly data: ({
+    readonly text: (string | null);
+  } | null);
   readonly " $fragmentType": "PlainUserNameRenderer_name";
 };
 export type PlainUserNameRenderer_name$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-conditional.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-conditional.expected
@@ -22,24 +22,24 @@ export type ExampleQuery$variables = {
   condition: boolean;
 };
 export type ExampleQuery$data = {
-  readonly node: {
+  readonly node: ({
     readonly " $fragmentSpreads": FragmentRefs<"FriendFragment">;
-  } | null;
+  } | null);
 };
 export type ExampleQuery$rawResponse = {
-  readonly node: {
+  readonly node: ({
     readonly __typename: "User";
     readonly id: string;
-    readonly name: string | null;
-    readonly lastName: string | null;
-    readonly feedback: {
+    readonly name: (string | null);
+    readonly lastName: (string | null);
+    readonly feedback: ({
       readonly id: string;
-      readonly name: string | null;
-    } | null;
+      readonly name: (string | null);
+    } | null);
   } | {
     readonly __typename: string;
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type ExampleQuery = {
   variables: ExampleQuery$variables;
@@ -49,12 +49,12 @@ export type ExampleQuery = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type FriendFragment$data = {
-  readonly name?: string | null;
-  readonly lastName?: string | null;
-  readonly feedback?: {
+  readonly name?: (string | null);
+  readonly lastName?: (string | null);
+  readonly feedback?: ({
     readonly id: string;
-    readonly name: string | null;
-  } | null;
+    readonly name: (string | null);
+  } | null);
   readonly " $fragmentType": "FriendFragment";
 };
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-literal-conditional.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-literal-conditional.expected
@@ -27,20 +27,20 @@ export type ExampleQuery$variables = {
   id: string;
 };
 export type ExampleQuery$data = {
-  readonly node: {
-    readonly username: string | null;
-    readonly friends?: {
-      readonly count: number | null;
-    } | null;
+  readonly node: ({
+    readonly username: (string | null);
+    readonly friends?: ({
+      readonly count: (number | null);
+    } | null);
     readonly " $fragmentSpreads": FragmentRefs<"FriendFragment">;
-  } | null;
+  } | null);
 };
 export type ExampleQuery$rawResponse = {
-  readonly node: {
+  readonly node: ({
     readonly __typename: string;
-    readonly username: string | null;
+    readonly username: (string | null);
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type ExampleQuery = {
   variables: ExampleQuery$variables;
@@ -50,12 +50,12 @@ export type ExampleQuery = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type FriendFragment$data = {
-  readonly name?: string | null;
-  readonly lastName?: string | null;
-  readonly feedback?: {
+  readonly name?: (string | null);
+  readonly lastName?: (string | null);
+  readonly feedback?: ({
     readonly id: string;
-    readonly name: string | null;
-  } | null;
+    readonly name: (string | null);
+  } | null);
   readonly " $fragmentType": "FriendFragment";
 };
 export type FriendFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.expected
@@ -19,46 +19,46 @@ query TestDefer @raw_response_type {
 ==================================== OUTPUT ===================================
 export type TestDefer$variables = {};
 export type TestDefer$data = {
-  readonly node: {
-    readonly name?: string | null;
-    readonly friends?: {
-      readonly edges: ReadonlyArray<{
-        readonly node: {
-          readonly actor: {
-            readonly name: string | null;
-          } | null;
-        } | null;
-      } | null> | null;
-    } | null;
-  } | null;
+  readonly node: ({
+    readonly name?: (string | null);
+    readonly friends?: ({
+      readonly edges: (ReadonlyArray<({
+        readonly node: ({
+          readonly actor: ({
+            readonly name: (string | null);
+          } | null);
+        } | null);
+      } | null)> | null);
+    } | null);
+  } | null);
 };
 export type TestDefer$rawResponse = {
-  readonly node: {
+  readonly node: ({
     readonly __typename: "User";
     readonly id: string;
-    readonly name: string | null;
-    readonly friends: {
-      readonly edges: ReadonlyArray<{
-        readonly node: {
-          readonly actor: {
+    readonly name: (string | null);
+    readonly friends: ({
+      readonly edges: (ReadonlyArray<({
+        readonly node: ({
+          readonly actor: ({
             readonly __typename: string;
-            readonly name: string | null;
+            readonly name: (string | null);
             readonly id: string;
-          } | null;
+          } | null);
           readonly id: string;
           readonly __typename: "User";
-        } | null;
-        readonly cursor: string | null;
-      } | null> | null;
-      readonly pageInfo: {
-        readonly endCursor: string | null;
-        readonly hasNextPage: boolean | null;
-      } | null;
-    } | null;
+        } | null);
+        readonly cursor: (string | null);
+      } | null)> | null);
+      readonly pageInfo: ({
+        readonly endCursor: (string | null);
+        readonly hasNextPage: (boolean | null);
+      } | null);
+    } | null);
   } | {
     readonly __typename: string;
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type TestDefer = {
   variables: TestDefer$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.expected
@@ -20,39 +20,39 @@ query TestStream @raw_response_type {
 ==================================== OUTPUT ===================================
 export type TestStream$variables = {};
 export type TestStream$data = {
-  readonly node: {
-    readonly name?: string | null;
-    readonly friends?: {
-      readonly edges: ReadonlyArray<{
-        readonly node: {
+  readonly node: ({
+    readonly name?: (string | null);
+    readonly friends?: ({
+      readonly edges: (ReadonlyArray<({
+        readonly node: ({
           readonly id: string;
-        } | null;
-      } | null> | null;
-    } | null;
-  } | null;
+        } | null);
+      } | null)> | null);
+    } | null);
+  } | null);
 };
 export type TestStream$rawResponse = {
-  readonly node: {
+  readonly node: ({
     readonly __typename: "User";
     readonly id: string;
-    readonly name: string | null;
-    readonly friends: {
-      readonly edges: ReadonlyArray<{
-        readonly node: {
+    readonly name: (string | null);
+    readonly friends: ({
+      readonly edges: (ReadonlyArray<({
+        readonly node: ({
           readonly id: string;
           readonly __typename: "User";
-        } | null;
-        readonly cursor: string | null;
-      } | null> | null;
-      readonly pageInfo: {
-        readonly endCursor: string | null;
-        readonly hasNextPage: boolean | null;
-      } | null;
-    } | null;
+        } | null);
+        readonly cursor: (string | null);
+      } | null)> | null);
+      readonly pageInfo: ({
+        readonly endCursor: (string | null);
+        readonly hasNextPage: (boolean | null);
+      } | null);
+    } | null);
   } | {
     readonly __typename: string;
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type TestStream = {
   variables: TestStream$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/refetchable-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/refetchable-fragment.expected
@@ -12,9 +12,9 @@ export type RefetchableFragmentQuery$variables = {
   id: string;
 };
 export type RefetchableFragmentQuery$data = {
-  readonly node: {
+  readonly node: ({
     readonly " $fragmentSpreads": FragmentRefs<"RefetchableFragment">;
-  } | null;
+  } | null);
 };
 export type RefetchableFragmentQuery = {
   variables: RefetchableFragmentQuery$variables;
@@ -24,9 +24,9 @@ export type RefetchableFragmentQuery = {
 import { FragmentRefs } from "relay-runtime";
 export type RefetchableFragment$data = {
   readonly id: string;
-  readonly fragAndField: {
-    readonly uri: string | null;
-  } | null;
+  readonly fragAndField: ({
+    readonly uri: (string | null);
+  } | null);
   readonly " $fragmentType": "RefetchableFragment";
 };
 export type RefetchableFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/refetchable.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/refetchable.expected
@@ -12,9 +12,9 @@ export type FlowRefetchableFragmentQuery$variables = {
   id: string;
 };
 export type FlowRefetchableFragmentQuery$data = {
-  readonly node: {
+  readonly node: ({
     readonly " $fragmentSpreads": FragmentRefs<"FlowRefetchableFragment">;
-  } | null;
+  } | null);
 };
 export type FlowRefetchableFragmentQuery = {
   variables: FlowRefetchableFragmentQuery$variables;
@@ -24,7 +24,7 @@ export type FlowRefetchableFragmentQuery = {
 import { FragmentRefs } from "relay-runtime";
 export type FlowRefetchableFragment$data = {
   readonly id: string;
-  readonly name?: string | null;
+  readonly name?: (string | null);
   readonly " $fragmentType": "FlowRefetchableFragment";
 };
 export type FlowRefetchableFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/relay-client-id-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/relay-client-id-field.expected
@@ -32,25 +32,25 @@ export type RelayClientIDFieldQuery$variables = {
 };
 export type RelayClientIDFieldQuery$data = {
   readonly __id: string;
-  readonly me: {
+  readonly me: ({
     readonly __id: string;
     readonly __typename: string;
     readonly id: string;
-  } | null;
-  readonly node: {
+  } | null);
+  readonly node: ({
     readonly __id: string;
     readonly __typename: string;
     readonly id: string;
-    readonly commentBody?: {
+    readonly commentBody?: ({
       readonly __id: string;
       readonly __typename: string;
-      readonly text?: {
+      readonly text?: ({
         readonly __id: string;
         readonly __typename: string;
-        readonly text: string | null;
-      } | null;
-    } | null;
-  } | null;
+        readonly text: (string | null);
+      } | null);
+    } | null);
+  } | null);
 };
 export type RelayClientIDFieldQuery = {
   variables: RelayClientIDFieldQuery$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-through-inline-fragments-to-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-through-inline-fragments-to-fragment.expected
@@ -9,7 +9,7 @@ fragment Foo on Node {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
-export type Foo$data = {
+export type Foo$data = ({
   readonly __typename: "User";
   readonly name: string;
   readonly " $fragmentType": "Foo";
@@ -18,7 +18,7 @@ export type Foo$data = {
   // value in case none of the concrete values match.
   readonly __typename: "%other";
   readonly " $fragmentType": "Foo";
-} | null;
+} | null);
 export type Foo$key = {
   readonly " $data"?: Foo$data;
   readonly " $fragmentSpreads": FragmentRefs<"Foo">;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-fragment.expected
@@ -5,11 +5,11 @@ fragment NonNullFragment on User {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
-export type NonNullFragment$data = {
-  readonly firstName: string | null;
+export type NonNullFragment$data = ({
+  readonly firstName: (string | null);
   readonly lastName: string;
   readonly " $fragmentType": "NonNullFragment";
-} | null;
+} | null);
 export type NonNullFragment$key = {
   readonly " $data"?: NonNullFragment$data;
   readonly " $fragmentSpreads": FragmentRefs<"NonNullFragment">;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-item-in-plural-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-item-in-plural-field.expected
@@ -9,11 +9,11 @@ fragment NonNullFragment on User {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type NonNullFragment$data = {
-  readonly firstName: string | null;
-  readonly screennames: ReadonlyArray<{
-    readonly name: string | null;
+  readonly firstName: (string | null);
+  readonly screennames: (ReadonlyArray<({
+    readonly name: (string | null);
     readonly service: string;
-  } | null> | null;
+  } | null)> | null);
   readonly " $fragmentType": "NonNullFragment";
 };
 export type NonNullFragment$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-query.expected
@@ -7,12 +7,12 @@ query FooQuery {
 }
 ==================================== OUTPUT ===================================
 export type FooQuery$variables = {};
-export type FooQuery$data = {
+export type FooQuery$data = ({
   readonly me: {
-    readonly firstName: string | null;
+    readonly firstName: (string | null);
     readonly lastName: string;
   };
-} | null;
+} | null);
 export type FooQuery = {
   variables: FooQuery$variables;
   response: FooQuery$data;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-up-to-mutation-response.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-up-to-mutation-response.expected
@@ -8,26 +8,26 @@ mutation CommentCreateMutation($input: CommentCreateInput!) {
 }
 ==================================== OUTPUT ===================================
 export type CommentCreateInput = {
-  clientMutationId?: string | null;
-  feedbackId?: string | null;
-  feedback?: CommentfeedbackFeedback | null;
+  clientMutationId?: (string | null);
+  feedbackId?: (string | null);
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentfeedbackFeedback = {
-  comment?: FeedbackcommentComment | null;
+  comment?: (FeedbackcommentComment | null);
 };
 export type FeedbackcommentComment = {
-  feedback?: CommentfeedbackFeedback | null;
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentCreateMutation$variables = {
   input: CommentCreateInput;
 };
-export type CommentCreateMutation$data = {
+export type CommentCreateMutation$data = ({
   readonly commentCreate: {
     readonly comment: {
       readonly id: string;
     };
   };
-} | null;
+} | null);
 export type CommentCreateMutation = {
   variables: CommentCreateMutation$variables;
   response: CommentCreateMutation$data;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-isolates-concrete-inline-fragments.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-isolates-concrete-inline-fragments.expected
@@ -29,35 +29,35 @@ fragment Foo on Node {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
-export type Bar$data = {
+export type Bar$data = ({
   readonly name?: string;
-  readonly body?: {
-    readonly text: string | null;
-  } | null;
+  readonly body?: ({
+    readonly text: (string | null);
+  } | null);
   readonly " $fragmentType": "Bar";
-} | null;
+} | null);
 export type Bar$key = {
   readonly " $data"?: Bar$data;
   readonly " $fragmentSpreads": FragmentRefs<"Bar">;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
-export type Foo$data = {
+export type Foo$data = ({
   readonly __typename: "User";
   readonly name: string;
   readonly " $fragmentType": "Foo";
 } | {
   readonly __typename: "Comment";
-  readonly body: {
-    readonly text: string | null;
-  } | null;
+  readonly body: ({
+    readonly text: (string | null);
+  } | null);
   readonly " $fragmentType": "Foo";
 } | {
   // This will never be '%other', but we need some
   // value in case none of the concrete values match.
   readonly __typename: "%other";
   readonly " $fragmentType": "Foo";
-} | null;
+} | null);
 export type Foo$key = {
   readonly " $data"?: Foo$data;
   readonly " $fragmentSpreads": FragmentRefs<"Foo">;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-raw-response-type.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-raw-response-type.expected
@@ -7,17 +7,17 @@ query MyQuery @raw_response_type {
 }
 ==================================== OUTPUT ===================================
 export type MyQuery$variables = {};
-export type MyQuery$data = {
+export type MyQuery$data = ({
   readonly me: {
     readonly id: string;
     readonly name: string;
   };
-} | null;
+} | null);
 export type MyQuery$rawResponse = {
-  readonly me: {
+  readonly me: ({
     readonly id: string;
-    readonly name: string | null;
-  } | null;
+    readonly name: (string | null);
+  } | null);
 };
 export type MyQuery = {
   variables: MyQuery$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throw-doesnt-bubbles-to-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throw-doesnt-bubbles-to-fragment.expected
@@ -6,7 +6,7 @@ fragment NonNullFragment on User {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type NonNullFragment$data = {
-  readonly firstName: string | null;
+  readonly firstName: (string | null);
   readonly lastName: string;
   readonly " $fragmentType": "NonNullFragment";
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.expected
@@ -9,8 +9,8 @@ query FooQuery {
 export type FooQuery$variables = {};
 export type FooQuery$data = {
   readonly me: {
-    readonly firstName: string | null;
-    readonly lastName: string | null;
+    readonly firstName: (string | null);
+    readonly lastName: (string | null);
   };
 };
 export type FooQuery = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throws-nested.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throws-nested.expected
@@ -8,10 +8,10 @@ query FooQuery {
 ==================================== OUTPUT ===================================
 export type FooQuery$variables = {};
 export type FooQuery$data = {
-  readonly me: {
-    readonly firstName: string | null;
+  readonly me: ({
+    readonly firstName: (string | null);
     readonly lastName: string;
-  } | null;
+  } | null);
 };
 export type FooQuery = {
   variables: FooQuery$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required.expected
@@ -8,10 +8,10 @@ query FooQuery {
 ==================================== OUTPUT ===================================
 export type FooQuery$variables = {};
 export type FooQuery$data = {
-  readonly me: {
-    readonly firstName: string | null;
+  readonly me: ({
+    readonly firstName: (string | null);
     readonly lastName: string;
-  } | null;
+  } | null);
 };
 export type FooQuery = {
   variables: FooQuery$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/roots.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/roots.expected
@@ -29,9 +29,9 @@ export type ExampleQuery$variables = {
   id: string;
 };
 export type ExampleQuery$data = {
-  readonly node: {
+  readonly node: ({
     readonly id: string;
-  } | null;
+  } | null);
 };
 export type ExampleQuery = {
   variables: ExampleQuery$variables;
@@ -39,25 +39,25 @@ export type ExampleQuery = {
 };
 -------------------------------------------------------------------------------
 export type CommentCreateInput = {
-  clientMutationId?: string | null;
-  feedbackId?: string | null;
-  feedback?: CommentfeedbackFeedback | null;
+  clientMutationId?: (string | null);
+  feedbackId?: (string | null);
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type CommentfeedbackFeedback = {
-  comment?: FeedbackcommentComment | null;
+  comment?: (FeedbackcommentComment | null);
 };
 export type FeedbackcommentComment = {
-  feedback?: CommentfeedbackFeedback | null;
+  feedback?: (CommentfeedbackFeedback | null);
 };
 export type TestMutation$variables = {
   input: CommentCreateInput;
 };
 export type TestMutation$data = {
-  readonly commentCreate: {
-    readonly comment: {
+  readonly commentCreate: ({
+    readonly comment: ({
       readonly id: string;
-    } | null;
-  } | null;
+    } | null);
+  } | null);
 };
 export type TestMutation = {
   variables: TestMutation$variables;
@@ -65,18 +65,18 @@ export type TestMutation = {
 };
 -------------------------------------------------------------------------------
 export type FeedbackLikeInput = {
-  clientMutationId?: string | null;
-  feedbackId?: string | null;
+  clientMutationId?: (string | null);
+  feedbackId?: (string | null);
 };
 export type TestSubscription$variables = {
-  input?: FeedbackLikeInput | null;
+  input?: (FeedbackLikeInput | null);
 };
 export type TestSubscription$data = {
-  readonly feedbackLikeSubscribe: {
-    readonly feedback: {
+  readonly feedbackLikeSubscribe: ({
+    readonly feedback: ({
       readonly id: string;
-    } | null;
-  } | null;
+    } | null);
+  } | null);
 };
 export type TestSubscription = {
   variables: TestSubscription$variables;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/scalar-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/scalar-field.expected
@@ -13,20 +13,20 @@ fragment ScalarField on User {
   }
 }
 ==================================== OUTPUT ===================================
-export type PersonalityTraits = "CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value";
+export type PersonalityTraits = ("CHEERFUL" | "DERISIVE" | "HELPFUL" | "SNARKY" | "%future added value");
 import { FragmentRefs } from "relay-runtime";
 export type ScalarField$data = {
   readonly id: string;
-  readonly name: string | null;
-  readonly websites: ReadonlyArray<string | null> | null;
-  readonly traits: ReadonlyArray<PersonalityTraits | null> | null;
-  readonly aliasedLinkedField: {
-    readonly aliasedField: number | null;
-  } | null;
-  readonly screennames: ReadonlyArray<{
-    readonly name: string | null;
-    readonly service: string | null;
-  } | null> | null;
+  readonly name: (string | null);
+  readonly websites: (ReadonlyArray<(string | null)> | null);
+  readonly traits: (ReadonlyArray<(PersonalityTraits | null)> | null);
+  readonly aliasedLinkedField: ({
+    readonly aliasedField: (number | null);
+  } | null);
+  readonly screennames: (ReadonlyArray<({
+    readonly name: (string | null);
+    readonly service: (string | null);
+  } | null)> | null);
   readonly " $fragmentType": "ScalarField";
 };
 export type ScalarField$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/simple.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/simple.expected
@@ -10,12 +10,12 @@ fragment LinkedField on User {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type LinkedField$data = {
-  readonly name: string | null;
-  readonly profilePicture: {
-    readonly uri: string | null;
-    readonly width: number | null;
-    readonly height: number | null;
-  } | null;
+  readonly name: (string | null);
+  readonly profilePicture: ({
+    readonly uri: (string | null);
+    readonly width: (number | null);
+    readonly height: (number | null);
+  } | null);
   readonly " $fragmentType": "LinkedField";
 };
 export type LinkedField$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/typename-inside-with-overlapping-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/typename-inside-with-overlapping-fields.expected
@@ -18,22 +18,22 @@ fragment TypenameInsideWithOverlappingFields on Viewer {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type TypenameInsideWithOverlappingFields$data = {
-  readonly actor: {
+  readonly actor: ({
     readonly __typename: "Page";
     readonly id: string;
-    readonly name: string | null;
+    readonly name: (string | null);
   } | {
     readonly __typename: "User";
     readonly id: string;
-    readonly name: string | null;
-    readonly profile_picture: {
-      readonly uri: string | null;
-    } | null;
+    readonly name: (string | null);
+    readonly profile_picture: ({
+      readonly uri: (string | null);
+    } | null);
   } | {
     // This will never be '%other', but we need some
     // value in case none of the concrete values match.
     readonly __typename: "%other";
-  } | null;
+  } | null);
   readonly " $fragmentType": "TypenameInsideWithOverlappingFields";
 };
 export type TypenameInsideWithOverlappingFields$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/typename-on-union.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/typename-on-union.expected
@@ -81,35 +81,35 @@ fragment TypenameAliases on Actor {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
-export type TypenameAlias$data = {
+export type TypenameAlias$data = ({
   readonly _typeAlias: "User";
-  readonly firstName: string | null;
+  readonly firstName: (string | null);
   readonly " $fragmentType": "TypenameAlias";
 } | {
   readonly _typeAlias: "Page";
-  readonly username: string | null;
+  readonly username: (string | null);
   readonly " $fragmentType": "TypenameAlias";
 } | {
   // This will never be '%other', but we need some
   // value in case none of the concrete values match.
   readonly _typeAlias: "%other";
   readonly " $fragmentType": "TypenameAlias";
-};
+});
 export type TypenameAlias$key = {
   readonly " $data"?: TypenameAlias$data;
   readonly " $fragmentSpreads": FragmentRefs<"TypenameAlias">;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
-export type TypenameAliases$data = {
+export type TypenameAliases$data = ({
   readonly _typeAlias1: "User";
   readonly _typeAlias2: "User";
-  readonly firstName: string | null;
+  readonly firstName: (string | null);
   readonly " $fragmentType": "TypenameAliases";
 } | {
   readonly _typeAlias1: "Page";
   readonly _typeAlias2: "Page";
-  readonly username: string | null;
+  readonly username: (string | null);
   readonly " $fragmentType": "TypenameAliases";
 } | {
   // This will never be '%other', but we need some
@@ -119,47 +119,47 @@ export type TypenameAliases$data = {
   // value in case none of the concrete values match.
   readonly _typeAlias2: "%other";
   readonly " $fragmentType": "TypenameAliases";
-};
+});
 export type TypenameAliases$key = {
   readonly " $data"?: TypenameAliases$data;
   readonly " $fragmentSpreads": FragmentRefs<"TypenameAliases">;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
-export type TypenameInside$data = {
+export type TypenameInside$data = ({
   readonly __typename: "User";
-  readonly firstName: string | null;
+  readonly firstName: (string | null);
   readonly " $fragmentType": "TypenameInside";
 } | {
   readonly __typename: "Page";
-  readonly username: string | null;
+  readonly username: (string | null);
   readonly " $fragmentType": "TypenameInside";
 } | {
   // This will never be '%other', but we need some
   // value in case none of the concrete values match.
   readonly __typename: "%other";
   readonly " $fragmentType": "TypenameInside";
-};
+});
 export type TypenameInside$key = {
   readonly " $data"?: TypenameInside$data;
   readonly " $fragmentSpreads": FragmentRefs<"TypenameInside">;
 };
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
-export type TypenameOutside$data = {
+export type TypenameOutside$data = ({
   readonly __typename: "User";
-  readonly firstName: string | null;
+  readonly firstName: (string | null);
   readonly " $fragmentType": "TypenameOutside";
 } | {
   readonly __typename: "Page";
-  readonly username: string | null;
+  readonly username: (string | null);
   readonly " $fragmentType": "TypenameOutside";
 } | {
   // This will never be '%other', but we need some
   // value in case none of the concrete values match.
   readonly __typename: "%other";
   readonly " $fragmentType": "TypenameOutside";
-};
+});
 export type TypenameOutside$key = {
   readonly " $data"?: TypenameOutside$data;
   readonly " $fragmentSpreads": FragmentRefs<"TypenameOutside">;
@@ -168,13 +168,13 @@ export type TypenameOutside$key = {
 import { FragmentRefs } from "relay-runtime";
 export type TypenameOutsideWithAbstractType$data = {
   readonly __typename: string;
-  readonly username?: string | null;
-  readonly address?: {
-    readonly city: string | null;
-    readonly country: string | null;
-    readonly street?: string | null;
-  } | null;
-  readonly firstName?: string | null;
+  readonly username?: (string | null);
+  readonly address?: ({
+    readonly city: (string | null);
+    readonly country: (string | null);
+    readonly street?: (string | null);
+  } | null);
+  readonly firstName?: (string | null);
   readonly " $fragmentType": "TypenameOutsideWithAbstractType";
 };
 export type TypenameOutsideWithAbstractType$key = {
@@ -185,9 +185,9 @@ export type TypenameOutsideWithAbstractType$key = {
 import { FragmentRefs } from "relay-runtime";
 export type TypenameWithCommonSelections$data = {
   readonly __typename: string;
-  readonly name: string | null;
-  readonly firstName?: string | null;
-  readonly username?: string | null;
+  readonly name: (string | null);
+  readonly firstName?: (string | null);
+  readonly username?: (string | null);
   readonly " $fragmentType": "TypenameWithCommonSelections";
 };
 export type TypenameWithCommonSelections$key = {
@@ -197,7 +197,7 @@ export type TypenameWithCommonSelections$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type TypenameWithoutSpreads$data = {
-  readonly firstName: string | null;
+  readonly firstName: (string | null);
   readonly __typename: "User";
   readonly " $fragmentType": "TypenameWithoutSpreads";
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/unmasked-fragment-spreads.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/unmasked-fragment-spreads.expected
@@ -28,8 +28,8 @@ fragment AnotherRecursiveFragment on Image {
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
 export type AnotherRecursiveFragment$data = {
-  readonly uri: string | null;
-  readonly height: number | null;
+  readonly uri: (string | null);
+  readonly height: (number | null);
   readonly " $fragmentType": "AnotherRecursiveFragment";
 };
 export type AnotherRecursiveFragment$key = {
@@ -39,8 +39,8 @@ export type AnotherRecursiveFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type PhotoFragment$data = {
-  readonly uri: string | null;
-  readonly width: number | null;
+  readonly uri: (string | null);
+  readonly width: (number | null);
   readonly " $fragmentType": "PhotoFragment";
 };
 export type PhotoFragment$key = {
@@ -50,8 +50,8 @@ export type PhotoFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type RecursiveFragment$data = {
-  readonly uri: string | null;
-  readonly width: number | null;
+  readonly uri: (string | null);
+  readonly width: (number | null);
 };
 export type RecursiveFragment$key = {
   readonly " $data"?: RecursiveFragment$data;
@@ -60,12 +60,12 @@ export type RecursiveFragment$key = {
 -------------------------------------------------------------------------------
 import { FragmentRefs } from "relay-runtime";
 export type UserProfile$data = {
-  readonly profilePicture: {
-    readonly uri: string | null;
-    readonly width: number | null;
-    readonly height: number | null;
+  readonly profilePicture: ({
+    readonly uri: (string | null);
+    readonly width: (number | null);
+    readonly height: (number | null);
     readonly " $fragmentSpreads": FragmentRefs<"PhotoFragment">;
-  } | null;
+  } | null);
   readonly " $fragmentType": "UserProfile";
 };
 export type UserProfile$key = {


### PR DESCRIPTION
Trying to start split #3280 into smaller parts. Not crazy about how many parentheses are being added as a result in the test fixtures. I could add a few more changes to reduce these when not needed. Thoughts?

@rbalicki2 