### PR TITLE
Remove `.js` and `.ts` from require / import

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -175,16 +175,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "once_cell",
+ "lazy_static",
  "regex",
  "strsim",
  "termcolor",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -354,6 +354,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
+ "parking_lot 0.12.1",
+ "rayon",
+ "serde",
+]
+
+[[package]]
 name = "dependency-analyzer"
 version = "0.0.0"
 dependencies = [
@@ -440,7 +453,7 @@ dependencies = [
  "colored",
  "diff",
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.11.2",
  "signedsource",
 ]
 
@@ -642,7 +655,7 @@ name = "graphql-ir-validations"
 version = "0.0.0"
 dependencies = [
  "common",
- "dashmap",
+ "dashmap 4.0.2",
  "errors",
  "fixture-tests",
  "graphql-cli",
@@ -876,7 +889,7 @@ dependencies = [
  "hashbrown",
  "indexmap",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "rand",
  "serde",
  "serde_bytes",
@@ -892,7 +905,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "serde",
 ]
 
@@ -1144,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -1234,7 +1247,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -1249,6 +1272,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1490,7 +1526,7 @@ dependencies = [
  "bincode",
  "common",
  "common-path",
- "dashmap",
+ "dashmap 5.1.0",
  "dependency-analyzer",
  "docblock-syntax",
  "errors",
@@ -1577,7 +1613,7 @@ version = "0.0.0"
 dependencies = [
  "common",
  "crossbeam",
- "dashmap",
+ "dashmap 5.1.0",
  "docblock-syntax",
  "extract-graphql",
  "fixture-tests",
@@ -1632,7 +1668,7 @@ name = "relay-transforms"
 version = "0.0.0"
 dependencies = [
  "common",
- "dashmap",
+ "dashmap 5.1.0",
  "errors",
  "fixture-tests",
  "fnv",
@@ -1647,7 +1683,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "regex",
  "relay-config",
  "relay-test-schema",
@@ -1727,7 +1763,7 @@ name = "schema"
 version = "0.0.0"
 dependencies = [
  "common",
- "dashmap",
+ "dashmap 5.1.0",
  "fixture-tests",
  "flatbuffers",
  "fnv",
@@ -2127,7 +2163,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -2325,9 +2361,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "watchman_client"
-version = "0.8.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839fea2d85719bb69089290d7970bba2131f544448db8f990ea75813c30775ca"
+checksum = "1afbab1186833c9b34f64132b80ed4b373ed4eab6f9efa1f55430835200f0a28"
 dependencies = [
  "anyhow",
  "bytes 1.0.1",
@@ -2371,6 +2407,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "zstd"

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -175,16 +175,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "regex",
  "strsim",
  "termcolor",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -354,19 +354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
-dependencies = [
- "cfg-if",
- "num_cpus",
- "parking_lot 0.12.1",
- "rayon",
- "serde",
-]
-
-[[package]]
 name = "dependency-analyzer"
 version = "0.0.0"
 dependencies = [
@@ -453,7 +440,7 @@ dependencies = [
  "colored",
  "diff",
  "lazy_static",
- "parking_lot 0.11.2",
+ "parking_lot",
  "signedsource",
 ]
 
@@ -655,7 +642,7 @@ name = "graphql-ir-validations"
 version = "0.0.0"
 dependencies = [
  "common",
- "dashmap 4.0.2",
+ "dashmap",
  "errors",
  "fixture-tests",
  "graphql-cli",
@@ -889,7 +876,7 @@ dependencies = [
  "hashbrown",
  "indexmap",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "rand",
  "serde",
  "serde_bytes",
@@ -905,7 +892,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "serde",
 ]
 
@@ -1157,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -1247,17 +1234,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.9.3",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1272,19 +1249,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys",
 ]
 
 [[package]]
@@ -1526,7 +1490,7 @@ dependencies = [
  "bincode",
  "common",
  "common-path",
- "dashmap 5.1.0",
+ "dashmap",
  "dependency-analyzer",
  "docblock-syntax",
  "errors",
@@ -1613,7 +1577,7 @@ version = "0.0.0"
 dependencies = [
  "common",
  "crossbeam",
- "dashmap 5.1.0",
+ "dashmap",
  "docblock-syntax",
  "extract-graphql",
  "fixture-tests",
@@ -1668,7 +1632,7 @@ name = "relay-transforms"
 version = "0.0.0"
 dependencies = [
  "common",
- "dashmap 5.1.0",
+ "dashmap",
  "errors",
  "fixture-tests",
  "fnv",
@@ -1683,7 +1647,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "regex",
  "relay-config",
  "relay-test-schema",
@@ -1763,7 +1727,7 @@ name = "schema"
 version = "0.0.0"
 dependencies = [
  "common",
- "dashmap 5.1.0",
+ "dashmap",
  "fixture-tests",
  "flatbuffers",
  "fnv",
@@ -2163,7 +2127,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -2361,9 +2325,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "watchman_client"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1afbab1186833c9b34f64132b80ed4b373ed4eab6f9efa1f55430835200f0a28"
+checksum = "839fea2d85719bb69089290d7970bba2131f544448db8f990ea75813c30775ca"
 dependencies = [
  "anyhow",
  "bytes 1.0.1",
@@ -2407,49 +2371,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "zstd"

--- a/compiler/crates/relay-codegen/src/printer.rs
+++ b/compiler/crates/relay-codegen/src/printer.rs
@@ -470,7 +470,15 @@ impl<'b> JSONPrinter<'b> {
             },
             Primitive::JSModuleDependency(key) => match self.js_module_format {
                 JsModuleFormat::CommonJS => {
-                    self.write_js_dependency(f, key.to_string(), format!("./{}", key))
+                    let mut path = format!("./{}", key);
+
+                    let extension = &path[path.len() - 3..path.len()];
+
+                    if extension == ".js" || extension == ".ts" {
+                        path = path[0..path.len() - 3].to_string();
+                    }
+
+                    self.write_js_dependency(f, key.to_string(), path)
                 }
                 JsModuleFormat::Haste => {
                     self.write_js_dependency(f, key.to_string(), key.to_string())

--- a/compiler/crates/relay-codegen/src/printer.rs
+++ b/compiler/crates/relay-codegen/src/printer.rs
@@ -478,8 +478,9 @@ impl<'b> JSONPrinter<'b> {
                         if extension == "ts" || extension == "js" {
                             let path_without_extension = path.with_extension("");
 
-                            let path_without_extension =
-                                path_without_extension.to_str().expect("yikes");
+                            let path_without_extension = path_without_extension
+                                .to_str()
+                                .expect("could not convert `path_without_extension` to a str");
 
                             return self.write_js_dependency(
                                 f,

--- a/packages/react-relay/__tests__/__generated__/ClientOnlyQueriesTest2Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/ClientOnlyQueriesTest2Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d94850375abe6a082ef568b4d8c8cdfb>>
+ * @generated SignedSource<<00a66fc2dc29a9620e857f980fe3ff29>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -56,7 +56,7 @@ var node/*: ClientRequest*/ = {
             "fragment": null,
             "kind": "RelayResolver",
             "name": "hello",
-            "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/HelloWorldResolver.js'),
+            "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/HelloWorldResolver'),
             "path": "hello"
           }
         ]

--- a/packages/react-relay/__tests__/__generated__/ClientOnlyQueriesTest3Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/ClientOnlyQueriesTest3Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d90ecf4f73501d47cf0978344dc6d985>>
+ * @generated SignedSource<<4cc6d4016699c9a60dba57b36250f2a3>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -62,7 +62,7 @@ return {
           "fragment": null,
           "kind": "RelayResolver",
           "name": "hello_user",
-          "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/HelloUserResolver.js'),
+          "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/HelloUserResolver'),
           "path": "hello_user"
         },
         "linkedField": {

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest10Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest10Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<99103c0bf735e6cb0996eb349954d26e>>
+ * @generated SignedSource<<48e1653a83dfb3e7ff819f9fa7ebce5f>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -74,7 +74,7 @@ return {
         },
         "kind": "RelayLiveResolver",
         "name": "counter",
-        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterResolver.js'),
+        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterResolver'),
         "path": "counter"
       }
     ],

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest11Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest11Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c65bc42656127db8f921efec91addd67>>
+ * @generated SignedSource<<c0c8a9a9da69e277c9d9915bf8a22bdd>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -47,7 +47,7 @@ var node/*: ClientRequest*/ = {
             "fragment": null,
             "kind": "RelayLiveResolver",
             "name": "counter_no_fragment",
-            "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterNoFragment.js'),
+            "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterNoFragment'),
             "path": "counter_no_fragment"
           }
         ]

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest12Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest12Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<32632ff69073457129bf9e7b05e46280>>
+ * @generated SignedSource<<6c3325b73c0ab66bd32ec2c01cf78a97>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -67,7 +67,7 @@ return {
             "fragment": null,
             "kind": "RelayLiveResolver",
             "name": "counter_no_fragment_with_arg",
-            "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterNoFragmentWithArg.js'),
+            "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterNoFragmentWithArg'),
             "path": "counter_no_fragment_with_arg"
           }
         ]

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest13Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest13Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<04b0332af15ea2b1b457c6005bc9e184>>
+ * @generated SignedSource<<c68b7409336201f125b0eb21644b0152>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -51,7 +51,7 @@ var node/*: ClientRequest*/ = {
           "fragment": null,
           "kind": "RelayLiveResolver",
           "name": "live_constant_client_edge",
-          "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveConstantClientEdgeResolver.js'),
+          "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveConstantClientEdgeResolver'),
           "path": "live_constant_client_edge"
         },
         "linkedField": {

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest14Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest14Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b8dd23d09c4789a16e9de8e3c2171d27>>
+ * @generated SignedSource<<cb7b132119689add051fdcdd1a88ae29>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -70,7 +70,7 @@ return {
             "fragment": null,
             "kind": "RelayLiveResolver",
             "name": "counter_no_fragment",
-            "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterNoFragment.js'),
+            "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterNoFragment'),
             "path": "counter_no_fragment"
           }
         ]

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest15Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest15Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<262c53b6c0db5158b5b35483e2a0b1bf>>
+ * @generated SignedSource<<a2b4fdc7a6dbaebecb90e150e1bebeef>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -51,7 +51,7 @@ var node/*: ClientRequest*/ = {
           "fragment": null,
           "kind": "RelayLiveResolver",
           "name": "live_user_resolver_always_suspend",
-          "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveUserAlwaysSuspendResolver.js'),
+          "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveUserAlwaysSuspendResolver'),
           "path": "live_user_resolver_always_suspend"
         },
         "linkedField": {

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest1Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest1Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<38c27889eca46bc1a1dbbcb7a1a7519e>>
+ * @generated SignedSource<<1373afea7f8ee7f74af6e08f44521c2f>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -51,7 +51,7 @@ var node/*: ConcreteRequest*/ = {
         },
         "kind": "RelayLiveResolver",
         "name": "counter",
-        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterResolver.js'),
+        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterResolver'),
         "path": "counter"
       }
     ],

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest2Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest2Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<77308b848aa87df31311e83c79ed9a16>>
+ * @generated SignedSource<<31f19bbd6a691e002d808a4bcb0095aa>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -51,7 +51,7 @@ var node/*: ConcreteRequest*/ = {
         },
         "kind": "RelayLiveResolver",
         "name": "counter",
-        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterResolver.js'),
+        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterResolver'),
         "path": "counter"
       }
     ],

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest3Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest3Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c5d48e772fef2bc68a2c65ac4d0bfec8>>
+ * @generated SignedSource<<22901e10b6825b66ecd2bcd57af360e2>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -50,7 +50,7 @@ var node/*: ConcreteRequest*/ = {
         },
         "kind": "RelayResolver",
         "name": "counter_plus_one",
-        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/CounterPlusOneResolver.js'),
+        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/CounterPlusOneResolver'),
         "path": "counter_plus_one"
       }
     ],

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest4Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest4Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5980f9c856fbecccd256920e5c0a2155>>
+ * @generated SignedSource<<94daecb72b36049ace65b0aa5e4852bd>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -51,7 +51,7 @@ var node/*: ConcreteRequest*/ = {
         },
         "kind": "RelayLiveResolver",
         "name": "ping",
-        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LivePingPongResolver.js'),
+        "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LivePingPongResolver'),
         "path": "ping"
       }
     ],

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest5Fragment.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest5Fragment.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2bd1564a268ef29b6acfa2ee1f19ef55>>
+ * @generated SignedSource<<ae6ee58cc5ed0f9edede278a5b2228ff>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -53,7 +53,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayLiveResolver",
       "name": "counter_suspends_when_odd",
-      "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/CounterSuspendsWhenOdd.js'),
+      "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/CounterSuspendsWhenOdd'),
       "path": "counter_suspends_when_odd"
     }
   ],

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest6Fragment.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest6Fragment.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<07f12643b9a243702064e01991c824a5>>
+ * @generated SignedSource<<c19798e6ebedd6ac71a81834fdf3c054>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -52,7 +52,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "user_name_and_counter_suspends_when_odd",
-      "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/UserNameAndCounterSuspendsWhenOdd.js'),
+      "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/UserNameAndCounterSuspendsWhenOdd'),
       "path": "user_name_and_counter_suspends_when_odd"
     }
   ],

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest7Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest7Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f7452975042a004e41c2cf992d8c3a97>>
+ * @generated SignedSource<<6189e8469758d23033ed2554b1bda3fd>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -106,7 +106,7 @@ return {
                 },
                 "kind": "RelayLiveResolver",
                 "name": "user_profile_picture_uri_suspends_when_the_counter_is_odd",
-                "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/UserProfilePictureUriSuspendsWhenTheCounterIsOdd.js'),
+                "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/UserProfilePictureUriSuspendsWhenTheCounterIsOdd'),
                 "path": "node.user_profile_picture_uri_suspends_when_the_counter_is_odd"
               }
             ],

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest8Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest8Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b1589cd570327f42fbac1e91b088aa0d>>
+ * @generated SignedSource<<b58c3af0e1b866ef5e4efe09f0d5ff1d>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -90,7 +90,7 @@ return {
                 },
                 "kind": "RelayLiveResolver",
                 "name": "resolver_that_throws",
-                "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/ResolverThatThrows.js'),
+                "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/ResolverThatThrows'),
                 "path": "node.resolver_that_throws"
               }
             ],

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTest9Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTest9Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<68399928102651a68e4d18ae5917ab64>>
+ * @generated SignedSource<<daf5c7df5e3cb536a7ffb81ac7ede2c3>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -97,7 +97,7 @@ return {
                 },
                 "kind": "RelayLiveResolver",
                 "name": "user_profile_picture_uri_suspends_when_the_counter_is_odd",
