### PR TITLE
Add language to suggested config file

### DIFF
--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -209,7 +209,8 @@ You can also pass the path to the configuration file as `relay-compiler ./path-t
 Example file:
 {{
   "src": "./src",
-  "schema": "./path-to/schema.graphql"
+  "schema": "./path-to/schema.graphql",
+  "language": "javascript"
 }}
 "#,
                     match loaders_sources.len() {


### PR DESCRIPTION
`language` is a required key. Without this the config is invalid. If we're going to propose a minimal config, it should be valid.