### PR TITLE
[VSCode Extension] Start the compiler in watch mode

### DIFF
--- a/vscode-extension/.eslintrc
+++ b/vscode-extension/.eslintrc
@@ -13,6 +13,8 @@
 
     // Opinionated
     "import/prefer-default-export": "off",
-    "no-await-in-loop": "off"
+    "no-await-in-loop": "off",
+    "no-use-before-define": "off",
+    "@typescript-eslint/no-use-before-define": ["error", { "functions": false }]
   }
 }

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -20,6 +20,8 @@ Search for "Relay for VSCode" in the VS Code extensions panel or install through
 
 ## Configuration
 
+- `relay.startCompiler` (default: `false`) Whether or not we should automatically start the Relay Compiler in watch mode when you open a project.
+
 - `relay.outputLevel` (default: `quiet-with-errors`) Specify the output level of the Relay language server. The available options are
 
   - quiet

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -33,7 +33,19 @@
       "type": "object",
       "title": "Relay",
       "properties": {
-        "relay.outputLevel": {
+        "relay.compilerOutputLevel": {
+          "scope": "window",
+          "type": "string",
+          "default": "verbose",
+          "enum": [
+            "quiet",
+            "quiet-with-errors",
+            "verbose",
+            "debug"
+          ],
+          "description": "Controls what is logged to the Output Channel for the Relay Compiler."
+        },
+        "relay.lspOutputLevel": {
           "scope": "window",
           "type": "string",
           "default": "quiet-with-errors",
@@ -43,7 +55,7 @@
             "verbose",
             "debug"
           ],
-          "description": "Controls what is logged to the Output Channel."
+          "description": "Controls what is logged to the Output Channel for the Relay language server."
         },
         "relay.pathToRelay": {
           "scope": "workspace",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -27,6 +27,14 @@
       {
         "command": "relay.restart",
         "title": "Relay: Restart"
+      },
+      {
+        "command": "relay.startCompiler",
+        "title": "Relay: Start Compiler"
+      },
+      {
+        "command": "relay.stopCompiler",
+        "title": "Relay: Stop Compiler"
       }
     ],
     "configuration": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -71,6 +71,12 @@
             "null"
           ],
           "description": "Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory."
+        },
+        "relay.startCompiler": {
+          "scope": "workspace",
+          "default": false,
+          "type": "boolean",
+          "description": "Whether or not we should automatically start the Relay Compiler in watch mode when you open a project."
         }
       }
     }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -25,8 +25,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "relay.restartLanguageServer",
-        "title": "Relay: Restart Language Server"
+        "command": "relay.restart",
+        "title": "Relay: Restart"
       }
     ],
     "configuration": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -84,7 +84,7 @@
           ],
           "description": "Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory."
         },
