### PR TITLE
Make artifact.path available to OperationPersister

### DIFF
--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -121,6 +121,8 @@ pub struct Config {
     /// and after each major transformation step (common, operations, etc)
     /// in the `apply_transforms(...)`.
     pub custom_transforms: Option<CustomTransformsConfig>,
+
+    pub export_persisted_query_ids_to_file: Option<PathBuf>,
 }
 
 pub enum FileSourceKind {
@@ -370,6 +372,7 @@ Example file:
             is_dev_variable_name: config_file.is_dev_variable_name,
             file_source_config: FileSourceKind::Watchman,
             custom_transforms: None,
+            export_persisted_query_ids_to_file: None,
         };
 
         let mut validation_errors = Vec::new();
@@ -974,9 +977,15 @@ pub type PersistId = String;
 
 pub type PersistResult<T> = std::result::Result<T, PersistError>;
 
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ArtifactForPersister {
+    pub text: String,
+    pub relative_path: PathBuf,
+}
+
 #[async_trait]
 pub trait OperationPersister {
-    async fn persist_artifact(&self, artifact_text: String) -> PersistResult<PersistId>;
+    async fn persist_artifact(&self, artifact: ArtifactForPersister) -> PersistResult<PersistId>;
 
     fn finalize(&self) -> PersistResult<()> {
         Ok(())

--- a/compiler/crates/relay-compiler/src/operation_persister/local_persister.rs
+++ b/compiler/crates/relay-compiler/src/operation_persister/local_persister.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use crate::config::ArtifactForPersister;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use md5::Md5;
@@ -61,11 +62,14 @@ impl LocalPersister {
 
 #[async_trait]
 impl OperationPersister for LocalPersister {
-    async fn persist_artifact(&self, artifact_text: String) -> Result<String, PersistError> {
-        let operation_hash = self.hash_operation(artifact_text.clone());
+    async fn persist_artifact(
+        &self,
+        artifact: ArtifactForPersister,
+    ) -> Result<String, PersistError> {
+        let operation_hash = self.hash_operation(artifact.text.clone());
 
         if !self.query_map.contains_key(&operation_hash) {
-            self.query_map.insert(operation_hash.clone(), artifact_text);
+            self.query_map.insert(operation_hash.clone(), artifact.text);
         }
 
         Ok(operation_hash)

--- a/compiler/crates/relay-compiler/src/operation_persister/remote_persister.rs
+++ b/compiler/crates/relay-compiler/src/operation_persister/remote_persister.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use crate::config::ArtifactForPersister;
 use async_trait::async_trait;
 use persist_query::{persist, PersistError};
 use relay_config::RemotePersistConfig;
@@ -27,16 +28,19 @@ impl RemotePersister {
 
 #[async_trait]
 impl OperationPersister for RemotePersister {
-    async fn persist_artifact(&self, artifact_text: String) -> Result<String, PersistError> {
+    async fn persist_artifact(
+        &self,
+        artifact: ArtifactForPersister,
+    ) -> Result<String, PersistError> {
         let params = &self.config.params;
         let url = &self.config.url;
         if let Some(semaphore) = &self.semaphore {
             let permit = (*semaphore).acquire().await.unwrap();
-            let result = persist(&artifact_text, url, params, empty()).await;
+            let result = persist(&artifact.text, url, params, empty()).await;
             drop(permit);
             result
         } else {
-            persist(&artifact_text, url, params, empty()).await
+            persist(&artifact.text, url, params, empty()).await
         }
     }
 }


### PR DESCRIPTION
Summary: Plumb the `artifact.path` into the `OperationPersister` to support emitting that path with persisted artifact hashes—allowing analysis tools to give sharper feedback.

Reviewed By: alunyov

Differential Revision: D37120669

