### PR TITLE
Show human readable compiler errors on compilation fail

### DIFF
--- a/compiler/crates/relay-bin/src/main.rs
+++ b/compiler/crates/relay-bin/src/main.rs
@@ -289,7 +289,7 @@ async fn handle_compiler_command(command: CompileCommand) -> Result<(), Error> {
             .compile()
             .await
             .map_err(|err| Error::CompilerError {
-                details: format!("{:?}", err),
+                details: format!("{}", err),
             })?;
     }
 


### PR DESCRIPTION
## Before
<img width="1123" alt="Screen Shot 2022-05-25 at 9 13 47 AM" src="https://user-images.githubusercontent.com/162735/170309477-608647df-812f-49fb-be99-eb9b5d65b792.png">

## After

<img width="1121" alt="Screen Shot 2022-05-25 at 9 13 58 AM" src="https://user-images.githubusercontent.com/162735/170309437-5d84df5c-52d9-4ba3-bd7b-51df4f53996d.png">
