### PR TITLE
Add a new package eslint-plugin-relay-internal

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
   root: true,
   // TODO - migrate this onto @react-native-community/eslint-config
   extends: ['fbjs'],
-  plugins: ['jest', 'relay', 'react-hooks'],
+  plugins: ['jest', 'relay', 'react-hooks', 'relay-internal'],
   parser: 'hermes-eslint',
   rules: {
     // Consistency with internal config
@@ -73,5 +73,8 @@ module.exports = {
 
     // depreciated rules
     'no-spaced-func': 0,
+
+    // Custom rules for our own codebase
+    'relay-internal/no-mixed-import-and-require': 'error',
   },
 };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "eslint-plugin-react": "7.30.1",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-relay": "1.8.3",
+    "eslint-plugin-relay-internal": "link:./packages/eslint-plugin-relay-internal",
+    "eslint-plugin-node": "^11.1.0",
     "fbjs": "^3.0.2",
     "flow-bin": "^0.194.0",
     "glob": "^7.1.1",

--- a/packages/eslint-plugin-relay-internal/README.md
+++ b/packages/eslint-plugin-relay-internal/README.md
@@ -1,0 +1,3 @@
+# eslint-plugin-relay-internal
+
+ESLint rules intended to run on Relay's own codebase.

--- a/packages/eslint-plugin-relay-internal/__tests__/lib/rules/no-mixed-import-and-require-test.js
+++ b/packages/eslint-plugin-relay-internal/__tests__/lib/rules/no-mixed-import-and-require-test.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+const rule = require('../../../lib/rules/no-mixed-import-and-require');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('no-mixed-import-and-require', rule, {
+  valid: [
+    `import foo from 'bar';`,
+    `import type foo from 'bar';`,
+    `
+      import typeof foo from 'bar';
+      require('foo');
+    `,
+    `
+      import typeof {foo} from 'bar';
+      require('foo');
+    `,
+    `
+      import foo from 'bar';
+      SomeModule.require('foo');
+    `,
+    `require('foo');`,
+    `
+       import type foo from 'bar';
+       require('foo');
+     `,
+  ],
+  invalid: [
+    {
+      code: `
+         import foo from 'bar';
+         const baz = require('baz');
+       `,
+      errors: [
+        {
+          messageId: 'noMixedImportAndRequire',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-relay-internal/lib/index.js
+++ b/packages/eslint-plugin-relay-internal/lib/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall relay
+ */
+
+//------------------------------------------------------------------------------
+// Plugin Definition
+//------------------------------------------------------------------------------
+
+// import all rules in lib/rules
+module.exports.rules = {
+  'no-mixed-import-and-require': require('./rules/no-mixed-import-and-require'),
+};

--- a/packages/eslint-plugin-relay-internal/lib/rules/no-mixed-import-and-require.js
+++ b/packages/eslint-plugin-relay-internal/lib/rules/no-mixed-import-and-require.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall eslint
+ */
+
+'use strict';
+
+// Enforces Flow's no-mixed-import-and-require config. Useful for code that gets
+// synced into a place where that Flow config is enabled.
+module.exports = {
+  meta: {
+    type: 'problem',
+    messages: {
+      noMixedImportAndRequire:
+        "Unexpected combination of require and import within a single module. This is incompatible with Flow's no-mixed-import-and-require config.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    let requireUse = null;
+    let importUse = null;
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'require'
+        ) {
+          requireUse = node;
+        }
+      },
+      ImportDeclaration(node) {
+        if (node.importKind !== 'type' && node.importKind !== 'typeof') {
+          importUse = node;
+        }
+      },
+      'Program:exit'() {
+        if (requireUse != null && importUse != null) {
+          context.report({
+            messageId: 'noMixedImportAndRequire',
+            node: importUse,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-relay-internal/package.json
+++ b/packages/eslint-plugin-relay-internal/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "eslint-plugin-relay-internal",
+  "private": true,
+  "version": "0.0.0",
+  "description": "ESLint rules intended to run on Relay's own codebase",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "license": "MIT",
+  "homepage": "https://relay.dev",
+  "bugs": "https://github.com/facebook/relay/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/relay.git",
+    "directory": "packages/relay-test-utils-internal"
+  },
+  "main": "./lib/index.js",
+  "exports": "./lib/index.js",
+  "dependencies": {},
+  "engines": {
+    "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+  },
+  "peerDependencies": {
+    "eslint": ">=7"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,14 +3295,6 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
-eslint-plugin-eslint-plugin@^5.0.0:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-5.0.6.tgz#76a32444b90525f5e58b1b7bdf0295110f6573a8"
-  integrity sha512-q1/sXPSMEAINj9jmYQDp0f7zu0PeU6Wy5Cn/l7OsjSGkq8NLCckFXZxhVIlGJcmAI+OeFSGfRSZ6Iku3eRv8QQ==
-  dependencies:
-    eslint-utils "^3.0.0"
-    estraverse "^5.2.0"
-
 eslint-plugin-ft-flow@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-ft-flow/-/eslint-plugin-ft-flow-2.0.1.tgz#57d9a12ef02b7af8f9bd6ccd6bd8fa4034809716"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,6 +3287,22 @@ eslint-plugin-babel@5.3.1:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
+eslint-plugin-es@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
+  integrity sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
+eslint-plugin-eslint-plugin@^5.0.0:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-5.0.6.tgz#76a32444b90525f5e58b1b7bdf0295110f6573a8"
+  integrity sha512-q1/sXPSMEAINj9jmYQDp0f7zu0PeU6Wy5Cn/l7OsjSGkq8NLCckFXZxhVIlGJcmAI+OeFSGfRSZ6Iku3eRv8QQ==
+  dependencies:
+    eslint-utils "^3.0.0"
+    estraverse "^5.2.0"
+
 eslint-plugin-ft-flow@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-ft-flow/-/eslint-plugin-ft-flow-2.0.1.tgz#57d9a12ef02b7af8f9bd6ccd6bd8fa4034809716"
@@ -3340,6 +3356,18 @@ eslint-plugin-jsx-a11y@6.6.0:
     minimatch "^3.1.2"
     semver "^6.3.0"
 
+eslint-plugin-node@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
+  integrity sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
+  dependencies:
+    eslint-plugin-es "^3.0.0"
+    eslint-utils "^2.0.0"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
+
 eslint-plugin-react-hooks@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
@@ -3364,6 +3392,10 @@ eslint-plugin-react@7.30.1:
     resolve "^2.0.0-next.3"
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
+
+"eslint-plugin-relay-internal@link:./packages/eslint-plugin-relay-internal":
+  version "0.0.0"
+  uid ""
 
 eslint-plugin-relay@1.8.3:
   version "1.8.3"
@@ -3401,6 +3433,13 @@ eslint-scope@^7.1.1:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
+eslint-utils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-utils@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
@@ -3408,7 +3447,7 @@ eslint-utils@^3.0.0:
   dependencies:
     eslint-visitor-keys "^2.0.0"
 
-eslint-visitor-keys@^1.0.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -4531,6 +4570,11 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha512-DUNFN5j7Tln0D+TxzloUjKB+CtVu6myn0JEFak6dG18mNt9YkQ6lzGCdafwofISZ1lLF3xRHJ98VKy9ynkcFaA==
+
+ignore@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.1.tgz#c2b1f76cb999ede1502f3a226a9310fdfe88d46c"
+  integrity sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==
 
 ignore@^5.2.0:
   version "5.2.0"
@@ -7207,7 +7251,7 @@ regexp.prototype.flags@^1.4.1, regexp.prototype.flags@^1.4.3:
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
 
-regexpp@^3.2.0:
+regexpp@^3.0.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -7320,7 +7364,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.4.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.4.0:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -7472,7 +7516,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
Adds a new package that we can use to add lint rules that apply just to the Relay code base. It starts with `no-mixed-import-and-require` which should catch when we mix require and import, which is disallowed in WWW's Flow config and so breaks our sync.

Pushing now to see what problems crop up when imported into Phabricator. Will followup there with whatever work is needed to get this to work with internal linting.

## Test Plan

I've confirmed that if I break the lint rule's tests they are caught by our top-level (Yarn workspace) jest run.

<img width="1586" alt="Screenshot 2022-12-08 at 3 37 12 PM" src="https://user-images.githubusercontent.com/162735/206589548-9ca3874a-7322-4c65-8b3b-3224acd9d5f1.png">

---
I've also confirmed that the lint rule triggers both in the editor and at the CLI.

<img width="1414" alt="Screenshot 2022-12-08 at 3 39 01 PM" src="https://user-images.githubusercontent.com/162735/206589585-0d2f51db-0fa6-43fb-a404-634eb832514b.png">

<img width="812" alt="Screenshot 2022-12-08 at 3 39 33 PM" src="https://user-images.githubusercontent.com/162735/206589635-5f0b5935-4902-4a74-ada7-8f88f2e0b410.png">