-                "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/UserProfilePictureUriSuspendsWhenTheCounterIsOdd.js'),
+                "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/UserProfilePictureUriSuspendsWhenTheCounterIsOdd'),
                 "path": "node.profile_picture_uri"
               }
             ],

--- a/packages/react-relay/__tests__/__generated__/QueryResourceClientEdgesTest2Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/QueryResourceClientEdgesTest2Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<53ba5776188bb4ebb5db943e5fd49f6d>>
+ * @generated SignedSource<<06eb0cadf810cdf0d226b13c9cfb6fbf>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -69,7 +69,7 @@ var node/*: ConcreteRequest*/ = {
               },
               "kind": "RelayResolver",
               "name": "client_edge",
-              "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/UserClientEdgeResolver.js'),
+              "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/UserClientEdgeResolver'),
               "path": "me.client_edge"
             },
             "linkedField": {

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/FragmentResourceClientEdgesTestFragment1.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/FragmentResourceClientEdgesTestFragment1.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e9c8b1beb6b5c7604d9420e37cf8449f>>
+ * @generated SignedSource<<d54d801a056de68837b5e0f887ff7ddb>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -59,7 +59,7 @@ var node/*: ReaderFragment*/ = {
         },
         "kind": "RelayResolver",
         "name": "client_edge",
-        "resolverModule": require('./../../../../relay-runtime/store/__tests__/resolvers/UserClientEdgeResolver.js'),
+        "resolverModule": require('./../../../../relay-runtime/store/__tests__/resolvers/UserClientEdgeResolver'),
         "path": "client_edge"
       },
       "linkedField": {

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/FragmentResourceResolverTestFragment1.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/FragmentResourceResolverTestFragment1.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<11bd8f8b325180e98b72605f45b3991d>>
+ * @generated SignedSource<<9c4c1823a58920e458e86096ff12acc5>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -52,7 +52,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "always_throws",
-      "resolverModule": require('./../../../../relay-runtime/store/__tests__/resolvers/UserAlwaysThrowsResolver.js'),
+      "resolverModule": require('./../../../../relay-runtime/store/__tests__/resolvers/UserAlwaysThrowsResolver'),
       "path": "always_throws"
     }
   ],

