### PR TITLE
[Compiler Explorer] Persist explorer state in the URL/local storage

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -25,6 +25,7 @@
     "classnames": "^2.2.6",
     "clsx": "^1.1.1",
     "docusaurus-plugin-internaldocs-fb": "0.10.7",
+    "lz-string": "^1.4.4",
     "monaco-editor": "^0.24.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/website/src/compiler-explorer/ExplorerState.js
+++ b/website/src/compiler-explorer/ExplorerState.js
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+import * as LZString from 'lz-string';
+
+const {useReducer, useCallback, useMemo, useEffect} = React;
+
+const DEFAULT_SCHEMA = `
+type User {
+  name: String
+  age: Int
+  best_friend: User
+}
+
+type Query {
+  me: User
+}
+ `.trim();
+
+const DEFAULT_DOCUMENT = `
+query MyQuery {
+  me {
+    name
+    ...AgeFragment
+    best_friend {
+      ...AgeFragment
+    }
+  }
+}
+
+fragment AgeFragment on User {
+  age
+}
+ `.trim();
+
+export const FEAUTRE_FLAGS = [
+  {
+    key: 'enable_flight_transform',
+    label: 'Flight Transforms',
+    kind: 'bool',
+    default: true,
+  },
+  {
+    key: 'hash_supported_argument',
+    label: 'Hash Supported Argument',
+    kind: 'enum',
+    default: true,
+  },
+  {key: 'no_inline', label: '@no_inline', kind: 'enum', default: true},
+  {
+    key: 'enable_3d_branch_arg_generation',
+    label: '3D Branch Arg Generation',
+    kind: 'bool',
+    default: true,
+  },
+  {
+    key: 'actor_change_support',
+    label: 'Actor Change Support',
+    kind: 'enum',
+    default: true,
+  },
+  {
+    key: 'text_artifacts',
+    label: 'Text Artifacts',
+    kind: 'enum',
+    default: true,
+  },
+  {
+    key: 'enable_client_edges',
+    label: 'Client Edges',
+    kind: 'enum',
+    default: true,
+  },
+];
+
+const DEFAULT_STATE = {
+  schemaText: DEFAULT_SCHEMA,
+  documentText: DEFAULT_DOCUMENT,
+  outputType: 'operation',
+  featureFlags: Object.fromEntries(
+    FEAUTRE_FLAGS.map((f) => [f.key, f.default]),
+  ),
+  language: 'typescript',
+};
+
+const LOCAL_STORAGE_KEY = 'relayCompilerExplorerLastContent';
+
+export function useExplorerState() {
+  const [state, dispatch] = useReducer(reducer, null, initializeState);
+
+  // Persist the current state to the URL hash and local storage.
+  useEffect(() => {
+    const serializedState = JSON.stringify(state);
+    const encoded = LZString.compressToEncodedURIComponent(serializedState);
+    const hash = `#0${encoded}`;
+    window.history.replaceState(null, null, hash);
+    localStorage.setItem(LOCAL_STORAGE_KEY, hash);
+  }, [state]);
+
+  const actionHandlers = useMemo(() => {
+    return {
+      setSchemaText: (schemaText) =>
+        dispatch({type: 'UPDATE_SCHEMA', schemaText}),
+      setDocumentText: (documentText) =>
+        dispatch({type: 'UPDATE_DOCUMENT', documentText}),
+      setFeatureFlag: (flag, value) =>
+        dispatch({type: 'SET_FEATURE_FLAG', flag, value}),
+      setLanguage: (language) => dispatch({type: 'SET_LANGUAGE', language}),
+      setOutputType: (outputType) =>
+        dispatch({type: 'SET_OUTPUT_TYPE', outputType}),
+    };
+  }, []);
+  return {
+    state,
+    ...actionHandlers,
+  };
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'UPDATE_SCHEMA':
+      return {...state, schemaText: action.schemaText};
+    case 'UPDATE_DOCUMENT':
+      return {...state, documentText: action.documentText};
+    case 'SET_OUTPUT_TYPE':
+      return {...state, outputType: action.outputType};
+    case 'SET_FEATURE_FLAG':
+      const featureFlags = {
+        ...state.featureFlags,
+        [action.flag]: action.value,
+      };
+      return {...state, featureFlags};
+    case 'SET_LANGUAGE':
+      return {...state, language: action.language};
+    default:
+      throw new Error('Unexpected action type: ' + action.type);
+  }
+}
+
+// Get the initial state. Either from the URL hash, local storage, or the default state.
+function initializeState() {
+  const hash = window.location.hash || localStorage.getItem(LOCAL_STORAGE_KEY);
+  if (hash[0] === '#' && hash.length > 1) {
+    const version = hash.slice(1, 2);
+    const encoded = hash.slice(2);
+    if (version === '0' && encoded.match(/^[a-zA-Z0-9+/=_-]+$/)) {
+      try {
+        return JSON.parse(LZString.decompressFromEncodedURIComponent(encoded));
+      } catch (e) {
+        console.warn('Failed to decode previous state: ', e);
+        return DEFAULT_STATE;
+      }
+    }
+  }
+  return DEFAULT_STATE;
+}
+
+// The wasm compiler expects feature flags as a JSON string with some flags modeled as an enum.
+// this hook derives that value.
+export function useSerializedFeatureFlags(state) {
+  return useMemo(() => {
+    const normalized = Object.fromEntries(
+      FEAUTRE_FLAGS.map(({key, kind}) => {
+        const value = state.featureFlags[key];
+        switch (kind) {
+          case 'enum':
+            return [key, {kind: value ? 'enabled' : 'disabled'}];
+          case 'bool':
+            return [key, value];
+          default:
+            throw new Error(`Unexpected feature flag kind: ${kind}`);
+        }
+      }),
+    );
+    return JSON.stringify(normalized, null, 2);
+  }, [state.featureFlags]);
+}

