### PR TITLE
Add locations to server sdls in build_schema_with_extensions

### DIFF
--- a/compiler/crates/relay-compiler/src/build_project/build_schema.rs
+++ b/compiler/crates/relay-compiler/src/build_project/build_schema.rs
@@ -37,9 +37,9 @@ pub fn build_schema(
             let mut schema_sources = Vec::new();
             schema_sources.extend(
                 compiler_state.schemas[&project_config.name]
-                    .get_sources()
+                    .get_sources_with_location()
                     .into_iter()
-                    .map(String::as_str),
+                    .map(|(schema, location_key)| (schema.as_str(), location_key)),
             );
             let mut schema =
                 relay_schema::build_schema_with_extensions(&schema_sources, &extensions)?;

--- a/compiler/crates/relay-compiler/src/compiler_state.rs
+++ b/compiler/crates/relay-compiler/src/compiler_state.rs
@@ -393,14 +393,14 @@ impl CompilerState {
         if schema_change == SchemaChange::None {
             true
         } else {
-            let current_sources = sources
+            let current_sources_with_location = sources
                 .get_sources_with_location()
                 .into_iter()
                 .map(|(schema, location_key)| (schema.as_str(), location_key))
                 .collect::<Vec<_>>();
 
             match relay_schema::build_schema_with_extensions(
-                &current_sources,
+                &current_sources_with_location,
                 &Vec::<(&str, SourceLocationKey)>::new(),
             ) {
                 Ok(schema) => schema_change.is_safe(&schema, schema_config),

--- a/compiler/crates/relay-compiler/src/compiler_state.rs
+++ b/compiler/crates/relay-compiler/src/compiler_state.rs
@@ -393,8 +393,14 @@ impl CompilerState {
         if schema_change == SchemaChange::None {
             true
         } else {
+            let current_sources = sources
+                .get_sources_with_location()
+                .into_iter()
+                .map(|(schema, location_key)| (schema.as_str(), location_key))
+                .collect::<Vec<_>>();
+
             match relay_schema::build_schema_with_extensions(
-                &current,
+                &current_sources,
                 &Vec::<(&str, SourceLocationKey)>::new(),
             ) {
                 Ok(schema) => schema_change.is_safe(&schema, schema_config),

--- a/compiler/crates/relay-schema/src/lib.rs
+++ b/compiler/crates/relay-schema/src/lib.rs
@@ -19,7 +19,7 @@ use std::iter::once;
 const RELAY_EXTENSIONS: &str = include_str!("./relay-extensions.graphql");
 
 pub fn build_schema_with_extensions<T: AsRef<str>, U: AsRef<str>>(
-    server_sdls: &[T],
+    server_sdls: &[(T, SourceLocationKey)],
     extension_sdls: &[(U, SourceLocationKey)],
 ) -> DiagnosticsResult<SDLSchema> {
     let extensions: Vec<(&str, SourceLocationKey)> =

--- a/compiler/crates/relay-test-schema/src/lib.rs
+++ b/compiler/crates/relay-test-schema/src/lib.rs
@@ -20,12 +20,21 @@ const TEST_SCHEMA_WITH_CUSTOM_ID_DATA: &str = include_str!("testschema_with_cust
 
 lazy_static! {
     pub static ref TEST_SCHEMA: Arc<SDLSchema> = Arc::new(
-        build_schema_with_extensions::<_, &str>(&[TEST_SCHEMA_DATA], &[])
-            .expect("Expected test schema to be valid")
+        build_schema_with_extensions::<_, &str>(
+            &[(TEST_SCHEMA_DATA, SourceLocationKey::generated())],
+            &[]
+        )
+        .expect("Expected test schema to be valid")
     );
     pub static ref TEST_SCHEMA_WITH_CUSTOM_ID: Arc<SDLSchema> = Arc::new(
-        build_schema_with_extensions::<_, &str>(&[TEST_SCHEMA_WITH_CUSTOM_ID_DATA], &[])
-            .expect("Expected test schema to be valid")
+        build_schema_with_extensions::<_, &str>(
+            &[(
+                TEST_SCHEMA_WITH_CUSTOM_ID_DATA,
+                SourceLocationKey::generated()
+            )],
+            &[]
+        )
+        .expect("Expected test schema to be valid")
     );
 }
 
@@ -42,8 +51,11 @@ pub fn get_test_schema_with_located_extensions(
     source_location: SourceLocationKey,
 ) -> Arc<SDLSchema> {
     Arc::new(
-        build_schema_with_extensions(&[TEST_SCHEMA_DATA], &[(extensions_sdl, source_location)])
-            .expect("Expected test schema (and extensions) to be valid"),
+        build_schema_with_extensions(
+            &[(TEST_SCHEMA_DATA, SourceLocationKey::generated())],
+            &[(extensions_sdl, source_location)],
+        )
+        .expect("Expected test schema (and extensions) to be valid"),
     )
 }
 
@@ -54,7 +66,10 @@ pub fn get_test_schema_with_custom_id() -> Arc<SDLSchema> {
 pub fn get_test_schema_with_custom_id_with_extensions(extensions_sdl: &str) -> Arc<SDLSchema> {
     Arc::new(
         build_schema_with_extensions(
-            &[TEST_SCHEMA_WITH_CUSTOM_ID_DATA],
+            &[(
+                TEST_SCHEMA_WITH_CUSTOM_ID_DATA,
+                SourceLocationKey::generated(),
+            )],
             &[(extensions_sdl, SourceLocationKey::generated())],
         )
         .expect("Expected test schema (and extensions) to be valid"),

--- a/compiler/crates/schema/tests/build_schema/mod.rs
+++ b/compiler/crates/schema/tests/build_schema/mod.rs
@@ -19,7 +19,9 @@ const SCHEMA_SEPARATOR: &str = "%extensions%";
 pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split(SCHEMA_SEPARATOR).collect();
     let result = match parts.as_slice() {
-        [base] => build_schema_with_extensions::<_, &str>(&[base], &[]),
+        [base] => {
+            build_schema_with_extensions::<_, &str>(&[(base, SourceLocationKey::generated())], &[])
+        }
         [base, extensions] => {
             // prepend a comment so the correct line + column number is reported for client extension
             // (since we source base and client schemas from one file)
@@ -27,7 +29,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
             assert!(nchars_base > 0);
             let prepended_extension = format!("{}\n{}", "#".repeat(nchars_base - 1), extensions);
             build_schema_with_extensions(
-                &[base],
+                &[(base, SourceLocationKey::generated())],
                 &[(
                     prepended_extension,
                     SourceLocationKey::standalone(fixture.file_name),


### PR DESCRIPTION
This enables the VSCode Extension to jump to definition on fields / typenames.