### PR TITLE
Report schema location for invalid types

### DIFF
--- a/compiler/crates/schema/src/in_memory/mod.rs
+++ b/compiler/crates/schema/src/in_memory/mod.rs
@@ -1348,7 +1348,7 @@ impl InMemorySchema {
                 .iter()
                 .map(|field_def| {
                     let arguments = self.build_arguments(&field_def.arguments)?;
-                    let type_ = self.build_type_reference(&field_def.type_)?;
+                    let type_ = self.build_type_reference(&field_def.type_, field_location_key)?;
                     let directives = self.build_directive_values(&field_def.directives);
                     let description = field_def.description.as_ref().map(|desc| desc.value);
                     Ok(self.build_field(Field {
@@ -1383,14 +1383,15 @@ impl InMemorySchema {
                 let field_name = field_def.name.value;
                 let field_location = Location::new(source_location_key, field_def.name.span);
                 if let Some(prev_location) = existing_fields.insert(field_name, field_location) {
-                    return Err(vec![
-                        Diagnostic::error(SchemaError::DuplicateField(field_name), field_location)
-                            .annotate("previously defined here", prev_location),
-                    ]);
+                    return Err(vec![Diagnostic::error(
+                        SchemaError::DuplicateField(field_name),
+                        field_location,
+                    )
+                    .annotate("previously defined here", prev_location)]);
                 }
                 let arguments = self.build_arguments(&field_def.arguments)?;
                 let directives = self.build_directive_values(&field_def.directives);
-                let type_ = self.build_type_reference(&field_def.type_)?;
+                let type_ = self.build_type_reference(&field_def.type_, source_location_key)?;
                 let description = field_def.description.as_ref().map(|desc| desc.value);
                 field_ids.push(self.build_field(Field {
                     name: WithLocation::new(field_location, field_name),
@@ -1465,22 +1466,23 @@ impl InMemorySchema {
     fn build_type_reference(
         &mut self,
         ast_type: &TypeAnnotation,
+        source_location: SourceLocationKey,
     ) -> DiagnosticsResult<TypeReference> {
         Ok(match ast_type {
             TypeAnnotation::Named(named_type) => TypeReference::Named(
                 *self.type_map.get(&named_type.name.value).ok_or_else(|| {
                     vec![Diagnostic::error(
                         SchemaError::UndefinedType(named_type.name.value),
-                        Location::generated(),
+                        Location::new(source_location, named_type.name.span),
                     )]
                 })?,
             ),
-            TypeAnnotation::NonNull(of_type) => {
-                TypeReference::NonNull(Box::new(self.build_type_reference(&of_type.type_)?))
-            }
-            TypeAnnotation::List(of_type) => {
-                TypeReference::List(Box::new(self.build_type_reference(&of_type.type_)?))
-            }
+            TypeAnnotation::NonNull(of_type) => TypeReference::NonNull(Box::new(
+                self.build_type_reference(&of_type.type_, source_location)?,
+            )),
+            TypeAnnotation::List(of_type) => TypeReference::List(Box::new(
+                self.build_type_reference(&of_type.type_, source_location)?,
+            )),
         })
     }
 


### PR DESCRIPTION
With Client Edges, if you specify an `@edge_to` with an invalid type name we were previously reporting an error at a generated location.

<img width="1124" alt="Screen Shot 2022-05-25 at 8 39 24 AM" src="https://user-images.githubusercontent.com/162735/170302170-2bf3004d-e118-4c2b-a863-fd2d899a6555.png">

This also ensures we provide a correct error location when you type a field type in a client schema extension.



## Test Plan

Create a Relay Resolver with `@edge_to Foo` and see an error message that points to the correct location:

<img width="1126" alt="Screen Shot 2022-05-25 at 8 28 44 AM" src="https://user-images.githubusercontent.com/162735/170302024-342524e0-8a64-4afb-a2a9-ea676f2eee11.png">

