### PR TITLE
VSCode extension pathToRelay doesn't allow relative paths

### DIFF
--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -11,6 +11,7 @@ import {
 } from 'vscode-languageclient';
 import { ServerOptions, LanguageClient } from 'vscode-languageclient/node';
 import { window } from 'vscode';
+import * as path from 'path';
 import { RelayExtensionContext } from './context';
 import { createErrorHandler } from './errorHandler';
 import { LSPStatusBarFeature } from './lspStatusBarFeature';
@@ -33,7 +34,10 @@ export function createAndStartLanguageClient(context: RelayExtensionContext) {
     options: {
       cwd: context.relayBinaryExecutionOptions.rootPath,
     },
-    command: context.relayBinaryExecutionOptions.binaryPath,
+    command: path.resolve(
+      context.relayBinaryExecutionOptions.rootPath,
+      context.relayBinaryExecutionOptions.binaryPath,
+    ),
     args,
   };
 


### PR DESCRIPTION
This PR is an attempt at allowing the `pathToRelay` configuration option in VSCode to have relative paths. When this happens, the path will be resolved relative to the `rootPath`.

This is to support shared settings across many developers in the same workspace, while also having a custom compiler instead of the default one coming from the relay-compiler package. Because the extension currently doesn't allow `pathToRelay` to be relative, this would mean that each developer in our repository would need a different value for this setting.

I'm not too familiar with how VSCode extensions or the LSP client works, so I'm sorry in advance if the change I'm proposing doesn't make sense. Happy to follow up with improvements based on your feedback.

I'm not sure why the `LanguageClient` doesn't allow a relative path in `serverOptions.command`, so what I did was convert that to an absolute path by leveraging `path.resolve` and using the `rootPath` value from context. I tried this in my setup, with the extension installed in my VSCode and it works as expected.