### PR TITLE
Relax Viewer requirements for refetchable fragments

### DIFF
--- a/compiler/crates/relay-transforms/src/refetchable_fragment/utils.rs
+++ b/compiler/crates/relay-transforms/src/refetchable_fragment/utils.rs
@@ -31,7 +31,6 @@ pub struct Constants {
     pub node_field_name: StringKey,
     pub node_type_name: StringKey,
     pub viewer_field_name: StringKey,
-    pub viewer_type_name: StringKey,
 }
 
 lazy_static! {
@@ -41,7 +40,6 @@ lazy_static! {
         node_field_name: "node".intern(),
         node_type_name: "Node".intern(),
         viewer_field_name: "viewer".intern(),
-        viewer_type_name: "Viewer".intern(),
     };
 }
 

--- a/compiler/crates/relay-transforms/src/refetchable_fragment/validation_message.rs
+++ b/compiler/crates/relay-transforms/src/refetchable_fragment/validation_message.rs
@@ -71,7 +71,7 @@ pub(super) enum ValidationMessage {
     InvalidNodeSchemaForRefetchableFragmentOnNode { fragment_name: StringKey },
 
     #[error(
-        "Invalid use of @refetchable on fragment '{fragment_name}', check that your schema defines a 'Viewer' object type and has a 'viewer: Viewer' field on the query type."
+        "Invalid use of @refetchable on fragment '{fragment_name}', check that your schema defines a 'viewer: ...' field on the query type that returns a singular object."
     )]
     InvalidViewerSchemaForRefetchableFragmentOnViewer { fragment_name: StringKey },
 


### PR DESCRIPTION
Problem: Currently [`@refetchable` directive](https://relay.dev/docs/api-reference/use-refetchable-fragment/#arguments) can be used on `Viewer` type. However, real-world the APIs often utilize a `User` type for this use-case ([GitHub, for example](https://docs.github.com/en/graphql/reference/queries#user)). This causes a lot of pain because there's no easy way to make a `Viewer` → `User` type alias in GraphQL.

Solution: infer the actual viewer type from the `viewer: ...` field instead of hardcoding it.