### PR TITLE
Restore cjs config extension

### DIFF
--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -511,11 +511,7 @@ impl fmt::Debug for Config {
         } = self;
 
         fn option_fn_to_string<T>(option: &Option<T>) -> &'static str {
-            if option.is_some() {
-                "Some(Fn)"
-            } else {
-                "None"
-            }
+            if option.is_some() { "Some(Fn)" } else { "None" }
         }
 
         f.debug_struct("Config")

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -171,6 +171,7 @@ impl Config {
                 LoaderSource::PackageJson("relay".to_string()),
                 LoaderSource::Json("relay.config.json".to_string()),
                 LoaderSource::Js("relay.config.js".to_string()),
+                LoaderSource::Js("relay.config.cjs".to_string()),
             ],
         )
     }
@@ -510,7 +511,11 @@ impl fmt::Debug for Config {
         } = self;
 
         fn option_fn_to_string<T>(option: &Option<T>) -> &'static str {
-            if option.is_some() { "Some(Fn)" } else { "None" }
+            if option.is_some() {
+                "Some(Fn)"
+            } else {
+                "None"
+            }
         }
 
         f.debug_struct("Config")


### PR DESCRIPTION
This restores `relay.config.cjs` as a potential target for the config autosearch the compiler CLI does. 

Rationale: `cjs` is an increasingly common config format now that projects like Vite are helping people move to ES modules.