### PR TITLE
Flow: Ignore nested node_modules

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,8 @@
 [ignore]
 <PROJECT_ROOT>/dist/.*
 <PROJECT_ROOT>/compiler/.*
+<PROJECT_ROOT>/website/node_modules/.*
+<PROJECT_ROOT>/vscode-extension/node_modules/.*
 
 [options]
 module.system=haste


### PR DESCRIPTION
Without these, if I build the website locally and then try to run Flow, I get the following error:
<img width="863" alt="Screen Shot 2022-06-07 at 9 18 52 PM" src="https://user-images.githubusercontent.com/162735/172530647-a589f872-1565-4a48-83c2-259ba097c818.png">

