### PR TITLE
make ActorIdentifier flow strict-local to unbreak OSS build

### DIFF
--- a/packages/relay-runtime/multi-actor-environment/ActorIdentifier.js
+++ b/packages/relay-runtime/multi-actor-environment/ActorIdentifier.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @emails oncall+relay
- * @flow strict
+ * @flow strict-local
  * @format
  */
 


### PR DESCRIPTION
Not the best fix (see context on phabricator) but at least it unbreaks the OSS build