### PR TITLE
Strip extensions on file import paths when writing out TypeScript generated code

### DIFF
--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -95,10 +95,24 @@ impl Writer for TypeScriptPrinter {
     }
 
     fn write_import_module_default(&mut self, name: &str, from: &str) -> FmtResult {
-        writeln!(&mut self.result, "import {} from \"{}\";", name, from)
+        let from_without_extension = if from.ends_with(".ts") {
+            from.strip_suffix(".ts").unwrap_or(from)
+        } else {
+            from
+        };
+        writeln!(
+            &mut self.result,
+            "import {} from \"{}\";",
+            name, from_without_extension
+        )
     }
 
     fn write_import_type(&mut self, types: &[&str], from: &str) -> FmtResult {
+        let from_without_extension = if from.ends_with(".ts") {
+            from.strip_suffix(".ts").unwrap_or(from)
+        } else {
+            from
+        };
         writeln!(
             &mut self.result,
             "import {}{{ {} }} from \"{}\";",
@@ -108,7 +122,7 @@ impl Writer for TypeScriptPrinter {
                 ""
             },
             types.iter().format(", "),
-            from
+            from_without_extension
         )
     }
 
@@ -519,6 +533,19 @@ mod tests {
         printer.write_import_type(&["A", "B"], "module").unwrap();
         assert_eq!(printer.into_string(), "import { A, B } from \"module\";\n");
 
+        let mut printer = Box::new(TypeScriptPrinter::new(&Default::default()));
+        printer.write_import_type(&["A", "B"], "module.ts").unwrap();
+        assert_eq!(printer.into_string(), "import { A, B } from \"module\";\n");
+
+        let mut printer = Box::new(TypeScriptPrinter::new(&Default::default()));
+        printer
+            .write_import_type(&["A", "B"], "../../../module.ts.ts")
+            .unwrap();
+        assert_eq!(
+            printer.into_string(),
+            "import { A, B } from \"../../../module.ts\";\n"
+        );
+
         let mut printer = Box::new(TypeScriptPrinter::new(&TypegenConfig {
             use_import_type_syntax: true,
             ..Default::default()
@@ -532,6 +559,21 @@ mod tests {
         let mut printer = Box::new(TypeScriptPrinter::new(&Default::default()));
         printer.write_import_module_default("A", "module").unwrap();
         assert_eq!(printer.into_string(), "import A from \"module\";\n");
+
+        let mut printer = Box::new(TypeScriptPrinter::new(&Default::default()));
+        printer
+            .write_import_module_default("A", "../../module.ts")
+            .unwrap();
+        assert_eq!(printer.into_string(), "import A from \"../../module\";\n");
+
+        let mut printer = Box::new(TypeScriptPrinter::new(&Default::default()));
+        printer
+            .write_import_module_default("A", "../../module.ts.ts")
+            .unwrap();
+        assert_eq!(
+            printer.into_string(),
+            "import A from \"../../module.ts\";\n"
+        );
     }
 
     #[test]

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -95,11 +95,7 @@ impl Writer for TypeScriptPrinter {
     }
 
     fn write_import_module_default(&mut self, name: &str, from: &str) -> FmtResult {
-        let from_without_extension = if from.ends_with(".ts") {
-            from.strip_suffix(".ts").unwrap_or(from)
-        } else {
-            from
-        };
+        let from_without_extension = from.strip_suffix(".ts").unwrap_or(from);
         writeln!(
             &mut self.result,
             "import {} from \"{}\";",
@@ -108,11 +104,7 @@ impl Writer for TypeScriptPrinter {
     }
 
     fn write_import_type(&mut self, types: &[&str], from: &str) -> FmtResult {
-        let from_without_extension = if from.ends_with(".ts") {
-            from.strip_suffix(".ts").unwrap_or(from)
-        } else {
-            from
-        };
+        let from_without_extension = from.strip_suffix(".ts").unwrap_or(from);
         writeln!(
             &mut self.result,
             "import {}{{ {} }} from \"{}\";",


### PR DESCRIPTION
Fixes #4056

In the typegen for Typescript when we're writing the pathname for module and type imports, this PR strips any trailing `.ts` that might exist on the path. This is required for TypeScript file imports which don't like the trailing file suffix. This was partially fixed in https://github.com/facebook/relay/pull/4002 but not completely. 

I'm new to this repo and it's been a while since I've written some Rust, so definitely let me know if I'm doing anything wrong here or if there's any code I've missed, thanks!

I've also filled out the CLA as well.