--- a/website/src/pages/compiler-explorer.js
+++ b/website/src/pages/compiler-explorer.js
@@ -11,36 +11,14 @@
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import * as React from 'react';
+import {
+  useExplorerState,
+  useSerializedFeatureFlags,
+  FEAUTRE_FLAGS,
+} from '../compiler-explorer/ExplorerState';
 
-const {useState, useEffect, useLayoutEffect, useMemo} = React;
-
-const DEFAULT_SCHEMA = `
-type User {
-  name: String
-  age: Int
-  best_friend: User
-}
-
-type Query {
-  me: User
-}
- `.trim();
-
-const DEFAULT_DOCUMENT = `
-query MyQuery {
-  me {
-    name
-    ...AgeFragment
-    best_friend {
-      ...AgeFragment
-    }
-  }
-}
-
-fragment AgeFragment on User {
-  age
-}
- `.trim();
+const {useState, useEffect, useLayoutEffect, useMemo, useReducer, useCallback} =
+  React;
 
 export default function App() {
   return (
@@ -75,18 +53,15 @@ function FillRemainingHeight({children, minHeight}) {
 }
 
 function CompilerExplorer() {
-  const [featureFlags, setFeatureFlags] = useState('{}');
-  const [typegenConfig, setTypegenConfig] = useState('{}');
-  const [schemaText, setSchemaText] = useState(DEFAULT_SCHEMA);
-  const [documentText, setDocumentText] = useState(DEFAULT_DOCUMENT);
-  const [outputType, setOutputType] = useState('operation');
-  const results = useResults({
-    schemaText,
-    documentText,
-    outputType,
-    featureFlags,
-    typegenConfig,
-  });
+  const {
+    state,
+    setOutputType,
+    setDocumentText,
+    setSchemaText,
+    setFeatureFlag,
+    setLanguage,
+  } = useExplorerState();
+  const results = useResults(state);
   const output = results.Ok ?? '';
   const schemaDiagnostics = results.Err?.SchemaDiagnostics;
   const documentDiagnostics = results.Err?.DocumentDiagnostics;
@@ -121,7 +96,7 @@ function CompilerExplorer() {
               {value: 'reader', label: 'Reader AST'},
               {value: 'types', label: 'Types'},
             ]}
-            selectedValue={outputType}
+            selectedValue={state.outputType}
             setSelectedValue={(selected) => setOutputType(selected)}
           />
         </div>
@@ -129,7 +104,7 @@ function CompilerExplorer() {
       <div style={{display: 'flex', flexGrow: 1, columnGap: padding}}>
         <div style={{width: '50%', display: 'flex', flexDirection: 'column'}}>
           <Editor
-            text={schemaText}
+            text={state.schemaText}
             onDidChange={setSchemaText}
             style={{flexGrow: 1}}
             // We don't actually track spans when we parse the schema, so the
@@ -138,14 +113,17 @@ function CompilerExplorer() {
           />
           <ExplorerHeading>Document</ExplorerHeading>
           <Editor
-            text={documentText}
+            text={state.documentText}
             onDidChange={setDocumentText}
             style={{flexGrow: 3}}
             diagnostics={documentDiagnostics}
           />
           <ExplorerHeading>Feature Flags</ExplorerHeading>
-          <Config onFeatureFlagsChanged={setFeatureFlags} />
-          <TypegenConfig onTypegenConfigChanged={setTypegenConfig} />
+          <Config
+            setFeatureFlag={setFeatureFlag}
+            featureFlags={state.featureFlags}
+          />
+          <TypegenConfig setLanguage={setLanguage} language={state.language} />
         </div>
         <div style={{width: '50%', display: 'flex'}}>
           <div style={{flexGrow: 1, display: 'flex', flexDirection: 'column'}}>
@@ -157,104 +135,40 @@ function CompilerExplorer() {
   );
 }
 
-function Config({onFeatureFlagsChanged}) {
-  const [flight, setFlight] = useState(true);
-  const [hashArgs, setHashArgs] = useState(true);
-  const [noInline, setNoInline] = useState(true);
-  const [threeDBranchArg, set3DBranchArg] = useState(true);
-  const [actorChangeSupport, setActorChangeSupport] = useState(true);
-  const [textArtifacts, setTextArtifacts] = useState(true);
-  const [clientEdges, setClientEdges] = useState(true);
-
-  useEffect(() => {
-    onFeatureFlagsChanged(
-      JSON.stringify({
-        enable_flight_transform: flight,
-        hash_supported_argument: {kind: hashArgs ? 'enabled' : 'disabled'},
-        no_inline: {kind: noInline ? 'enabled' : 'disabled'},
-        enable_3d_branch_arg_generation: threeDBranchArg,
-        actor_change_support: {
-          kind: actorChangeSupport ? 'enabled' : 'disabled',
-        },
-        text_artifacts: {kind: textArtifacts ? 'enabled' : 'disabled'},
-        enable_client_edges: {kind: clientEdges ? 'enabled' : 'disabled'},
-      }),
-    );
-  }, [
-    flight,
-    hashArgs,
-    noInline,
-    threeDBranchArg,
-    actorChangeSupport,
-    textArtifacts,
-    clientEdges,
-    onFeatureFlagsChanged,
-  ]);
-
+function Config({featureFlags, setFeatureFlag}) {
   return (
     <div
       style={{
         display: 'grid',
         gridTemplateColumns: 'repeat(2, 1fr)',
       }}>
-      <ConfigOption checked={flight} set={setFlight}>
-        Flight Transform
-      </ConfigOption>
-      <ConfigOption checked={hashArgs} set={setHashArgs}>
-        Hash Supported Arguments
-      </ConfigOption>
-      <ConfigOption checked={noInline} set={setNoInline}>
-        @no_inline
-      </ConfigOption>
-      <ConfigOption checked={threeDBranchArg} set={set3DBranchArg}>
-        3D Branch Arg Generation
-      </ConfigOption>
-      <ConfigOption checked={actorChangeSupport} set={setActorChangeSupport}>
-        Actor Change Support
-      </ConfigOption>
-      <ConfigOption checked={textArtifacts} set={setTextArtifacts}>
-        Text Artifacts
-      </ConfigOption>
-      <ConfigOption checked={clientEdges} set={setClientEdges}>
-        Client Edges
-      </ConfigOption>
+      {FEAUTRE_FLAGS.map(({key, label}) => {
+        return (
+          <label key={key} style={{display: 'block'}}>
+            <input
+              type="checkbox"
+              checked={featureFlags[key]}
+              onChange={(e) => setFeatureFlag(key, e.target.checked)}
+            />
+            {label}
+          </label>
+        );
+      })}
     </div>
   );
 }
 
-function TypegenConfig({onTypegenConfigChanged}) {
-  const [language, setLangauge] = useState('flow');
-  useEffect(() => {
-    onTypegenConfigChanged(
-      JSON.stringify({
-        language,
-      }),
-    );
-  }, [language, onTypegenConfigChanged]);
-
+function TypegenConfig({setLanguage, language}) {
   return (
     <div>
       <label>
         Type Generation Language:
-        <select onChange={(e) => setLangauge(e.target.value)}>
+        <select onChange={(e) => setLanguage(e.target.value)} value={language}>
           <option value="flow">Flow</option>
           <option value="typescript">TypeScript</option>
         </select>
       </label>
     </div>
-  );
-}
-
-function ConfigOption({checked, set, children}) {
-  return (
-    <label style={{display: 'block'}}>
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => set(e.target.checked)}
-      />
-      {children}
-    </label>
   );
 }
 
@@ -291,13 +205,10 @@ function ExplorerHeading({children}) {
   return <h3 style={{margin: 0, padding}}>{children}</h3>;
 }
 
-function useResults({
-  schemaText,
-  documentText,
-  outputType,
-  featureFlags,
-  typegenConfig,
-}) {
+function useResults(state) {
+  const {schemaText, documentText, language, outputType} = state;
+  const featureFlags = useSerializedFeatureFlags(state);
+
   const wasm = useWasm();
   return useMemo(() => {
     if (wasm == null) {
@@ -333,6 +244,7 @@ function useResults({
           );
         }
         case 'types': {
+          const typegenConfig = JSON.stringify({language});
           return JSON.parse(
             wasm.parse_to_types(
               featureFlags,
@@ -350,7 +262,7 @@ function useResults({
       // diagnostic, so we return this as an `Ok`.
       return {Ok: `Error: The compiler crashed: ${e.message}`};
     }
-  }, [schemaText, documentText, outputType, wasm, featureFlags, typegenConfig]);
+  }, [schemaText, documentText, outputType, wasm, featureFlags, language]);
 }
 
 // The Wasm module must be initialized async. Return `null` until the module is ready.

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8915,6 +8915,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
 magic-string@^0.25.0, magic-string@^0.25.1, magic-string@^0.25.3:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"


### PR DESCRIPTION
This should allow the compiler explorer to be used as a mechanism for sharing minimal reproducible compiler bugs and other examples of compiler behavior.

The general idea is to consolidate all the state in the compiler explorer into a single object (Redux style):

* Schema
* Document
* Feature Flags
* Language
* Selected tab

And then (json) serialize and compress that state and persist it to the URL hash and local storage. Note that by using the URL hash we ensure the content of the explorer is never sent to the server, and thus the privacy of the content is improved.

## Test Plan

https://user-images.githubusercontent.com/162735/171328459-a675c8e5-a9a6-4a27-af2e-1230245b84d2.mov


