### PR TITLE
Minor vscode package tweaks

### DIFF
--- a/vscode-extension/.gitignore
+++ b/vscode-extension/.gitignore
@@ -1,2 +1,3 @@
 out/
 tsconfig.tsbuildinfo
+*.vsix

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,13 @@
   "name": "relay",
   "displayName": "Relay GraphQL",
   "version": "0.0.1",
-  "description": "Relay LSP Client for VSCode",
+  "description": "Relay-powered IDE experience",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/relay",
+    "directory": "vscode-extension"
+  },
+  "license": "MIT",
   "main": "./out/extension.js",
   "activationEvents": [
     "onLanguage:plaintext",
@@ -55,7 +61,8 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "prettier-check": "prettier -c .",
-    "lint": "eslint --max-warnings 0 ."
+    "lint": "eslint --max-warnings 0 .",
+    "vscode:prepublish": "tsc"
   },
   "engines": {
     "vscode": "^1.65.0"


### PR DESCRIPTION
Thought I'd take a look at whether I could use this locally, but I got hit with

```
Starting the Relay GraphQL extension...
Using relay binary: /home/orta/dev/app/node_modules/relay-compiler/linux-x64/relay
[Error - 4:44:06 PM] Connection to server got closed. Server will not be restarted.
[0m[31m[ERROR] [0mFailed to read config file `lsp`.

```

Which I'm guessing is because that command comes from unreleased code (I upgraded to 13.2.0 just in case). Either way, this is probably some quality of life changes