### PR TITLE
fix flow errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -26,6 +26,7 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
+suppress_type=$FlowExpectedError
 
 format.bracket_spacing=false
 

--- a/flow-typed/npm/jest_v23.x.x.js
+++ b/flow-typed/npm/jest_v23.x.x.js
@@ -903,7 +903,7 @@ type JestObjectType = {
    * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
    * setImmediate and clearImmediate).
    */
-  useFakeTimers(): JestObjectType,
+  useFakeTimers(type?: 'legacy' | 'modern'): JestObjectType,
   /**
    * Instructs Jest to use the real versions of the standard timer functions.
    */


### PR DESCRIPTION
* added `suppress_type=$FlowExpectedError` to `.flowconfig` (45a3afbe4e6424e6b4626f5682d99c08bb267fc3 introduced it. `suppress_type=$FlowExpectedError` exists in `.flowconfig` in Meta's internal repos but not in OSS.)
* updated flowtype defs for `jest.useFakeTimers` (corresponding to 6b16da161f887c5dd59ecdff64de4a1a6ca9039f, making change to flowtype defs as done by https://github.com/facebook/react-native/commit/09a910f80beff678c38f0f1a65e6f08e240f6644)