### PR TITLE
Fixed typescript generation for empty variables query

### DIFF
--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -225,7 +225,7 @@ impl TypeScriptPrinter {
 
     fn write_object(&mut self, props: &[Prop]) -> FmtResult {
         if props.is_empty() {
-            write!(&mut self.result, "{{}}")?;
+            write!(&mut self.result, "{{ [K in any]: never }}")?;
             return Ok(());
         }
 
@@ -402,7 +402,7 @@ mod tests {
     fn exact_object() {
         assert_eq!(
             print_type(&AST::ExactObject(ExactObject::new(Vec::new()))),
-            r"{}".to_string()
+            r"{ [K in any]: never }".to_string()
         );
 
         assert_eq!(
@@ -487,7 +487,7 @@ mod tests {
     fn inexact_object() {
         assert_eq!(
             print_type(&AST::InexactObject(InexactObject::new(Vec::new()))),
-            "{}".to_string()
+            "{ [K in any]: never }".to_string()
         );
 
         assert_eq!(

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-fragment-raw-response-type.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-fragment-raw-response-type.expected
@@ -13,7 +13,7 @@ fragment MyUserFragment on User {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
-export type MyQuery$variables = {};
+export type MyQuery$variables = { [K in any]: never };
 export type MyQuery$data = {
   readonly me: {
     readonly my_inline_fragment: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-fragment-spread-in-abstract-selection.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-fragment-spread-in-abstract-selection.expected
@@ -10,7 +10,7 @@ query RelayReaderNamedFragmentsTest2Query {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
-export type RelayReaderNamedFragmentsTest2Query$variables = {};
+export type RelayReaderNamedFragmentsTest2Query$variables = { [K in any]: never };
 export type RelayReaderNamedFragmentsTest2Query$data = {
   readonly node: {
     readonly named_fragment: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-fragment-spread.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-fragment-spread.expected
@@ -10,7 +10,7 @@ query RelayReaderNamedFragmentsTest2Query {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
-export type RelayReaderNamedFragmentsTest2Query$variables = {};
+export type RelayReaderNamedFragmentsTest2Query$variables = { [K in any]: never };
 export type RelayReaderNamedFragmentsTest2Query$data = {
   readonly me: {
     readonly named_fragment: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.expected
@@ -8,7 +8,7 @@ query RelayReaderNamedFragmentsTest2Query {
   }
 }
 ==================================== OUTPUT ===================================
-export type RelayReaderNamedFragmentsTest2Query$variables = {};
+export type RelayReaderNamedFragmentsTest2Query$variables = { [K in any]: never };
 export type RelayReaderNamedFragmentsTest2Query$data = {
   readonly me: {
     readonly id: string;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.expected
@@ -8,7 +8,7 @@ query RelayReaderNamedFragmentsTest2Query {
   }
 }
 ==================================== OUTPUT ===================================
-export type RelayReaderNamedFragmentsTest2Query$variables = {};
+export type RelayReaderNamedFragmentsTest2Query$variables = { [K in any]: never };
 export type RelayReaderNamedFragmentsTest2Query$data = {
   readonly named_fragment: {
     readonly me: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-inline-fragment-spread.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/aliased-inline-fragment-spread.expected
@@ -8,7 +8,7 @@ query RelayReaderNamedFragmentsTest2Query {
   }
 }
 ==================================== OUTPUT ===================================
-export type RelayReaderNamedFragmentsTest2Query$variables = {};
+export type RelayReaderNamedFragmentsTest2Query$variables = { [K in any]: never };
 export type RelayReaderNamedFragmentsTest2Query$data = {
   readonly me: {
     readonly id: string;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-field.expected
@@ -27,7 +27,7 @@ query UnionTypeTest {
   }
 }
 ==================================== OUTPUT ===================================
-export type UnionTypeTest$variables = {};
+export type UnionTypeTest$variables = { [K in any]: never };
 export type UnionTypeTest$data = {
   readonly neverNode: {
     readonly __typename: "FakeNode";

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field-in-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/match-field-in-query.expected
@@ -24,7 +24,7 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs } from "relay-runtime";
-export type NameRendererQuery$variables = {};
+export type NameRendererQuery$variables = { [K in any]: never };
 export type NameRendererQuery$data = {
   readonly me: {
     readonly nameRenderer: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-match-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-match-fields.expected
@@ -29,7 +29,7 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs, Local3DPayload } from "relay-runtime";
-export type Test$variables = {};
+export type Test$variables = { [K in any]: never };
 export type Test$data = {
   readonly node: {
     readonly " $fragmentSpreads": FragmentRefs<"NameRendererFragment">;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-module-field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-module-field.expected
@@ -18,7 +18,7 @@ fragment Test_userRenderer on PlainUserRenderer {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs, Local3DPayload } from "relay-runtime";
-export type Test$variables = {};
+export type Test$variables = { [K in any]: never };
 export type Test$data = {
   readonly node: {
     readonly " $fragmentSpreads": FragmentRefs<"Test_user">;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-multiple-match-fields.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-multiple-match-fields.expected
@@ -49,7 +49,7 @@ fragment MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
 }
 ==================================== OUTPUT ===================================
 import { FragmentRefs, Local3DPayload } from "relay-runtime";
-export type Test$variables = {};
+export type Test$variables = { [K in any]: never };
 export type Test$data = {
   readonly node: {
     readonly username?: string | null;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream-connection.expected
@@ -17,7 +17,7 @@ query TestDefer @raw_response_type {
   }
 }
 ==================================== OUTPUT ===================================
-export type TestDefer$variables = {};
+export type TestDefer$variables = { [K in any]: never };
 export type TestDefer$data = {
   readonly node: {
     readonly friends?: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-stream.expected
@@ -18,7 +18,7 @@ query TestStream @raw_response_type {
   }
 }
 ==================================== OUTPUT ===================================
-export type TestStream$variables = {};
+export type TestStream$variables = { [K in any]: never };
 export type TestStream$data = {
   readonly node: {
     readonly friends?: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/relay-resolver-with-output-type-client-object.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/relay-resolver-with-output-type-client-object.expected
@@ -27,7 +27,7 @@ extend type User {
   pop_star_name: ClientUser @relay_resolver(fragment_name: "PopStarNameResolverFragment_name", import_path: "PopStarNameResolver", has_output_type: true)
 }
 ==================================== OUTPUT ===================================
-export type User__pop_star_name$normalization$variables = {};
+export type User__pop_star_name$normalization$variables = { [K in any]: never };
 export type User__pop_star_name$normalization$data = {
   readonly name: string | null;
 };

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-bubbles-to-query.expected
@@ -6,7 +6,7 @@ query FooQuery {
   }
 }
 ==================================== OUTPUT ===================================
-export type FooQuery$variables = {};
+export type FooQuery$variables = { [K in any]: never };
 export type FooQuery$data = {
   readonly me: {
     readonly firstName: string | null;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-raw-response-type.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-raw-response-type.expected
@@ -6,7 +6,7 @@ query MyQuery @raw_response_type {
   }
 }
 ==================================== OUTPUT ===================================
-export type MyQuery$variables = {};
+export type MyQuery$variables = { [K in any]: never };
 export type MyQuery$data = {
   readonly me: {
     readonly id: string;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.expected
@@ -6,7 +6,7 @@ query FooQuery {
   }
 }
 ==================================== OUTPUT ===================================
-export type FooQuery$variables = {};
+export type FooQuery$variables = { [K in any]: never };
 export type FooQuery$data = {
   readonly me: {
     readonly firstName: string | null;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throws-nested.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-throws-nested.expected
@@ -6,7 +6,7 @@ query FooQuery {
   }
 }
 ==================================== OUTPUT ===================================
-export type FooQuery$variables = {};
+export type FooQuery$variables = { [K in any]: never };
 export type FooQuery$data = {
   readonly me: {
     readonly firstName: string | null;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-within-aliased-inline-fragment-on-abstract.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-within-aliased-inline-fragment-on-abstract.expected
@@ -7,7 +7,7 @@ query RelayReaderNamedFragmentsTest2Query {
   }
 }
 ==================================== OUTPUT ===================================
-export type RelayReaderNamedFragmentsTest2Query$variables = {};
+export type RelayReaderNamedFragmentsTest2Query$variables = { [K in any]: never };
 export type RelayReaderNamedFragmentsTest2Query$data = {
   readonly node: {
     readonly named_fragment: {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-within-aliased-inline-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required-within-aliased-inline-fragment.expected
@@ -8,7 +8,7 @@ query RelayReaderNamedFragmentsTest2Query {
   }
 }
 ==================================== OUTPUT ===================================
-export type RelayReaderNamedFragmentsTest2Query$variables = {};
+export type RelayReaderNamedFragmentsTest2Query$variables = { [K in any]: never };
 export type RelayReaderNamedFragmentsTest2Query$data = {
   readonly me: {
     readonly id: string;

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/required.expected
@@ -6,7 +6,7 @@ query FooQuery {
   }
 }
 ==================================== OUTPUT ===================================
-export type FooQuery$variables = {};
+export type FooQuery$variables = { [K in any]: never };
 export type FooQuery$data = {
   readonly me: {
     readonly firstName: string | null;


### PR DESCRIPTION
Fixes #4111 

I built the relay compiler from main with this change and tested it on our project, and it fixes the issue