### PR TITLE
Update Compiler Playground tests

### DIFF
--- a/compiler/crates/relay-compiler-playground/README.md
+++ b/compiler/crates/relay-compiler-playground/README.md
@@ -5,8 +5,7 @@ playground.
 
 ## Build The Wasm Module
 
-Ensure you have wasm-pack >= 0.10.0 installed. Go
-[here](https://rustwasm.github.io/wasm-pack/installer/) if you don't.
+Ensure you have wasm-pack >= 0.10.0 installed. Type `cargo install wasm-pack` if you don't.
 
 To build the wasm module:
 
@@ -57,4 +56,4 @@ yarn link relay-compiler-playground
 yarn start
 ```
 
-Navigate to `http://localhost:3000/compiler-playground`
+Navigate to `http://localhost:3000/compiler-explorer`

--- a/compiler/crates/relay-compiler-playground/__tests__/__snapshots__/relay_compiler_playground-test.js.snap
+++ b/compiler/crates/relay-compiler-playground/__tests__/__snapshots__/relay_compiler_playground-test.js.snap
@@ -162,66 +162,63 @@ fragment AgeFragment on User {
 `;
 
 exports[`Ok types (flow) 1`] = `
-"import type { FragmentReference } from \\"relay-runtime\\";
-declare export opaque type AgeFragment$ref: FragmentReference;
-declare export opaque type AgeFragment$fragmentType: AgeFragment$ref;
-export type AgeFragment = {|
+"import type { FragmentType } from \\"relay-runtime\\";
+declare export opaque type AgeFragment$fragmentType: FragmentType;
+export type AgeFragment$data = {|
   +age: ?number,
-  +$refType: AgeFragment$ref,
+  +$fragmentType: AgeFragment$fragmentType,
 |};
-export type AgeFragment$data = AgeFragment;
 export type AgeFragment$key = {
   +$data?: AgeFragment$data,
-  +$fragmentRefs: AgeFragment$ref,
+  +$fragmentSpreads: AgeFragment$fragmentType,
   ...
 };
 
 
-import type { AgeFragment$ref } from \\"AgeFragment.graphql\\";
-export type MyQueryVariables = {||};
-export type MyQueryResponse = {|
+type AgeFragment$fragmentType = any;
+export type MyQuery$variables = {||};
+export type MyQuery$data = {|
   +me: ?{|
-    +name: ?string,
     +best_friend: ?{|
-      +$fragmentRefs: AgeFragment$ref,
+      +$fragmentSpreads: AgeFragment$fragmentType,
     |},
-    +$fragmentRefs: AgeFragment$ref,
+    +name: ?string,
+    +$fragmentSpreads: AgeFragment$fragmentType,
   |},
 |};
 export type MyQuery = {|
-  variables: MyQueryVariables,
-  response: MyQueryResponse,
+  response: MyQuery$data,
+  variables: MyQuery$variables,
 |};
 "
 `;
 
 exports[`Ok types (typescript) 1`] = `
 "import { FragmentRefs } from \\"relay-runtime\\";
-export type AgeFragment = {
+export type AgeFragment$data = {
   readonly age: number | null;
-  readonly \\" $refType\\": \\"AgeFragment\\";
+  readonly \\" $fragmentType\\": \\"AgeFragment\\";
 };
-export type AgeFragment$data = AgeFragment;
 export type AgeFragment$key = {
   readonly \\" $data\\"?: AgeFragment$data;
-  readonly \\" $fragmentRefs\\": FragmentRefs<\\"AgeFragment\\">;
+  readonly \\" $fragmentSpreads\\": FragmentRefs<\\"AgeFragment\\">;
 };
 
 
 import { FragmentRefs } from \\"relay-runtime\\";
-export type MyQueryVariables = {};
-export type MyQueryResponse = {
+export type MyQuery$variables = {};
+export type MyQuery$data = {
   readonly me: {
-    readonly name: string | null;
     readonly best_friend: {
-      readonly \\" $fragmentRefs\\": FragmentRefs<\\"AgeFragment\\">;
+      readonly \\" $fragmentSpreads\\": FragmentRefs<\\"AgeFragment\\">;
     } | null;
-    readonly \\" $fragmentRefs\\": FragmentRefs<\\"AgeFragment\\">;
+    readonly name: string | null;
+    readonly \\" $fragmentSpreads\\": FragmentRefs<\\"AgeFragment\\">;
   } | null;
 };
 export type MyQuery = {
-  variables: MyQueryVariables;
-  response: MyQueryResponse;
+  response: MyQuery$data;
+  variables: MyQuery$variables;
 };
 "
 `;

--- a/compiler/crates/relay-compiler-playground/__tests__/relay_compiler_playground-test.js
+++ b/compiler/crates/relay-compiler-playground/__tests__/relay_compiler_playground-test.js
@@ -95,7 +95,7 @@ describe('Ok', () => {
 
   test('types (flow)', () => {
     const actual = JSON.parse(
-      playground.parse_to_types('{}', '{}', SCHEMA, DOCUMENT),
+      playground.parse_to_types('{}', '{"language": "flow"}', SCHEMA, DOCUMENT),
     );
     expect(actual.Ok).toMatchSnapshot();
   });
@@ -115,7 +115,7 @@ describe('Ok', () => {
   test('parse_to_reader_ast @required', () => {
     const actual = JSON.parse(
       playground.parse_to_reader_ast(
-        '{"enable_required_transform": true}',
+        '{}',
         SCHEMA,
         `fragment AgeFragment on User {
             age @required(action: LOG)
@@ -139,7 +139,7 @@ describe('Err', () => {
     );
     expect(actual.Err).toEqual({
       ConfigError:
-        'unknown field `this_key_does_not_exist`, expected one of `enable_flight_transform`, `enable_required_transform`, `enable_relay_resolver_transform`, `hash_supported_argument`, `no_inline`, `enable_3d_branch_arg_generation`, `actor_change_support`, `text_artifacts`, `enable_client_edges` at line 1 column 26',
+        'unknown field `this_key_does_not_exist`, expected one of `enable_flight_transform`, `enable_relay_resolver_transform`, `hash_supported_argument`, `no_inline`, `enable_3d_branch_arg_generation`, `actor_change_support`, `text_artifacts`, `enable_client_edges`, `enable_provided_variables`, `skip_printing_nulls`, `enable_fragment_aliases` at line 1 column 26',
     });
   });
   test('parse_to_ast', () => {
@@ -231,7 +231,12 @@ describe('Err', () => {
 
   test('parse_to_types', () => {
     const actual = JSON.parse(
-      playground.parse_to_types('{}', '{}', SCHEMA, INVALID_DOCUMENT),
+      playground.parse_to_types(
+        '{}',
+        '{"language": "typescript"}',
+        SCHEMA,
+        INVALID_DOCUMENT,
+      ),
     );
     expect(actual.Err).toEqual({
       DocumentDiagnostics: [
@@ -258,7 +263,7 @@ describe('Err', () => {
     );
     expect(actual.Err).toEqual({
       TypegenConfigError:
-        'unknown variant `should_not_exist`, expected `flow` or `typescript` at line 1 column 31',
+        'unknown variant `should_not_exist`, expected one of `javascript`, `typescript`, `flow` at line 1 column 31',
     });
   });
 
@@ -275,29 +280,6 @@ describe('Err', () => {
           line_start: 3,
           message:
             'The type `User` has no field `does_not_exist`.:<generated>:34:48\n',
-        },
-      ],
-    });
-  });
-  test('parse_to_reader_ast @required', () => {
-    const actual = JSON.parse(
-      playground.parse_to_reader_ast(
-        '{"enable_required_transform": false}',
-        SCHEMA,
-        `fragment AgeFragment on User {
-            age @required(action: LOG)
-        }`,
-      ),
-    );
-    expect(actual.Err).toEqual({
-      DocumentDiagnostics: [
-        {
-          column_end: 25,
-          column_start: 16,
-          line_end: 1,
-          line_start: 1,
-          message:
-            'The @required directive is experimental and not yet supported for use in product code:<generated>:47:56\n',
         },
       ],
     });


### PR DESCRIPTION
The compiler playground does not currently build due to the version of parkling_lot that we are using being incompatible with wasm-pack. I manually updated the parking_lot version to `0.12` in order to get it building again. This uncovered some tests which are currently failing. Updating these tests will make it easier to get the the compiler playground building again once we upgrade parking_lot officially.

Currently upgrading is somewhat complicated because we try to only have one version of each dependency installed at any given time in the Meta monorepo.