--- a/packages/relay-runtime/mutations/__tests__/__generated__/readUpdatableQueryEXPERIMENTALTest1Query.graphql.js
+++ b/packages/relay-runtime/mutations/__tests__/__generated__/readUpdatableQueryEXPERIMENTALTest1Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<05a8c7f8569c43f851634c898a26283e>>
+ * @generated SignedSource<<99ce042d42ad38de74e220e2fe36629c>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -16,10 +16,9 @@
 
 /*::
 import type { UpdatableQuery, ConcreteUpdatableQuery } from 'relay-runtime';
-import type { OpaqueScalarType } from "../OpaqueScalarType";
 export type readUpdatableQueryEXPERIMENTALTest1Query$variables = {||};
 export type readUpdatableQueryEXPERIMENTALTest1Query$data = {|
-  updatable_scalar_field: ?OpaqueScalarType,
+  updatable_scalar_field: ?any,
 |};
 export type readUpdatableQueryEXPERIMENTALTest1Query = {|
   response: readUpdatableQueryEXPERIMENTALTest1Query$data,

--- a/packages/relay-runtime/mutations/__tests__/__generated__/readUpdatableQueryEXPERIMENTALTest2Query.graphql.js
+++ b/packages/relay-runtime/mutations/__tests__/__generated__/readUpdatableQueryEXPERIMENTALTest2Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9a735230a8009f2a65fc857165a8c9e3>>
+ * @generated SignedSource<<f17c10cca2de0d8553d79691eaf2505f>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -16,10 +16,9 @@
 
 /*::
 import type { ClientRequest, ClientQuery } from 'relay-runtime';
-import type { OpaqueScalarType } from "../OpaqueScalarType";
 export type readUpdatableQueryEXPERIMENTALTest2Query$variables = {||};
 export type readUpdatableQueryEXPERIMENTALTest2Query$data = {|
-  +updatable_scalar_field: ?OpaqueScalarType,
+  +updatable_scalar_field: ?any,
 |};
 export type readUpdatableQueryEXPERIMENTALTest2Query = {|
   response: readUpdatableQueryEXPERIMENTALTest2Query$data,

--- a/packages/relay-runtime/store/__tests__/__generated__/ClientEdgeToClientObjectTest1Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/ClientEdgeToClientObjectTest1Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1d040f2361036a3ebcc35538c8373a1a>>
+ * @generated SignedSource<<10bfb6d50c2d86bf900e290fc780ac8d>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -87,7 +87,7 @@ v1 = {
   },
   "kind": "RelayResolver",
   "name": "name",
-  "resolverModule": require('./../resolvers/AstrologicalSignNameResolver.js'),
+  "resolverModule": require('./../resolvers/AstrologicalSignNameResolver'),
   "path": "me.name"
 },
 v2 = {
@@ -100,7 +100,7 @@ v2 = {
   },
   "kind": "RelayResolver",
   "name": "house",
-  "resolverModule": require('./../resolvers/AstrologicalSignHouseResolver.js'),
+  "resolverModule": require('./../resolvers/AstrologicalSignHouseResolver'),
   "path": "me.house"
 },
 v3 = {
@@ -113,7 +113,7 @@ v3 = {
   },
   "kind": "RelayResolver",
   "name": "opposite",
-  "resolverModule": require('./../resolvers/AstrologicalSignOppositeResolver.js'),
+  "resolverModule": require('./../resolvers/AstrologicalSignOppositeResolver'),
   "path": "me.opposite"
 };
 return {
@@ -146,7 +146,7 @@ return {
               },
               "kind": "RelayResolver",
               "name": "astrological_sign",
-              "resolverModule": require('./../resolvers/UserAstrologicalSignResolver.js'),
+              "resolverModule": require('./../resolvers/UserAstrologicalSignResolver'),
               "path": "me.astrological_sign"
             },
             "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/ClientEdgeToClientObjectTest2Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/ClientEdgeToClientObjectTest2Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f9bc5c20a30d8edaeb33da89a63e3db2>>
+ * @generated SignedSource<<8856d7ee49828b6ac71c57ed2a791b7e>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -64,7 +64,7 @@ var node/*: ConcreteRequest*/ = {
           },
           "kind": "RelayResolver",
           "name": "all_astrological_signs",
