### PR TITLE
Bump version of VSCode extension, update README

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -12,7 +12,7 @@ Search for "Relay GraphQL" in the VS Code extensions panel or install through [t
 
 ## Setup
 
-- Make sure you have a Relay config file somewhere in your project.
+- Make sure you have at least one Relay config file somewhere in your project.
   - We support standard config file formats (`.yml`, `.js`, `.json`), and the the `relay` field in your `package.json`
 - Make sure you have the `relay-compiler` installed in your project. The bare minimum for this extension is v13.
 - Make sure you are able to run the `relay-compiler` command from the command line. If `yarn relay-compiler` works, it's very likely that the extension will work. See more on [debugging below](#debugging).
@@ -36,11 +36,17 @@ Search for "Relay GraphQL" in the VS Code extensions panel or install through [t
   - verbose
   - debug
 
-- `relay.pathToBinary` (default: null) A path relative to the Relay binary relative to the root of your project. If this is not specified, we will try to find one in your `node_modules` folder.
+- `relay.pathToBinary` (default: `null`) A path relative to the Relay binary relative to the root of your project. If this is not specified, we will try to find one in your `node_modules` folder.
+
+- `relay.projects` (default: `null`) An array of project configuration in the form `{name: string, rootDirectory: string, pathToConfig: string}`. If omitted, it is assumed your workspace uses a single Relay config and the compiler will search for your config file. But you can also use this configuration if your Relay config is in a nested directory. This configuration must be used if your workspace has multiple Relay projects, each with their own config file.
+
+  - `name`: The name of the project. This will be used to display messages related to the project's output.
+  - `rootDirectory`: A path relative to the root of your VSCode project for the extension to work from. The default value is the root of your project. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the relay config is found. This is helpful if your project is in a nested directory.
+  - `pathToConfig`: Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory.
 
 - `relay.rootDirectory` (default: VSCode project root) A path relative to the root of your VSCode project for the extension to work from. The default value is the root of your project. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the relay config is found. This is helpful if your project is in a nested directory.
 
-- `relay.pathToConfig` (default: null) Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory.
+- `relay.pathToConfig` (default: `null`) Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory.
 
 ## Features
 
@@ -49,6 +55,7 @@ Search for "Relay GraphQL" in the VS Code extensions panel or install through [t
 - Diagnostics (Errors, Warnings)
 - Go to Definition for fragments, fields, GraphQL types, etc.
 - GraphQL syntax highlighting within .graphql and JavaScript/TypeScript files.
+- Supports workspaces with multiple Relay projects. [Example](https://github.com/relayjs/relay-examples/blob/main/.vscode/settings.json)
 
 ## Commands
 
@@ -59,20 +66,6 @@ Search for "Relay GraphQL" in the VS Code extensions panel or install through [t
 ### Relay Compiler > v13
 
 We built the language server around the new Rust compiler. We do not have plans to support any version < v13.
-
-### One Relay Config
-
-The new Relay Compiler supports multi-project configs. If you have multiple projects using Relay inside of a single repo, you should try out this new config format. Currently, the VSCode extension only works with a singular Relay config.
-
-e.g. if you have your `relay.config.js` in a nested directory like `/projects/projectA/relay.config.js`, the extension will fail to start since the Relay Compiler will not be able to find the Relay config.
-
-**Exception**
-
-If you open the nested directory as the root workspace in VSCode, the extension may work, your mileage may vary.
-
-### VSCode Workspaces
-
-We do not support running multiple instances of the LSP at once. We currently use the deprecated `rootPath` property from the VSCode API. This means we will start the Relay Compiler at the directory which your VSCode project is opened. **Once we fix this, we will be able to support multiple Relay configs.**
 
 ## Credits
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -44,10 +44,6 @@ Search for "Relay GraphQL" in the VS Code extensions panel or install through [t
   - `rootDirectory`: A path relative to the root of your VSCode project for the extension to work from. The default value is the root of your project. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the relay config is found. This is helpful if your project is in a nested directory.
   - `pathToConfig`: Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory.
 
-- `relay.rootDirectory` (default: VSCode project root) A path relative to the root of your VSCode project for the extension to work from. The default value is the root of your project. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the relay config is found. This is helpful if your project is in a nested directory.
-
-- `relay.pathToConfig` (default: `null`) Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory.
-
 ## Features
 
 - IntelliSense

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -20,29 +20,55 @@ Search for "Relay GraphQL" in the VS Code extensions panel or install through [t
 
 ## Configuration
 
-- `relay.autoStartCompiler` (default: `false`) Whether or not we should automatically start the Relay Compiler in watch mode when you open a project.
+Some of the configuration options for this extension only apply depending on whether you have a single or multiple Relay configs in your project.
 
-- `relay.compilerOutputLevel` (default: `verbose`) Specify the output level of the Relay compiler. The available options are
+### Common Configuration Options
 
-  - quiet
-  - quiet-with-errors
-  - verbose
-  - debug
+#### `relay.autoStartCompiler` (default: `false`)
 
-- `relay.lspOutputLevel` (default: `quiet-with-errors`) Specify the output level of the Relay language server. The available options are
+Whether or not we should automatically start the Relay Compiler in watch mode when you open a project.
 
-  - quiet
-  - quiet-with-errors
-  - verbose
-  - debug
+#### `relay.compilerOutputLevel` (default: `verbose`)
 
-- `relay.pathToBinary` (default: `null`) A path relative to the Relay binary relative to the root of your project. If this is not specified, we will try to find one in your `node_modules` folder.
+Specify the output level of the Relay compiler. The available options are
 
-- `relay.projects` (default: `null`) An array of project configuration in the form `{name: string, rootDirectory: string, pathToConfig: string}`. If omitted, it is assumed your workspace uses a single Relay config and the compiler will search for your config file. But you can also use this configuration if your Relay config is in a nested directory. This configuration must be used if your workspace has multiple Relay projects, each with their own config file.
+- quiet
+- quiet-with-errors
+- verbose
+- debug
 
-  - `name`: The name of the project. This will be used to display messages related to the project's output.
-  - `rootDirectory`: A path relative to the root of your VSCode project for the extension to work from. The default value is the root of your project. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the relay config is found. This is helpful if your project is in a nested directory.
-  - `pathToConfig`: Path to a relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your relay project is in a nested directory.
+#### `relay.lspOutputLevel` (default: `quiet-with-errors`)
+
+Specify the output level of the Relay language server. The available options are
+
+- quiet
+- quiet-with-errors
+- verbose
+- debug
+
+#### `relay.pathToBinary` (default: `null`)
+
+A path to the Relay binary relative to the root of your project. If this is not specified, we will try to find one in your `node_modules` folder.
+
+### Single Relay Config Options
+
+#### `relay.name` (default: `default`)
+
+The name of the project. This will be used to display messages related to the project's output.
+
+#### `relay.rootDirectory` (default: Root of project)
+
+A path relative to the root of your VSCode project for the extension to work from. This will change where we start looking for the relay-compiler node module. This will also affect where the LSP server is started, therefore affecting how the Relay config is found. This is helpful if your project is in a nested directory.
+
+#### `relay.pathToConfig` (default: `null`)
+
+Path to a Relay config relative to the `rootDirectory`. Without this, the compiler will search for your config. This is helpful if your Relay project is in a nested directory.
+
+### Multiple Relay Config Options
+
+#### `relay.projects` (default: `null`)
+
+An array of project configuration in the form `{name: string, rootDirectory: string, pathToConfig: string}`. If omitted, it is assumed your workspace uses a single Relay config and the compiler will search for your config file. But you can also use this configuration if your Relay config is in a nested directory. This configuration must be used if your workspace has multiple Relay projects, each with their own config file.
 
 ## Features
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relay",
   "displayName": "Relay GraphQL",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Relay-powered IDE experience",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Does a major bump of the VSCode extension and adds new configuration options to README. I did a major version bump because (from what I could tell) the old `config.rootDirectory` and `config. pathToConfig` aren't taken into account, so this would likely break for users upgrading.