### PR TITLE
Use `import type` in typescript for all imports

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.10"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c5a7f9997be616e47f0577ee38c91decb33392c5be4866494f34cdf329a9aa"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -403,6 +403,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "errors"
 version = "0.0.0"
 dependencies = [
@@ -490,9 +511,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -505,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -515,15 +536,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -532,17 +553,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -550,21 +570,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -576,8 +596,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -726,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
  "serde",
@@ -847,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -894,6 +912,12 @@ dependencies = [
  "parking_lot",
  "serde",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "iovec"
@@ -952,9 +976,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -1315,18 +1345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,7 +1506,7 @@ dependencies = [
  "extract-graphql",
  "fixture-tests",
  "fnv",
- "futures 0.3.13",
+ "futures 0.3.24",
  "glob",
  "graphql-cli",
  "graphql-ir",
@@ -1687,6 +1705,20 @@ dependencies = [
  "intern",
  "relay-test-schema",
  "schema",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2042,19 +2074,19 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 dependencies = [
  "terminal_size",
  "unicode-width",
@@ -2321,7 +2353,7 @@ checksum = "839fea2d85719bb69089290d7970bba2131f544448db8f990ea75813c30775ca"
 dependencies = [
  "anyhow",
  "bytes 1.0.1",
- "futures 0.3.13",
+ "futures 0.3.24",
  "maplit",
  "serde",
  "serde_bser",
@@ -2361,6 +2393,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "zstd"

--- a/compiler/crates/relay-compiler/src/artifact_content/content.rs
+++ b/compiler/crates/relay-compiler/src/artifact_content/content.rs
@@ -96,7 +96,7 @@ pub fn generate_updatable_query(
     }
 
     write_import_type_from(
-        &project_config.typegen_config.language,
+        &project_config,
         &mut section,
         generated_types.imported_types,
         "relay-runtime",
@@ -260,7 +260,7 @@ pub fn generate_operation(
     }
 
     write_import_type_from(
-        &project_config.typegen_config.language,
+        &project_config,
         &mut section,
         generated_types.imported_types,
         "relay-runtime",
@@ -426,7 +426,7 @@ pub fn generate_split_operation(
         writeln!(section, "/*::")?;
     }
     write_import_type_from(
-        &project_config.typegen_config.language,
+        &project_config,
         &mut section,
         "NormalizationSplitOperation",
         "relay-runtime",
@@ -600,7 +600,7 @@ fn generate_read_only_fragment(
     }
 
     write_import_type_from(
-        &project_config.typegen_config.language,
+        &project_config,
         &mut section,
         generated_types.imported_types,
         "relay-runtime",
@@ -790,15 +790,26 @@ fn generate_use_strict_section(language: &TypegenLanguage) -> Result<GenericSect
 }
 
 fn write_import_type_from(
-    language: &TypegenLanguage,
+    project_config: &ProjectConfig,
     section: &mut dyn Write,
     type_: &str,
     from: &str,
 ) -> FmtResult {
+    let language = &project_config.typegen_config.language;
     match language {
         TypegenLanguage::JavaScript => Ok(()),
         TypegenLanguage::Flow => writeln!(section, "import type {{ {} }} from '{}';", type_, from),
-        TypegenLanguage::TypeScript => writeln!(section, "import {{ {} }} from '{}';", type_, from),
+        TypegenLanguage::TypeScript => writeln!(
+            section,
+            "import {}{{ {} }} from \"{}\";",
+            if project_config.typegen_config.use_import_type_syntax {
+                "type "
+            } else {
+                ""
+            },
+            type_,
+            from
+        ),
     }
 }
 

--- a/compiler/crates/relay-typegen/tests/generate_typescript_import_syntax/fixtures/simple.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_import_syntax/fixtures/simple.expected
@@ -1,0 +1,24 @@
+==================================== INPUT ====================================
+fragment LinkedField on User {
+  name
+  profilePicture {
+    uri
+    width
+    height
+  }
+}
+==================================== OUTPUT ===================================
+import type { FragmentRefs } from "relay-runtime";
+export type LinkedField$data = {
+  readonly name: string | null;
+  readonly profilePicture: {
+    readonly height: number | null;
+    readonly uri: string | null;
+    readonly width: number | null;
+  } | null;
+  readonly " $fragmentType": "LinkedField";
+};
+export type LinkedField$key = {
+  readonly " $data"?: LinkedField$data;
+  readonly " $fragmentSpreads": FragmentRefs<"LinkedField">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript_import_syntax/fixtures/simple.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_import_syntax/fixtures/simple.graphql
@@ -1,0 +1,8 @@
+fragment LinkedField on User {
+  name
+  profilePicture {
+    uri
+    width
+    height
+  }
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript_import_syntax/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_import_syntax/mod.rs
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::sync::Arc;
+
+use common::ConsoleLogger;
+use common::FeatureFlag;
+use common::FeatureFlags;
+use common::SourceLocationKey;
+use fixture_tests::Fixture;
+use fnv::FnvBuildHasher;
+use fnv::FnvHashMap;
+use graphql_ir::build;
+use graphql_ir::Program;
+use graphql_syntax::parse_executable;
+use indexmap::IndexMap;
+use intern::string_key::Intern;
+use relay_codegen::JsModuleFormat;
+use relay_config::CustomScalarType;
+use relay_config::CustomScalarTypeImport;
+use relay_config::ProjectConfig;
+use relay_test_schema::get_test_schema;
+use relay_test_schema::get_test_schema_with_extensions;
+use relay_transforms::apply_transforms;
+use relay_typegen::FragmentLocations;
+use relay_typegen::TypegenConfig;
+use relay_typegen::TypegenLanguage;
+use relay_typegen::{self};
+
+type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
+
+pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+    let parts = fixture.content.split("%extensions%").collect::<Vec<_>>();
+    let (source, schema) = match parts.as_slice() {
+        [source, extensions] => (source, get_test_schema_with_extensions(extensions)),
+        [source] => (source, get_test_schema()),
+        _ => panic!(),
+    };
+
+    let source_location = SourceLocationKey::standalone(fixture.file_name);
+
+    let mut sources = FnvHashMap::default();
+    sources.insert(source_location, source);
+    let ast = parse_executable(source, source_location).unwrap_or_else(|e| {
+        panic!("Encountered error building AST: {:?}", e);
+    });
+    let ir = build(&schema, &ast.definitions).unwrap_or_else(|e| {
+        panic!("Encountered error building IR {:?}", e);
+    });
+    let program = Program::from_definitions(Arc::clone(&schema), ir);
+    let mut custom_scalar_types = FnvIndexMap::default();
+    custom_scalar_types.insert(
+        "JSON".intern(),
+        CustomScalarType::Path(CustomScalarTypeImport {
+            name: "JSON".intern(),
+            path: "TypeDefsFile".into(),
+        }),
+    );
+    let project_config = ProjectConfig {
+        name: "test".intern(),
+        js_module_format: JsModuleFormat::Haste,
+        typegen_config: TypegenConfig {
+            language: TypegenLanguage::TypeScript,
+            use_import_type_syntax: true,
+            custom_scalar_types,
+            ..Default::default()
+        },
+        feature_flags: Arc::new(FeatureFlags {
+            enable_fragment_aliases: FeatureFlag::Enabled,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let programs = apply_transforms(
+        &project_config,
+        Arc::new(program),
+        Default::default(),
+        Arc::new(ConsoleLogger),
+        None,
+        None,
+    )
+    .unwrap();
+
+    let fragment_locations = FragmentLocations::new(programs.typegen.fragments());
+    let mut operations: Vec<_> = programs.typegen.operations().collect();
+    operations.sort_by_key(|op| op.name.item);
+    let operation_strings = operations.into_iter().map(|typegen_operation| {
+        let normalization_operation = programs
+            .normalization
+            .operation(typegen_operation.name.item)
+            .unwrap();
+        relay_typegen::generate_operation_type_exports_section(
+            typegen_operation,
+            normalization_operation,
+            &schema,
+            &project_config,
+            &fragment_locations,
+        )
+    });
+
+    let mut fragments: Vec<_> = programs.typegen.fragments().collect();
+    fragments.sort_by_key(|frag| frag.name.item);
+    let fragment_strings = fragments.into_iter().map(|frag| {
+        relay_typegen::generate_fragment_type_exports_section(
+            frag,
+            &schema,
+            &project_config,
+            &fragment_locations,
+        )
+    });
+
+    let mut result: Vec<String> = operation_strings.collect();
+    result.extend(fragment_strings);
+    Ok(result
+        .join("-------------------------------------------------------------------------------\n"))
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript_import_syntax_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_import_syntax_test.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<fbb84200234cfe7d4293dd0c63574aab>>
+ */
+
+mod generate_typescript_import_syntax;
+
+use fixture_tests::test_fixture;
+use generate_typescript_import_syntax::transform_fixture;
+
+#[test]
+fn simple() {
+    let input = include_str!("generate_typescript_import_syntax/fixtures/simple.graphql");
+    let expected = include_str!("generate_typescript_import_syntax/fixtures/simple.expected");
+    test_fixture(
+        transform_fixture,
+        "simple.graphql",
+        "generate_typescript_import_syntax/fixtures/simple.expected",
+        input,
+        expected,
+    );
+}


### PR DESCRIPTION
This makes the following change to typescript artifacts:

```diff
-import { ConcreteRequest, Query } from "relay-runtime";
+import type { ConcreteRequest, Query } from "relay-runtime";
 import type { FragmentRefs } from "relay-runtime";
```

Using the existing `useImportTypeSyntax` config.

As stated in the config, the `import type` syntax introduced in Typescript version 3.8 and prevents warnings from `importsNotUsedAsValues`. This setting also assists naive bundlers from taking a dependency on `relay-runtime`, when only the types are needed.

I kept this simple. Other paths for implementation would be
 - There's a mix of distinct typegen printers e.g. compiler/crates/relay-typegen/src/typescript.rs, and the inline use of conditionals on the language directly in compiler/crates/relay-compiler/src/artifact_content/content.rs. Consolidating these would allow sharing the existing `write_import_type` function
 - The imports could instead be consolidated and printed together, rather than potentially having multiple imports from the same file as it is now