### PR TITLE
Validate compiler output in OSS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'facebook/relay'
-    needs: [js-tests, js-lint, typecheck, rust-tests, build-compiler]
+    needs: [js-tests, js-lint, typecheck, build-tests, build-compiler]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Flow
         run: yarn run typecheck
 
-  rust-tests:
+  build-tests:
     name: Rust Tests (${{ matrix.os }})
     strategy:
       matrix:
@@ -98,6 +98,12 @@ jobs:
       - name: "Build test project"
         run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml
         working-directory: ./compiler/test-project
+      - name: "Run compiler on Relay unit-tests"
+        run: './compile-tests.sh'
+        working-directory: ./scripts
+      - name: "Check working directory"
+        run: './check-git-status.sh'
+        working-directory: ./scripts
 
   rust-lint:
     name: Rust Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,13 @@ jobs:
           command: test
           # add --locked back when we have a better way to ensure it's up to date
           args: --manifest-path=compiler/Cargo.toml
-      - name: "Build test project"
+      - name: "Build compiler test project"
         run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml
         working-directory: ./compiler/test-project
-      - name: "Run compiler on Relay unit-tests"
+      - name: "Build relay Unit-tests"
         run: './compile-tests.sh'
         working-directory: ./scripts
-      - name: "Check working directory"
+      - name: "Check working directory status"
         run: './check-git-status.sh'
         working-directory: ./scripts
 

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1442,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "relay"
@@ -1580,6 +1580,7 @@ dependencies = [
  "graphql-test-helpers",
  "intern",
  "lazy_static",
+ "relay-config",
  "relay-schema",
  "relay-test-schema",
  "schema",

--- a/compiler/test-project/src/__generated__/AppQuery.graphql.js
+++ b/compiler/test-project/src/__generated__/AppQuery.graphql.js
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
- * 
+ *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0c604ff17e837edf7ee69c9059e1e6b1>>
+ * @generated SignedSource<<a55377ccde8cd5c41e914b95c668b64b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,6 @@
 /* eslint-disable */
 
 'use strict';
-
 
 var node = (function(){
 var v0 = [
@@ -98,4 +97,5 @@ return {
 })();
 
 node.hash = "942e72826c882d3a02cb0cfbf267dd83";
+
 module.exports = node;

--- a/compiler/test-project/src/__generated__/Component_node.graphql.js
+++ b/compiler/test-project/src/__generated__/Component_node.graphql.js
@@ -1,16 +1,17 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
- * 
+ *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<523579bc8f499b4549395145eeb9a939>>
+ * @generated SignedSource<<f4476ba720564b2622c9964ee06b81eb>>
  * @lightSyntaxTransform
  * @nogrep
  */
 
 /* eslint-disable */
 
+'use strict';
 
 var node = {
   "argumentDefinitions": [],
@@ -31,4 +32,5 @@ var node = {
 };
 
 node.hash = "c1076fdf6414be9f597194edf35d01a0";
+
 module.exports = node;

--- a/packages/relay-runtime/store/__tests__/DataChecker-test.js
+++ b/packages/relay-runtime/store/__tests__/DataChecker-test.js
@@ -38,7 +38,6 @@ const getRelayHandleKey = require('../../util/getRelayHandleKey');
 const RelayFeatureFlags = require('../../util/RelayFeatureFlags');
 const {check} = require('../DataChecker');
 const defaultGetDataID = require('../defaultGetDataID');
-const RelayModernRecord = require('../RelayModernRecord');
 const {createNormalizationSelector} = require('../RelayModernSelector');
 const RelayModernStore = require('../RelayModernStore');
 const RelayRecordSource = require('../RelayRecordSource');

--- a/scripts/check-git-status.sh
+++ b/scripts/check-git-status.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+if [ -z "$(git status --porcelain)" ]; then 
+  # Working directory clean
+  exit 0
+else 
+  echo "Detected changes in the working directory:"
+  git --no-pager diff --stat
+  exit 1
+fi

--- a/scripts/compile-tests.sh
+++ b/scripts/compile-tests.sh
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+set -e
+
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 GITHUB_ROOT=$(dirname "$SCRIPT_DIR")
 


### PR DESCRIPTION
This change will check the `git status` after we run the compiler on test project and build unit-tests. 

The check will fail if there are changed files. This will ensure that the changes to config.test.json internally are in sync with the OSS config.test.json. 