### PR TITLE
[VSCode Extension] Fix comment blocks

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relay",
   "displayName": "Relay GraphQL",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Relay-powered IDE experience",
   "repository": {
     "type": "git",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -52,7 +52,10 @@
           "source.tsx"
         ],
         "scopeName": "inline.graphql",
-        "path": "./grammars/graphql.js.json"
+        "path": "./grammars/graphql.js.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
       }
     ],
     "commands": [


### PR DESCRIPTION
Without this definition, VSCode doesn't recognize the embedded language inside of a JS file. It only does syntax highlighting, nothing more.

Fixes https://github.com/facebook/relay/issues/3998#issuecomment-1175851851