### PR TITLE
[Prototype][RFC] Explore allowing fragments to read from query root

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -175,16 +175,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "regex",
  "strsim",
  "termcolor",
@@ -195,15 +195,24 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1193,9 +1202,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "ouroboros"

--- a/compiler/crates/relay-transforms/Cargo.toml
+++ b/compiler/crates/relay-transforms/Cargo.toml
@@ -23,6 +23,10 @@ name = "graphql_generate_id_field_test"
 path = "tests/generate_id_field_test.rs"
 
 [[test]]
+name = "query_field_test"
+path = "tests/query_field_test.rs"
+
+[[test]]
 name = "graphql_generate_typename_test"
 path = "tests/generate_typename_test.rs"
 

--- a/compiler/crates/relay-transforms/src/apply_transforms.rs
+++ b/compiler/crates/relay-transforms/src/apply_transforms.rs
@@ -13,6 +13,7 @@ use crate::assignable_fragment_spread::{
     annotate_updatable_fragment_spreads, replace_updatable_fragment_spreads,
 };
 use crate::match_::hash_supported_argument;
+use crate::query_field::query_field;
 use common::{sync::try_join, DiagnosticsResult, PerfLogEvent, PerfLogger};
 use graphql_ir::Program;
 use intern::string_key::StringKeySet;
