### PR TITLE
Enabled bracketSpacing in VSCode Extension's prettier config

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -54,7 +54,7 @@
   },
   "prettier": {
     "bracketSameLine": true,
-    "bracketSpacing": false,
+    "bracketSpacing": true,
     "singleQuote": true,
     "trailingComma": "all"
   },

--- a/vscode-extension/src/commands/register.ts
+++ b/vscode-extension/src/commands/register.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {commands} from 'vscode';
-import {RelayExtensionContext} from '../context';
-import {handleRestartLanguageServerCommand} from './restartLanguageServer';
-import {handleShowOutputCommand} from './showOutput';
+import { commands } from 'vscode';
+import { RelayExtensionContext } from '../context';
+import { handleRestartLanguageServerCommand } from './restartLanguageServer';
+import { handleShowOutputCommand } from './showOutput';
 
 export function registerCommands(context: RelayExtensionContext) {
   context.extensionContext.subscriptions.push(

--- a/vscode-extension/src/commands/restartLanguageServer.ts
+++ b/vscode-extension/src/commands/restartLanguageServer.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {window} from 'vscode';
-import {RelayExtensionContext} from '../context';
-import {createAndStartClient} from '../languageClient';
+import { window } from 'vscode';
+import { RelayExtensionContext } from '../context';
+import { createAndStartClient } from '../languageClient';
 
 export function handleRestartLanguageServerCommand(
   context: RelayExtensionContext,

--- a/vscode-extension/src/commands/showOutput.ts
+++ b/vscode-extension/src/commands/showOutput.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {RelayExtensionContext} from '../context';
+import { RelayExtensionContext } from '../context';
 
 export function handleShowOutputCommand(context: RelayExtensionContext): void {
   context.outputChannel.show();

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {ConfigurationScope, workspace} from 'vscode';
+import { ConfigurationScope, workspace } from 'vscode';
 
 export type Config = {
   pathToRelay: string | null;

--- a/vscode-extension/src/context.ts
+++ b/vscode-extension/src/context.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {ExtensionContext, OutputChannel, StatusBarItem} from 'vscode';
-import {LanguageClient} from 'vscode-languageclient/node';
+import { ExtensionContext, OutputChannel, StatusBarItem } from 'vscode';
+import { LanguageClient } from 'vscode-languageclient/node';
 
 // Mutable object to pass around to command handlers so they
 // can reference the current state of the extension

--- a/vscode-extension/src/errorHandler.ts
+++ b/vscode-extension/src/errorHandler.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {window} from 'vscode';
-import {CloseAction, ErrorAction, ErrorHandler} from 'vscode-languageclient';
-import {RelayExtensionContext} from './context';
+import { window } from 'vscode';
+import { CloseAction, ErrorAction, ErrorHandler } from 'vscode-languageclient';
+import { RelayExtensionContext } from './context';
 
 export function createErrorHandler(
   context: RelayExtensionContext,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {ExtensionContext, window} from 'vscode';
-import {registerCommands} from './commands/register';
+import { ExtensionContext, window } from 'vscode';
+import { registerCommands } from './commands/register';
 
-import {RelayExtensionContext} from './context';
-import {createAndStartClient} from './languageClient';
-import {createStatusBarItem, intializeStatusBarItem} from './statusBarItem';
+import { RelayExtensionContext } from './context';
+import { createAndStartClient } from './languageClient';
+import { createStatusBarItem, intializeStatusBarItem } from './statusBarItem';
 
 let relayExtensionContext: RelayExtensionContext | undefined;
 

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -5,17 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {workspace} from 'vscode';
+import { workspace } from 'vscode';
 import {
   LanguageClientOptions,
   RevealOutputChannelOn,
 } from 'vscode-languageclient';
-import {ServerOptions, LanguageClient} from 'vscode-languageclient/node';
-import {getConfig} from './config';
-import {RelayExtensionContext} from './context';
-import {createErrorHandler} from './errorHandler';
-import {LSPStatusBarFeature} from './lspStatusBarFeature';
-import {findRelayBinary} from './utils';
+import { ServerOptions, LanguageClient } from 'vscode-languageclient/node';
+import { getConfig } from './config';
+import { RelayExtensionContext } from './context';
+import { createErrorHandler } from './errorHandler';
+import { LSPStatusBarFeature } from './lspStatusBarFeature';
+import { findRelayBinary } from './utils';
 
 export async function createAndStartClient(context: RelayExtensionContext) {
   const config = getConfig();
@@ -49,10 +49,10 @@ export async function createAndStartClient(context: RelayExtensionContext) {
       isTrusted: true,
     },
     documentSelector: [
-      {scheme: 'file', language: 'javascript'},
-      {scheme: 'file', language: 'typescript'},
-      {scheme: 'file', language: 'typescriptreact'},
-      {scheme: 'file', language: 'javascriptreact'},
+      { scheme: 'file', language: 'javascript' },
+      { scheme: 'file', language: 'typescript' },
+      { scheme: 'file', language: 'typescriptreact' },
+      { scheme: 'file', language: 'javascriptreact' },
     ],
 
     outputChannel: context.outputChannel,

--- a/vscode-extension/src/lspStatusBarFeature.ts
+++ b/vscode-extension/src/lspStatusBarFeature.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Disposable} from 'vscode';
+import { Disposable } from 'vscode';
 import {
   StaticFeature,
   InitializeParams,
   RequestType,
 } from 'vscode-languageclient';
-import {RelayExtensionContext} from './context';
+import { RelayExtensionContext } from './context';
 
 // the following type definitions are one to one mappings of the types defined
 // by the lsp_types package in this rust crate.

--- a/vscode-extension/src/statusBarItem.ts
+++ b/vscode-extension/src/statusBarItem.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {StatusBarAlignment, StatusBarItem, window} from 'vscode';
+import { StatusBarAlignment, StatusBarItem, window } from 'vscode';
 
-import {RelayExtensionContext} from './context';
+import { RelayExtensionContext } from './context';
 
 const SHOW_OUTPUT_COMMAND = 'relay.showOutput';
 


### PR DESCRIPTION
This config was conflicting with Meta prettier configs.