### PR TITLE
VSCode Extension | Support custom root directory / config path

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -31,7 +31,7 @@ Search for "Relay for VSCode" in the VS Code extensions panel or install through
 
 - `relay.rootDirectory` (default: VSCode project root) A path relative to the root of your VSCode project for the extension to work from. The default value is the root of your project. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the relay config is found. This is helpful if your project is in a nested directory.
 
-- `relay.pathToConfig` (default: null) Path to a relay config relative to the `rootDirectory`. This is helpful if your relay project is in a nested directory.
+- `relay.pathToConfig` (default: null) Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory.
 
 ## Features
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -29,6 +29,10 @@ Search for "Relay for VSCode" in the VS Code extensions panel or install through
 
 - `relay.pathToBinary` (default: null) A path relative to the Relay binary relative to the root of your project. If this is not specified, we will try to find one in your `node_modules` folder.
 
+- `relay.rootDirectory` (default: VSCode project root) A path relative to the root of your VSCode project for the extension to work from. The default value is the root of your project. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the relay config is found. This is helpful if your project is in a nested directory.
+
+- `relay.pathToConfig` (default: null) Path to a relay config relative to the `rootDirectory`. This is helpful if your relay project is in a nested directory.
+
 ## Features
 
 - IntelliSense

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -49,14 +49,14 @@
           ],
           "description": "Absolute path to the relay binary. If not provided, the extension will look in the nearest node_modules directory"
         },
-        "relay.lspWorkingDirectory": {
+        "relay.rootDirectory": {
           "scope": "workspace",
           "default": null,
           "type": [
             "string",
             "null"
           ],
-          "description": "Path to set as the current working directory relative to the project root when running the LSP. This is helpful if your relay project is in a nested directory."
+          "description": "A path relative to the root of your VSCode project for the extension to work from. The default value is the root of your project. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the relay config is found. This is helpful if your project is in a nested directory."
         },
         "relay.pathToConfig": {
           "scope": "workspace",
@@ -65,7 +65,7 @@
             "string",
             "null"
           ],
-          "description": "Path to a relay config relative to the project root. This is helpful if your relay project is in a nested directory."
+          "description": "Path to a relay config relative to the `rootDirectory`. This is helpful if your relay project is in a nested directory."
         }
       }
     }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -65,7 +65,7 @@
             "string",
             "null"
           ],
-          "description": "Path to a relay config relative to the `rootDirectory`. This is helpful if your relay project is in a nested directory."
+          "description": "Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory."
         }
       }
     }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -41,13 +41,31 @@
           "description": "Controls what is logged to the Output Channel."
         },
         "relay.pathToRelay": {
-          "scope": "window",
+          "scope": "workspace",
           "default": null,
           "type": [
             "string",
             "null"
           ],
           "description": "Absolute path to the relay binary. If not provided, the extension will look in the nearest node_modules directory"
+        },
+        "relay.lspWorkingDirectory": {
+          "scope": "workspace",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to set as the current working directory relative to the project root when running the LSP. This is helpful if your relay project is in a nested directory."
+        },
+        "relay.pathToConfig": {
+          "scope": "workspace",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to a relay config relative to the project root. This is helpful if your relay project is in a nested directory."
         }
       }
     }

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -8,7 +8,7 @@
 import { ConfigurationScope, workspace } from 'vscode';
 
 export type Config = {
-  lspWorkingDirectory: string | null;
+  rootDirectory: string | null;
   pathToRelay: string | null;
   pathToConfig: string | null;
   outputLevel: string;
@@ -21,6 +21,6 @@ export function getConfig(scope?: ConfigurationScope): Config {
     pathToRelay: configuration.get('pathToRelay') ?? null,
     pathToConfig: configuration.get('pathToConfig') ?? null,
     outputLevel: configuration.get('outputLevel') ?? 'quiet-with-errros',
-    lspWorkingDirectory: configuration.get('lspWorkingDirectory') ?? null,
+    rootDirectory: configuration.get('rootDirectory') ?? null,
   };
 }

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -8,7 +8,9 @@
 import { ConfigurationScope, workspace } from 'vscode';
 
 export type Config = {
+  lspWorkingDirectory: string | null;
   pathToRelay: string | null;
+  pathToConfig: string | null;
   outputLevel: string;
 };
 
