### PR TITLE
adding support for client extensions in mock payload generator

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
  "version_check",

--- a/packages/relay-test-utils/__tests__/RelayMockPayloadGenerator-test.js
+++ b/packages/relay-test-utils/__tests__/RelayMockPayloadGenerator-test.js
@@ -21,9 +21,13 @@ const {FIXTURE_TAG} = require('relay-test-utils-internal');
 function testGeneratedData<TVariables: Variables, TData, TRawResponse>(
   query: Query<TVariables, TData, TRawResponse>,
   mockResolvers: ?MockResolvers,
+  options: ?{mockClientData?: boolean},
 ): void {
   const operation = createOperationDescriptor(query, {});
-  const payload = RelayMockPayloadGenerator.generate(operation, mockResolvers);
+  const mockClientData = options?.mockClientData ?? false;
+  const payload = mockClientData
+    ? RelayMockPayloadGenerator.generateWithClientData(operation, mockResolvers)
+    : RelayMockPayloadGenerator.generate(operation, mockResolvers);
 
   expect({
     [FIXTURE_TAG]: true,
@@ -1432,22 +1436,6 @@ describe('with @relay_test_operation', () => {
     );
   });
 
-  test('generate mock for client extensions', () => {
-    testGeneratedData(
-      graphql`
-        query RelayMockPayloadGeneratorTest43Query @relay_test_operation {
-          node(id: "my-id") {
-            ... on User {
-              id
-              client_name
-              client_code
-            }
-          }
-        }
-      `,
-    );
-  });
-
   test('should generate data for @module', () => {
     graphql`
       fragment RelayMockPayloadGeneratorTestNameRendererFragment on User {
@@ -1652,5 +1640,30 @@ describe('with @relay_test_operation', () => {
         },
       },
     );
+  });
+
+  describe('with client extensions', () => {
+    const clientExtensionsQuery = graphql`
+      query RelayMockPayloadGeneratorTest43Query @relay_test_operation {
+        node(id: "my-id") {
+          ... on User {
+            id
+            client_name
+            client_code
+          }
+        }
+      }
+    `;
+    test('generate mock for client extensions with client generation disabled', () => {
+      testGeneratedData(clientExtensionsQuery, undefined, {
+        mockClientData: false,
+      });
+    });
+
+    test('generate mock for client extensions with client generation enabled', () => {
+      testGeneratedData(clientExtensionsQuery, undefined, {
+        mockClientData: true,
+      });
+    });
   });
 });

--- a/packages/relay-test-utils/__tests__/__snapshots__/RelayMockPayloadGenerator-test.js.snap
+++ b/packages/relay-test-utils/__tests__/__snapshots__/RelayMockPayloadGenerator-test.js.snap
@@ -1137,29 +1137,6 @@ query RelayMockPayloadGeneratorTest35Query {
 }
 `;
 
-exports[`with @relay_test_operation generate mock for client extensions 1`] = `
-~~~~~~~~~~ INPUT ~~~~~~~~~~
-query RelayMockPayloadGeneratorTest43Query {
-  node(id: "my-id") {
-    __typename
-    ... on User {
-      id
-    }
-    id
-  }
-}
-
-~~~~~~~~~~ OUTPUT ~~~~~~~~~~
-{
-  "data": {
-    "node": {
-      "__typename": "User",
-      "id": "<Node-mock-id-1>"
-    }
-  }
-}
-`;
-
 exports[`with @relay_test_operation generate mock for enum in arrays 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 query RelayMockPayloadGeneratorTest40Query {
@@ -2177,3 +2154,51 @@ fragment RelayMockPayloadGeneratorTest5MarkdownUserNameRenderer_name on Markdown
 `;
 
 exports[`with @relay_test_operation should throw if invalid default value provide for __module_operation. 1`] = `"RelayMockPayloadGenerator(): Unexpected default value for a field \`__module_operation\` in the mock resolver for @module dependency. Provided value is \\"{\\"kind\\":\\"InvalidObject\\"}\\" and we're expecting an object of a type \`NormalizationSplitOperation\`. Please adjust mock resolver for the type \\"MarkdownUserNameRenderer\\". Typically it should require a file \\"RelayMockPayloadGeneratorTest4MarkdownUserNameRenderer_name$normalization.graphql\\"."`;
+
+exports[`with @relay_test_operation with client extensions generate mock for client extensions with client generation disabled 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query RelayMockPayloadGeneratorTest43Query {
+  node(id: "my-id") {
+    __typename
+    ... on User {
+      id
+    }
+    id
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "data": {
+    "node": {
+      "__typename": "User",
+      "id": "<Node-mock-id-1>"
+    }
+  }
+}
+`;
+
+exports[`with @relay_test_operation with client extensions generate mock for client extensions with client generation enabled 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query RelayMockPayloadGeneratorTest43Query {
+  node(id: "my-id") {
+    __typename
+    ... on User {
+      id
+    }
+    id
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "data": {
+    "node": {
+      "__typename": "User",
+      "id": "<Node-mock-id-1>",
+      "client_name": "<mock-value-for-field-\\"client_name\\">",
+      "client_code": "<mock-value-for-field-\\"client_code\\">"
+    }
+  }
+}
+`;


### PR DESCRIPTION
## Problem
At Twitter we've been hoping to use MockPayloadGenerator to allow us to scaffold data in tests/[stories](https://storybook.js.org/) while our components use client side schema extensions. One of the engineers on my team discovered that this support is explicitly disallowed in the `relay` repo. I reached out to the discord channel and received feedback that enabling this would make sense.

## Solution
Within `RelayMockPayloadGenerator.js`, modify the logic within `_traverseSelections` to recursively traverse the nested selections. This places the logic alongside `DEFER` and `STREAM`. 

A snapshot was updated as a result of this change —  local client extension `client_name` and `client_code` now have generated mocked fields. 

