### PR TITLE
add exact_by_default=true to .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,8 @@
 <PROJECT_ROOT>/.*/node_modules/.*
 
 [options]
+exact_by_default=true
+
 module.system=haste
 module.system.haste.use_name_reducers=true
 # get basename


### PR DESCRIPTION
matching `.flowconfig` option used in dev env setups internally at Meta where we sync relay into