### PR TITLE
[relay] Do not use path in snapshots, they are different on windows.

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "beef"
@@ -457,7 +457,7 @@ dependencies = [
  "colored",
  "diff",
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.11.2",
  "signedsource",
 ]
 
@@ -617,7 +617,7 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -833,7 +833,7 @@ dependencies = [
  "httpdate",
  "itoa 0.4.7",
  "pin-project-lite",
- "socket2 0.4.0",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -894,7 +894,7 @@ dependencies = [
  "hashbrown",
  "indexmap",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "rand",
  "serde",
  "serde_bytes",
@@ -910,7 +910,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "serde",
 ]
 
@@ -1093,25 +1093,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
-dependencies = [
- "socket2 0.3.19",
- "winapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1130,15 +1119,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1256,7 +1236,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.4",
 ]
 
 [[package]]
@@ -1271,6 +1261,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1577,6 +1580,7 @@ dependencies = [
  "graphql-test-helpers",
  "intern",
  "lazy_static",
+ "relay-schema",
  "relay-test-schema",
  "schema",
  "thiserror",
@@ -1625,6 +1629,7 @@ version = "0.0.0"
 dependencies = [
  "common",
  "intern",
+ "lazy_static",
  "schema",
 ]
 
@@ -1658,7 +1663,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "regex",
  "relay-config",
  "relay-test-schema",
@@ -1682,6 +1687,7 @@ dependencies = [
  "lazy_static",
  "relay-codegen",
  "relay-config",
+ "relay-schema",
  "relay-test-schema",
  "relay-transforms",
  "schema",
@@ -1719,7 +1725,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1984,20 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -2080,7 +2075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -2140,19 +2135,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
+ "autocfg",
  "bytes 1.0.1",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "tracing",
  "winapi",
@@ -2348,6 +2344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "watchman_client"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,12 +2404,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2416,10 +2439,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2428,16 +2463,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "zstd"

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-es-modules.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-es-modules.expected
@@ -14,17 +14,18 @@ query relayResolverEsModules_Query {
 # %extensions%
 
 extend type User {
-  pop_star_name: String @relay_resolver(fragment_name: "relayResolverEsModules_PopStarNameResolverFragment_name", import_path: "./path/to/PopStarNameResolver.js", import_name: "pop_star_name")
+  pop_star_name: String @relay_resolver(fragment_name: "relayResolverEsModules_PopStarNameResolverFragment_name", import_path: "PopStarNameResolver", import_name: "pop_star_name")
 }
 
 
 %project_config%
 {
   "eagerEsModules": true,
-  "language": "flow"
+  "language": "flow",
+  "jsModuleFormat": "haste"
 }
 ==================================== OUTPUT ===================================
-import {pop_star_name as userPopStarNameResolver} from './.././path/to/PopStarNameResolver';
+import {pop_star_name as userPopStarNameResolver} from 'PopStarNameResolver';
 {
   "fragment": {
     "argumentDefinitions": [],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-es-modules.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-es-modules.graphql
@@ -13,12 +13,13 @@ query relayResolverEsModules_Query {
 # %extensions%
 
 extend type User {
-  pop_star_name: String @relay_resolver(fragment_name: "relayResolverEsModules_PopStarNameResolverFragment_name", import_path: "./path/to/PopStarNameResolver.js", import_name: "pop_star_name")
+  pop_star_name: String @relay_resolver(fragment_name: "relayResolverEsModules_PopStarNameResolverFragment_name", import_path: "PopStarNameResolver", import_name: "pop_star_name")
 }
 
 
 %project_config%
 {
   "eagerEsModules": true,
-  "language": "flow"
+  "language": "flow",
+  "jsModuleFormat": "haste"
 }

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ApplyUpdate-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ApplyUpdate-test.js
@@ -235,7 +235,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         beforeEach(() => {
           taskID = 0;
-          tasks = new Map<string, () => void>();
+          tasks = new Map();
           scheduler = {
             cancel: (id: string) => {
               tasks.delete(id);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
@@ -349,7 +349,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         beforeEach(() => {
           taskID = 0;
-          tasks = new Map<string, () => void>();
+          tasks = new Map();
           scheduler = {
             cancel: (id: string) => {
               tasks.delete(id);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitUpdate-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitUpdate-test.js
@@ -103,7 +103,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         beforeEach(() => {
           taskID = 0;
-          tasks = new Map<string, () => void>();
+          tasks = new Map();
           scheduler = {
             cancel: (id: string) => {
               tasks.delete(id);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
@@ -705,7 +705,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         beforeEach(() => {
           taskID = 0;
-          tasks = new Map<string, () => void>();
+          tasks = new Map();
           scheduler = {
             cancel: (id: string) => {
               tasks.delete(id);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStream-test.js
@@ -503,7 +503,7 @@ describe('execute() a query with @stream', () => {
 
   it('processes streamed payloads with scheduling', () => {
     let taskID = 0;
-    const tasks = new Map<string, () => void>();
+    const tasks = new Map();
     const scheduler = {
       cancel: (id: string) => {
         tasks.delete(id);
@@ -604,7 +604,7 @@ describe('execute() a query with @stream', () => {
 
   it('cancels processing of streamed payloads with scheduling', () => {
     let taskID = 0;
-    const tasks = new Map<string, () => void>();
+    const tasks = new Map();
     const scheduler = {
       cancel: (id: string) => {
         tasks.delete(id);


### PR DESCRIPTION
The main issue is that is causing the path to the resolver on the windows to be different is this:

https://github.com/Manishearth/pathdiff/blob/a78acde0955a556b2bdf11e6a9efae459c4bcf80/src/lib.rs#L75

In the compiler we try to construct a path from the generated artifact to the JS module, using this `pathdiff` utility. And it looks like on windows, when we construct this relative path the components are joined using an os-specific separator.

I believe this is correct: constructing an os-specific path. But it breaks the os-specific snapshot tests (and I don't think we have a good way of disabling these generated tests based on the OS, atm).

Additional concern for `pathdiff`, it may also create a problem when people may keep checked-in artifacts in the repo, and also use mixed dev environments (windows/Linux laptops) to run relay. 

I think we may somehow address this issue in a separate PR, but this PR is just to unblock Rust build on CI, and fix: https://github.com/facebook/relay/issues/4089