### PR TITLE
[ci] update rustfmt toolchain version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-04-01
+          toolchain: nightly-2022-06-26
           override: true
           components: rustfmt
       - name: "rustfmt"


### PR DESCRIPTION
bccbac1fe0e588214887272b2c7dffb91dde87e4 broke ci. updating to match internal version.