### PR TITLE
Fix: Field alias completions

### DIFF
--- a/compiler/crates/graphql-syntax/src/parser.rs
+++ b/compiler/crates/graphql-syntax/src/parser.rs
@@ -1239,7 +1239,19 @@ impl<'a> Parser<'a> {
         let (name, alias) = if self.peek_token_kind() == TokenKind::Colon {
             let colon = self.parse_kind(TokenKind::Colon)?;
             let alias = name;
-            let name = self.parse_identifier_with_error_recovery();
+            let name = {
+                match self.peek_token_kind() {
+                    TokenKind::Identifier => self.parse_identifier()?,
+                    token_kind => {
+                        let name = self.empty_identifier();
+                        self.record_error(Diagnostic::error(
+                            format!("Incomplete field alias, expected {} but found {}", TokenKind::Identifier, token_kind),
+                            Location::new(self.source_location, Span::new(start, name.span.end)),
+                        ));
+                        name
+                    }
+                }
+            };
             (
                 name,
                 Some(Alias {
@@ -1387,12 +1399,7 @@ impl<'a> Parser<'a> {
                             Span::new(start, self.peek().span.start),
                         ),
                     ));
-                    let empty_token = self.empty_token();
-                    Identifier {
-                        span: empty_token.span,
-                        token: empty_token,
-                        value: "".intern(),
-                    }
+                    self.empty_identifier()
                 })()
             };
 
@@ -1808,17 +1815,12 @@ impl<'a> Parser<'a> {
                 }
             }
             _ => {
-                let token = self.empty_token();
-                let error = Diagnostic::error(
+                let identifier = self.empty_identifier();
+                self.record_error(Diagnostic::error(
                     SyntaxError::Expected(TokenKind::Identifier),
-                    Location::new(self.source_location, token.span),
-                );
-                self.record_error(error);
-                Identifier {
-                    span: token.span,
-                    token,
-                    value: "".intern(),
-                }
+                    Location::new(self.source_location, identifier.span),
+                ));
+                identifier
             }
         }
     }
@@ -2067,6 +2069,15 @@ impl<'a> Parser<'a> {
         Token {
             span: Span::new(index, index),
             kind: TokenKind::Empty,
+        }
+    }
+
+    fn empty_identifier(&self) -> Identifier {
+        let token = self.empty_token();
+        Identifier {
+            span: token.span,
+            token,
+            value: "".intern(),
         }
     }
 }

--- a/compiler/crates/graphql-syntax/src/parser.rs
+++ b/compiler/crates/graphql-syntax/src/parser.rs
@@ -1239,7 +1239,7 @@ impl<'a> Parser<'a> {
         let (name, alias) = if self.peek_token_kind() == TokenKind::Colon {
             let colon = self.parse_kind(TokenKind::Colon)?;
             let alias = name;
-            let name = self.parse_identifier()?;
+            let name = self.parse_identifier_with_error_recovery();
             (
                 name,
                 Some(Alias {


### PR DESCRIPTION
# Fix field alias completions

The parser currently refuses to parse documents with incomplete aliases, e.g.,

```graphql
query {
  user {
    aliasField: # Expected a non-variable identifier (e.g. 'x' or 'Foo')
  }
}
```

And also places the error dialog in the wrong location - on the 

## Before

<img width="912" alt="Screenshot 2022-11-22 at 23 00 50" src="https://user-images.githubusercontent.com/17055343/203438640-e1e522f5-6d35-4682-9a6b-6d4e6487593d.png">

#### Before (error message visible)

<img width="912" alt="Screenshot 2022-11-22 at 23 00 12" src="https://user-images.githubusercontent.com/17055343/203438644-88bf0339-3d26-4c0a-9f3b-f41e4d5568a0.png">

## After

<img width="912" alt="Screenshot 2022-11-22 at 22 57 56" src="https://user-images.githubusercontent.com/17055343/203438647-e4558b3a-9a88-457d-bcd7-47f53c96f65b.png">