-          "resolverModule": require('./../resolvers/QueryAllAstrologicalSignsResolver.js'),
+          "resolverModule": require('./../resolvers/QueryAllAstrologicalSignsResolver'),
           "path": "all_astrological_signs"
         },
         "linkedField": {
@@ -85,7 +85,7 @@ var node/*: ConcreteRequest*/ = {
               },
               "kind": "RelayResolver",
               "name": "name",
-              "resolverModule": require('./../resolvers/AstrologicalSignNameResolver.js'),
+              "resolverModule": require('./../resolvers/AstrologicalSignNameResolver'),
               "path": "name"
             }
           ],

--- a/packages/relay-runtime/store/__tests__/__generated__/ClientEdgeToClientObjectTest3Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/ClientEdgeToClientObjectTest3Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<97b5f88dd076c5aa231437e61ec0ee90>>
+ * @generated SignedSource<<1991bcca2be185d5f67c05f9c6bac973>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -76,7 +76,7 @@ var node/*: ConcreteRequest*/ = {
               },
               "kind": "RelayResolver",
               "name": "astrological_sign",
-              "resolverModule": require('./../resolvers/UserAstrologicalSignResolver.js'),
+              "resolverModule": require('./../resolvers/UserAstrologicalSignResolver'),
               "path": "me.astrological_sign"
             },
             "linkedField": {
@@ -104,7 +104,7 @@ var node/*: ConcreteRequest*/ = {
                   },
                   "kind": "RelayResolver",
                   "name": "name",
-                  "resolverModule": require('./../resolvers/AstrologicalSignNameResolver.js'),
+                  "resolverModule": require('./../resolvers/AstrologicalSignNameResolver'),
                   "path": "me.name"
                 },
                 {

--- a/packages/relay-runtime/store/__tests__/__generated__/RefetchableClientEdgeQuery_RelayReaderClientEdgesTest4Query_me__client_edge.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RefetchableClientEdgeQuery_RelayReaderClientEdgesTest4Query_me__client_edge.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<59a6d4329ec5da08385c532b02e8c4fe>>
+ * @generated SignedSource<<0961dd5f5110a292310f690771cc26e1>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -69,7 +69,7 @@ var node/*: ReaderFragment*/ = {
         },
         "kind": "RelayResolver",
         "name": "another_client_edge",
-        "resolverModule": require('./../resolvers/UserAnotherClientEdgeResolver.js'),
+        "resolverModule": require('./../resolvers/UserAnotherClientEdgeResolver'),
         "path": "another_client_edge"
       },
       "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest1Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest1Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cf17149da222947ef977ef9fd9fe75e7>>
+ * @generated SignedSource<<deae6f8c9cd6d1f660079e2782063dae>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -75,7 +75,7 @@ return {
               },
               "kind": "RelayResolver",
               "name": "client_edge",
-              "resolverModule": require('./../resolvers/UserClientEdgeResolver.js'),
+              "resolverModule": require('./../resolvers/UserClientEdgeResolver'),
               "path": "me.client_edge"
             },
             "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest2Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest2Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a9b6a3dddec133a8be767723d99f36e7>>
