### PR TITLE
fix(website): Broken link on versions page

### DIFF
--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -47,7 +47,7 @@ function Version() {
                     <Link to={latestVersion.path}>Documentation</Link>
                   </td>
                   <td>
-                    <a href={`${repoUrl}/releases/tag/v${latestVersion.name}`}>
+                    <a href={`${repoUrl}/releases/tag/${latestVersion.name}`}>
                       Release Notes
                     </a>
                   </td>


### PR DESCRIPTION
The Release notes link on for the Current version (Stable) block on the `/versions` page is broken. 

The link currently renders as follows;

```
<a href="https://github.com/facebook/relay/releases/tag/vv14.0.0">Release Notes</a>
```

Which contains an extra version prefix, `v`

This PR removes the additional `v` from the _Current version (Stable)_ block to ensure a correct redirect.

The link construction elsewhere in the file also omits this additional v.

**Additional information**

Contributor License Agreement (CLA) has been completed.