### PR TITLE
[relay-compiler] Build linux arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,12 @@ jobs:
             os: ubuntu-latest
             build-name: relay
             artifact-name: relay-bin-linux-arm64
-            packages: "musl-tools:arm64"
+            packages:
+              - musl-tools:arm64
+              - gcc:arm64
+              - cpp:arm64
+              - gcc-9:arm64
+              - binutils:arm64
             features: vendored
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -167,7 +172,6 @@ jobs:
           echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security multiverse" | sudo tee -a /etc/apt/sources.list
 
           sudo apt-get update
-
       - name: Install packages
         if: matrix.target.os == 'ubuntu-latest' && matrix.target.packages
         run: sudo apt install ${{ matrix.target.packages }} -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,12 +112,7 @@ jobs:
             os: ubuntu-latest
             build-name: relay
             artifact-name: relay-bin-linux-arm64
-            packages:
-              - musl-tools:arm64
-              - gcc:arm64
-              - cpp:arm64
-              - gcc-9:arm64
-              - binutils:arm64
+            packages: musl-tools:arm64 gcc:arm64 cpp:arm64 gcc-9:arm64 binutils:arm64
             features: vendored
           - target: x86_64-apple-darwin
             os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
             os: ubuntu-latest
             build-name: relay
             artifact-name: relay-bin-linux-arm64
-            packages: musl-tools
+            packages: "musl-tools:arm64"
             features: vendored
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -147,6 +147,9 @@ jobs:
         run: yarn gulp setCompilerMainVersion
         env:
           RELEASE_COMMIT_SHA: ${{ github.sha }}
+      - name: Configure Multiarch for Linux ARM64
+        if: matrix.target.target == 'aarch64-unknown-linux-musl'
+        run: sudo dpkg --add-architecture && sudo apt-get update
       - name: Install packages
         if: matrix.target.os == 'ubuntu-latest' && matrix.target.packages
         run: sudo apt install ${{ matrix.target.packages }} -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,19 +152,19 @@ jobs:
         # Following https://askubuntu.com/a/1307721 for Ubuntu 20.04
         run: |
           sudo dpkg --add-architecture arm64
-          
+
           sudo sed -i "s/deb h/deb [arch=amd64] h/g" /etc/apt/sources.list
-          sudo echo "# arm64 repositories" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main restricted" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main restricted" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal universe" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates universe" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal multiverse" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates multiverse" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main restricted universe multiverse" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main restricted" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security universe" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security multiverse" >> /etc/apt/sources.list
+          echo "# arm64 repositories" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main restricted" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main restricted" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal universe" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates universe" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal multiverse" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates multiverse" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main restricted" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security universe" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security multiverse" | sudo tee -a /etc/apt/sources.list
 
           sudo apt-get update
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,25 @@ jobs:
           RELEASE_COMMIT_SHA: ${{ github.sha }}
       - name: Configure Multiarch for Linux ARM64
         if: matrix.target.target == 'aarch64-unknown-linux-musl'
-        run: sudo dpkg --add-architecture arm64 && sudo apt-get update
+        # Following https://askubuntu.com/a/1307721 for Ubuntu 20.04
+        run: |
+          sudo dpkg --add-architecture arm64
+          
+          sudo sed -i "s/deb h/deb [arch=amd64] h/g" /etc/apt/sources.list
+          sudo echo "# arm64 repositories" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main restricted" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main restricted" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal universe" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates universe" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal multiverse" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates multiverse" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-backports main restricted universe multiverse" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security main restricted" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security universe" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-security multiverse" >> /etc/apt/sources.list
+
+          sudo apt-get update
+
       - name: Install packages
         if: matrix.target.os == 'ubuntu-latest' && matrix.target.packages
         run: sudo apt install ${{ matrix.target.packages }} -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           RELEASE_COMMIT_SHA: ${{ github.sha }}
       - name: Configure Multiarch for Linux ARM64
         if: matrix.target.target == 'aarch64-unknown-linux-musl'
-        run: sudo dpkg --add-architecture && sudo apt-get update
+        run: sudo dpkg --add-architecture arm64 && sudo apt-get update
       - name: Install packages
         if: matrix.target.os == 'ubuntu-latest' && matrix.target.packages
         run: sudo apt install ${{ matrix.target.packages }} -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,12 @@ jobs:
             artifact-name: relay-bin-linux-x64
             packages: musl-tools
             features: vendored
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            build-name: relay
+            artifact-name: relay-bin-linux-arm64
+            packages: musl-tools
+            features: vendored
           - target: x86_64-apple-darwin
             os: macos-latest
             build-name: relay
@@ -173,6 +179,11 @@ jobs:
         with:
           name: relay-bin-linux-x64
           path: artifacts/linux-x64
+      - name: Download artifact relay-bin-linux-arm64
+        uses: actions/download-artifact@v2
+        with:
+          name: relay-bin-linux-arm64
+          path: artifacts/linux-arm64
       - name: Download artifact relay-bin-macos-x64
         uses: actions/download-artifact@v2
         with:
@@ -192,6 +203,7 @@ jobs:
         working-directory: artifacts
         run: |
           chmod +x linux-x64/relay
+          chmod +x linux-arm64/relay
           chmod +x macos-x64/relay
           chmod +x macos-arm64/relay
 

--- a/packages/relay-compiler/index.js
+++ b/packages/relay-compiler/index.js
@@ -22,6 +22,8 @@ if (process.platform === 'darwin' && process.arch === 'x64') {
   binary = path.join(__dirname, 'macos-arm64', 'relay');
 } else if (process.platform === 'linux' && process.arch === 'x64') {
   binary = path.join(__dirname, 'linux-x64', 'relay');
+} else if (process.platform === 'linux' && process.arch === 'arm64') {
+  binary = path.join(__dirname, 'linux-arm64', 'relay');
 } else if (process.platform === 'win32' && process.arch === 'x64') {
   binary = path.join(__dirname, 'win-x64', 'relay.exe');
 } else {

--- a/vscode-extension/src/utils.ts
+++ b/vscode-extension/src/utils.ts
@@ -26,6 +26,8 @@ function getBinaryPathRelativeToPackageJson() {
     binaryPathRelativeToPackageJson = path.join('macos-arm64', 'relay');
   } else if (process.platform === 'linux' && process.arch === 'x64') {
     binaryPathRelativeToPackageJson = path.join('linux-x64', 'relay');
+  } else if (process.platform === 'linux' && process.arch === 'arm64') {
+    binaryPathRelativeToPackageJson = path.join('linux-arm64', 'relay');
   } else if (process.platform === 'win32' && process.arch === 'x64') {
     binaryPathRelativeToPackageJson = path.join('win-x64', 'relay.exe');
   } else {


### PR DESCRIPTION
Following discussions in https://github.com/facebook/relay/issues/3799 this PR adds support for a Linux ARM64 target for `relay-compiler`