+ * @generated SignedSource<<dbcccff42bb536790587a4e920affe3f>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -77,7 +77,7 @@ return {
               },
               "kind": "RelayResolver",
               "name": "client_edge",
-              "resolverModule": require('./../resolvers/UserClientEdgeResolver.js'),
+              "resolverModule": require('./../resolvers/UserClientEdgeResolver'),
               "path": "me.client_edge"
             },
             "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest3Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest3Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3e7a3ada03cf6ac73792871b392e8f68>>
+ * @generated SignedSource<<e4b32ba5ef6928bf10bfd2ec4cb60eeb>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -68,7 +68,7 @@ var node/*: ConcreteRequest*/ = {
               },
               "kind": "RelayResolver",
               "name": "client_edge",
-              "resolverModule": require('./../resolvers/UserClientEdgeResolver.js'),
+              "resolverModule": require('./../resolvers/UserClientEdgeResolver'),
               "path": "me.client_edge"
             },
             "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest4Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest4Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f29640901dd1ef51791e6db731f05084>>
+ * @generated SignedSource<<c57ba62a14057969c632fa9a28c489e7>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -84,7 +84,7 @@ return {
               },
               "kind": "RelayResolver",
               "name": "client_edge",
-              "resolverModule": require('./../resolvers/UserClientEdgeResolver.js'),
+              "resolverModule": require('./../resolvers/UserClientEdgeResolver'),
               "path": "me.client_edge"
             },
             "linkedField": {
@@ -108,7 +108,7 @@ return {
                     },
                     "kind": "RelayResolver",
                     "name": "another_client_edge",
-                    "resolverModule": require('./../resolvers/UserAnotherClientEdgeResolver.js'),
+                    "resolverModule": require('./../resolvers/UserAnotherClientEdgeResolver'),
                     "path": "me.another_client_edge"
                   },
                   "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest5Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest5Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fcfe80d9e403ade7db3b59ae0bd8d0a0>>
+ * @generated SignedSource<<8b8fa5863da7aa1391c36427ac3a5846>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -95,7 +95,7 @@ return {
                       },
                       "kind": "RelayResolver",
                       "name": "client_edge",
-                      "resolverModule": require('./../resolvers/UserClientEdgeResolver.js'),
+                      "resolverModule": require('./../resolvers/UserClientEdgeResolver'),
                       "path": "me.client_extension_linked_field.client_edge"
                     },
                     "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest6Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest6Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<783cfd5bca4c5317a1929891b8cd53d5>>
+ * @generated SignedSource<<2407a00aac88f2232f23e11fa8883138>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -75,7 +75,7 @@ return {
               },
               "kind": "RelayResolver",
               "name": "client_edge",
-              "resolverModule": require('./../resolvers/UserClientEdgeResolver.js'),
+              "resolverModule": require('./../resolvers/UserClientEdgeResolver'),
               "path": "me.the_alias"
             },
             "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest7Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTest7Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<795cc27947fb95b4b99a369c01c35749>>
+ * @generated SignedSource<<43ec772e59fa3ace88e7103704ae25d6>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -75,7 +75,7 @@ return {
               },
               "kind": "RelayResolver",
               "name": "null_client_edge",
-              "resolverModule": require('./../resolvers/UserNullClientEdgeResolver.js'),
+              "resolverModule": require('./../resolvers/UserNullClientEdgeResolver'),
               "path": "me.null_client_edge"
             },
             "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTestMissingClientEdgeDataQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderClientEdgesTestMissingClientEdgeDataQuery.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<34bb8da0c531a1202a47f4255a061b54>>
+ * @generated SignedSource<<fea14f5515fe1cb611bbe36285b8909b>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "reads_client_edge",
-            "resolverModule": require('./../resolvers/UserReadsClientEdgeResolver.js'),
+            "resolverModule": require('./../resolvers/UserReadsClientEdgeResolver'),
             "path": "me.reads_client_edge"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest10Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest10Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3bf98a8711860dc3aa3d762084b724aa>>
+ * @generated SignedSource<<99b7f9fcd59102406e7a106a3c63fa66>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "greeting",
-            "resolverModule": require('./../resolvers/UserGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserGreetingResolver'),
             "path": "me.greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest11Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest11Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6881fa12ff077f7b4ed157da5eeeb1ff>>
+ * @generated SignedSource<<a67bb8c5c16c76ebbdf27dbfc19c7306>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "greeting",
-            "resolverModule": require('./../resolvers/UserGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserGreetingResolver'),
             "path": "me.the_alias"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest12Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest12Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<006fe8f63715b11eba4f12b570cae418>>
+ * @generated SignedSource<<9dc6c5f1045a855ac104635a5fe22482>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "always_throws",
-            "resolverModule": require('./../resolvers/UserAlwaysThrowsResolver.js'),
+            "resolverModule": require('./../resolvers/UserAlwaysThrowsResolver'),
             "path": "me.always_throws"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest13Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest13Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2e74f55c92c1a1d9d9b111fbe1bfc415>>
+ * @generated SignedSource<<61d26e58360cdb052918e56fefdecb9a>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "always_throws_transitively",
-            "resolverModule": require('./../resolvers/UserAlwaysThrowsTransitivelyResolver.js'),
+            "resolverModule": require('./../resolvers/UserAlwaysThrowsTransitivelyResolver'),
             "path": "me.always_throws_transitively"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest14Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest14Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f2608abf11f4e667e5506d8c9bd36d39>>
+ * @generated SignedSource<<f4281ee8edc1e88f49b9a3f96893bd55>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -50,7 +50,7 @@ var node/*: ConcreteRequest*/ = {
         },
         "kind": "RelayResolver",
         "name": "throw_before_read",
-        "resolverModule": require('./../resolvers/ThrowBeforeReadResolver.js'),
+        "resolverModule": require('./../resolvers/ThrowBeforeReadResolver'),
         "path": "throw_before_read"
       }
     ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest15Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest15Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<088055ab58f999bdd940c32cf328da7d>>
