### PR TITLE
Resolvers without fragments don't have dependencies

### DIFF
--- a/packages/react-relay/__tests__/LiveResolvers-test.js
+++ b/packages/react-relay/__tests__/LiveResolvers-test.js
@@ -38,6 +38,7 @@ const {
   disallowConsoleErrors,
   disallowWarnings,
 } = require('relay-test-utils-internal');
+const counterNoFragmentResolver = require('relay-runtime/store/__tests__/resolvers/LiveCounterNoFragment');
 
 disallowWarnings();
 disallowConsoleErrors();
@@ -256,6 +257,76 @@ test('Can handle a Live Resolver that triggers an update immediately on subscrib
   expect(data).toEqual({
     ping: 'pong',
   });
+});
+
+test("Resolvers without fragments aren't reevaluated when their parent record updates.", async () => {
+  const source = RelayRecordSource.create({
+    'client:root': {
+      __id: 'client:root',
+      __typename: '__Root',
+    },
+  });
+
+  const FooQuery = graphql`
+    query LiveResolversTest13Query {
+      counter_no_fragment
+
+      # An additional field on Query which can be updated, invalidating the root record.
+      me {
+        __typename
+      }
+    }
+  `;
+
+  const store = new LiveResolverStore(source, {gcReleaseBufferSize: 0});
+
+  const mockPayload = Promise.resolve({
+    data: {
+      me: {
+        id: '1',
+        __typename: 'User',
+      },
+    },
+  });
+
+  const environment = new RelayModernEnvironment({
+    network: RelayNetwork.create(() => mockPayload),
+    store,
+  });
+
+  function Environment({children}: {|children: React.Node|}) {
+    return (
+      <RelayEnvironmentProvider environment={environment}>
+        <React.Suspense fallback="Loading...">{children}</React.Suspense>
+      </RelayEnvironmentProvider>
+    );
+  }
+
+  function TestComponent() {
+    const queryData = useLazyLoadQuery(FooQuery, {});
+    return queryData.counter_no_fragment;
+  }
+
+  const initialCallCount = counterNoFragmentResolver.callCount;
+
+  const renderer = TestRenderer.create(
+    <Environment>
+      <TestComponent />
+    </Environment>,
+  );
+
+  expect(counterNoFragmentResolver.callCount).toBe(initialCallCount + 1);
+  // Initial render evaluates (and caches) the `counter_no_fragment` resolver.
+  expect(renderer.toJSON()).toEqual('Loading...');
+
+  // When the network response returns, it updates the query root, which would
+  // invalidate a resolver with a fragment on Query. However,
+  // `counter_no_fragment` has no fragment, so it should not be revaluated.
+  await mockPayload;
+  TestRenderer.act(() => jest.runAllImmediates());
+
+  expect(counterNoFragmentResolver.callCount).toBe(initialCallCount + 1);
+  expect(renderer.toJSON()).toEqual('0');
 });
 
 test('Can suspend', () => {

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest13Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest13Query.graphql.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<7d69b142c8097c66bd54d8523e8e2644>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import queryCounterNoFragmentResolver from "../../../relay-runtime/store/__tests__/resolvers/LiveCounterNoFragment.js";
+// Type assertion validating that `queryCounterNoFragmentResolver` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(queryCounterNoFragmentResolver: () => mixed);
+export type LiveResolversTest13Query$variables = {||};
+export type LiveResolversTest13Query$data = {|
+  +counter_no_fragment: ?$Call<$Call<<R>((...empty[]) => R) => R, typeof queryCounterNoFragmentResolver>["read"]>,
+  +me: ?{|
+    +__typename: "User",
+  |},
+|};
+export type LiveResolversTest13Query = {|
+  response: LiveResolversTest13Query$data,
+  variables: LiveResolversTest13Query$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "LiveResolversTest13Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "kind": "ClientExtension",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "fragment": null,
+            "kind": "RelayLiveResolver",
+            "name": "counter_no_fragment",
+            "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterNoFragment.js'),
+            "path": "counter_no_fragment"
+          }
+        ]
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "LiveResolversTest13Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "kind": "ClientExtension",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__id",
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "0f61df004cd035559712142c355cc2ee",
+    "id": null,
+    "metadata": {},
+    "name": "LiveResolversTest13Query",
+    "operationKind": "query",
+    "text": "query LiveResolversTest13Query {\n  me {\n    __typename\n    id\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "522b963019f8649aac13999a714dcea9";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  LiveResolversTest13Query$variables,
+  LiveResolversTest13Query$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/resolvers/LiveCounterNoFragment.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/LiveCounterNoFragment.js
@@ -27,6 +27,7 @@ const {GLOBAL_STORE, Selectors} = require('./ExampleExternalStateStore');
  * Resolver interface.
  */
 function counter(): LiveState<number> {
+  counter.callCount += 1;
   return {
     read() {
       return Selectors.getNumber(GLOBAL_STORE.getState());
@@ -38,5 +39,7 @@ function counter(): LiveState<number> {
     },
   };
 }
+
+counter.callCount = 0;
 
 module.exports = counter;

--- a/packages/relay-runtime/store/experimental-live-resolvers/LiveResolverCache.js
+++ b/packages/relay-runtime/store/experimental-live-resolvers/LiveResolverCache.js
@@ -163,18 +163,20 @@ class LiveResolverCache implements ResolverCache {
       RelayModernRecord.setLinkedRecordID(nextRecord, storageKey, linkedID);
       recordSource.set(RelayModernRecord.getDataID(nextRecord), nextRecord);
 
-      // Put records observed by the resolver into the dependency graph:
-      const resolverID = evaluationResult.resolverID;
-      addDependencyEdge(this._resolverIDToRecordIDs, resolverID, linkedID);
-      addDependencyEdge(this._recordIDToResolverIDs, recordID, resolverID);
-      const seenRecordIds = evaluationResult.snapshot?.seenRecords;
-      if (seenRecordIds != null) {
-        for (const seenRecordID of seenRecordIds) {
-          addDependencyEdge(
-            this._recordIDToResolverIDs,
-            seenRecordID,
-            resolverID,
-          );
+      if (field.fragment != null) {
+        // Put records observed by the resolver into the dependency graph:
+        const resolverID = evaluationResult.resolverID;
+        addDependencyEdge(this._resolverIDToRecordIDs, resolverID, linkedID);
+        addDependencyEdge(this._recordIDToResolverIDs, recordID, resolverID);
+        const seenRecordIds = evaluationResult.snapshot?.seenRecords;
+        if (seenRecordIds != null) {
+          for (const seenRecordID of seenRecordIds) {
+            addDependencyEdge(
+              this._recordIDToResolverIDs,
+              seenRecordID,
+              resolverID,
+            );
+          }
         }
       }
     } else if (


### PR DESCRIPTION
Previously we would mark a resolver as having a dependency on the parent record. If the parent record was updated, would invalidate the resolver.

On a subsequent render, we would check the resolver's validity, and trigger a warning here: https://github.com/facebook/relay/blob/baa2e6d728672b59e31ffc564a89c7be960aa7e9/packages/relay-runtime/store/experimental-live-resolvers/LiveResolverCache.js#L405