### PR TITLE
fix artistId typo in example

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -233,7 +233,7 @@ const artistsQuery = graphql\`
 const artistsQueryReference = loadQuery(
   environment,
   artistsQuery,
-  {artistId: "1"}
+  {artistID: "1"}
 );
 
 export default function ArtistPage() {


### PR DESCRIPTION
closes #3875

Docs look correct now when running locally. I have also checked some other references in the docs where `artistID` is used, but did not find any typos.

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/7454248/163629444-ad114616-9b57-48d4-b0fb-a2a57c8da848.png">
