### PR TITLE
Remove note on Haste requirement for resolvers

### DIFF
--- a/website/docs/guides/relay-resolvers.md
+++ b/website/docs/guides/relay-resolvers.md
@@ -247,4 +247,3 @@ const data = useLazyLoadQuery(graphql`
 ## Current Limitations
 
 - Relay Resolvers are still considered experimental. To use them you must ensure that the `ENABLE_RELAY_RESOLVERS` runtime feature flag is enabled, and that the `enable_relay_resolver_transform` feature flag is enabled in your project’s Relay config file.
-- Relay Resolvers don’t yet have access to query variables. If this is functionality that would be useful to you, please get in touch.

--- a/website/docs/guides/relay-resolvers.md
+++ b/website/docs/guides/relay-resolvers.md
@@ -248,4 +248,3 @@ const data = useLazyLoadQuery(graphql`
 
 - Relay Resolvers are still considered experimental. To use them you must ensure that the `ENABLE_RELAY_RESOLVERS` runtime feature flag is enabled, and that the `enable_relay_resolver_transform` feature flag is enabled in your project’s Relay config file.
 - Relay Resolvers don’t yet have access to query variables. If this is functionality that would be useful to you, please get in touch.
-- Currently Relay Resolvers only work with Haste module resolution, where modules are imported using their globally unique name, rather than by path.

--- a/website/versioned_docs/version-v14.0.0/guides/relay-resolvers.md
+++ b/website/versioned_docs/version-v14.0.0/guides/relay-resolvers.md
@@ -247,5 +247,3 @@ const data = useLazyLoadQuery(graphql`
 ## Current Limitations
 
 - Relay Resolvers are still considered experimental. To use them you must ensure that the `ENABLE_RELAY_RESOLVERS` runtime feature flag is enabled, and that the `enable_relay_resolver_transform` feature flag is enabled in your project’s Relay config file.
-- Relay Resolvers don’t yet have access to query variables. If this is functionality that would be useful to you, please get in touch.
-- Currently Relay Resolvers only work with Haste module resolution, where modules are imported using their globally unique name, rather than by path.


### PR DESCRIPTION
I tried this out (with a CommonJS-based project) and it works fine!

The generated query resolver correctly `require`s based on the relative path:

```
...
"kind": "RelayResolver",
"name": "greeting",
"resolverModule": require('./../user/UserGreetingResolver.js'),
"path": "viewer.greeting"
...
```

And it works at runtime

Not entirely sure if I'm modifying the docs in the right place