### PR TITLE
Add configuration option to keep both ID and query text in artifacts

### DIFF
--- a/compiler/crates/relay-compiler/src/artifact_content/content.rs
+++ b/compiler/crates/relay-compiler/src/artifact_content/content.rs
@@ -178,11 +178,16 @@ pub fn generate_operation(
     fragment_locations: &FragmentLocations,
 ) -> Result<Vec<u8>, FmtError> {
     let mut request_parameters = build_request_params(normalization_operation);
-    if id_and_text_hash.is_some() {
+
+    if id_and_text_hash.is_some() && project_config.always_keep_operation_text {
+        request_parameters.id = id_and_text_hash;
+        request_parameters.text = text.clone();
+    } else if id_and_text_hash.is_some() {
         request_parameters.id = id_and_text_hash;
     } else {
         request_parameters.text = text.clone();
     };
+
     let operation_fragment = FragmentDefinition {
         name: reader_operation.name.map(|x| FragmentDefinitionName(x.0)),
         variable_definitions: reader_operation.variable_definitions.clone(),

--- a/compiler/crates/relay-compiler/src/artifact_content/content.rs
+++ b/compiler/crates/relay-compiler/src/artifact_content/content.rs
@@ -178,15 +178,8 @@ pub fn generate_operation(
     fragment_locations: &FragmentLocations,
 ) -> Result<Vec<u8>, FmtError> {
     let mut request_parameters = build_request_params(normalization_operation);
-
-    if id_and_text_hash.is_some() && project_config.always_keep_operation_text {
-        request_parameters.id = id_and_text_hash;
-        request_parameters.text = text.clone();
-    } else if id_and_text_hash.is_some() {
-        request_parameters.id = id_and_text_hash;
-    } else {
-        request_parameters.text = text.clone();
-    };
+    request_parameters.id = id_and_text_hash;
+    request_parameters.text = text.clone();
 
     let operation_fragment = FragmentDefinition {
         name: reader_operation.name.map(|x| FragmentDefinitionName(x.0)),

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -364,7 +364,6 @@ Example file:
                     js_module_format: config_file_project.js_module_format,
                     module_import_config: config_file_project.module_import_config,
                     diagnostic_report_config: config_file_project.diagnostic_report_config,
-                    always_keep_operation_text: config_file_project.always_keep_operation_text
                 };
                 Ok((project_name, project_config))
             })
@@ -1015,9 +1014,6 @@ pub struct ConfigFileProject {
 
     #[serde(default)]
     pub diagnostic_report_config: DiagnosticReportConfig,
-
-    #[serde(default)]
-    pub always_keep_operation_text: bool,
 }
 
 pub type PersistId = String;

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -364,6 +364,7 @@ Example file:
                     js_module_format: config_file_project.js_module_format,
                     module_import_config: config_file_project.module_import_config,
                     diagnostic_report_config: config_file_project.diagnostic_report_config,
+                    always_keep_operation_text: config_file_project.always_keep_operation_text
                 };
                 Ok((project_name, project_config))
             })
@@ -1014,6 +1015,9 @@ pub struct ConfigFileProject {
 
     #[serde(default)]
     pub diagnostic_report_config: DiagnosticReportConfig,
+
+    #[serde(default)]
+    pub always_keep_operation_text: bool,
 }
 
 pub type PersistId = String;

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -62,6 +62,9 @@ pub struct RemotePersistConfig {
         deserialize_with = "deserialize_semaphore_permits"
     )]
     pub semaphore_permits: Option<usize>,
+
+    #[serde(default)]
+    pub keep_original_text: bool,
 }
 
 fn deserialize_semaphore_permits<'de, D>(d: D) -> Result<Option<usize>, D::Error>
@@ -98,6 +101,9 @@ pub struct LocalPersistConfig {
 
     #[serde(default)]
     pub algorithm: LocalPersistAlgorithm,
+
+    #[serde(default)]
+    pub keep_original_text: bool,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -105,6 +111,15 @@ pub struct LocalPersistConfig {
 pub enum PersistConfig {
     Remote(RemotePersistConfig),
     Local(LocalPersistConfig),
+}
+
+impl PersistConfig {
+    pub fn keep_original_text(&self) -> bool {
+        match &self {
+            PersistConfig::Remote(config) => config.keep_original_text,
+            PersistConfig::Local(config) => config.keep_original_text,
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for PersistConfig {
@@ -207,7 +222,6 @@ pub struct ProjectConfig {
     pub js_module_format: JsModuleFormat,
     pub module_import_config: ModuleImportConfig,
     pub diagnostic_report_config: DiagnosticReportConfig,
-    pub always_keep_operation_text: bool,
 }
 
 impl Default for ProjectConfig {
@@ -235,7 +249,6 @@ impl Default for ProjectConfig {
             js_module_format: Default::default(),
             module_import_config: Default::default(),
             diagnostic_report_config: Default::default(),
-            always_keep_operation_text: false,
         }
     }
 }
@@ -265,7 +278,6 @@ impl Debug for ProjectConfig {
             js_module_format,
             module_import_config,
             diagnostic_report_config,
-            always_keep_operation_text,
         } = self;
         f.debug_struct("ProjectConfig")
             .field("name", name)
@@ -304,7 +316,6 @@ impl Debug for ProjectConfig {
             .field("js_module_format", js_module_format)
             .field("module_import_config", module_import_config)
             .field("diagnostic_report_config", diagnostic_report_config)
-            .field("keep_original_operation_text", always_keep_operation_text)
             .finish()
     }
 }

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -207,6 +207,7 @@ pub struct ProjectConfig {
     pub js_module_format: JsModuleFormat,
     pub module_import_config: ModuleImportConfig,
     pub diagnostic_report_config: DiagnosticReportConfig,
+    pub always_keep_operation_text: bool,
 }
 
 impl Default for ProjectConfig {
@@ -234,6 +235,7 @@ impl Default for ProjectConfig {
             js_module_format: Default::default(),
             module_import_config: Default::default(),
             diagnostic_report_config: Default::default(),
+            always_keep_operation_text: false,
         }
     }
 }
@@ -263,6 +265,7 @@ impl Debug for ProjectConfig {
             js_module_format,
             module_import_config,
             diagnostic_report_config,
+            always_keep_operation_text,
         } = self;
         f.debug_struct("ProjectConfig")
             .field("name", name)
@@ -301,6 +304,7 @@ impl Debug for ProjectConfig {
             .field("js_module_format", js_module_format)
             .field("module_import_config", module_import_config)
             .field("diagnostic_report_config", diagnostic_report_config)
+            .field("keep_original_operation_text", always_keep_operation_text)
             .finish()
     }
 }


### PR DESCRIPTION
This pull request is not complete, but I'd love to get your thoughts before pushing it further.

We are currently in the process of adopting PQs. However, we want to do so progressively.  An approach we're interested in is keeping both the original text and the `id` on the client, meaning we could dynamically switch between IDs and full query documents at runtime. In this PR I've added a config option that enables this behaviour.

It's a bit challenging to test given that the current compiler tests don't exercise the code path leading to the generation of an ID, so I may need to use another approach if going for this solution.