### PR TITLE
Fix spelling mistake inside the vscode extension

### DIFF
--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -81,7 +81,7 @@ export function createAndStartLanguageClient(context: RelayExtensionContext) {
   client.registerFeature(new LSPStatusBarFeature(context));
 
   context.primaryOutputChannel.appendLine(
-    `Starting the Relay Langauge Server with these options: ${JSON.stringify(
+    `Starting the Relay Language Server with these options: ${JSON.stringify(
       serverOptions,
     )}`,
   );


### PR DESCRIPTION
Was trying the new vscode-extension and noticed this spelling error, not a big deal :-)

<img width="396" alt="Screen Shot 2022-08-10 at 9 37 13 pm" src="https://user-images.githubusercontent.com/21725/183891843-b88d706d-6cfc-4cfd-a205-e04c9b493287.png">
