### PR TITLE
Set inFlight to true before calling commitMutationFn

### DIFF
--- a/packages/react-relay/relay-hooks/useMutation.js
+++ b/packages/react-relay/relay-hooks/useMutation.js
@@ -97,6 +97,9 @@ function useMutation<TMutation: MutationParameters>(
 
   const commit = useCallback(
     (config: UseMutationConfig<TMutation>) => {
+      if (isMountedRef.current) {
+        setMutationInFlight(true);
+      }
       const disposable = commitMutationFn(environment, {
         ...config,
         mutation,
@@ -117,9 +120,6 @@ function useMutation<TMutation: MutationParameters>(
         },
       });
       inFlightMutationsRef.current.add(disposable);
-      if (isMountedRef.current) {
-        setMutationInFlight(true);
-      }
       return disposable;
     },
     [cleanup, commitMutationFn, environment, isMountedRef, mutation],


### PR DESCRIPTION
In environments with local resolvers (i.e. during tests), setMutationInFlight can lose a race to a commitMutationFn callback, causing inFlight to be stuck on true. Setting isMutationInFlight to true before calling commitMutationFn prevents this.