### PR TITLE
Move tslint-disable to below eslint-disable

### DIFF
--- a/compiler/crates/relay-compiler/src/artifact_content/content.rs
+++ b/compiler/crates/relay-compiler/src/artifact_content/content.rs
@@ -765,8 +765,8 @@ fn generate_disable_lint_section(language: &TypegenLanguage) -> Result<GenericSe
     let mut section = GenericSection::default();
     match language {
         TypegenLanguage::TypeScript => {
-            writeln!(section, "/* tslint:disable */")?;
             writeln!(section, "/* eslint-disable */")?;
+            writeln!(section, "/* tslint:disable */")?;
             writeln!(section, "// @ts-nocheck")?;
         }
         TypegenLanguage::Flow | TypegenLanguage::JavaScript => {


### PR DESCRIPTION
## Summary:
This PR moves the `eslint-disable` comment on typescript generated files to be above the `tslint-disable` one.

Solves the following:

<img width="636" alt="Screenshot 2022-08-15 at 20 20 00" src="https://user-images.githubusercontent.com/8649362/184704089-f1205e5f-264b-4a32-a856-60f44f348b6c.png">


## Reasoning:
**given that**:
- `tslint` is deprecated
- some [popular presets](https://github.com/typescript-eslint/typescript-eslint/blob/921cdf17e548845311d0591249616ec844503926/packages/eslint-plugin/src/configs/strict.ts#L9) on `typescript-eslint` project forbids the usage of `tslint`

**then**: makes sense to reverse the order the disable comments are hidden.

---

**downside**: typescript projects that commit this generated files will have a large diff when upgrading
(but I guess compiler updates may generate this sorts of diffs anyways).

**fun fact**: generated TS files pass all rules in the `strict` `typescript-eslint` preset, except this one 😄 