@@ -330,6 +331,9 @@ fn apply_operation_transforms(
     program = log_event.time("generate_live_query_metadata", || {
         generate_live_query_metadata(&program)
     })?;
+
+    // TODO: Maybe this should go before the id transform so we can prune selections that are empty?
+    program = log_event.time("query_field", || query_field(&program))?;
 
     program = apply_after_custom_transforms(
         &program,

--- a/compiler/crates/relay-transforms/src/lib.rs
+++ b/compiler/crates/relay-transforms/src/lib.rs
@@ -40,6 +40,7 @@ mod murmurhash;
 mod no_inline;
 mod preloadable_directive;
 mod provided_variable_fragment_transform;
+mod query_field;
 mod react_flight;
 mod refetchable_fragment;
 mod relay_actor_change;
@@ -131,6 +132,7 @@ pub use match_::{
 pub use no_inline::NO_INLINE_DIRECTIVE_NAME;
 pub use preloadable_directive::{is_operation_preloadable, should_generate_hack_preloader};
 pub use provided_variable_fragment_transform::provided_variable_fragment_transform;
+pub use query_field::query_field;
 pub use react_flight::{
     react_flight, ReactFlightLocalComponentsMetadata, REACT_FLIGHT_SCALAR_FLIGHT_FIELD_METADATA_KEY,
 };

--- a/compiler/crates/relay-transforms/src/query_field.rs
+++ b/compiler/crates/relay-transforms/src/query_field.rs
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use common::{Diagnostic, DiagnosticsResult};
+use graphql_ir::{
+    reexport::{Intern, StringKey},
+    LinkedField, OperationDefinition, Program, Selection, Transformed, Transformer,
+};
+use lazy_static::lazy_static;
+use schema::Schema;
+
+lazy_static! {
+    pub static ref QUERY_FIELD_NAME: StringKey = "__query".intern();
+}
+
+/**
+ * TODO:
+ *
+ * In incomplete list of things that would need to be done to take this across the finish line:
+ *
+ * - Enforce that __query is only read at a fragment root
+ * - Memoize fragment transformation
+ * - What about fragments spread into mutations?
+ * - Think about what this means for consumers of our schema/IR crates that are not Relay. Can they turn off `__query`?
+ * - Test with refetchable and client edges
+ * - Test with @requried (should "just work" since its does as part of reader)
+ * - Test with @defer
+ * - Test in Resolvers (should just work)
+ * - Documentation
+ * - End to end tests (test __query using `useFragment`)
+ */
+
+// Strips out all access to the Relay specific `__query` field, and hoists those
+// selections up to the query root.
+//
+// Expected to applied to the operation/normalization AST.
+pub fn query_field(program: &Program) -> DiagnosticsResult<Program> {
+    let mut transform = QueryField::new(program);
+
+    let next_program = transform
+        .transform_program(program)
+        .replace_or_else(|| program.clone());
+
+    if transform.errors.is_empty() {
+        Ok(next_program)
+    } else {
+        Err(transform.errors)
+    }
+}
+
+struct QueryField<'s> {
+    program: &'s Program,
+    errors: Vec<Diagnostic>,
+    operation_query_selections: Vec<Selection>,
+}
+
+impl<'program> QueryField<'program> {
+    fn new(program: &'program Program) -> Self {
+        Self {
+            program,
+            errors: Default::default(),
+            operation_query_selections: Default::default(),
+        }
+    }
+}
+
+impl<'s> Transformer for QueryField<'s> {
+    const NAME: &'static str = "QueryFieldTransform";
+    const VISIT_ARGUMENTS: bool = false;
+    const VISIT_DIRECTIVES: bool = false;
+
+    fn transform_operation(
+        &mut self,
+        operation: &OperationDefinition,
+    ) -> Transformed<OperationDefinition> {
+        self.operation_query_selections = Vec::new();
+        let transformed = self.default_transform_operation(operation);
+        match transformed {
+            Transformed::Delete => Transformed::Delete,
+            Transformed::Keep => {
+                let mut selections = operation.selections.clone();
+                selections.extend(self.operation_query_selections.clone());
+                Transformed::Replace(OperationDefinition {
+                    selections,
+                    ..operation.clone()
+                })
+            }
+            Transformed::Replace(operation) => {
+                let mut selections = operation.selections.clone();
+                selections.extend(self.operation_query_selections.clone());
+                Transformed::Replace(OperationDefinition {
+                    selections,
+                    ..operation.clone()
+                })
+            }
+        }
+    }
+
+    fn transform_fragment(
+        &mut self,
+        fragment: &graphql_ir::FragmentDefinition,
+    ) -> Transformed<graphql_ir::FragmentDefinition> {
+        // TODO: Memoize here?
+        self.default_transform_fragment(fragment)
+    }
+
+    fn transform_linked_field(
+        &mut self,
+        field: &LinkedField,
+    ) -> Transformed<graphql_ir::Selection> {
+        let transforemed = self.default_transform_linked_field(field);
+        if field.definition.item == self.program.schema.query_field() {
+            self.operation_query_selections
+                .extend(field.selections.clone());
+            Transformed::Delete
+        } else {
+            transforemed
+        }
+    }
+
+    fn transform_fragment_spread(
+        &mut self,
+        spread: &graphql_ir::FragmentSpread,
+    ) -> Transformed<Selection> {
+        // Ensure we traverse into fragments and discover any query fields nested within.
+        // TODO: Memoize to ensure we don't visit the same fragment twice.
+        let fragment = self.program.fragment(spread.fragment.item).unwrap();
+        if let Transformed::Delete = self.transform_fragment(&fragment) {
+            // If the fragment is deleted, we can delete the spread.
+            Transformed::Delete
+        } else {
+            Transformed::Keep
+        }
+    }
+
+    // TODO: What about resolvers?
+}

--- a/compiler/crates/relay-transforms/tests/query_field/fixtures/read_query_field.expected
+++ b/compiler/crates/relay-transforms/tests/query_field/fixtures/read_query_field.expected
@@ -1,0 +1,28 @@
+==================================== INPUT ====================================
+query MyQuery {
+    me {
+        ...UserFragment
+    }
+}
+
+fragment UserFragment on User {
+    __query {
+        defaultSettings {
+            notificationSounds
+        }
+    }
+    firstName
+}
+==================================== OUTPUT ===================================
+query MyQuery {
+  me {
+    ...UserFragment
+  }
+  defaultSettings {
+    notificationSounds
+  }
+}
+
+fragment UserFragment on User {
+  firstName
+}

--- a/compiler/crates/relay-transforms/tests/query_field/fixtures/read_query_field.graphql
+++ b/compiler/crates/relay-transforms/tests/query_field/fixtures/read_query_field.graphql
@@ -1,0 +1,14 @@
+query MyQuery {
+    me {
+        ...UserFragment
+    }
+}
+
+fragment UserFragment on User {
+    __query {
+        defaultSettings {
+            notificationSounds
+        }
+    }
+    firstName
+}

--- a/compiler/crates/relay-transforms/tests/query_field/mod.rs
+++ b/compiler/crates/relay-transforms/tests/query_field/mod.rs
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use fixture_tests::Fixture;
+use graphql_test_helpers::apply_transform_for_test;
+use relay_transforms::query_field;
+
+pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+    apply_transform_for_test(fixture, query_field)
+}

--- a/compiler/crates/relay-transforms/tests/query_field_test.rs
+++ b/compiler/crates/relay-transforms/tests/query_field_test.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<d8711219e10b1f666a01fa60e6b5d967>>
+ */
+
+mod query_field;
+
+use fixture_tests::test_fixture;
+use query_field::transform_fixture;
+
+#[test]
+fn read_query_field() {
+    let input = include_str!("query_field/fixtures/read_query_field.graphql");
+    let expected = include_str!("query_field/fixtures/read_query_field.expected");
+    test_fixture(
+        transform_fixture,
+        "read_query_field.graphql",
+        "query_field/fixtures/read_query_field.expected",
+        input,
+        expected,
+    );
+}

--- a/compiler/crates/schema/src/flatbuffer/wrapper.rs
+++ b/compiler/crates/schema/src/flatbuffer/wrapper.rs
@@ -36,6 +36,7 @@ const TYPENAME_FIELD_ID: FieldID = FieldID(10_000_001);
 const FETCH_TOKEN_FIELD_ID: FieldID = FieldID(10_000_002);
 const STRONGID_FIELD_ID: FieldID = FieldID(10_000_003);
 const IS_FULFILLED_FIELD_ID: FieldID = FieldID(10_000_004);
+const QUERY_FIELD_ID: FieldID = FieldID(10_000_005);
 
 pub struct SchemaWrapper {
     clientid_field_name: StringKey,
@@ -97,6 +98,19 @@ impl SchemaWrapper {
             name: WithLocation::generated(result.typename_field_name),
             is_extension: false,
             arguments: ArgumentDefinitions::new(Default::default()),
+            type_: TypeReference::NonNull(Box::new(TypeReference::Named(
+                result.get_type("String".intern()).unwrap(),
+            ))),
+            directives: Vec::new(),
+            parent_type: None,
+            description: None,
+        });
+
+        result.fields.get(QUERY_FIELD_ID, || Field {
+            name: WithLocation::generated(result.typename_field_name),
+            is_extension: false,
+            arguments: ArgumentDefinitions::new(Default::default()),
+            // TODO: Use the correct type here!
             type_: TypeReference::NonNull(Box::new(TypeReference::Named(
                 result.get_type("String".intern()).unwrap(),
             ))),
@@ -208,6 +222,10 @@ impl Schema for SchemaWrapper {
     }
 
     fn typename_field(&self) -> FieldID {
+        TYPENAME_FIELD_ID
+    }
+
+    fn query_field(&self) -> FieldID {
         TYPENAME_FIELD_ID
     }
 
@@ -335,6 +353,14 @@ impl Schema for SchemaWrapper {
             if name == self.is_fulfilled_field_name {
                 return Some(IS_FULFILLED_FIELD_ID);
             }
+            if true {
+                panic!("Heelo")
+            }
+            /*
+            if name == self.query_field_name {
+                return Some(QUERY_FIELD_ID);
+            }
+            */
         }
 
         let fields = match parent_type {

--- a/compiler/crates/schema/src/graphql_schema.rs
+++ b/compiler/crates/schema/src/graphql_schema.rs
@@ -22,6 +22,8 @@ pub trait Schema {
 
     fn typename_field(&self) -> FieldID;
 
+    fn query_field(&self) -> FieldID;
+
     fn fetch_token_field(&self) -> FieldID;
 
     fn is_fulfilled_field(&self) -> FieldID;

--- a/compiler/crates/schema/src/in_memory/mod.rs
+++ b/compiler/crates/schema/src/in_memory/mod.rs
@@ -27,12 +27,14 @@ pub struct InMemorySchema {
     clientid_field: FieldID,
     strongid_field: FieldID,
     typename_field: FieldID,
+    query_field: FieldID,
     fetch_token_field: FieldID,
     is_fulfilled_field: FieldID,
 
     clientid_field_name: StringKey,
     strongid_field_name: StringKey,
     typename_field_name: StringKey,
+    query_field_name: StringKey,
     fetch_token_field_name: StringKey,
     is_fulfilled_field_name: StringKey,
 
@@ -75,6 +77,10 @@ impl Schema for InMemorySchema {
 
     fn typename_field(&self) -> FieldID {
         self.typename_field
+    }
+
+    fn query_field(&self) -> FieldID {
+        self.query_field
     }
 
     fn fetch_token_field(&self) -> FieldID {
@@ -172,6 +178,9 @@ impl Schema for InMemorySchema {
             if name == self.strongid_field_name {
                 return Some(self.strongid_field);
             }
+            if name == self.query_field_name {
+                return Some(self.query_field);
+            }
         }
 
         let fields = match parent_type {
@@ -218,11 +227,13 @@ impl Schema for InMemorySchema {
             clientid_field: _clientid_field,
             strongid_field: _strongid_field,
             typename_field: _typename_field,
+            query_field: _query_field,
             fetch_token_field: _fetch_token_field,
             is_fulfilled_field: _is_fulfilled_field,
             clientid_field_name: _clientid_field_name,
             strongid_field_name: _strongid_field_name,
             typename_field_name: _typename_field_name,
+            query_field_name: _query_field_name,
             fetch_token_field_name: _fetch_token_field_name,
             is_fulfilled_field_name: _is_fulfilled_field_name,
             string_type: _string_type,
@@ -633,11 +644,13 @@ impl InMemorySchema {
             clientid_field: FieldID(0),
             strongid_field: FieldID(0),
             typename_field: FieldID(0),
+            query_field: FieldID(0),
             fetch_token_field: FieldID(0),
             is_fulfilled_field: FieldID(0),
             clientid_field_name: "__id".intern(),
             strongid_field_name: "strong_id__".intern(),
             typename_field_name: "__typename".intern(),
+            query_field_name: "__query".intern(),
             fetch_token_field_name: "__token".intern(),
             is_fulfilled_field_name: "is_fulfilled__".intern(),
             string_type: None,
@@ -760,11 +773,13 @@ impl InMemorySchema {
             clientid_field: FieldID(0), // dummy value, overwritten later
             strongid_field: FieldID(0), // dummy value, overwritten later
             typename_field: FieldID(0), // dummy value, overwritten later
+            query_field: FieldID(0),    // dummy value, overwritten later
             fetch_token_field: FieldID(0), // dummy value, overwritten later
             is_fulfilled_field: FieldID(0), // dummy value, overwritten later
             clientid_field_name: "__id".intern(),
             strongid_field_name: "strong_id__".intern(),
             typename_field_name: "__typename".intern(),
+            query_field_name: "__query".intern(),
             fetch_token_field_name: "__token".intern(),
             is_fulfilled_field_name: "is_fulfilled__".intern(),
             string_type: Some(string_type),
@@ -825,6 +840,7 @@ impl InMemorySchema {
     fn load_defaults(&mut self) {
         self.load_default_root_types();
         self.load_default_typename_field();
+        self.load_default_query_field();
         self.load_default_fetch_token_field();
         self.load_default_clientid_field();
         self.load_default_strongid_field();
@@ -869,6 +885,22 @@ impl InMemorySchema {
             directives: Vec::new(),
             parent_type: None,
             description: None,
+        });
+    }
+
+    fn load_default_query_field(&mut self) {
+        let query_field_id = self.fields.len();
+        self.query_field = FieldID(query_field_id.try_into().unwrap());
+        let query_type = self.query_type.expect("Expect to have a query type");
+
+        self.fields.push(Field {
+            name: WithLocation::generated(self.query_field_name),
+            is_extension: false,
+            arguments: ArgumentDefinitions::new(Default::default()),
+            type_: TypeReference::NonNull(Box::new(TypeReference::Named(Type::Object(query_type)))),
+            parent_type: None,
+            description: None,
+            directives: Default::default(),
         });
     }
 

--- a/compiler/crates/schema/src/schema.rs
+++ b/compiler/crates/schema/src/schema.rs
@@ -61,6 +61,13 @@ impl Schema for SDLSchema {
         }
     }
 
+    fn query_field(&self) -> FieldID {
+        match self {
+            SDLSchema::FlatBuffer(schema) => schema.query_field(),
+            SDLSchema::InMemory(schema) => schema.query_field(),
+        }
+    }
+
     fn fetch_token_field(&self) -> FieldID {
         match self {
             SDLSchema::FlatBuffer(schema) => schema.fetch_token_field(),

--- a/packages/relay-runtime/mutations/__tests__/__generated__/readUpdatableQueryEXPERIMENTALTest1Query.graphql.js
+++ b/packages/relay-runtime/mutations/__tests__/__generated__/readUpdatableQueryEXPERIMENTALTest1Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<05a8c7f8569c43f851634c898a26283e>>
+ * @generated SignedSource<<99ce042d42ad38de74e220e2fe36629c>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -16,10 +16,9 @@
 
 /*::
 import type { UpdatableQuery, ConcreteUpdatableQuery } from 'relay-runtime';
-import type { OpaqueScalarType } from "../OpaqueScalarType";
 export type readUpdatableQueryEXPERIMENTALTest1Query$variables = {||};
 export type readUpdatableQueryEXPERIMENTALTest1Query$data = {|
-  updatable_scalar_field: ?OpaqueScalarType,
+  updatable_scalar_field: ?any,
 |};
 export type readUpdatableQueryEXPERIMENTALTest1Query = {|
   response: readUpdatableQueryEXPERIMENTALTest1Query$data,

--- a/packages/relay-runtime/mutations/__tests__/__generated__/readUpdatableQueryEXPERIMENTALTest2Query.graphql.js
+++ b/packages/relay-runtime/mutations/__tests__/__generated__/readUpdatableQueryEXPERIMENTALTest2Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9a735230a8009f2a65fc857165a8c9e3>>
+ * @generated SignedSource<<f17c10cca2de0d8553d79691eaf2505f>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -16,10 +16,9 @@
 
 /*::
 import type { ClientRequest, ClientQuery } from 'relay-runtime';
-import type { OpaqueScalarType } from "../OpaqueScalarType";
 export type readUpdatableQueryEXPERIMENTALTest2Query$variables = {||};
 export type readUpdatableQueryEXPERIMENTALTest2Query$data = {|
-  +updatable_scalar_field: ?OpaqueScalarType,
+  +updatable_scalar_field: ?any,
 |};
 export type readUpdatableQueryEXPERIMENTALTest2Query = {|
   response: readUpdatableQueryEXPERIMENTALTest2Query$data,

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -788,9 +788,13 @@ class RelayReader {
     record: Record,
     data: SelectorData,
   ): ?mixed {
+    console.log(field);
     const applicationName = field.alias ?? field.name;
     const storageKey = getStorageKey(field, this._variables);
-    const linkedID = RelayModernRecord.getLinkedRecordID(record, storageKey);
+    const linkedID =
+      field.name === '__query'
+        ? ROOT_ID
+        : RelayModernRecord.getLinkedRecordID(record, storageKey);
     if (linkedID == null) {
       data[applicationName] = linkedID;
       if (linkedID === undefined) {

--- a/packages/relay-runtime/store/__tests__/RelayReader-FragmentQuery-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-FragmentQuery-test.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+relay
+ */
+
+'use strict';
+
+const {getRequest, graphql} = require('../../query/GraphQLTag');
+const RelayFeatureFlags = require('../../util/RelayFeatureFlags');
+const {
+  createOperationDescriptor,
+} = require('../RelayModernOperationDescriptor');
+const {createReaderSelector} = require('../RelayModernSelector');
+const {read} = require('../RelayReader');
+const RelayRecordSource = require('../RelayRecordSource');
+const {ROOT_ID} = require('../RelayStoreUtils');
+const {TYPE_SCHEMA_TYPE, generateTypeID} = require('../TypeID');
+
+describe('RelayReader', () => {
+  let source;
+
+  beforeEach(() => {
+    const data = {
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        firstName: 'Alice',
+      },
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+    };
+
+    source = RelayRecordSource.create(data);
+  });
+
+  it('reads query data from a fragment', () => {
+    const UserQuery = graphql`
+      query RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery {
+        me {
+          ...RelayReaderFragmentQueryTestFragment
+        }
+      }
+    `;
+
+    const BarFragment = graphql`
+      fragment RelayReaderFragmentQueryTestFragment on User {
+        __query {
+          me {
+            firstName
+          }
+        }
+      }
+    `;
+    const owner = createOperationDescriptor(UserQuery, {});
+    const {data, seenRecords} = read(
+      source,
+      createReaderSelector(BarFragment, '1', {}, owner.request),
+    );
+    expect(data).toEqual({
+      __query: {
+        me: {
+          firstName: 'Alice',
+        },
+      },
+    });
+  });
+});

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderFragmentQueryTestFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderFragmentQueryTestFragment.graphql.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<1a4bda021cbaa88551a68f90cbdbf709>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RelayReaderFragmentQueryTestFragment$fragmentType: FragmentType;
+export type RelayReaderFragmentQueryTestFragment$data = {|
+  +__query: {|
+    +me: ?{|
+      +firstName: ?string,
+    |},
+  |},
+  +$fragmentType: RelayReaderFragmentQueryTestFragment$fragmentType,
+|};
+export type RelayReaderFragmentQueryTestFragment$key = {
+  +$data?: RelayReaderFragmentQueryTestFragment$data,
+  +$fragmentSpreads: RelayReaderFragmentQueryTestFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayReaderFragmentQueryTestFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Query",
+      "kind": "LinkedField",
+      "name": "__query",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "User",
+          "kind": "LinkedField",
+          "name": "me",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "firstName",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "1929e561e4ba155c697e55525fdd4d5a";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  RelayReaderFragmentQueryTestFragment$fragmentType,
+  RelayReaderFragmentQueryTestFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery.graphql.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<0cafa1ed051f30883509d2ac303d14ce>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+type RelayReaderFragmentQueryTestFragment$fragmentType = any;
+export type RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery$variables = {||};
+export type RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery$data = {|
+  +me: ?{|
+    +$fragmentSpreads: RelayReaderFragmentQueryTestFragment$fragmentType,
+  |},
+|};
+export type RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery = {|
+  response: RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery$data,
+  variables: RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "RelayReaderFragmentQueryTestFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "firstName",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "8de692e11a11fcac82e045b5f78ee2ca",
+    "id": null,
+    "metadata": {},
+    "name": "RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery",
+    "operationKind": "query",
+    "text": "query RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery {\n  me {\n    id\n    firstName\n  }\n}\n"
+  }
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "562fa9640e8c9e1f22243c323ec336ed";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery$variables,
+  RelayReaderFragmentQueryTestReadsQueryDataFromAFragmentQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTestQueryFieldFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTestQueryFieldFragment.graphql.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<50dd211a62b06de0d96f19b9f1d5a81b>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RelayResponseNormalizerTestQueryFieldFragment$fragmentType: FragmentType;
+export type RelayResponseNormalizerTestQueryFieldFragment$data = {|
+  +__query: {|
+    +defaultSettings: ?{|
+      +notificationSounds: ?boolean,
+    |},
+  |},
+  +firstName: ?string,
+  +$fragmentType: RelayResponseNormalizerTestQueryFieldFragment$fragmentType,
+|};
+export type RelayResponseNormalizerTestQueryFieldFragment$key = {
+  +$data?: RelayResponseNormalizerTestQueryFieldFragment$data,
+  +$fragmentSpreads: RelayResponseNormalizerTestQueryFieldFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayResponseNormalizerTestQueryFieldFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Query",
+      "kind": "LinkedField",
+      "name": "__query",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Settings",
+          "kind": "LinkedField",
+          "name": "defaultSettings",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "notificationSounds",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "firstName",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "b7bbac04f0da22e55c369761359e95ed";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  RelayResponseNormalizerTestQueryFieldFragment$fragmentType,
+  RelayResponseNormalizerTestQueryFieldFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTestQueryFieldQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTestQueryFieldQuery.graphql.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<03f7e769b4dfcfcb86d056ccd05fa127>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+type RelayResponseNormalizerTestQueryFieldFragment$fragmentType = any;
+export type RelayResponseNormalizerTestQueryFieldQuery$variables = {||};
+export type RelayResponseNormalizerTestQueryFieldQuery$data = {|
+  +me: ?{|
+    +$fragmentSpreads: RelayResponseNormalizerTestQueryFieldFragment$fragmentType,
+  |},
+|};
+export type RelayResponseNormalizerTestQueryFieldQuery = {|
+  response: RelayResponseNormalizerTestQueryFieldQuery$data,
+  variables: RelayResponseNormalizerTestQueryFieldQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayResponseNormalizerTestQueryFieldQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "RelayResponseNormalizerTestQueryFieldFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "RelayResponseNormalizerTestQueryFieldQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "firstName",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Settings",
+        "kind": "LinkedField",
+        "name": "defaultSettings",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "notificationSounds",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "74abd04d8fae9daa961ae7c19a7dfe1f",
+    "id": null,
+    "metadata": {},
+    "name": "RelayResponseNormalizerTestQueryFieldQuery",
+    "operationKind": "query",
+    "text": "query RelayResponseNormalizerTestQueryFieldQuery {\n  me {\n    ...RelayResponseNormalizerTestQueryFieldFragment\n    id\n  }\n  defaultSettings {\n    notificationSounds\n  }\n}\n\nfragment RelayResponseNormalizerTestQueryFieldFragment on User {\n  firstName\n}\n"
+  }
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "0771594b4d7cb002368d59870f51aaaa";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  RelayResponseNormalizerTestQueryFieldQuery$variables,
+  RelayResponseNormalizerTestQueryFieldQuery$data,
+>*/);


### PR DESCRIPTION
This PR is just to show a sketch of how we might allow any fragment to also query data off of `Query`. If we decide this is something we wanted to support, there are a number of things that would be needed in order to take it across the finish line. This is just intended to start the conversation.

The idea here is that any fragment can also read from a field `__query` which re-exposes the query root. This would allow deeply nested components to add data dependencies that are not easy to access from their existing fragment. For example, a component on a Comment might want to look at some information about the current user to decide how to render. currently that requires threading two fragments through the React hierarchy. One referencing the comment and one referencing the viewer/user.

## How it Looks

```JavaScript
const comment = useFragment(graphql`
  fragment Foo on Comment {
    __query {
      me {
        preferences {
          auto_expand_comments
        }
      }
    }
    text
  }`, key);

if (comment.__query.me.preference.auto_expand_comments) {
  return comment.text;
} else {
  return comment.text.slice(0, 100)
}
```

## How it Works

We teach the schema about a special field `__query` that exists on every object and exposes the root Query type. Before generating the query text (and normalization artifact) we traverse the query and collect all the selections made on `__query` and inline them into the query root selection.

When generating the reader artifacts, we treat the `__query` field as if it really exists, trusting that the data was put into the store by the original query.

## Next Steps?

Possibly none. However, if people are interested in this, we should start to collect a list of other Relay features that may play poorly with this approach, or would need special handling.

---
This came up in a conversation with @tbezman and Chris yesterday and it got me thinking about how it could be done. 