### PR TITLE
Add SDLSchema.get_unions()

### DIFF
--- a/compiler/crates/schema/src/in_memory/mod.rs
+++ b/compiler/crates/schema/src/in_memory/mod.rs
@@ -346,6 +346,10 @@ impl InMemorySchema {
         self.objects.iter()
     }
 
+    pub fn get_unions(&self) -> impl Iterator<Item = &Union> {
+        self.unions.iter()
+    }
+
     pub fn has_directive(&self, directive_name: StringKey) -> bool {
         self.directives.contains_key(&directive_name)
     }

--- a/compiler/crates/schema/src/schema.rs
+++ b/compiler/crates/schema/src/schema.rs
@@ -366,6 +366,13 @@ impl SDLSchema {
         }
     }
 
+    pub fn get_unions(&self) -> impl Iterator<Item = &Union> {
+        match self {
+            SDLSchema::FlatBuffer(_schema) => todo!(),
+            SDLSchema::InMemory(schema) => schema.get_unions(),
+        }
+    }
+
     pub fn has_directive(&self, directive_name: StringKey) -> bool {
         match self {
             SDLSchema::FlatBuffer(_schema) => todo!(),


### PR DESCRIPTION
We have `get_*` functions for other types but `unions` was missing. Adding `get_unions` function to have consistency and support relevant use cases.

Reviewed By: schaitoff

Differential Revision: D38387300