-        "relay.startCompiler": {
+        "relay.autoStartCompiler": {
           "scope": "workspace",
           "default": false,
           "type": "boolean",

--- a/vscode-extension/src/commands/register.ts
+++ b/vscode-extension/src/commands/register.ts
@@ -7,13 +7,13 @@
 
 import { commands } from 'vscode';
 import { RelayExtensionContext } from '../context';
-import { handleRestartLanguageServerCommand } from './restartLanguageServer';
+import { handleRestartLanguageServerCommand } from './restart';
 import { handleShowOutputCommand } from './showOutput';
 
 export function registerCommands(context: RelayExtensionContext) {
   context.extensionContext.subscriptions.push(
     commands.registerCommand(
-      'relay.restartLanguageServer',
+      'relay.restart',
       handleRestartLanguageServerCommand.bind(null, context),
     ),
     commands.registerCommand(

--- a/vscode-extension/src/commands/register.ts
+++ b/vscode-extension/src/commands/register.ts
@@ -9,9 +9,19 @@ import { commands } from 'vscode';
 import { RelayExtensionContext } from '../context';
 import { handleRestartLanguageServerCommand } from './restart';
 import { handleShowOutputCommand } from './showOutput';
+import { handleStartCompilerCommand } from './startCompiler';
+import { handleStopCompilerCommand } from './stopCompiler';
 
 export function registerCommands(context: RelayExtensionContext) {
   context.extensionContext.subscriptions.push(
+    commands.registerCommand(
+      'relay.startCompiler',
+      handleStartCompilerCommand.bind(null, context),
+    ),
+    commands.registerCommand(
+      'relay.stopCompiler',
+      handleStopCompilerCommand.bind(null, context),
+    ),
     commands.registerCommand(
       'relay.restart',
       handleRestartLanguageServerCommand.bind(null, context),

--- a/vscode-extension/src/commands/restart.ts
+++ b/vscode-extension/src/commands/restart.ts
@@ -16,6 +16,18 @@ export function handleRestartLanguageServerCommand(
     return;
   }
 
+  if (context.compilerProcess) {
+    const killedCompilerSuccessfully = context.compilerProcess.kill();
+
+    if (!killedCompilerSuccessfully) {
+      window.showErrorMessage(
+        'An error occurred while trying to stop the Relay Compiler. Try restarting VSCode.',
+      );
+
+      return;
+    }
+  }
+
   context.client
     .stop()
     .then(() => {
@@ -24,6 +36,7 @@ export function handleRestartLanguageServerCommand(
       );
 
       context.client = null;
+      context.compilerProcess = null;
 
       createAndStartClient(context);
     })

--- a/vscode-extension/src/commands/restart.ts
+++ b/vscode-extension/src/commands/restart.ts
@@ -7,7 +7,7 @@
 
 import { window } from 'vscode';
 import { RelayExtensionContext } from '../context';
-import { createAndStartClient } from '../languageClient';
+import { createAndStartLanguageClient } from '../languageClient';
 
 export function handleRestartLanguageServerCommand(
   context: RelayExtensionContext,
@@ -38,7 +38,7 @@ export function handleRestartLanguageServerCommand(
       context.client = null;
       context.compilerProcess = null;
 
-      createAndStartClient(context);
+      createAndStartLanguageClient(context);
     })
     .catch(() => {
       window.showErrorMessage(

--- a/vscode-extension/src/commands/restartLanguageServer.ts
+++ b/vscode-extension/src/commands/restartLanguageServer.ts
@@ -19,7 +19,7 @@ export function handleRestartLanguageServerCommand(
   context.client
     .stop()
     .then(() => {
-      context.outputChannel.appendLine(
+      context.primaryOutputChannel.appendLine(
         'Successfully stopped existing relay lsp client',
       );
 

--- a/vscode-extension/src/commands/showOutput.ts
+++ b/vscode-extension/src/commands/showOutput.ts
@@ -8,5 +8,5 @@
 import { RelayExtensionContext } from '../context';
 
 export function handleShowOutputCommand(context: RelayExtensionContext): void {
-  context.outputChannel.show();
+  context.primaryOutputChannel.show();
 }

--- a/vscode-extension/src/commands/startCompiler.ts
+++ b/vscode-extension/src/commands/startCompiler.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { window } from 'vscode';
+import { RelayExtensionContext } from '../context';
+import { createAndStartCompiler } from '../compiler';
+
+export function handleStartCompilerCommand(
+  context: RelayExtensionContext,
+): void {
+  if (context.compilerProcess) {
+    window.showWarningMessage(
+      'Relay Compiler already running. Restart it with relay.restart',
+    );
+
+    return;
+  }
+
+  createAndStartCompiler(context);
+}

--- a/vscode-extension/src/commands/stopCompiler.ts
+++ b/vscode-extension/src/commands/stopCompiler.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { window } from 'vscode';
+import { RelayExtensionContext } from '../context';
+import { killCompiler } from '../compiler';
+
+export function handleStopCompilerCommand(
+  context: RelayExtensionContext,
+): void {
+  if (!context.compilerProcess) {
+    window.showWarningMessage('Relay Compiler not running.');
+
+    return;
+  }
+
+  killCompiler(context);
+}

--- a/vscode-extension/src/compiler.ts
+++ b/vscode-extension/src/compiler.ts
@@ -6,6 +6,7 @@
  */
 
 import { spawn } from 'child_process';
+import { window } from 'vscode';
 import { RelayExtensionContext } from './context';
 import { getConfig } from './config';
 
@@ -38,4 +39,30 @@ export function createAndStartCompiler(context: RelayExtensionContext) {
   });
 
   context.compilerProcess = process;
+}
+
+type DidNotError = boolean;
+
+export function killCompiler(context: RelayExtensionContext): DidNotError {
+  if (!context.compilerProcess) {
+    return true;
+  }
+
+  const killedCompilerSuccessfully = context.compilerProcess.kill();
+
+  if (!killedCompilerSuccessfully) {
+    window.showErrorMessage(
+      'An error occurred while trying to stop the Relay Compiler. Try restarting VSCode.',
+    );
+
+    return false;
+  }
+
+  context.primaryOutputChannel.appendLine(
+    'Successfully stopped existing relay compiler',
+  );
+
+  context.compilerProcess = null;
+
+  return true;
 }

--- a/vscode-extension/src/compiler.ts
+++ b/vscode-extension/src/compiler.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { spawn } from 'child_process';
+import { RelayExtensionContext } from './context';
+import { getConfig } from './config';
+
+export function createAndStartCompiler(context: RelayExtensionContext) {
+  const config = getConfig();
+
+  const args: string[] = ['--watch', `--output=${config.compilerOutpuLevel}`];
+
+  if (config.pathToConfig) {
+    args.push(config.pathToConfig);
+  }
+
+  context.primaryOutputChannel.appendLine(
+    [
+      'Starting the Relay Compiler with the following command:',
+      `${context.relayBinaryExecutionOptions.binaryPath} ${args.join(' ')}`,
+    ].join(' '),
+  );
+
+  const process = spawn(context.relayBinaryExecutionOptions.binaryPath, args, {
+    cwd: context.relayBinaryExecutionOptions.rootPath,
+  });
+
+  process.stdout.on('data', (data) => {
+    context.primaryOutputChannel.append(`${data}`);
+  });
+
+  process.stderr.on('data', (data) => {
+    context.primaryOutputChannel.append(`${data}`);
+  });
+
+  context.compilerProcess = process;
+}

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -12,6 +12,7 @@ export type Config = {
   pathToRelay: string | null;
   pathToConfig: string | null;
   outputLevel: string;
+  startCompiler: boolean;
 };
 
 export function getConfig(scope?: ConfigurationScope): Config {
@@ -22,5 +23,6 @@ export function getConfig(scope?: ConfigurationScope): Config {
     pathToConfig: configuration.get('pathToConfig') ?? null,
     outputLevel: configuration.get('outputLevel') ?? 'quiet-with-errros',
     rootDirectory: configuration.get('rootDirectory') ?? null,
+    startCompiler: configuration.get('startCompiler') ?? false,
   };
 }

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -13,7 +13,7 @@ export type Config = {
   pathToConfig: string | null;
   lspOutputLevel: string;
   compilerOutpuLevel: string;
-  startCompiler: boolean;
+  autoStartCompiler: boolean;
 };
 
 export function getConfig(scope?: ConfigurationScope): Config {
@@ -25,6 +25,6 @@ export function getConfig(scope?: ConfigurationScope): Config {
     lspOutputLevel: configuration.get('lspOutputLevel') ?? 'quiet-with-errros',
     compilerOutpuLevel: configuration.get('compilerOutputLevel') ?? 'info',
     rootDirectory: configuration.get('rootDirectory') ?? null,
-    startCompiler: configuration.get('startCompiler') ?? false,
+    autoStartCompiler: configuration.get('autoStartCompiler') ?? false,
   };
 }

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -11,7 +11,8 @@ export type Config = {
   rootDirectory: string | null;
   pathToRelay: string | null;
   pathToConfig: string | null;
-  outputLevel: string;
+  lspOutputLevel: string;
+  compilerOutpuLevel: string;
   startCompiler: boolean;
 };
 
@@ -21,7 +22,8 @@ export function getConfig(scope?: ConfigurationScope): Config {
   return {
     pathToRelay: configuration.get('pathToRelay') ?? null,
     pathToConfig: configuration.get('pathToConfig') ?? null,
-    outputLevel: configuration.get('outputLevel') ?? 'quiet-with-errros',
+    lspOutputLevel: configuration.get('lspOutputLevel') ?? 'quiet-with-errros',
+    compilerOutpuLevel: configuration.get('compilerOutputLevel') ?? 'info',
     rootDirectory: configuration.get('rootDirectory') ?? null,
     startCompiler: configuration.get('startCompiler') ?? false,
   };

--- a/vscode-extension/src/context.ts
+++ b/vscode-extension/src/context.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { ChildProcess } from 'child_process';
 import { ExtensionContext, OutputChannel, StatusBarItem } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 
@@ -22,7 +23,9 @@ import { LanguageClient } from 'vscode-languageclient/node';
 // https://code.visualstudio.com/api/extension-capabilities/common-capabilities#data-storage
 export type RelayExtensionContext = {
   client: LanguageClient | null;
-  outputChannel: OutputChannel;
+  primaryOutputChannel: OutputChannel;
+  lspOutputChannel: OutputChannel;
   extensionContext: ExtensionContext;
   statusBar: StatusBarItem;
+  compilerProcess: ChildProcess | null;
 };

--- a/vscode-extension/src/context.ts
+++ b/vscode-extension/src/context.ts
@@ -22,10 +22,14 @@ import { LanguageClient } from 'vscode-languageclient/node';
 // as it's persisted to disk.
 // https://code.visualstudio.com/api/extension-capabilities/common-capabilities#data-storage
 export type RelayExtensionContext = {
+  statusBar: StatusBarItem;
   client: LanguageClient | null;
-  primaryOutputChannel: OutputChannel;
   lspOutputChannel: OutputChannel;
   extensionContext: ExtensionContext;
-  statusBar: StatusBarItem;
+  primaryOutputChannel: OutputChannel;
   compilerProcess: ChildProcess | null;
+  relayBinaryExecutionOptions: {
+    rootPath: string;
+    binaryPath: string;
+  };
 };

--- a/vscode-extension/src/errorHandler.ts
+++ b/vscode-extension/src/errorHandler.ts
@@ -37,7 +37,7 @@ export function createErrorHandler(
         )
         .then((selected) => {
           if (selected === 'Go to output') {
-            context.outputChannel.show();
+            context.primaryOutputChannel.show();
           }
         });
 
@@ -53,7 +53,7 @@ export function createErrorHandler(
         )
         .then((selected) => {
           if (selected === 'Go to output') {
-            context.outputChannel.show();
+            context.primaryOutputChannel.show();
           }
         });
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5,37 +5,86 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ExtensionContext, window } from 'vscode';
+import path = require('path');
+import { ExtensionContext, window, workspace } from 'vscode';
 import { registerCommands } from './commands/register';
+import { createAndStartCompiler } from './compiler';
+import { getConfig } from './config';
 
 import { RelayExtensionContext } from './context';
-import { createAndStartClient } from './languageClient';
+import { createAndStartLanguageClient } from './languageClient';
 import { createStatusBarItem, intializeStatusBarItem } from './statusBarItem';
+import { findRelayBinaryWithWarnings } from './utils/findRelayBinary';
 
-let relayExtensionContext: RelayExtensionContext | undefined;
+let relayExtensionContext: RelayExtensionContext | null = null;
 
-export async function activate(extensionContext: ExtensionContext) {
-  const primaryOutputChannel = window.createOutputChannel('Relay');
-
-  const lspOutputChannel = window.createOutputChannel('Relay LSP Logs');
+async function buildRelayExtensionContext(
+  extensionContext: ExtensionContext,
+): Promise<RelayExtensionContext | null> {
+  const config = getConfig();
 
   const statusBar = createStatusBarItem();
+  const primaryOutputChannel = window.createOutputChannel('Relay');
+  const lspOutputChannel = window.createOutputChannel('Relay LSP Logs');
 
-  relayExtensionContext = {
-    statusBar,
-    client: null,
-    extensionContext,
-    lspOutputChannel,
-    primaryOutputChannel,
-    compilerProcess: null,
-  };
-
-  extensionContext.subscriptions.push(primaryOutputChannel);
   extensionContext.subscriptions.push(statusBar);
+  extensionContext.subscriptions.push(lspOutputChannel);
+  extensionContext.subscriptions.push(primaryOutputChannel);
 
-  intializeStatusBarItem(relayExtensionContext);
-  registerCommands(relayExtensionContext);
-  createAndStartClient(relayExtensionContext);
+  let rootPath = workspace.rootPath || process.cwd();
+  if (config.rootDirectory) {
+    rootPath = path.join(rootPath, config.rootDirectory);
+  }
+
+  const binaryPath = await findRelayBinaryWithWarnings(primaryOutputChannel);
+
+  if (binaryPath) {
+    return {
+      statusBar,
+      client: null,
+      extensionContext,
+      lspOutputChannel,
+      primaryOutputChannel,
+      compilerProcess: null,
+      relayBinaryExecutionOptions: {
+        rootPath,
+        binaryPath,
+      },
+    };
+  }
+
+  primaryOutputChannel.appendLine(
+    'Stopping execution of the Relay VSCode extension since we could not find a valid compiler binary.',
+  );
+
+  return null;
+}
+
+export async function activate(extensionContext: ExtensionContext) {
+  const config = getConfig();
+
+  relayExtensionContext = await buildRelayExtensionContext(extensionContext);
+
+  if (relayExtensionContext) {
+    relayExtensionContext.primaryOutputChannel.appendLine(
+      'Starting the Relay GraphQL extension...',
+    );
+
+    intializeStatusBarItem(relayExtensionContext);
+    registerCommands(relayExtensionContext);
+    createAndStartLanguageClient(relayExtensionContext);
+
+    if (config.autoStartCompiler) {
+      createAndStartCompiler(relayExtensionContext);
+    } else {
+      relayExtensionContext.primaryOutputChannel.appendLine(
+        [
+          'Not starting the Relay Compiler.',
+          'Please enable relay.autoStartCompiler in your settings if you want the compiler to start when you open your project.',
+        ].join(' '),
+      );
+    }
+  }
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,17 +15,22 @@ import { createStatusBarItem, intializeStatusBarItem } from './statusBarItem';
 let relayExtensionContext: RelayExtensionContext | undefined;
 
 export async function activate(extensionContext: ExtensionContext) {
-  const outputChannel = window.createOutputChannel('Relay Language Server');
+  const primaryOutputChannel = window.createOutputChannel('Relay');
+
+  const lspOutputChannel = window.createOutputChannel('Relay LSP Logs');
+
   const statusBar = createStatusBarItem();
 
   relayExtensionContext = {
     statusBar,
     client: null,
-    outputChannel,
     extensionContext,
+    lspOutputChannel,
+    primaryOutputChannel,
+    compilerProcess: null,
   };
 
-  extensionContext.subscriptions.push(outputChannel);
+  extensionContext.subscriptions.push(primaryOutputChannel);
   extensionContext.subscriptions.push(statusBar);
 
   intializeStatusBarItem(relayExtensionContext);
@@ -34,7 +39,7 @@ export async function activate(extensionContext: ExtensionContext) {
 }
 
 export function deactivate(): Thenable<void> | undefined {
-  relayExtensionContext?.outputChannel.dispose();
+  relayExtensionContext?.primaryOutputChannel.dispose();
 
   return relayExtensionContext?.client?.stop();
 }

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -10,6 +10,7 @@ import {
   RevealOutputChannelOn,
 } from 'vscode-languageclient';
 import { ServerOptions, LanguageClient } from 'vscode-languageclient/node';
+import { window } from 'vscode';
 import { RelayExtensionContext } from './context';
 import { createErrorHandler } from './errorHandler';
 import { LSPStatusBarFeature } from './lspStatusBarFeature';
@@ -84,4 +85,33 @@ export function createAndStartLanguageClient(context: RelayExtensionContext) {
   // Start the client. This will also launch the server
   client.start();
   context.client = client;
+}
+
+type DidNotError = boolean;
+
+export async function killLanguageClient(
+  context: RelayExtensionContext,
+): Promise<DidNotError> {
+  if (!context.client) {
+    return true;
+  }
+
+  return context.client
+    .stop()
+    .then(() => {
+      context.primaryOutputChannel.appendLine(
+        'Successfully stopped existing relay lsp client',
+      );
+
+      context.client = null;
+
+      return true;
+    })
+    .catch(() => {
+      window.showErrorMessage(
+        'An error occurred while trying to stop the Relay LSP Client. Try restarting VSCode.',
+      );
+
+      return false;
+    });
 }

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -5,155 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { window, workspace } from 'vscode';
-import path = require('path');
 import {
   LanguageClientOptions,
   RevealOutputChannelOn,
 } from 'vscode-languageclient';
 import { ServerOptions, LanguageClient } from 'vscode-languageclient/node';
-import { spawn } from 'child_process';
 import { RelayExtensionContext } from './context';
 import { createErrorHandler } from './errorHandler';
 import { LSPStatusBarFeature } from './lspStatusBarFeature';
-import { findRelayCompilerBinary } from './utils';
 import { getConfig } from './config';
 
-export async function createAndStartClient(context: RelayExtensionContext) {
+export function createAndStartLanguageClient(context: RelayExtensionContext) {
   const config = getConfig();
 
   context.primaryOutputChannel.appendLine(
-    'Starting the Relay GraphQL extension...',
+    `Using relay binary: ${context.relayBinaryExecutionOptions.binaryPath}`,
   );
-
-  let rootPath = workspace.rootPath || process.cwd();
-  if (config.rootDirectory) {
-    rootPath = path.join(rootPath, config.rootDirectory);
-  }
-
-  context.primaryOutputChannel.appendLine(
-    `Searching for the relay-compiler starting at: ${rootPath}`,
-  );
-  const relayBinaryResult = await findRelayCompilerBinary(rootPath);
-
-  let relayBinary: string | undefined;
-  if (config.pathToRelay) {
-    context.primaryOutputChannel.appendLine(
-      "You've manually specified 'relay.pathToBinary'. We cannot confirm this version of the Relay Compiler is supported by this version of the extension. I hope you know what you're doing.",
-    );
-
-    relayBinary = config.pathToRelay;
-  } else if (relayBinaryResult.kind === 'versionDidNotMatch') {
-    window.showErrorMessage(
-      // Array syntax so it's easier to read this message in the source code.
-      [
-        `The installed version of the Relay Compiler is version: '${relayBinaryResult.version}'.`,
-        `We found this version in the package.json at the following path: ${relayBinaryResult.path}`,
-        `This version of the extension supports the following semver range: '${relayBinaryResult.expectedRange}'.`,
-        'Please update your extension / relay-compiler to accommodate the version requirements.',
-      ].join(' '),
-      'Okay',
-    );
-
-    return;
-  } else if (relayBinaryResult.kind === 'packageNotFound') {
-    context.primaryOutputChannel.appendLine(
-      "Could not find the 'relay-compiler' package in your node_modules. Maybe you're not inside of a project with relay installed.",
-    );
-
-    return;
-  } else if (relayBinaryResult.kind === 'architectureNotSupported') {
-    context.primaryOutputChannel.appendLine(
-      `The 'relay-compiler' does not ship a binary for the architecture: ${process.arch}`,
-    );
-
-    return;
-  } else if (relayBinaryResult.kind === 'prereleaseCompilerFound') {
-    context.primaryOutputChannel.appendLine(
-      [
-        'You have a pre-release version of the relay-compiler package installed.',
-        'We are unable to confirm if this version is compatible with the Relay',
-        'VSCode Extension. Proceeding on the assumption that you know what you are',
-        'doing.',
-      ].join(' '),
-    );
-
-    relayBinary = relayBinaryResult.path;
-  } else if (relayBinaryResult.kind === 'compilerFound') {
-    relayBinary = relayBinaryResult.path;
-  }
-
-  if (!relayBinary) {
-    context.primaryOutputChannel.appendLine(
-      'Stopping execution of the Relay VSCode extension since we could not find a valid compiler binary.',
-    );
-
-    return;
-  }
-
-  context.primaryOutputChannel.appendLine(`Using relay binary: ${relayBinary}`);
-
-  startLspClient({ rootPath, relayBinary, context });
-
-  if (config.autoStartCompiler) {
-    startCompiler({ rootPath, relayBinary, context });
-  } else {
-    context.primaryOutputChannel.appendLine(
-      [
-        'Not starting the Relay Compiler.',
-        'Please enable relay.autoStartCompiler in your settings if you want the compiler to start when you open your project.',
-      ].join(' '),
-    );
-  }
-}
-
-type StartCompilerArgs = {
-  rootPath: string;
-  relayBinary: string;
-  context: RelayExtensionContext;
-};
-
-function startCompiler({ rootPath, relayBinary, context }: StartCompilerArgs) {
-  const config = getConfig();
-
-  const args: string[] = ['--watch', `--output=${config.compilerOutpuLevel}`];
-
-  if (config.pathToConfig) {
-    args.push(config.pathToConfig);
-  }
-
-  context.primaryOutputChannel.appendLine(
-    [
-      'Starting the Relay Compiler with the following command:',
-      `${relayBinary} ${args.join(' ')}`,
-    ].join(' '),
-  );
-
-  const process = spawn(relayBinary, args, { cwd: rootPath });
-
-  process.stdout.on('data', (data) => {
-    context.primaryOutputChannel.append(`${data}`);
-  });
-
-  process.stderr.on('data', (data) => {
-    context.primaryOutputChannel.append(`${data}`);
-  });
-
-  context.compilerProcess = process;
-}
-
-type StartLspClientArgs = {
-  rootPath: string;
-  relayBinary: string;
-  context: RelayExtensionContext;
-};
-
-function startLspClient({
-  rootPath,
-  relayBinary,
-  context,
-}: StartLspClientArgs) {
-  const config = getConfig();
 
   const args = ['lsp', `--output=${config.lspOutputLevel}`];
 
@@ -163,9 +30,9 @@ function startLspClient({
 
   const serverOptions: ServerOptions = {
     options: {
-      cwd: rootPath,
+      cwd: context.relayBinaryExecutionOptions.rootPath,
     },
-    command: relayBinary,
+    command: context.relayBinaryExecutionOptions.binaryPath,
     args,
   };
 
@@ -213,6 +80,7 @@ function startLspClient({
       serverOptions,
     )}`,
   );
+
   // Start the client. This will also launch the server
   client.start();
   context.client = client;

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -95,13 +95,13 @@ export async function createAndStartClient(context: RelayExtensionContext) {
 
   startLspClient({ rootPath, relayBinary, context });
 
-  if (config.startCompiler) {
+  if (config.autoStartCompiler) {
     startCompiler({ rootPath, relayBinary, context });
   } else {
     context.primaryOutputChannel.appendLine(
       [
         'Not starting the Relay Compiler.',
-        'Please enable relay.startCompiler in your settings if you want the compiler to start when you open your project.',
+        'Please enable relay.autoStartCompiler in your settings if you want the compiler to start when you open your project.',
       ].join(' '),
     );
   }

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -93,7 +93,7 @@ export async function createAndStartClient(context: RelayExtensionContext) {
 
   context.primaryOutputChannel.appendLine(`Using relay binary: ${relayBinary}`);
 
-  startClient({ rootPath, relayBinary, context });
+  startLspClient({ rootPath, relayBinary, context });
 
   if (config.startCompiler) {
     startCompiler({ rootPath, relayBinary, context });
@@ -116,7 +116,7 @@ type StartCompilerArgs = {
 function startCompiler({ rootPath, relayBinary, context }: StartCompilerArgs) {
   const config = getConfig();
 
-  const args: string[] = ['--watch', `--output=${config.outputLevel}`];
+  const args: string[] = ['--watch', `--output=${config.compilerOutpuLevel}`];
 
   if (config.pathToConfig) {
     args.push(config.pathToConfig);
@@ -142,16 +142,20 @@ function startCompiler({ rootPath, relayBinary, context }: StartCompilerArgs) {
   context.compilerProcess = process;
 }
 
-type StartClientArgs = {
+type StartLspClientArgs = {
   rootPath: string;
   relayBinary: string;
   context: RelayExtensionContext;
 };
 
-function startClient({ rootPath, relayBinary, context }: StartClientArgs) {
+function startLspClient({
+  rootPath,
+  relayBinary,
+  context,
+}: StartLspClientArgs) {
   const config = getConfig();
 
-  const args = ['lsp', `--output=${config.outputLevel}`];
+  const args = ['lsp', `--output=${config.lspOutputLevel}`];
 
   if (config.pathToConfig) {
     args.push(config.pathToConfig);


### PR DESCRIPTION
Alright, so the main goal here is to have the compiler run in watch mode alongside the lsp when a user opens a project. A couple of things had to change to support this.

- Two configs for the compiler output level. one for the lsp, one for the compiler.
- New config `autoStartCompiler` which runs the compiler in watch mode (default false)
- Changed `restartLanguageServer` to `restart` since you definitely want to restart both if you're restarting one.
  - This will restart the compiler if it was previously running.
- Added `relay.startCompiler`, and `relay.stopCompiler`
- Rearchitected `RelayExtensionContext` to include the relay binary path since it's needed in other contexts.
  - You need it when you're restarting the compiler.
  - You need it when you're restarting the LSP
  - I didn't want to tie together starting / restarting the lsp / compiler with looking for the relay binary. Now we can update the binary path / root dir in isolation.
 