+ * @generated SignedSource<<6c42ba0f7ddca44bc1b7a230a7b568e8>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -50,7 +50,7 @@ var node/*: ConcreteRequest*/ = {
         },
         "kind": "RelayResolver",
         "name": "undefined_field",
-        "resolverModule": require('./../resolvers/UndefinedFieldResolver.js'),
+        "resolverModule": require('./../resolvers/UndefinedFieldResolver'),
         "path": "undefined_field"
       }
     ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest16Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest16Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<771ced02422091d21b294d48c2c7edc1>>
+ * @generated SignedSource<<ebbcb5345f33884e37f0884037e64480>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -80,7 +80,7 @@ return {
             },
             "kind": "RelayResolver",
             "name": "user_profile_picture_uri_with_scale",
-            "resolverModule": require('./../resolvers/UserProfilePictureResolver.js'),
+            "resolverModule": require('./../resolvers/UserProfilePictureResolver'),
             "path": "me.user_profile_picture_uri_with_scale"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest17Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest17Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d08a52f14ac282c41e482a413e9de774>>
+ * @generated SignedSource<<38d35452c766634944219f8057e250ff>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -63,7 +63,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "user_profile_picture_uri_with_scale_and_default_value",
-            "resolverModule": require('./../resolvers/UserProfilePictureWithDefaultValueResolver.js'),
+            "resolverModule": require('./../resolvers/UserProfilePictureWithDefaultValueResolver'),
             "path": "me.user_profile_picture_uri_with_scale_and_default_value"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest18Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest18Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7bb18e229958083f5f35549102c22a44>>
+ * @generated SignedSource<<31e3506baabcb5dfe220c3fbbe7c4fd1>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -71,7 +71,7 @@ return {
             },
             "kind": "RelayResolver",
             "name": "user_profile_picture_uri_with_scale_and_default_value",
-            "resolverModule": require('./../resolvers/UserProfilePictureWithDefaultValueResolver.js'),
+            "resolverModule": require('./../resolvers/UserProfilePictureWithDefaultValueResolver'),
             "path": "me.profile_picture2"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest19Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest19Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0c0f8368eca6c93115535f11529198c7>>
+ * @generated SignedSource<<7c542455b0facc994bed98c907fa1b00>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -108,7 +108,7 @@ return {
             },
             "kind": "RelayResolver",
             "name": "user_profile_picture_uri_with_scale_and_default_value",
-            "resolverModule": require('./../resolvers/UserProfilePictureWithDefaultValueResolver.js'),
+            "resolverModule": require('./../resolvers/UserProfilePictureWithDefaultValueResolver'),
             "path": "me.profile_picture2"
           },
           (v3/*: any*/)

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest1Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest1Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<97064133319761cf2b1aeb6ec6fbeef3>>
+ * @generated SignedSource<<d4527a343da5f950de428b106df8ac52>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "greeting",
-            "resolverModule": require('./../resolvers/UserGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserGreetingResolver'),
             "path": "me.greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest20Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest20Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ff21ddd768f4c6a8e1fc3edbeea9420c>>
+ * @generated SignedSource<<0a28645c1f6f234a9a808db554eef1d0>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -80,7 +80,7 @@ return {
             },
             "kind": "RelayResolver",
             "name": "user_profile_picture_uri_with_scale",
-            "resolverModule": require('./../resolvers/UserProfilePictureResolver.js'),
+            "resolverModule": require('./../resolvers/UserProfilePictureResolver'),
             "path": "me.profile_picture"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest21Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest21Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3a66141fe1fd5ede68262cea8b1063cb>>
+ * @generated SignedSource<<96a6b3c7450c8fb883f1d44e9069a436>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -80,7 +80,7 @@ return {
             },
             "kind": "RelayResolver",
             "name": "user_profile_picture_uri_with_scale",
-            "resolverModule": require('./../resolvers/UserProfilePictureResolver.js'),
+            "resolverModule": require('./../resolvers/UserProfilePictureResolver'),
             "path": "me.profile_picture"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest22Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest22Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9a73f0d0cda7927165c89771868c6909>>
+ * @generated SignedSource<<9b8707072f542051b2c9e46b5cd88d9b>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -94,7 +94,7 @@ return {
             },
             "kind": "RelayResolver",
             "name": "user_profile_picture_uri_with_scale_and_additional_argument",
-            "resolverModule": require('./../resolvers/UserProfilePictureWithRuntimeArgumentResolver.js'),
+            "resolverModule": require('./../resolvers/UserProfilePictureWithRuntimeArgumentResolver'),
             "path": "me.profile_picture"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest24Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest24Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<dc619f102296a833ef86990faf366396>>
+ * @generated SignedSource<<8837389093778be511ecaad71271a415>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -67,7 +67,7 @@ var node/*: ConcreteRequest*/ = {
               },
               "kind": "RelayResolver",
               "name": "client_edge",
