### PR TITLE
Fix LSP completion icon for fields

### DIFF
--- a/compiler/crates/relay-lsp/src/completion/mod.rs
+++ b/compiler/crates/relay-lsp/src/completion/mod.rs
@@ -889,8 +889,7 @@ fn resolve_completion_items_from_fields<T: TypeWithFields + Named>(
                 Type::Union(_) => Some(CompletionItemKind::INTERFACE),
                 Type::Object(_) => Some(CompletionItemKind::STRUCT),
                 Type::InputObject(_) => Some(CompletionItemKind::STRUCT),
-                type_ if schema.is_string(type_) => Some(CompletionItemKind::TEXT),
-                _ => Some(CompletionItemKind::VALUE),
+                _ => Some(CompletionItemKind::FIELD),
             };
 
             CompletionItem {

--- a/compiler/crates/relay-lsp/src/completion/mod.rs
+++ b/compiler/crates/relay-lsp/src/completion/mod.rs
@@ -884,12 +884,10 @@ fn resolve_completion_items_from_fields<T: TypeWithFields + Named>(
 
             let kind = match field.type_.inner() {
                 Type::Enum(_) => Some(CompletionItemKind::ENUM),
-                Type::Interface(_) => Some(CompletionItemKind::INTERFACE),
                 // There is no Kind for union, so we'll use interface
-                Type::Union(_) => Some(CompletionItemKind::INTERFACE),
-                Type::Object(_) => Some(CompletionItemKind::STRUCT),
-                Type::InputObject(_) => Some(CompletionItemKind::STRUCT),
-                _ => Some(CompletionItemKind::FIELD),
+                Type::Interface(_) | Type::Union(_) => Some(CompletionItemKind::INTERFACE),
+                Type::Object(_) | Type::InputObject(_) => Some(CompletionItemKind::STRUCT),
+                Type::Scalar(_) => Some(CompletionItemKind::FIELD),
             };
 
             CompletionItem {


### PR DESCRIPTION
# Incorrect LSP completion icons for scalar fields

I noticed that the VSCode extension seemed to use weird icons for completion suggestions of _value_ and _text_ for items which are actually _field_s based on the VSCode IntelliSense [docs](https://code.visualstudio.com/docs/editor/intellisense#_types-of-completions). E.g., `String` types were showing up just as plaintext type. All non-struct/union/interface/object types should just be considered a field.

### Before
<img width="813" alt="Screenshot 2022-11-15 at 22 20 32" src="https://user-images.githubusercontent.com/17055343/202040587-7386e0de-d50c-43ac-a5ad-074b9566f32c.png">


### After
<img width="813" alt="Screenshot 2022-11-15 at 22 46 01" src="https://user-images.githubusercontent.com/17055343/202040808-80dee358-5505-4248-b3db-e91e66f4fc2a.png">
