### PR TITLE
Export ProfilerContext in react-relay

### DIFF
--- a/packages/react-relay/hooks.js
+++ b/packages/react-relay/hooks.js
@@ -26,6 +26,7 @@ const useRelayEnvironment = require('./relay-hooks/useRelayEnvironment');
 const useSubscribeToInvalidationState = require('./relay-hooks/useSubscribeToInvalidationState');
 const useSubscription = require('./relay-hooks/useSubscription');
 const RelayRuntime = require('relay-runtime');
+const ProfilerContext = require('./relay-hooks/ProfilerContext');
 
 export type * from './relay-hooks/EntryPointTypes.flow';
 export type {
@@ -76,6 +77,8 @@ module.exports = {
 
   EntryPointContainer: EntryPointContainer,
   RelayEnvironmentProvider: RelayEnvironmentProvider,
+
+  ProfilerContext: ProfilerContext,
 
   fetchQuery: RelayRuntime.fetchQuery,
 

--- a/packages/react-relay/index.js
+++ b/packages/react-relay/index.js
@@ -33,6 +33,7 @@ const useRelayEnvironment = require('./relay-hooks/useRelayEnvironment');
 const useSubscribeToInvalidationState = require('./relay-hooks/useSubscribeToInvalidationState');
 const useSubscription = require('./relay-hooks/useSubscription');
 const RelayRuntime = require('relay-runtime');
+const ProfilerContext = require('./relay-hooks/ProfilerContext');
 
 export type {
   $FragmentRef,
@@ -106,6 +107,8 @@ module.exports = {
   // Relay Hooks
   EntryPointContainer: EntryPointContainer,
   RelayEnvironmentProvider: RelayEnvironmentProvider,
+
+  ProfilerContext: ProfilerContext,
 
   fetchQuery: RelayRuntime.fetchQuery,
 


### PR DESCRIPTION
This context allows re-association of log events with their location in the react tree. We're aiming to use this information for understanding performance the same way Meta does.

The matching type was already being exported.

Fixes #4048 (the flow side of the picture)