### PR TITLE
fix(compiler): make LocalPersister include trailing newline

### DIFF
--- a/compiler/crates/relay-compiler/src/operation_persister/local_persister.rs
+++ b/compiler/crates/relay-compiler/src/operation_persister/local_persister.rs
@@ -13,6 +13,8 @@ use relay_config::{LocalPersistAlgorithm, LocalPersistConfig};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufWriter, Write};
 
 use crate::OperationPersister;
 
@@ -76,9 +78,10 @@ impl OperationPersister for LocalPersister {
             .map(|x| (x.key().clone(), x.value().clone()))
             .collect();
 
-        let content = serde_json::to_string_pretty(&ordered)?;
-        std::fs::write(&self.config.file, content)?;
-
+        let mut writer = BufWriter::new(File::create(&self.config.file)?);
+        serde_json::to_writer_pretty(&mut writer, &ordered)?;
+        writer.write(b"\n")?;
+        writer.flush()?;
         Ok(())
     }
 }


### PR DESCRIPTION
We're seeing noise in our diffs because the LocalPersister does not include a trailing newline in its JSON output, but many editors append one automatically (for example, when people inspect the file):

<img width="418" alt="image" src="https://user-images.githubusercontent.com/7074/171994227-310aea2d-16ca-4da8-a1dd-e678bebb76ac.png">

Presumably, editors are doing this to be "helpful" because [POSIX defines a "line"](https://stackoverflow.com/a/729795/2103996) as (paraphrasing) "some or no non-newline stuff followed by a newline", but the unexpected diff output can be confusing for developers working in a large project — many of whom may not even know what persisted queries are.

This PR makes a small edit to append the newline automatically to Serde JSON's pretty output.