### PR TITLE
Fix relay LSP crash

### DIFF
--- a/compiler/crates/relay-bin/src/main.rs
+++ b/compiler/crates/relay-bin/src/main.rs
@@ -89,7 +89,7 @@ struct LspCommand {
     config: Option<PathBuf>,
 
     /// Verbosity level
-    #[clap(long, arg_enum, default_value = "info")]
+    #[clap(long, arg_enum, default_value = "quiet-with-errors")]
     output: OutputKind,
 }
 


### PR DESCRIPTION
`info` was not actually an option. this caused a crash every time you try to start the lsp. `quiet-with-errors` seems the most reasonable.