### PR TITLE
[vscode-extension] Adds a way to quickly create a component fragment 

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -153,8 +153,7 @@
     "bracketSameLine": true,
     "bracketSpacing": false,
     "singleQuote": true,
-    "trailingComma": "all",
-    "printWidth": 100
+    "trailingComma": "all"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -70,8 +70,20 @@
       {
         "command": "relay.stopCompiler",
         "title": "Relay: Stop Compiler"
+      },
+      {
+        "command": "relay.createNewFragmentComponent",
+        "title": "Relay: Create New Fragment Component"
       }
     ],
+    "menus": {
+			"explorer/context": [
+				{
+					"command": "relay.createNewFragmentComponent",
+					"group": "Relay@1"
+				}
+      ]
+    },
     "configuration": {
       "type": "object",
       "title": "Relay",
@@ -141,7 +153,8 @@
     "bracketSameLine": true,
     "bracketSpacing": false,
     "singleQuote": true,
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "printWidth": 100
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/vscode-extension/src/commands/createNewFragmentComponent.ts
+++ b/vscode-extension/src/commands/createNewFragmentComponent.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as vscode from 'vscode';
+import {basename} from 'path';
+import {RelayExtensionContext} from '../context';
+
+export async function createNewFragmentComponent(
+  _: RelayExtensionContext,
+  fsLocationClicked?: vscode.Uri,
+) {
+  //    context.primaryOutputChannel.show();
+  let target = fsLocationClicked;
+  if (!target) {
+    const files = await vscode.window.showOpenDialog({
+      canSelectFolders: true,
+      canSelectMany: false,
+      canSelectFiles: false,
+      title: 'Select a folder for your new fragment component',
+    });
+
+    target = files && files[0];
+  }
+
+  if (!target) {
+    vscode.window.showErrorMessage('No folder selected for creating a new fragment component');
+    return;
+  }
+
+  const wsedit = new vscode.WorkspaceEdit();
+  const newFileName = await vscode.window.showInputBox({
+    title: '',
+    prompt: 'Name of your fragment component',
+    value: 'SomethingView',
+    valueSelection: [0, 9],
+  });
+
+  const isFolder = target.path.endsWith('/');
+
+  // TODO: Ideally we have an extension wide way to know if we should be writing a flow
+  // or TypeScript component. A cheap check right now is that if there is a .js file inside
+  // the folder we assume it is a flow component.
+
+  let isJS = target.path.endsWith('.js');
+  if (isFolder) {
+    const files = await vscode.workspace.fs.readDirectory(target);
+    isJS = files.some(f => f[0].endsWith('.js'));
+  }
+
+  const fileType = isJS ? 'js' : 'tsx';
+
+  const newPathString = isFolder
+    ? `${basename(target.fsPath)}/${newFileName}.${fileType}`
+    : `${target.fsPath}/${newFileName}.${fileType}`;
+
+  const newFilePath = vscode.Uri.file(newPathString);
+
+  const content = `import React from 'react';
+import { graphql } from 'react-relay';
+
+const GameFrag = graphql\`
+  fragment ${newFileName}Fragment on [Fill] {
+    
+  }
+\`
+
+type Props = { 
+    [fill]: ${newFileName}$key
+}
+
+export const ${newFileName} = () => {
+    return <></>
+}
+`;
+
+  wsedit.createFile(newFilePath);
+  wsedit.set(newFilePath, [vscode.TextEdit.insert(new vscode.Position(0, 0), content)]);
+
+  vscode.workspace.applyEdit(wsedit);
+
+  vscode.commands.executeCommand('vscode.open', newFilePath);
+  vscode.window.showInformationMessage(
+    `Created new fragment component: ${basename(newFilePath.fsPath)}`,
+  );
+}

--- a/vscode-extension/src/commands/createNewFragmentComponent.ts
+++ b/vscode-extension/src/commands/createNewFragmentComponent.ts
@@ -37,7 +37,13 @@ export async function createNewFragmentComponent(
     prompt: 'Name of your fragment component',
     value: 'SomethingView',
     valueSelection: [0, 9],
+    ignoreFocusOut: true,
   });
+
+  // NOOP (you may have left the input box empty)
+  if (!newFileName) {
+    return;
+  }
 
   const isFolder = target.path.endsWith('/');
 

--- a/vscode-extension/src/commands/register.ts
+++ b/vscode-extension/src/commands/register.ts
@@ -7,6 +7,7 @@
 
 import {commands} from 'vscode';
 import {RelayExtensionContext} from '../context';
+import {createNewFragmentComponent} from './createNewFragmentComponent';
 import {handleRestartLanguageServerCommand} from './restart';
 import {handleShowOutputCommand} from './showOutput';
 import {handleStartCompilerCommand} from './startCompiler';
@@ -29,6 +30,10 @@ export function registerCommands(context: RelayExtensionContext) {
     commands.registerCommand(
       'relay.showOutput',
       handleShowOutputCommand.bind(null, context),
+    ),
+    commands.registerCommand(
+      'relay.createNewFragmentComponent',
+      createNewFragmentComponent.bind(null, context),
     ),
   );
 }


### PR DESCRIPTION
**Opening this to start a discussion** - I'd like to have the extension ship an easy way to get started with new files. This PR is an _example_ which shows how to do that with all the high-level vscode workspace APIs. It takes into account JS vs TS, but it more or less the lower bounds for what could be mergable.

---

You can right-click in the explorer, or run the command "Relay: Create a new fragment component" :
![image](https://user-images.githubusercontent.com/49038/180436465-1bce3873-d115-41c6-b3ef-30f9dc7d287c.png)

You are then asked about what the file name is:
![image](https://user-images.githubusercontent.com/49038/180436883-590d88af-67a2-478a-b343-884c66fef1a7.png)

It then generates the file;
![image](https://user-images.githubusercontent.com/49038/180436993-2d180738-e66c-48aa-9699-33266f31ba40.png)