-              "resolverModule": require('./../resolvers/UserClientEdgeResolver.js'),
+              "resolverModule": require('./../resolvers/UserClientEdgeResolver'),
               "path": "me.client_edge"
             },
             "linkedField": {

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest2Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest2Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4d23e4a4c227810a45458ef63c1cd28e>>
+ * @generated SignedSource<<47a00617a275dd39f937cbcd4939b09c>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "constant_dependent",
-            "resolverModule": require('./../resolvers/UserConstantDependentResolver.js'),
+            "resolverModule": require('./../resolvers/UserConstantDependentResolver'),
             "path": "me.constant_dependent"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest3Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest3Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<171dcf088b2be5b0c12f06425fe9c28d>>
+ * @generated SignedSource<<cc8ca1ed0f1cd4ea2f8747efdb0683a2>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "greeting",
-            "resolverModule": require('./../resolvers/UserGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserGreetingResolver'),
             "path": "me.greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest4Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest4Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a9977cfc5470365f5a6c1bf885abc13d>>
+ * @generated SignedSource<<26cf4b248310e636dd17c2fd41669c1d>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -68,7 +68,7 @@ return {
             },
             "kind": "RelayResolver",
             "name": "best_friend_greeting",
-            "resolverModule": require('./../resolvers/UserBestFriendGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserBestFriendGreetingResolver'),
             "path": "me.best_friend_greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest5Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest5Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e4ed35cc1a9762da1776f948c66fb9b8>>
+ * @generated SignedSource<<eee3ce2703b8d1b6d72b5777b41d1d51>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "shouted_greeting",
-            "resolverModule": require('./../resolvers/UserShoutedGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserShoutedGreetingResolver'),
             "path": "me.shouted_greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest6Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest6Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<300ea9d15691cbfa6649ce2b0ef3fec9>>
+ * @generated SignedSource<<597d4c7c46bfe9c8713a35c8853b43fb>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -68,7 +68,7 @@ return {
             },
             "kind": "RelayResolver",
             "name": "best_friend_shouted_greeting",
-            "resolverModule": require('./../resolvers/UserBestFriendShoutedGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserBestFriendShoutedGreetingResolver'),
             "path": "me.best_friend_shouted_greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest7Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest7Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<187efdbd3e4d449c5b2b62350eec898f>>
+ * @generated SignedSource<<b60d40c07a96e11b662934708b81a431>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "greeting",
-            "resolverModule": require('./../resolvers/UserGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserGreetingResolver'),
             "path": "me.greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest8Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest8Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9945cab265e13e8e76f473cc219a714d>>
+ * @generated SignedSource<<bec8365f33f1172d9b766dc4899b6845>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -62,7 +62,7 @@ var node/*: ConcreteRequest*/ = {
               },
               "kind": "RelayResolver",
               "name": "name_passthrough",
-              "resolverModule": require('./../resolvers/UserNamePassthroughResolver.js'),
+              "resolverModule": require('./../resolvers/UserNamePassthroughResolver'),
               "path": "me.name_passthrough"
             },
             "action": "NONE",

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest9Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTest9Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<dd62eefb5df5b1b4401c3332e803c27b>>
+ * @generated SignedSource<<ce37ce2b090d1dec0462e0f4d4b2a62a>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "greeting",
-            "resolverModule": require('./../resolvers/UserGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserGreetingResolver'),
             "path": "me.greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTestCustomGreetingDynamicQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTestCustomGreetingDynamicQuery.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d908216520e283a0b9dfbc90b32c2b6d>>
+ * @generated SignedSource<<fa3ea6df938336ffeb6f13d87f7e9fa6>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -82,7 +82,7 @@ return {
             "fragment": (v1/*: any*/),
             "kind": "RelayResolver",
             "name": "custom_greeting",
-            "resolverModule": require('./../resolvers/UserCustomGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserCustomGreetingResolver'),
             "path": "me.dynamic_greeting"
           },
           {
@@ -97,7 +97,7 @@ return {
             "fragment": (v1/*: any*/),
             "kind": "RelayResolver",
             "name": "custom_greeting",
-            "resolverModule": require('./../resolvers/UserCustomGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserCustomGreetingResolver'),
             "path": "me.greetz"
           },
           {
@@ -112,7 +112,7 @@ return {
             "fragment": (v1/*: any*/),
             "kind": "RelayResolver",
             "name": "custom_greeting",
-            "resolverModule": require('./../resolvers/UserCustomGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserCustomGreetingResolver'),
             "path": "me.willkommen"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTestMissingDataQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTestMissingDataQuery.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<956c8aabb489de6b24520205ccfca3b9>>
+ * @generated SignedSource<<de22a6701a9bfe56ad5d11fc3cc082c2>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "greeting",
-            "resolverModule": require('./../resolvers/UserGreetingResolver.js'),
+            "resolverModule": require('./../resolvers/UserGreetingResolver'),
             "path": "me.greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTestRequiredQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTestRequiredQuery.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7b581f07809d7a30a5470df9e643b587>>
+ * @generated SignedSource<<1748c5c7e7baea8dad859f93a65565e2>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "required_name",
-            "resolverModule": require('./../resolvers/UserRequiredNameResolver.js'),
+            "resolverModule": require('./../resolvers/UserRequiredNameResolver'),
             "path": "me.required_name"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTestRequiredWithParentQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderResolverTestRequiredWithParentQuery.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<48d1322d526decd91ab520b774150778>>
+ * @generated SignedSource<<6d64463b07aa08697b78e34f94426f03>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -69,7 +69,7 @@ return {
             },
             "kind": "RelayResolver",
             "name": "required_name",
-            "resolverModule": require('./../resolvers/UserRequiredNameResolver.js'),
+            "resolverModule": require('./../resolvers/UserRequiredNameResolver'),
             "path": "me.required_name"
           },
           {

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/AstrologicalSignHouseResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/AstrologicalSignHouseResolver.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<201eb25e1e81a782f562bedfa7605ba4>>
+ * @generated SignedSource<<eb0769e9ddb7ffe32a0bdc124cc93246>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -52,7 +52,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "self",
-      "resolverModule": require('./../AstrologicalSignSelfResolver.js'),
+      "resolverModule": require('./../AstrologicalSignSelfResolver'),
       "path": "self"
     }
   ],

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/AstrologicalSignNameResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/AstrologicalSignNameResolver.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3aaa6d3cdcfb970e5f227d6c7ce288a5>>
+ * @generated SignedSource<<3d343c5a536e500e7c0454878a27f230>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -52,7 +52,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "self",
-      "resolverModule": require('./../AstrologicalSignSelfResolver.js'),
+      "resolverModule": require('./../AstrologicalSignSelfResolver'),
       "path": "self"
     }
   ],

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/AstrologicalSignOppositeResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/AstrologicalSignOppositeResolver.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f2d2da3ed7e1e0bbefcdfdd872feb498>>
+ * @generated SignedSource<<9604665ea9acc877af307fdf4ba76763>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -52,7 +52,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "self",
-      "resolverModule": require('./../AstrologicalSignSelfResolver.js'),
+      "resolverModule": require('./../AstrologicalSignSelfResolver'),
       "path": "self"
     }
   ],

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/CounterPlusOneResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/CounterPlusOneResolver.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a2ed2a24960c76392c6734ae42747258>>
+ * @generated SignedSource<<7ad400309c41e3aee611ea37816e75a0>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -55,7 +55,7 @@ var node/*: ReaderFragment*/ = {
         },
         "kind": "RelayLiveResolver",
         "name": "counter",
