### PR TITLE
Add a script that runs the compiler from Cargo without any config

### DIFF
--- a/scripts/dev-compiler.sh
+++ b/scripts/dev-compiler.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Compile and run the OSS compiler binary. Useful for testing and for using the
+# VSCode extension on our test files. An example VSCode project settings.json file:
+#
+# {
+#    "relay.pathToConfig": "./scripts/config.tests.json",
+#    "relay.pathToRelay": "./scripts/dev-compiler.sh",
+#    "relay.autoStartCompiler": true
+# }
+
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+GITHUB_ROOT=$(dirname "$SCRIPT_DIR")
+
+cd "$GITHUB_ROOT"/compiler
+cargo run --bin relay --release -- "$@" 


### PR DESCRIPTION
While working on our tests, I always want LSP support and to have the Relay compiler open in watch mode automatically. With this script (and @tbezman's VSCode plugin) we can have that!

Here's the VSCode project settings.json file I'm using:

```
{
    "typescript.validate.enable": false,
    "javascript.validate.enable": false,
    "relay.pathToConfig": "./scripts/config.tests.json",
    "relay.pathToRelay": "./scripts/dev-compiler.sh",
    "relay.autoStartCompiler": true,
}
```

Using the LSP in our tests (with the compiler auto starting in watch mode):

https://user-images.githubusercontent.com/162735/172533113-d2fdfbb4-d3f6-405c-af09-b519d612e7fa.mov


