### PR TITLE
Compact GraphQL query text

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "prettier.enable": true,
+    "rust-analyzer.rustfmt.extraArgs": [
+      "+nightly"
+    ],
 
 
     // Enable these to get Relay GraphQL editor support working on test files.

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.10"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c5a7f9997be616e47f0577ee38c91decb33392c5be4866494f34cdf329a9aa"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -403,6 +403,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "errors"
 version = "0.0.0"
 dependencies = [
@@ -490,9 +511,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -505,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -515,15 +536,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -532,17 +553,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -550,21 +570,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -576,8 +596,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -692,6 +710,7 @@ dependencies = [
  "graphql-syntax",
  "intern",
  "relay-test-schema",
+ "relay-transforms",
  "schema",
 ]
 
@@ -726,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
  "serde",
@@ -847,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -894,6 +913,12 @@ dependencies = [
  "parking_lot",
  "serde",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "iovec"
@@ -952,9 +977,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -1315,18 +1346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,7 +1507,7 @@ dependencies = [
  "extract-graphql",
  "fixture-tests",
  "fnv",
- "futures 0.3.13",
+ "futures 0.3.24",
  "glob",
  "graphql-cli",
  "graphql-ir",
@@ -1687,6 +1706,20 @@ dependencies = [
  "intern",
  "relay-test-schema",
  "schema",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2042,19 +2075,19 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 dependencies = [
  "terminal_size",
  "unicode-width",
@@ -2321,7 +2354,7 @@ checksum = "839fea2d85719bb69089290d7970bba2131f544448db8f990ea75813c30775ca"
 dependencies = [
  "anyhow",
  "bytes 1.0.1",
- "futures 0.3.13",
+ "futures 0.3.24",
  "maplit",
  "serde",
  "serde_bser",
@@ -2361,6 +2394,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "zstd"

--- a/compiler/crates/common/src/feature_flags.rs
+++ b/compiler/crates/common/src/feature_flags.rs
@@ -58,6 +58,10 @@ pub struct FeatureFlags {
     /// Enable support for the experimental `@alias` directive on fragment spreads.
     #[serde(default)]
     pub enable_fragment_aliases: FeatureFlag,
+
+    /// Print queries in compact form
+    #[serde(default)]
+    pub compact_query_text: FeatureFlag,
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]

--- a/compiler/crates/graphql-text-printer/Cargo.toml
+++ b/compiler/crates/graphql-text-printer/Cargo.toml
@@ -25,3 +25,4 @@ schema = { path = "../schema" }
 [dev-dependencies]
 fixture-tests = { path = "../fixture-tests" }
 relay-test-schema = { path = "../relay-test-schema" }
+relay-transforms = { path = "../relay-transforms" }

--- a/compiler/crates/graphql-text-printer/src/print_full_operation.rs
+++ b/compiler/crates/graphql-text-printer/src/print_full_operation.rs
@@ -18,9 +18,14 @@ use graphql_ir::Visitor;
 
 use crate::print_fragment;
 use crate::print_operation;
+use crate::PrinterOptions;
 
-pub fn print_full_operation(program: &Program, operation: &OperationDefinition) -> String {
-    let mut printer = OperationPrinter::new(program);
+pub fn print_full_operation(
+    program: &Program,
+    operation: &OperationDefinition,
+    options: PrinterOptions,
+) -> String {
+    let mut printer = OperationPrinter::new(program, options);
     printer.print(operation)
 }
 
@@ -28,28 +33,36 @@ pub struct OperationPrinter<'s> {
     fragment_result: FnvHashMap<FragmentDefinitionName, String>,
     reachable_fragments: FnvHashMap<FragmentDefinitionName, Arc<FragmentDefinition>>,
     program: &'s Program,
+    options: PrinterOptions,
 }
 
 impl<'s> OperationPrinter<'s> {
-    pub fn new(program: &'s Program) -> Self {
+    pub fn new(program: &'s Program, options: PrinterOptions) -> Self {
         Self {
             fragment_result: Default::default(),
             reachable_fragments: Default::default(),
             program,
+            options,
         }
     }
 
     pub fn print(&mut self, operation: &OperationDefinition) -> String {
-        let mut result = print_operation(&self.program.schema, operation, Default::default());
+        let mut result = print_operation(&self.program.schema, operation, self.options);
         self.visit_operation(operation);
         let mut fragments: Vec<(FragmentDefinitionName, Arc<FragmentDefinition>)> =
             self.reachable_fragments.drain().collect();
         fragments.sort_unstable_by_key(|(name, _)| *name);
         for (_, fragment) in fragments {
-            result.push_str("\n\n");
+            if self.options.compact {
+                result.push_str(" ");
+            } else {
+                result.push_str("\n\n");
+            }
             result.push_str(self.print_fragment(&fragment));
         }
-        result.push('\n');
+        if !self.options.compact {
+            result.push('\n');
+        }
         result
     }
 
@@ -57,7 +70,7 @@ impl<'s> OperationPrinter<'s> {
         let schema = &self.program.schema;
         self.fragment_result
             .entry(fragment.name.item)
-            .or_insert_with(|| print_fragment(schema, fragment, Default::default()))
+            .or_insert_with(|| print_fragment(schema, fragment, self.options))
     }
 }
 

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_directives.expected
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_directives.expected
@@ -1,0 +1,21 @@
+==================================== INPUT ====================================
+query MyQuery($id: ID, $cond: Boolean!) {
+  my_alias: node(id: $id) {
+    id
+    ... on User @include(if: $cond) {
+      name
+    }
+    ...UserFragment @include(if: $cond)
+  }
+}
+
+fragment UserFragment on User {
+  id
+  name @include(if: $cond)
+  otherName: name @customDirective(level: 3) @skip(if: $cond)
+  address @skip(if: true) {
+    city
+  }
+}
+==================================== OUTPUT ===================================
+query MyQuery($id:ID,$cond:Boolean!){my_alias:node(id:$id){id,...on User@include(if:$cond){name},...UserFragment@include(if:$cond)}} fragment UserFragment on User{id,name@include(if:$cond),otherName:name@skip(if:$cond)@customDirective(level:3),address@skip(if:true){city}}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_directives.graphql
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_directives.graphql
@@ -1,0 +1,18 @@
+query MyQuery($id: ID, $cond: Boolean!) {
+  my_alias: node(id: $id) {
+    id
+    ... on User @include(if: $cond) {
+      name
+    }
+    ...UserFragment @include(if: $cond)
+  }
+}
+
+fragment UserFragment on User {
+  id
+  name @include(if: $cond)
+  otherName: name @customDirective(level: 3) @skip(if: $cond)
+  address @skip(if: true) {
+    city
+  }
+}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_query.expected
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_query.expected
@@ -1,0 +1,14 @@
+==================================== INPUT ====================================
+query MyQuery($id: ID) {
+  my_alias: node(id: $id) {
+    id
+    ... on User {
+      name
+      likers(first: 5) {
+        count
+      }
+    }
+  }
+}
+==================================== OUTPUT ===================================
+query MyQuery($id:ID){my_alias:node(id:$id){id,...on User{name,likers(first:5){count}}}}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_query.graphql
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_query.graphql
@@ -1,0 +1,11 @@
+query MyQuery($id: ID) {
+  my_alias: node(id: $id) {
+    id
+    ... on User {
+      name
+      likers(first: 5) {
+        count
+      }
+    }
+  }
+}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_var_defs.expected
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_var_defs.expected
@@ -1,0 +1,17 @@
+==================================== INPUT ====================================
+query MyQuery($id: ID, $count: Int! = 5, $envs: [Environment!]! = [WEB]) {
+  my_alias: node(id: $id) {
+    id
+    ... on User {
+      name
+      likers(first: $count) {
+        count
+      }
+      checkins(environments: $envs) {
+        query
+      }
+    }
+  }
+}
+==================================== OUTPUT ===================================
+query MyQuery($id:ID,$count:Int!=5,$envs:[Environment!]!=[WEB]){my_alias:node(id:$id){id,...on User{name,likers(first:$count){count},checkins(environments:$envs){query}}}}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_var_defs.graphql
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/basic_var_defs.graphql
@@ -1,0 +1,14 @@
+query MyQuery($id: ID, $count: Int! = 5, $envs: [Environment!]! = [WEB]) {
+  my_alias: node(id: $id) {
+    id
+    ... on User {
+      name
+      likers(first: $count) {
+        count
+      }
+      checkins(environments: $envs) {
+        query
+      }
+    }
+  }
+}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/compact_test.expected
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/compact_test.expected
@@ -1,0 +1,17 @@
+==================================== INPUT ====================================
+query Test { 
+    #comments go away
+    aliasOfFoo : username(name : "val1"  ) @customDirective(level: 2) { #   and this comment as well
+        emailAddresses
+        firstName(if: false, unless: false)
+    }
+    ...FX
+}
+
+fragment FX on Query {
+    aliased : username(name : "argVal") {
+        thin:  emailAddresses
+    }
+}
+==================================== OUTPUT ===================================
+query Test{aliasOfFoo:username(name:"val1")@customDirective(level:2){emailAddresses,firstName(if:false,unless:false)},...FX} fragment FX on Query{aliased:username(name:"argVal"){thin:emailAddresses}}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/compact_test.graphql
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/compact_test.graphql
@@ -1,0 +1,14 @@
+query Test { 
+    #comments go away
+    aliasOfFoo : username(name : "val1"  ) @customDirective(level: 2) { #   and this comment as well
+        emailAddresses
+        firstName(if: false, unless: false)
+    }
+    ...FX
+}
+
+fragment FX on Query {
+    aliased : username(name : "argVal") {
+        thin:  emailAddresses
+    }
+}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/empty_args.expected
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/empty_args.expected
@@ -1,0 +1,11 @@
+==================================== INPUT ====================================
+query EmptyArgs {
+  route(waypoints: []) {
+    __typename
+  }
+  items(filter: {}) {
+    __typename
+  }
+}
+==================================== OUTPUT ===================================
+query EmptyArgs{route(waypoints:[]){__typename},items(filter:{}){__typename}}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/empty_args.graphql
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/empty_args.graphql
@@ -1,0 +1,8 @@
+query EmptyArgs {
+  route(waypoints: []) {
+    __typename
+  }
+  items(filter: {}) {
+    __typename
+  }
+}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/kitchen-sink.expected
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/kitchen-sink.expected
@@ -1,0 +1,79 @@
+==================================== INPUT ====================================
+query NodeQuery(
+  $cond: Boolean! = false
+  $id: ID!
+  $size: [Int] = [32]
+  $query: CheckinSearchInput!
+) {
+  node(id: $id) {
+    id
+    ... on User @include(if: $cond) {
+      name
+    }
+    ...UserFragment @include(if: $cond) @arguments(size: $size)
+  }
+  checkinSearchQuery(query: $query) {
+    query
+  }
+}
+
+fragment UserFragment on User
+  @argumentDefinitions(
+    after: {type: "ID"}
+    first: {type: "Int", defaultValue: 5}
+    size: {type: "[Int]"}
+    storyType: {type: "StoryType", defaultValue: DIRECTED}
+    # storyType_invalid_string: {type: "StoryType", defaultValue: "DIRECTED"}
+    # storyType_invalid_lowercase: {type: "StoryType", defaultValue: directed}
+  ) {
+  id
+  __typename
+  checkins(environments: [WEB]) {
+    __typename
+  }
+  nakedEnum: checkins(environments: WEB) {
+    __typename
+  }
+  friends(after: $after, first: $first, traits: [HELPFUL]) {
+    count
+  }
+  secondFriends: friends(first: 10) {
+    count
+  }
+  name @include(if: $cond)
+  otherName: name @customDirective(level: 3)
+  thumbnail: profilePicture2(
+    size: 32
+    cropPosition: CENTER
+    fileExtension: PNG
+    # TODO add support for custom scalars
+    # additionalParameters: {filter: "Boston"}
+    options: {newName: null}
+  ) {
+    height
+    width
+    src: uri
+  }
+  profilePicture(size: $size) @include(if: $cond) @skip(if: $foo) {
+    height
+    width
+    src: uri
+  }
+  storySearch(query: {type: DIRECTED}) {
+    id
+  }
+  ... @include(if: $cond) @skip(if: $foo) {
+    address {
+      city
+    }
+    alternate_name
+  }
+
+  ... @include(if: $cond) {
+    address {
+      city
+    }
+  }
+}
+==================================== OUTPUT ===================================
+query NodeQuery($cond:Boolean!=false,$id:ID!,$size:[Int]=[32],$query:CheckinSearchInput!){node(id:$id){id,...on User@include(if:$cond){name},...UserFragment@include(if:$cond)@arguments(size:$size)},checkinSearchQuery(query:$query){query}} fragment UserFragment on User@argumentDefinitions(after:{type:"ID"},first:{type:"Int",defaultValue:5},size:{type:"[Int]"},storyType:{type:"StoryType",defaultValue:DIRECTED}){id,__typename,checkins(environments:[WEB]){__typename},nakedEnum:checkins(environments:WEB){__typename},friends(after:$after,first:$first,traits:[HELPFUL]){count},secondFriends:friends(first:10){count},name@include(if:$cond),otherName:name@customDirective(level:3),thumbnail:profilePicture2(size:32,cropPosition:CENTER,fileExtension:PNG,options:{newName:null}){height,width,src:uri},profilePicture(size:$size)@include(if:$cond)@skip(if:$foo){height,width,src:uri},storySearch(query:{type:DIRECTED}){id},...@include(if:$cond)@skip(if:$foo){address{city},alternate_name},...@include(if:$cond){address{city}}}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/kitchen-sink.graphql
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/kitchen-sink.graphql
@@ -1,0 +1,76 @@
+query NodeQuery(
+  $cond: Boolean! = false
+  $id: ID!
+  $size: [Int] = [32]
+  $query: CheckinSearchInput!
+) {
+  node(id: $id) {
+    id
+    ... on User @include(if: $cond) {
+      name
+    }
+    ...UserFragment @include(if: $cond) @arguments(size: $size)
+  }
+  checkinSearchQuery(query: $query) {
+    query
+  }
+}
+
+fragment UserFragment on User
+  @argumentDefinitions(
+    after: {type: "ID"}
+    first: {type: "Int", defaultValue: 5}
+    size: {type: "[Int]"}
+    storyType: {type: "StoryType", defaultValue: DIRECTED}
+    # storyType_invalid_string: {type: "StoryType", defaultValue: "DIRECTED"}
+    # storyType_invalid_lowercase: {type: "StoryType", defaultValue: directed}
+  ) {
+  id
+  __typename
+  checkins(environments: [WEB]) {
+    __typename
+  }
+  nakedEnum: checkins(environments: WEB) {
+    __typename
+  }
+  friends(after: $after, first: $first, traits: [HELPFUL]) {
+    count
+  }
+  secondFriends: friends(first: 10) {
+    count
+  }
+  name @include(if: $cond)
+  otherName: name @customDirective(level: 3)
+  thumbnail: profilePicture2(
+    size: 32
+    cropPosition: CENTER
+    fileExtension: PNG
+    # TODO add support for custom scalars
+    # additionalParameters: {filter: "Boston"}
+    options: {newName: null}
+  ) {
+    height
+    width
+    src: uri
+  }
+  profilePicture(size: $size) @include(if: $cond) @skip(if: $foo) {
+    height
+    width
+    src: uri
+  }
+  storySearch(query: {type: DIRECTED}) {
+    id
+  }
+  ... @include(if: $cond) @skip(if: $foo) {
+    address {
+      city
+    }
+    alternate_name
+  }
+
+  ... @include(if: $cond) {
+    address {
+      city
+    }
+  }
+}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/single-value-array-of-objects.expected
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/single-value-array-of-objects.expected
@@ -1,0 +1,11 @@
+==================================== INPUT ====================================
+query SingleValueArrayQuery {
+  route(waypoints: {lat: "123", lon: "456"}) {
+    steps {
+      lat
+      lon
+    }
+  }
+}
+==================================== OUTPUT ===================================
+query SingleValueArrayQuery{route(waypoints:{lat:"123",lon:"456"}){steps{lat,lon}}}

--- a/compiler/crates/graphql-text-printer/tests/compact/fixtures/single-value-array-of-objects.graphql
+++ b/compiler/crates/graphql-text-printer/tests/compact/fixtures/single-value-array-of-objects.graphql
@@ -1,0 +1,8 @@
+query SingleValueArrayQuery {
+  route(waypoints: {lat: "123", lon: "456"}) {
+    steps {
+      lat
+      lon
+    }
+  }
+}

--- a/compiler/crates/graphql-text-printer/tests/compact/mod.rs
+++ b/compiler/crates/graphql-text-printer/tests/compact/mod.rs
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::sync::Arc;
+
+use common::SourceLocationKey;
+use fixture_tests::Fixture;
+use graphql_ir::build;
+use graphql_ir::node_identifier::LocationAgnosticPartialEq;
+use graphql_ir::ExecutableDefinition;
+use graphql_ir::Program;
+use graphql_syntax::parse_executable;
+use graphql_text_printer::print_full_operation;
+use graphql_text_printer::PrinterOptions;
+use relay_test_schema::TEST_SCHEMA;
+use relay_transforms::RelayLocationAgnosticBehavior;
+
+pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+    let source_location = SourceLocationKey::standalone(fixture.file_name);
+    let initial_ast = parse_executable(fixture.content, source_location).unwrap();
+    let initial_ir = build(&TEST_SCHEMA, &initial_ast.definitions).unwrap();
+    let initial_ir_copy = initial_ir.clone();
+    let program = Program::from_definitions(Arc::clone(&TEST_SCHEMA), initial_ir.clone());
+    let options = PrinterOptions {
+        compact: true,
+        ..Default::default()
+    };
+
+    // Print the IR into a GraphQL string for the fixture
+    let output = initial_ir
+        .into_iter()
+        .filter_map(|definition| match definition {
+            ExecutableDefinition::Operation(operation) => Some(operation),
+            _ => None,
+        })
+        .map(|operation| print_full_operation(&program, &operation, options))
+        .collect::<Vec<String>>()
+        .join("\n\n");
+
+    // Roundtrip the output back into an IR
+    let roundtrip_ast = parse_executable(output.as_str(), SourceLocationKey::Generated).unwrap();
+    let roundtrip_ir = build(&TEST_SCHEMA, &roundtrip_ast.definitions).unwrap();
+
+    // Check the roundtripped IR matches the initial IR to ensure we printed a valid schema
+    assert!(roundtrip_ir.location_agnostic_eq::<RelayLocationAgnosticBehavior>(&initial_ir_copy));
+
+    Ok(output)
+}

--- a/compiler/crates/graphql-text-printer/tests/compact_test.rs
+++ b/compiler/crates/graphql-text-printer/tests/compact_test.rs
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<dd56e861b0bff2823f35d73903e01dc6>>
+ */
+
+mod compact;
+
+use compact::transform_fixture;
+use fixture_tests::test_fixture;
+
+#[test]
+fn compact_test() {
+    let input = include_str!("compact/fixtures/compact_test.graphql");
+    let expected = include_str!("compact/fixtures/compact_test.expected");
+    test_fixture(
+        transform_fixture,
+        "compact_test.graphql",
+        "compact/fixtures/compact_test.expected",
+        input,
+        expected,
+    );
+}
+
+#[test]
+fn compact_basic_directives() {
+    let input = include_str!("compact/fixtures/basic_directives.graphql");
+    let expected = include_str!("compact/fixtures/basic_directives.expected");
+    test_fixture(
+        transform_fixture,
+        "basic_directives.graphql",
+        "compact/fixtures/basic_directives.expected",
+        input,
+        expected,
+    );
+}
+
+#[test]
+fn compact_basic_query() {
+    let input = include_str!("compact/fixtures/basic_query.graphql");
+    let expected = include_str!("compact/fixtures/basic_query.expected");
+    test_fixture(
+        transform_fixture,
+        "basic_query.graphql",
+        "compact/fixtures/basic_query.expected",
+        input,
+        expected,
+    );
+}
+
+#[test]
+fn compact_basic_var_defs() {
+    let input = include_str!("compact/fixtures/basic_var_defs.graphql");
+    let expected = include_str!("compact/fixtures/basic_var_defs.expected");
+    test_fixture(
+        transform_fixture,
+        "basic_var_defs.graphql",
+        "compact/fixtures/basic_var_defs.expected",
+        input,
+        expected,
+    );
+}
+
+#[test]
+fn compact_empty_args() {
+    let input = include_str!("compact/fixtures/empty_args.graphql");
+    let expected = include_str!("compact/fixtures/empty_args.expected");
+    test_fixture(
+        transform_fixture,
+        "empty_args.graphql",
+        "compact/fixtures/empty_args.expected",
+        input,
+        expected,
+    );
+}
+
+#[test]
+fn compact_kitchen_sink() {
+    let input = include_str!("compact/fixtures/kitchen-sink.graphql");
+    let expected = include_str!("compact/fixtures/kitchen-sink.expected");
+    test_fixture(
+        transform_fixture,
+        "kitchen-sink.graphql",
+        "compact/fixtures/kitchen-sink.expected",
+        input,
+        expected,
+    );
+}
+
+#[test]
+fn compact_single_value_array_of_objects() {
+    let input = include_str!("compact/fixtures/single-value-array-of-objects.graphql");
+    let expected = include_str!("compact/fixtures/single-value-array-of-objects.expected");
+    test_fixture(
+        transform_fixture,
+        "single-value-array-of-objects.graphql",
+        "compact/fixtures/single-value-array-of-objects.expected",
+        input,
+        expected,
+    );
+}

--- a/compiler/crates/graphql-text-printer/tests/operation_printer/mod.rs
+++ b/compiler/crates/graphql-text-printer/tests/operation_printer/mod.rs
@@ -28,7 +28,11 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
                 .into_iter()
                 .filter_map(|definition| {
                     if let ExecutableDefinition::Operation(operation) = definition {
-                        Some(print_full_operation(&program, &operation))
+                        Some(print_full_operation(
+                            &program,
+                            &operation,
+                            Default::default(),
+                        ))
                     } else {
                         None
                     }

--- a/compiler/crates/relay-compiler/src/build_project/generate_artifacts.rs
+++ b/compiler/crates/relay-compiler/src/build_project/generate_artifacts.rs
@@ -14,6 +14,7 @@ use fnv::FnvHashMap;
 use graphql_ir::FragmentDefinition;
 use graphql_ir::OperationDefinition;
 use graphql_text_printer::OperationPrinter;
+use graphql_text_printer::PrinterOptions;
 use intern::string_key::StringKey;
 use relay_transforms::ClientEdgeGeneratedQueryMetadataDirective;
 use relay_transforms::Programs;
@@ -45,7 +46,14 @@ pub fn generate_artifacts(
     programs: &Programs,
     source_hashes: Arc<SourceHashes>,
 ) -> Vec<Artifact> {
-    let mut operation_printer = OperationPrinter::new(&programs.operation_text);
+    let printer_options = PrinterOptions {
+        compact: project_config
+            .feature_flags
+            .compact_query_text
+            .is_fully_enabled(),
+        ..Default::default()
+    };
+    let mut operation_printer = OperationPrinter::new(&programs.operation_text, printer_options);
     return group_operations(programs)
         .into_iter()
         .map(|(_, operations)| -> Artifact {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
@@ -116,6 +116,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         enable_client_edges: FeatureFlag::Enabled,
         skip_printing_nulls: FeatureFlag::Disabled,
         enable_fragment_aliases: FeatureFlag::Enabled,
+        compact_query_text: FeatureFlag::Disabled,
     };
 
     let default_project_config = ProjectConfig {
@@ -230,7 +231,11 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
                 let text = print_operation_node.map_or_else(
                     || "Query Text is Empty.".to_string(),
                     |print_operation_node| {
-                        print_full_operation(&programs.operation_text, print_operation_node)
+                        print_full_operation(
+                            &programs.operation_text,
+                            print_operation_node,
+                            Default::default(),
+                        )
                     },
                 );
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id/mod.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id/mod.rs
@@ -86,6 +86,7 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
         enable_client_edges: FeatureFlag::Enabled,
         skip_printing_nulls: FeatureFlag::Disabled,
         enable_fragment_aliases: FeatureFlag::Enabled,
+        compact_query_text: FeatureFlag::Disabled,
     };
 
     let project_config = ProjectConfig {
@@ -136,7 +137,11 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
                 let text = print_operation_node.map_or_else(
                     || "Query Text is Empty.".to_string(),
                     |print_operation_node| {
-                        print_full_operation(&programs.operation_text, print_operation_node)
+                        print_full_operation(
+                            &programs.operation_text,
+                            print_operation_node,
+                            Default::default(),
+                        )
                     },
                 );
 

--- a/compiler/crates/relay-lsp/src/graphql_tools/mod.rs
+++ b/compiler/crates/relay-lsp/src/graphql_tools/mod.rs
@@ -159,6 +159,7 @@ fn print_full_operation_text(programs: Programs, operation_name: StringKey) -> O
     Some(print_full_operation(
         &programs.operation_text,
         print_operation_node,
+        Default::default(),
     ))
 }
 


### PR DESCRIPTION
We noticed that some of our query text contains a significant amount of unnecessary whitespace. Unlike server->client requests, client->server requests generally aren't compressed and would require a js compression library to do so.

This PR adds a feature flag to compact the query text. I saw the pre-existing `compact` mode wasn't wired up to anything, so I've co-opted it.

As an example of the benefit, we have one query which this shrinks from `84kb` to `31kb`

We're slowly [making our way to persisted queries](https://github.com/facebook/relay/pull/3917), but this is an immediate improvement and I imagine we're not the only ones who will benefit from smaller network payloads

Happy to make this a config rather than a feature flag, if you don't think this should be the default output