-        "resolverModule": require('./../LiveCounterResolver.js'),
+        "resolverModule": require('./../LiveCounterResolver'),
         "path": "counter"
       },
       "action": "THROW",

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/ResolverTest1Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/ResolverTest1Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fc29ea6a1eaa4b9745dda588a214156d>>
+ * @generated SignedSource<<00ab9aebbbceb38012e8c12474cd9af0>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -60,7 +60,7 @@ var node/*: ConcreteRequest*/ = {
             },
             "kind": "RelayResolver",
             "name": "greeting",
-            "resolverModule": require('./../UserGreetingResolver.js'),
+            "resolverModule": require('./../UserGreetingResolver'),
             "path": "me.greeting"
           }
         ],

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/ResolverTest2Fragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/ResolverTest2Fragment.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1e32ee69fa437a9b58401f44e52373b3>>
+ * @generated SignedSource<<1997ed57db7094d276c947d0519ae103>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -63,7 +63,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "greeting",
-      "resolverModule": require('./../UserGreetingResolver.js'),
+      "resolverModule": require('./../UserGreetingResolver'),
       "path": "greeting"
     },
     {

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/ResolverTest3Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/ResolverTest3Query.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b841ad5cf168377f7bf1308327552266>>
+ * @generated SignedSource<<6982fdaf6e612803d7171feccb5f102a>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -67,7 +67,7 @@ var node/*: ConcreteRequest*/ = {
               },
               "kind": "RelayResolver",
               "name": "client_edge",
-              "resolverModule": require('./../UserClientEdgeResolver.js'),
+              "resolverModule": require('./../UserClientEdgeResolver'),
               "path": "me.client_edge"
             },
             "linkedField": {

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserAlwaysThrowsTransitivelyResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserAlwaysThrowsTransitivelyResolver.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fb4cdd49c40d66e4548349c18fd53df9>>
+ * @generated SignedSource<<46eb5b74f788ece3b774b4de513505cb>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -52,7 +52,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "always_throws",
-      "resolverModule": require('./../UserAlwaysThrowsResolver.js'),
+      "resolverModule": require('./../UserAlwaysThrowsResolver'),
       "path": "always_throws"
     }
   ],

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserBestFriendShoutedGreetingResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserBestFriendShoutedGreetingResolver.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e58abb9cceb22d2499d4c29495cae273>>
+ * @generated SignedSource<<27fc62a2b09fa7bd1abb85f059fba5a1>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -96,7 +96,7 @@ var node/*: ReaderFragment*/ = {
                   },
                   "kind": "RelayResolver",
                   "name": "greeting",
-                  "resolverModule": require('./../UserGreetingResolver.js'),
+                  "resolverModule": require('./../UserGreetingResolver'),
                   "path": "friends.edges.node.greeting"
                 }
               ],

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserConstantDependentResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserConstantDependentResolver.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6898f0339ff098bb3cac0e588de03303>>
+ * @generated SignedSource<<02415624a723cb701f653d3ae5576935>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -52,7 +52,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "constant",
-      "resolverModule": require('./../UserConstantResolver.js'),
+      "resolverModule": require('./../UserConstantResolver'),
       "path": "constant"
     }
   ],

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserNameAndCounterSuspendsWhenOdd.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserNameAndCounterSuspendsWhenOdd.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a0fa273fa8cbc49214652916a158166c>>
+ * @generated SignedSource<<5704f54ca20a96a9b35ceba2b9ba3a8e>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -74,7 +74,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayLiveResolver",
       "name": "counter_suspends_when_odd",
-      "resolverModule": require('./../CounterSuspendsWhenOdd.js'),
+      "resolverModule": require('./../CounterSuspendsWhenOdd'),
       "path": "counter_suspends_when_odd"
     }
   ],

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserProfilePictureUriSuspendsWhenTheCounterIsOdd.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserProfilePictureUriSuspendsWhenTheCounterIsOdd.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<71546d1df22976de93117f5b08ced0e5>>
+ * @generated SignedSource<<99e10e4f589ff001e7dfadcecd2bc668>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -69,7 +69,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "greeting",
-      "resolverModule": require('./../UserGreetingResolver.js'),
+      "resolverModule": require('./../UserGreetingResolver'),
       "path": "greeting"
     },
     {
@@ -88,7 +88,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "user_profile_picture_uri_with_scale",
-      "resolverModule": require('./../UserProfilePictureResolver.js'),
+      "resolverModule": require('./../UserProfilePictureResolver'),
       "path": "uri"
     }
   ],

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserReadsClientEdgeResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserReadsClientEdgeResolver.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<95794afa3da2a819466fa31d7fe02260>>
+ * @generated SignedSource<<b751d6445e8e05beb51299d387ca042b>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -59,7 +59,7 @@ var node/*: ReaderFragment*/ = {
         },
         "kind": "RelayResolver",
         "name": "client_edge",
-        "resolverModule": require('./../UserClientEdgeResolver.js'),
+        "resolverModule": require('./../UserClientEdgeResolver'),
         "path": "client_edge"
       },
       "linkedField": {

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserShoutedGreetingResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserShoutedGreetingResolver.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d286177c6d4258ee61f63f5a9f70ec85>>
+ * @generated SignedSource<<6bf78c93e1f23c70e543a010c1a07c64>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -52,7 +52,7 @@ var node/*: ReaderFragment*/ = {
       },
       "kind": "RelayResolver",
       "name": "greeting",
-      "resolverModule": require('./../UserGreetingResolver.js'),
+      "resolverModule": require('./../UserGreetingResolver'),
       "path": "greeting"
     }
   ],


### PR DESCRIPTION
Fixes https://github.com/facebook/relay/issues/3989#issuecomment-1175374119

This PR updates `relay-codegen`'s printer not to include the file's extension when writing imports /  requires. This might be a naive implementation, maybe there's a better, more holistic approach.