### PR TITLE
Add PreloadedQuery import to render example

### DIFF
--- a/website/docs/guided-tour/rendering/queries.md
+++ b/website/docs/guided-tour/rendering/queries.md
@@ -76,6 +76,7 @@ To *render* a query in Relay, you can use the `usePreloadedQuery` hook. `usePrel
 
 ```js
 import type {HomeTabQuery} from 'HomeTabQuery.graphql';
+import type {PreloadedQuery} from 'react-relay';
 
 const React = require('React');
 const {graphql, usePreloadedQuery} = require('react-relay');


### PR DESCRIPTION
It's unclear as to where `PreloadedQuery` is coming from. Adding the import to make it clear.