### PR TITLE
Allow persisting to also include the query text for safe migration

### DIFF
--- a/compiler/crates/relay-codegen/src/build_ast.rs
+++ b/compiler/crates/relay-codegen/src/build_ast.rs
@@ -1870,20 +1870,16 @@ impl<'schema, 'builder, 'config> CodegenBuilder<'schema, 'builder, 'config> {
         // Construct metadata object
         let mut params_object = vec![];
 
-        match (&request_parameters.text, request_parameters.id) {
-            (Some(ref text), _) => {
-                params_object.push(ObjectEntry {
-                    key: CODEGEN_CONSTANTS.cache_id,
-                    value: Primitive::RawString(md5(&text)),
-                });
-            }
-            (None, None) => {
-                params_object.push(ObjectEntry {
-                    key: CODEGEN_CONSTANTS.cache_id,
-                    value: Primitive::RawString(md5(operation.name.item.0.lookup())),
-                });
-            }
-            _ => (),
+        if let Some(ref text) = &request_parameters.text {
+            params_object.push(ObjectEntry {
+                key: CODEGEN_CONSTANTS.cache_id,
+                value: Primitive::RawString(md5(&text)),
+            });
+        } else if request_parameters.id.is_none() {
+            params_object.push(ObjectEntry {
+                key: CODEGEN_CONSTANTS.cache_id,
+                value: Primitive::RawString(md5(operation.name.item.0.lookup())),
+            });
         }
 
         params_object.push(ObjectEntry {

--- a/compiler/crates/relay-codegen/src/build_ast.rs
+++ b/compiler/crates/relay-codegen/src/build_ast.rs
@@ -1868,24 +1868,25 @@ impl<'schema, 'builder, 'config> CodegenBuilder<'schema, 'builder, 'config> {
         metadata_items.sort_unstable_by_key(|entry| entry.key);
 
         // Construct metadata object
-        let metadata_prop = ObjectEntry {
-            key: CODEGEN_CONSTANTS.metadata,
-            value: Primitive::Key(self.object(metadata_items)),
-        };
-        let name_prop = ObjectEntry {
-            key: CODEGEN_CONSTANTS.name,
-            value: Primitive::String(request_parameters.name),
-        };
-        let operation_kind_prop = ObjectEntry {
-            key: CODEGEN_CONSTANTS.operation_kind,
-            value: Primitive::String(match request_parameters.operation_kind {
-                OperationKind::Query => CODEGEN_CONSTANTS.query,
-                OperationKind::Mutation => CODEGEN_CONSTANTS.mutation,
-                OperationKind::Subscription => CODEGEN_CONSTANTS.subscription,
-            }),
-        };
+        let mut params_object = vec![];
 
-        let id_prop = ObjectEntry {
+        match (&request_parameters.text, request_parameters.id) {
+            (Some(ref text), _) => {
+                params_object.push(ObjectEntry {
+                    key: CODEGEN_CONSTANTS.cache_id,
+                    value: Primitive::RawString(md5(&text)),
+                });
+            }
+            (None, None) => {
+                params_object.push(ObjectEntry {
+                    key: CODEGEN_CONSTANTS.cache_id,
+                    value: Primitive::RawString(md5(operation.name.item.0.lookup())),
+                });
+            }
+            _ => (),
+        }
+
+        params_object.push(ObjectEntry {
             key: CODEGEN_CONSTANTS.id,
             value: match request_parameters.id {
                 Some(QueryID::Persisted { id, .. }) => Primitive::RawString(id.clone()),
@@ -1897,50 +1898,31 @@ impl<'schema, 'builder, 'config> CodegenBuilder<'schema, 'builder, 'config> {
                 }
                 None => Primitive::Null,
             },
-        };
+        });
+        params_object.push(ObjectEntry {
+            key: CODEGEN_CONSTANTS.metadata,
+            value: Primitive::Key(self.object(metadata_items)),
+        });
+        params_object.push(ObjectEntry {
+            key: CODEGEN_CONSTANTS.name,
+            value: Primitive::String(request_parameters.name),
+        });
+        params_object.push(ObjectEntry {
+            key: CODEGEN_CONSTANTS.operation_kind,
+            value: Primitive::String(match request_parameters.operation_kind {
+                OperationKind::Query => CODEGEN_CONSTANTS.query,
+                OperationKind::Mutation => CODEGEN_CONSTANTS.mutation,
+                OperationKind::Subscription => CODEGEN_CONSTANTS.subscription,
+            }),
+        });
 
-        let mut params_object = if let Some(text) = request_parameters.text {
-            vec![
-                ObjectEntry {
-                    key: CODEGEN_CONSTANTS.cache_id,
-                    value: Primitive::RawString(md5(&text)),
-                },
-                id_prop,
-                metadata_prop,
-                name_prop,
-                operation_kind_prop,
-                ObjectEntry {
-                    key: CODEGEN_CONSTANTS.text,
-                    value: Primitive::RawString(text),
-                },
-            ]
-        } else if request_parameters.id.is_some() {
-            vec![
-                id_prop,
-                metadata_prop,
-                name_prop,
-                operation_kind_prop,
-                ObjectEntry {
-                    key: CODEGEN_CONSTANTS.text,
-                    value: Primitive::Null,
-                },
-            ]
-        } else {
-            vec![
-                ObjectEntry {
-                    key: CODEGEN_CONSTANTS.cache_id,
-                    value: Primitive::RawString(md5(operation.name.item.0.lookup())),
-                },
-                id_prop,
-                metadata_prop,
-                name_prop,
-                operation_kind_prop,
-                ObjectEntry {
-                    key: CODEGEN_CONSTANTS.text,
-                    value: Primitive::Null,
-                },
-            ]
-        };
+        params_object.push(ObjectEntry {
+            key: CODEGEN_CONSTANTS.text,
+            value: match request_parameters.text {
+                Some(text) => Primitive::RawString(text),
+                None => Primitive::Null,
+            },
+        });
 
         let provided_variables = if top_level_statements
             .contains(CODEGEN_CONSTANTS.provided_variables_definition.lookup())

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -43,7 +43,7 @@ type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 pub type ProjectName = StringKey;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct RemotePersistConfig {
     /// URL to send a POST request to to persist.
     pub url: String,
@@ -62,6 +62,9 @@ pub struct RemotePersistConfig {
         deserialize_with = "deserialize_semaphore_permits"
     )]
     pub semaphore_permits: Option<usize>,
+
+    #[serde(default)]
+    pub include_query_text: bool,
 }
 
 fn deserialize_semaphore_permits<'de, D>(d: D) -> Result<Option<usize>, D::Error>

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -101,6 +101,9 @@ pub struct LocalPersistConfig {
 
     #[serde(default)]
     pub algorithm: LocalPersistAlgorithm,
+
+    #[serde(default)]
+    pub include_query_text: bool,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -108,6 +111,15 @@ pub struct LocalPersistConfig {
 pub enum PersistConfig {
     Remote(RemotePersistConfig),
     Local(LocalPersistConfig),
+}
+
+impl PersistConfig {
+    pub fn include_query_text(&self) -> bool {
+        match self {
+            PersistConfig::Remote(remote_config) => remote_config.include_query_text,
+            PersistConfig::Local(local_config) => local_config.include_query_text,
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for PersistConfig {

--- a/packages/relay-runtime/util/RelayConcreteNode.js
+++ b/packages/relay-runtime/util/RelayConcreteNode.js
@@ -43,30 +43,20 @@ export type ProvidedVariablesType = {+[key: string]: {get(): mixed}};
 
 /**
  * Contains the parameters required for executing a GraphQL request.
- * The operation can either be provided as a persisted `id` or `text`. If given
- * in `text` format, a `cacheID` as a hash of the text should be set to be used
- * for local caching.
+ * The operation can either be provided as a persisted `id` or `text` or both.
+ * If `text` format is provided, a `cacheID` as a hash of the text should be set
+ * to be used for local caching.
  */
-export type RequestParameters =
-  | {
-      +id: string,
-      +text: null,
-      // common fields
-      +name: string,
-      +operationKind: 'mutation' | 'query' | 'subscription',
-      +providedVariables?: ProvidedVariablesType,
-      +metadata: {[key: string]: mixed, ...},
-    }
-  | {
-      +cacheID: string,
-      +id: null,
-      +text: string | null,
-      // common fields
-      +name: string,
-      +operationKind: 'mutation' | 'query' | 'subscription',
-      +providedVariables?: ProvidedVariablesType,
-      +metadata: {[key: string]: mixed, ...},
-    };
+export type RequestParameters = {
+  +cacheID?: string,
+  +id: string | null,
+  +text: string | null,
+  // common fields
+  +name: string,
+  +operationKind: 'mutation' | 'query' | 'subscription',
+  +providedVariables?: ProvidedVariablesType,
+  +metadata: {[key: string]: mixed, ...},
+};
 
 export type ClientRequestParameters = {
   +cacheID: string,

--- a/packages/relay-runtime/util/RelayConcreteNode.js
+++ b/packages/relay-runtime/util/RelayConcreteNode.js
@@ -47,16 +47,26 @@ export type ProvidedVariablesType = {+[key: string]: {get(): mixed}};
  * If `text` format is provided, a `cacheID` as a hash of the text should be set
  * to be used for local caching.
  */
-export type RequestParameters = {
-  +cacheID?: string,
-  +id: string | null,
-  +text: string | null,
-  // common fields
-  +name: string,
-  +operationKind: 'mutation' | 'query' | 'subscription',
-  +providedVariables?: ProvidedVariablesType,
-  +metadata: {[key: string]: mixed, ...},
-};
+export type RequestParameters =
+  | {
+      +id: string,
+      +text: string | null,
+      // common fields
+      +name: string,
+      +operationKind: 'mutation' | 'query' | 'subscription',
+      +providedVariables?: ProvidedVariablesType,
+      +metadata: {[key: string]: mixed, ...},
+    }
+  | {
+      +cacheID: string,
+      +id: null,
+      +text: string | null,
+      // common fields
+      +name: string,
+      +operationKind: 'mutation' | 'query' | 'subscription',
+      +providedVariables?: ProvidedVariablesType,
+      +metadata: {[key: string]: mixed, ...},
+    };
 
 export type ClientRequestParameters = {
   +cacheID: string,


### PR DESCRIPTION
Hi folks.

We're attempting to start using persisted queries. However, we're not 100% confident in our ability to switch over to them in one big step safely.

Fetching the persisted documents is a new capability for our GraphQL server. If something goes wrong fetching the document, or if it introduces unexpected latency to our existing production queries we want to be able to fallback to the query text until we're more confident in its maturity.

Relay currently supports outputting the query text, or outputting the persisted document id. This PR introduces a middle state, where the text and id are both output. When both are sent with the GraphQL request from the client to the server, the server is able to control the rollout of persisted queries via a feature flag.

This PR introduces a `safeMigration` bool to the remote persist config, which when set will also output the query text in the operation params as well as the id
```js
persistConfig: {
  url: ...,
  params: ...,
  includeQueryText: true
}
```

The benefits of persisted queries (saving the network bytes) won't come until we've progressed past the migration stage, but it makes it possible to do the move in the first place.