### PR TITLE
update rustfmt used by ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-04-01
+          toolchain: nightly-2022-06-15 
           override: true
           components: rustfmt
       - name: "rustfmt"


### PR DESCRIPTION
GitHub CI broke after 5998146e0ddd4843b137638f966487dc54cfd9eb. Matching the rustfmt toolchain version to the one used internally.