### PR TITLE
Support @live resolver with client edge and no fragment

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -229,6 +229,7 @@ dependencies = [
  "md-5",
  "rayon",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -349,7 +350,6 @@ version = "0.0.0"
 dependencies = [
  "common",
  "fixture-tests",
- "fnv",
  "graphql-ir",
  "graphql-syntax",
  "intern",
@@ -608,7 +608,6 @@ version = "0.0.0"
 dependencies = [
  "colored",
  "common",
- "graphql-syntax",
 ]
 
 [[package]]
@@ -1332,11 +1331,11 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1579,6 +1578,7 @@ dependencies = [
  "fnv",
  "graphql-ir",
  "graphql-syntax",
+ "graphql-test-helpers",
  "graphql-text-printer",
  "graphql-watchman",
  "intern",
@@ -2012,13 +2012,13 @@ checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2223,6 +2223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,12 +2248,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"

--- a/packages/react-relay/__tests__/LiveResolvers-test.js
+++ b/packages/react-relay/__tests__/LiveResolvers-test.js
@@ -809,7 +809,7 @@ test('apply optimistic updates to live resolver field', () => {
   let update;
   TestRenderer.act(() => {
     update = environment.applyUpdate({
-      storeUpdater: store => {
+      storeUpdater: (store) => {
         const alice = store.get('1');
         if (alice == null) {
           throw new Error('Expected to have record "1"');
@@ -1005,4 +1005,15 @@ test('with client-only field and args', () => {
     GLOBAL_STORE.dispatch({type: 'INCREMENT'});
   });
   expect(renderer.toJSON()).toEqual('Counter is 2');
+});
+
+test('Can read a live client edge without a fragment', () => {
+  // ... this panics in the compiler
+  const FooQuery = graphql`
+    query LiveResolversTest13Query {
+      live_constant_client_edge @waterfall {
+        name
+      }
+    }
+  `;
 });

--- a/packages/react-relay/__tests__/LiveResolvers-test.js
+++ b/packages/react-relay/__tests__/LiveResolvers-test.js
@@ -44,11 +44,13 @@ disallowConsoleErrors();
 
 beforeEach(() => {
   RelayFeatureFlags.ENABLE_RELAY_RESOLVERS = true;
+  RelayFeatureFlags.ENABLE_CLIENT_EDGES = true;
   resetStore();
 });
 
 afterEach(() => {
   RelayFeatureFlags.ENABLE_RELAY_RESOLVERS = false;
+  RelayFeatureFlags.ENABLE_CLIENT_EDGES = false;
 });
 
 test('Can read an external state resolver directly', () => {
@@ -1008,7 +1010,19 @@ test('with client-only field and args', () => {
 });
 
 test('Can read a live client edge without a fragment', () => {
-  // ... this panics in the compiler
+  const source = RelayRecordSource.create({
+    'client:root': {
+      __id: 'client:root',
+      __typename: '__Root',
+    },
+    '1338': {
+      __id: '1338',
+      id: '1338',
+      __typename: 'User',
+      name: 'Elizabeth',
+    },
+  });
+
   const FooQuery = graphql`
     query LiveResolversTest13Query {
       live_constant_client_edge @waterfall {
@@ -1016,4 +1030,21 @@ test('Can read a live client edge without a fragment', () => {
       }
     }
   `;
+
+  const operation = createOperationDescriptor(FooQuery, {});
+  const store = new LiveResolverStore(source, {
+    gcReleaseBufferSize: 0,
+  });
+
+  const environment = new RelayModernEnvironment({
+    network: RelayNetwork.create(jest.fn()),
+    store,
+  });
+
+  const data = environment.lookup(operation.fragment).data;
+  expect(data).toEqual({
+    live_constant_client_edge: {
+      name: 'Elizabeth',
+    },
+  });
 });

--- a/packages/react-relay/__tests__/__generated__/ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge.graphql.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<a7fa19c25b6587ad1e0ba953cca6ac3d>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+type RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$fragmentType = any;
+export type ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$variables = {|
+  id: string,
+|};
+export type ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$data = {|
+  +node: ?{|
+    +$fragmentSpreads: RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$fragmentType,
+  |},
+|};
+export type ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge = {|
+  response: ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$data,
+  variables: ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "940a88381f0c747160590c93c309489b",
+    "id": null,
+    "metadata": {},
+    "name": "ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge",
+    "operationKind": "query",
+    "text": "query ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge\n    id\n  }\n}\n\nfragment RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge on User {\n  name\n  id\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "5e0a692af3d1acd9f3fbcb5fe00b0e77";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$variables,
+  ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$data,
+>*/);

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest13Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest13Query.graphql.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<0e72f5a78b970707f3d9f84cfe005f5c>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type LiveResolversTest13Query$variables = {||};
+export type LiveResolversTest13Query$data = {|
+  +live_constant_client_edge: ?{|
+    +name: ?string,
+  |},
+|};
+export type LiveResolversTest13Query = {|
+  response: LiveResolversTest13Query$data,
+  variables: LiveResolversTest13Query$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": {
+      "hasClientEdges": true
+    },
+    "name": "LiveResolversTest13Query",
+    "selections": [
+      {
+        "kind": "ClientEdgeToServerObject",
+        "operation": require('./ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge.graphql'),
+        "backingField": {
+          "alias": null,
+          "args": null,
+          "fragment": null,
+          "kind": "RelayLiveResolver",
+          "name": "live_constant_client_edge",
+          "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveConstantClientEdgeResolver.js'),
+          "path": "live_constant_client_edge"
+        },
+        "linkedField": {
+          "alias": null,
+          "args": null,
+          "concreteType": "User",
+          "kind": "LinkedField",
+          "name": "live_constant_client_edge",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "name",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "LiveResolversTest13Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__typename",
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "6ec98599d8edc2ea9337de04801eb284",
+    "id": null,
+    "metadata": {},
+    "name": "LiveResolversTest13Query",
+    "operationKind": "query",
+    "text": "query LiveResolversTest13Query {\n  __typename\n}\n"
+  }
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "5e0a692af3d1acd9f3fbcb5fe00b0e77";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  LiveResolversTest13Query$variables,
+  LiveResolversTest13Query$data,
+>*/);

--- a/packages/react-relay/__tests__/__generated__/RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge.graphql.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<038b161eee98dfb458a7d1a7609b4ca7>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$fragmentType: FragmentType;
+type ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$variables = any;
+export type RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$data = {|
+  +id: string,
+  +name: ?string,
+  +$fragmentType: RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$fragmentType,
+|};
+export type RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$key = {
+  +$data?: RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$data,
+  +$fragmentSpreads: RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": require('./ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge.graphql'),
+      "identifierField": "id"
+    }
+  },
+  "name": "RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "5e0a692af3d1acd9f3fbcb5fe00b0e77";
+}
+
+module.exports = ((node/*: any*/)/*: RefetchableFragment<
+  RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$fragmentType,
+  RefetchableClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$data,
+  ClientEdgeQuery_LiveResolversTest13Query_live_constant_client_edge$variables,
+>*/);

--- a/packages/relay-runtime/store/__tests__/resolvers/LiveConstantClientEdgeResolver.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/LiveConstantClientEdgeResolver.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ * @emails oncall+relay
+ */
+
+// flowlint ambiguous-object-type:error
+
+'use strict';
+
+import type {LiveState} from 'relay-runtime/store/experimental-live-resolvers/LiveResolverStore';
+import type {DataID} from 'relay-runtime';
+
+const {graphql} = require('relay-runtime');
+const {readFragment} = require('relay-runtime/store/ResolverFragments');
+
+/**
+ * @RelayResolver
+ * @fieldName live_constant_client_edge
+ * @onType Query
+ * @edgeTo User
+ * @live
+ */
+function LiveConstantClientEdgeResolver(
+): LiveState<DataID> {
+  return {
+    read() {
+      return '1338';
+    },
+    subscribe(cb) {
+      // noop
+    }
+}
+
+module.exports = LiveConstantClientEdgeResolver;

--- a/packages/relay-runtime/store/__tests__/resolvers/LiveConstantClientEdgeResolver.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/LiveConstantClientEdgeResolver.js
@@ -26,15 +26,15 @@ const {readFragment} = require('relay-runtime/store/ResolverFragments');
  * @edgeTo User
  * @live
  */
-function LiveConstantClientEdgeResolver(
-): LiveState<DataID> {
+function LiveConstantClientEdgeResolver(): LiveState<DataID> {
   return {
     read() {
       return '1338';
     },
     subscribe(cb) {
       // noop
-    }
+    },
+  };
 }
 
 module.exports = LiveConstantClientEdgeResolver;


### PR DESCRIPTION
Running `./scripts/compile-tests.sh` results in a compiler panic:

```
╭─[00:00]: captbaritone at moffo in ~/projects/relay on branch*
╰─➤ ./scripts/compile-tests.sh
warning: /Users/captbaritone/projects/relay/compiler/crates/relay-compiler/Cargo.toml: version requirement `0.11.1+zstd.1.5.2` for dependency `zstd` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
    Finished release [optimized] target(s) in 0.08s
     Running `target/release/relay /Users/captbaritone/projects/relay/scripts/config.tests.json`
[INFO] querying files to compile...
[INFO] [tests] compiling...
thread 'tokio-runtime-worker' panicked at 'Expected Client Edge backing field to be a fragment spread representing a Relay Resolver. ScalarField {
    alias: None,
    definition: WithLocation {
        location: <generated>:0:0,
        item: FieldID(559),
    },
    arguments: [],
    directives: [
        Directive {
            name: WithLocation {
                location: <generated>:0:0,
                item: "__RelayResolverMetadata",
            },
            arguments: [],
            data: Some(
                RelayResolverMetadata {
                    field_parent_type: "Query",
                    import_path: "packages/relay-runtime/store/__tests__/resolvers/LiveConstantClientEdgeResolver.js",
                    field_name: "live_constant_client_edge",
                    field_alias: None,
                    field_path: "live_constant_client_edge",
                    field_arguments: [],
                    live: true,
                },
            ),
        },
        Directive {
            name: WithLocation {
                location: packages/react-relay/__tests__/LiveResolvers-test.js:70:80,
                item: "waterfall",
            },
            arguments: [],
            data: None,
        },
    ],
}', crates/relay-codegen/src/build_ast.rs:1040:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[ERROR] A thread that the Relay compiler spun up did not shut down gracefully: panic
[ERROR] Compilation failed.
[ERROR] Unable to run relay compiler. Error details:
A thread that the Relay compiler spun up did not shut down gracefully: panic
```