### PR TITLE
Allow passing custom headers when persisting queries

### DIFF
--- a/compiler/crates/relay-compiler/src/operation_persister/remote_persister.rs
+++ b/compiler/crates/relay-compiler/src/operation_persister/remote_persister.rs
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::iter::empty;
-
 use async_trait::async_trait;
 use persist_query::persist;
 use persist_query::PersistError;
@@ -35,14 +33,16 @@ impl OperationPersister for RemotePersister {
         artifact: ArtifactForPersister,
     ) -> Result<String, PersistError> {
         let params = &self.config.params;
+        let headers = &self.config.headers;
+
         let url = &self.config.url;
         if let Some(semaphore) = &self.semaphore {
             let permit = (*semaphore).acquire().await.unwrap();
-            let result = persist(&artifact.text, url, params, empty()).await;
+            let result = persist(&artifact.text, url, params, headers).await;
             drop(permit);
             result
         } else {
-            persist(&artifact.text, url, params, empty()).await
+            persist(&artifact.text, url, params, headers).await
         }
     }
 }

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -51,6 +51,10 @@ pub struct RemotePersistConfig {
     #[serde(default)]
     pub params: FnvIndexMap<String, String>,
 
+    /// Additional headers to send
+    #[serde(default)]
+    pub headers: FnvIndexMap<String, String>,
+
     #[serde(
         default,
         rename = "concurrency",


### PR DESCRIPTION
Specifiy headers in the config (use JS config for dynamic values)
```
persist: {
  url: "https://persist-service/path",
  headers: {
    Authorization: "bearer TOKEN",
  },
}
```

And they'll sent along on the request
```
POST https://persist-service/path
Content-Type: application/x-www-form-urlencoded
Authorization: bearer TOKEN
```