### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   vscode-extension-lint:
     name: VSCode Extension Lint

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -10,8 +10,12 @@ on:
     branches:
       - main
 
+permissions: {}
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write # to push changes in repo (jamesives/github-pages-deploy-action)
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -2,6 +2,9 @@ name: Publish Relay VS Code Extension
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   vscode-release:
     name: VSCode Extension Release


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.