### PR TITLE
Expose Relay schema extensions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -339,6 +339,20 @@ const relayCompiler = gulp.parallel(
       .src(['LICENSE'])
       .pipe(gulp.dest(path.join(DIST, 'relay-compiler')));
   },
+  function copyGraphQLExtensions() {
+    return gulp
+      .src(
+        path.join(
+          '.',
+          'compiler',
+          'crates',
+          'relay-schema',
+          'src',
+          'relay-extensions.graphql',
+        ),
+      )
+      .pipe(gulp.dest(path.join(DIST, 'relay-compiler')));
+  },
   function copyPackageFiles() {
     return gulp
       .src(['README.md', 'package.json', 'cli.js', 'index.js'], {


### PR DESCRIPTION
fixes #3787

# Context

From @erictaylor:

> Pre v13 I know that `relay-compiler` exposed some of the schema extensions that are specific to Relay (ie directives) so that other third party libraries and tools could easily add them (ex: IDE GraphQL hinting/tooling, etc).
> 
> I noticed that since v13 that `relay-compiler` has been simplified (obviously) down to just exposing the underlying binary.

From @josephsavona

> It seems reasonable to expose the schema extensions for other tools to pick up, we'd be happy to support a PR to that effect.

# Test

Run `RELEASE_COMMIT_SHA=212d8d66d9031180f08acf76f43c88162c6208e0 yarn gulp mainrelease`

## Before
<img width="360" alt="Screen Shot 2022-04-04 at 5 42 54 PM" src="https://user-images.githubusercontent.com/127199/161656917-f9407b8d-2760-4230-bdf7-7378a82625b7.png">

## After
<img width="261" alt="Screen Shot 2022-04-04 at 5 43 40 PM" src="https://user-images.githubusercontent.com/127199/161656926-5807a58f-6016-4638-955f-39870a5e0bc6.png">