### PR TITLE
docs: Update search term in Relay for VSCode docs

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -8,7 +8,7 @@ The official extension to support Relay in VSCode.
 
 ## Installation
 
-Search for "Relay for VSCode" in the VS Code extensions panel or install through [the marketplace](https://marketplace.visualstudio.com/items?itemName=meta.relay).
+Search for "Relay GraphQL" in the VS Code extensions panel or install through [the marketplace](https://marketplace.visualstudio.com/items?itemName=meta.relay).
 
 ## Setup
 


### PR DESCRIPTION
The search term "Relay for VSCode" doesn't show the extension "Relay GraphQL".

| Relay for VSCode | Relay GraphQL |
| --- | --- |
| <img width="354" alt="Screenshot 2022-06-09 at 12 50 40" src="https://user-images.githubusercontent.com/4691889/172830255-9f8ab843-a5c0-4bcf-8bbb-8a0594a697c1.png"> | <img width="354" alt="Screenshot 2022-06-09 at 12 50 04" src="https://user-images.githubusercontent.com/4691889/172830151-fff2fccf-91df-443e-83ce-4e87a2eda773.png">|