@@ -17,6 +19,8 @@ export function getConfig(scope?: ConfigurationScope): Config {
 
   return {
     pathToRelay: configuration.get('pathToRelay') ?? null,
+    pathToConfig: configuration.get('pathToConfig') ?? null,
     outputLevel: configuration.get('outputLevel') ?? 'quiet-with-errros',
+    lspWorkingDirectory: configuration.get('lspWorkingDirectory') ?? null,
   };
 }

--- a/vscode-extension/src/constants.ts
+++ b/vscode-extension/src/constants.ts
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export const SEMVER_RANGE = '>=13.2.x <14';
+export const SEMVER_RANGE = '>=13.3.x <14';

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -22,8 +22,15 @@ export async function createAndStartClient(context: RelayExtensionContext) {
   context.outputChannel.appendLine('Starting the Relay GraphQL extension...');
 
   const config = getConfig();
-  const rootPath = workspace.rootPath || process.cwd();
 
+  let rootPath = workspace.rootPath || process.cwd();
+  if (config.rootDirectory) {
+    rootPath = path.join(rootPath, config.rootDirectory);
+  }
+
+  context.outputChannel.appendLine(
+    `Searching for the relay-compiler starting at: ${rootPath}`,
+  );
   const relayBinaryResult = await findRelayCompilerBinary(rootPath);
 
   let relayBinary: string | undefined;
@@ -80,9 +87,7 @@ export async function createAndStartClient(context: RelayExtensionContext) {
 
   const serverOptions: ServerOptions = {
     options: {
-      cwd: config.lspWorkingDirectory
-        ? path.join(rootPath, config.lspWorkingDirectory)
-        : undefined,
+      cwd: rootPath,
     },
     command: relayBinary,
     args,
@@ -125,6 +130,11 @@ export async function createAndStartClient(context: RelayExtensionContext) {
 
   client.registerFeature(new LSPStatusBarFeature(context));
 
+  context.outputChannel.appendLine(
+    `Starting the Relay Langauge Server with these options: ${JSON.stringify(
+      serverOptions,
+    )}`,
+  );
   // Start the client. This will also launch the server
   client.start();
   context.client = client;

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -6,6 +6,7 @@
  */
 
 import { window, workspace } from 'vscode';
+import path = require('path');
 import {
   LanguageClientOptions,
   RevealOutputChannelOn,
@@ -71,9 +72,20 @@ export async function createAndStartClient(context: RelayExtensionContext) {
 
   context.outputChannel.appendLine(`Using relay binary: ${relayBinary}`);
 
+  const args = ['lsp', `--output=${config.outputLevel}`];
+
+  if (config.pathToConfig) {
+    args.push(config.pathToConfig);
+  }
+
   const serverOptions: ServerOptions = {
+    options: {
+      cwd: config.lspWorkingDirectory
+        ? path.join(rootPath, config.lspWorkingDirectory)
+        : undefined,
+    },
     command: relayBinary,
-    args: ['lsp', `--output=${config.outputLevel}`],
+    args,
   };
 
   // Options to control the language client


### PR DESCRIPTION
To enable projects who have their relay config / node modules in a nested directory, we provide two new options. 

- `relay.rootDirectory` (default: VSCode project root) A path relative to the root of your VSCode project for the extension to work from. The default value is the root of your project. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the relay config is found. This is helpful if your project is in a nested directory.

- `relay.pathToConfig` (default: null) Path to a relay config relative to the `rootDirectory`. This is helpful if your relay project is in a nested directory.

I also added some more logging to help debug.

