### PR TITLE
update flowconfig to ignore malformed_package_json in node modules

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 <PROJECT_ROOT>/dist/.*
 <PROJECT_ROOT>/compiler/.*
 <PROJECT_ROOT>/.*/node_modules/.*
+.*/node_modules/resolve/test/resolver/malformed_package_json/package.json
 
 [options]
 exact_by_default=true


### PR DESCRIPTION
flow check is failing on this repo right now

```
yarn run v1.22.19
$ flow check
Error --------------------------------------- node_modules/resolve/test/resolver/malformed_package_json/package.json:2:1
Unexpected end of input, expected the token `}`
   2|
Found 1 error
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 2.
```

I wish https://github.com/facebook/flow/issues/2364 was addressed that I didn't have to do this :( 