### PR TITLE
Fix VSCode extension semver range

### DIFF
--- a/vscode-extension/src/constants.ts
+++ b/vscode-extension/src/constants.ts
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export const SEMVER_RANGE = '>=13.3.x <14';
+export const SEMVER_RANGE = '>=13.3.x';


### PR DESCRIPTION
I guess this was initially expected to be released as a 13.x release rather than as part of a new major

When a breaking change is made, it's worth bumping up the minimum.
Not sure if you do actually want to limit forward compatibility here. It's pretty hard to guess at what will break. Instead it probably makes more sense to warn that they're using an old version of the extension on a newer version of relay and that they can always upgrade the extension to suit

fixes #3957