### PR TITLE
Replace some links pointing to internalfb.com with public equivalents

### DIFF
--- a/website/docs/api-reference/hooks/use-query-loader.md
+++ b/website/docs/api-reference/hooks/use-query-loader.md
@@ -90,7 +90,7 @@ A tuple containing the following values:
     * Parameters
         * `variables`: the variables with which the query is loaded.
         * `options`: `LoadQueryOptions`. An optional options object, containing the following keys:
-            * `fetchPolicy`: _*[Optional]*_ Determines if cached data should be used, and when to send a network request based on the cached data that is currently available in the Relay store (for more details, see our [Fetch Policies](https://www.internalfb.com/intern/wiki/Relay/guided-tour-of-relay/reusing-cached-data-for-rendering/#fetch-policies) and [Garbage Collection](https://www.internalfb.com/intern/wiki/Relay/guided-tour-of-relay/reusing-cached-data-for-rendering/#garbage-collection-in-re) guides):
+            * `fetchPolicy`: _*[Optional]*_ Determines if cached data should be used, and when to send a network request based on the cached data that is currently available in the Relay store (for more details, see our [Fetch Policies](../../guided-tour/reusing-cached-data/fetch-policies) and [Garbage Collection](../../guided-tour/reusing-cached-data/presence-of-data) guides):
                 * "store-or-network": _*(default)*_ *will* reuse locally cached data and will *only* send a network request if any data for the query is missing. If the query is fully cached, a network request will *not* be made.
                 * "store-and-network": *will* reuse locally cached data and will *always* send a network request, regardless of whether any data was missing from the local cache or not.
                 * "network-only": *will* *not* reuse locally cached data, and will *always* send a network request to fetch the query, ignoring any data that might be locally cached in Relay.


### PR DESCRIPTION
In https://relay.dev/docs/, there're several links pointing to internalfb.com, which is not public (maybe related: https://github.com/facebook/relay/issues/3574 )
In this p-r, I replaced such links in https://relay.dev/docs/next/api-reference/use-query-loader/ with public equivalents.
I believe they point to intended documents, since https://relay.dev/docs/next/api-reference/use-lazy-load-query/ already has  similar links. (But I cannot confirm it, since I cannot access internalfb.com 😅).

