### PR TITLE
Add a link to the compiler settings from the intro

### DIFF
--- a/website/versioned_docs/version-v14.0.0/getting-started/introduction.md
+++ b/website/versioned_docs/version-v14.0.0/getting-started/introduction.md
@@ -25,7 +25,7 @@ To get started, check out the following resources:
 - An overview of the **[prerequisites](./getting-started/prerequisites/)** for using Relay, and an **[installation and setup guide](./getting-started/installation-and-setup/)**.
 - The **[guided tour](./guided-tour/)**, for a comprehensive overview of Relay's different APIs and concepts, and usage examples for different use cases.
 - The **[API reference](./api-reference/relay-environment-provider/)**, for a reference of our APIs including a detailed overview of their inputs and outputs.
-- The [compiler settings](https://github.com/facebook/relay/tree/main/packages/relay-compiler#configuration)**, includes all of the options for configuring  relay.
+- The **[compiler settings](https://github.com/facebook/relay/tree/main/packages/relay-compiler#configuration)**, includes all of the options for configuring  relay.
 
 </OssOnly>
 

--- a/website/versioned_docs/version-v14.0.0/getting-started/introduction.md
+++ b/website/versioned_docs/version-v14.0.0/getting-started/introduction.md
@@ -25,6 +25,7 @@ To get started, check out the following resources:
 - An overview of the **[prerequisites](./getting-started/prerequisites/)** for using Relay, and an **[installation and setup guide](./getting-started/installation-and-setup/)**.
 - The **[guided tour](./guided-tour/)**, for a comprehensive overview of Relay's different APIs and concepts, and usage examples for different use cases.
 - The **[API reference](./api-reference/relay-environment-provider/)**, for a reference of our APIs including a detailed overview of their inputs and outputs.
+- The [compiler settings](https://github.com/facebook/relay/tree/main/packages/relay-compiler#configuration)**, includes all of the options for configuring  relay.
 
 </OssOnly>
 


### PR DESCRIPTION
This isn't a _great_ way to get to it (maybe a sidebar link, which is where I first looked) but the configuration for the package.json isn't available in the search etc - so this at least puts it in a place where I looked after the sidebar