### PR TITLE
[bugfix] Fix CI Rust build error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           args: --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 
   build-test-projects:
-    name: Build artifacts check (${{ matrix.target.os }})
+    name: Compiler output check (${{ matrix.target.os }})
     strategy:
       matrix:
         target:
@@ -113,8 +113,9 @@ jobs:
             features: vendored
           - target: macos-latest
             os: macos-latest
-          - target: windows-latest
-            os: windows-latest
+          # TODO: Fix windows build. It is failing on Resolvers
+          # - target: windows-latest
+          #   os: windows-latest
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: yarn run typecheck
 
   build-tests:
-    name: Rust Tests (${{ matrix.os }})
+    name: Rust Tests (${{ matrix.target.os }})
     strategy:
       matrix:
         target:
@@ -90,7 +90,7 @@ jobs:
             os: macos-latest
           - target: windows-latest
             os: windows-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -108,6 +108,7 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
+      - run: sudo apt install libssl-dev
       - name: "Build compiler test project"
         run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml
         working-directory: ./compiler/test-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           command: run
           args: --manifest-path=compiler/Cargo.toml --bin relay --release --features vendored ./scripts/config.tests.json
       - name: "Check working directory status"
-        run: './check-git-status.sh'
+        run: './scripts/check-git-status.sh'
 
   rust-lint:
     name: Rust Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,9 @@ jobs:
       - name: "Build compiler test project"
         run: cargo build --manifest-path=compiler/Cargo.toml --features vendored
       - name: "Run compiler for test project"
-        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release ./compiler/test-project/relay.config.js
+        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release --features vendored ./compiler/test-project/relay.config.js 
       - name: "Build relay unit-tests"
-        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release ./scripts/config.tests.json
+        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release --features vendored ./scripts/config.tests.json
       - name: "Check working directory status"
         run: './check-git-status.sh'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,11 @@ jobs:
           toolchain: 1.64.0
           override: true
       - name: "Build compiler test project"
-        run: cargo build --features vendored
+        run: cargo build --manifest-path=compiler/Cargo.toml --features vendored
       - name: "Run compiler for test project"
-        run: cargo run --bin relay --release ./compiler/test-project/relay.config.js
+        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release ./compiler/test-project/relay.config.js
       - name: "Build relay unit-tests"
-        run: cargo run --bin relay --release ./scripts/config.tests.json
+        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release ./scripts/config.tests.json
       - name: "Check working directory status"
         run: './check-git-status.sh'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,16 +109,13 @@ jobs:
           toolchain: 1.64.0
           override: true
       - name: "Build compiler test project"
-        run: cargo build --manifest-path=../crates/relay-bin/Cargo.toml --features vendored
+        run: cargo build --features vendored
       - name: "Run compiler for test project"
-        run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml --bin relay --release
-        working-directory: ./compiler/test-project
+        run: cargo run --bin relay --release ./compiler/test-project/relay.config.js
       - name: "Build relay unit-tests"
-        run: './compile-tests.sh'
-        working-directory: ./scripts
+        run: cargo run --bin relay --release ./scripts/config.tests.json
       - name: "Check working directory status"
         run: './check-git-status.sh'
-        working-directory: ./scripts
 
   rust-lint:
     name: Rust Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,8 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - run: sudo apt-get install pkg-config libssl-dev
       - name: "Build compiler test project"
-        run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml
+        run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml --feature vendored
         working-directory: ./compiler/test-project
       - name: "Build relay unit-tests"
         run: './compile-tests.sh'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,14 +90,21 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - uses: actions-rs/cargo@v1
+      - run: cargo test --manifest-path=compiler/Cargo.toml --locked
+
+  build-test-projects:
+    name: Build artifacts for test projects and runtime unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
-          command: test
-          args: --manifest-path=compiler/Cargo.toml --locked
+          toolchain: 1.64.0
+          override: true
       - name: "Build compiler test project"
         run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml
         working-directory: ./compiler/test-project
-      - name: "Build relay Unit-tests"
+      - name: "Build relay unit-tests"
         run: './compile-tests.sh'
         working-directory: ./scripts
       - name: "Check working directory status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - run: sudo apt install libssl-dev
+      - run: sudo apt-get install pkg-config libssl-dev
       - name: "Build compiler test project"
         run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml
         working-directory: ./compiler/test-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,18 @@ jobs:
           args: --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 
   build-test-projects:
-    name: Build artifacts for test projects and runtime unit tests
-    runs-on: ubuntu-latest
+    name: Build artifacts check (${{ matrix.target.os }})
+    strategy:
+      matrix:
+        target:
+          - target: ubuntu-latest
+            os: ubuntu-latest
+            features: vendored
+          - target: macos-latest
+            os: macos-latest
+          - target: windows-latest
+            os: windows-latest
+    runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -116,12 +126,12 @@ jobs:
         name: "Build test project"
         with:
           command: run
-          args: --manifest-path=compiler/Cargo.toml --bin relay --release --features vendored ./compiler/test-project/relay.config.json
+          args: --manifest-path=compiler/Cargo.toml --bin relay --release ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }} ./compiler/test-project/relay.config.json
       - uses: actions-rs/cargo@v1
         name: "Build Relay unit-test artifacts"
         with:
           command: run
-          args: --manifest-path=compiler/Cargo.toml --bin relay --release --features vendored ./scripts/config.tests.json
+          args: --manifest-path=compiler/Cargo.toml --bin relay --release ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }} ./scripts/config.tests.json
       - name: "Check working directory status"
         run: './scripts/check-git-status.sh'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,11 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - run: cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
+      - uses: actions-rs/cargo@v1
+        name: "test"
+        with:
+          command: test
+          args: --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 
   build-test-projects:
     name: Build artifacts for test projects and runtime unit tests
@@ -108,12 +112,16 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - name: "Build compiler test project"
-        run: cargo build --manifest-path=compiler/Cargo.toml --features vendored
-      - name: "Run compiler for test project"
-        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release --features vendored ./compiler/test-project/relay.config.js 
-      - name: "Build relay unit-tests"
-        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release --features vendored ./scripts/config.tests.json
+      - uses: actions-rs/cargo@v1
+        name: "Build test project"
+        with:
+          command: run
+          args: --manifest-path=compiler/Cargo.toml --bin relay --release --features vendored ./compiler/test-project/relay.config.json
+      - uses: actions-rs/cargo@v1
+        name: "Build Relay unit-test artifacts"
+        with:
+          command: run
+          args: --manifest-path=compiler/Cargo.toml --bin relay --release --features vendored ./scripts/config.tests.json
       - name: "Check working directory status"
         run: './check-git-status.sh'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,14 @@ jobs:
     name: Rust Tests (${{ matrix.os }})
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        target:
+          - target: ubuntu-latest
+            os: ubuntu-latest
+            features: vendored
+          - target: macos-latest
+            os: macos-latest
+          - target: windows-latest
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -90,7 +97,7 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - run: cargo test --manifest-path=compiler/Cargo.toml --locked
+      - run: cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 
   build-test-projects:
     name: Build artifacts for test projects and runtime unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,8 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - uses: actions-rs/cargo@v1
-        name: "test"
-        with:
-          command: test
-          args: --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
+      - name: "Run tests"
+        run: cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 
   build-test-projects:
     name: Compiler output check (${{ matrix.target.os }})
@@ -123,16 +120,10 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - uses: actions-rs/cargo@v1
-        name: "Build test project"
-        with:
-          command: run
-          args: --manifest-path=compiler/Cargo.toml --bin relay --release ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }} ./compiler/test-project/relay.config.json
-      - uses: actions-rs/cargo@v1
-        name: "Build Relay unit-test artifacts"
-        with:
-          command: run
-          args: --manifest-path=compiler/Cargo.toml --bin relay --release ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }} ./scripts/config.tests.json
+      - name: "Build test project"
+        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }} ./compiler/test-project/relay.config.json
+      - name: "Build Relay unit-test artifacts"
+        run: cargo run --manifest-path=compiler/Cargo.toml --bin relay --release ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }} ./scripts/config.tests.json
       - name: "Check working directory status"
         run: './scripts/check-git-status.sh'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           toolchain: 1.64.0
           override: true
       - name: "Build compiler test project"
-        run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml --feature vendored
+        run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml --features vendored
         working-directory: ./compiler/test-project
       - name: "Build relay unit-tests"
         run: './compile-tests.sh'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,9 @@ jobs:
           toolchain: 1.64.0
           override: true
       - name: "Build compiler test project"
-        run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml --features vendored
+        run: cargo build --manifest-path=../crates/relay-bin/Cargo.toml --features vendored
+      - name: "Run compiler for test project"
+        run: cargo run --manifest-path=../crates/relay-bin/Cargo.toml --bin relay --release
         working-directory: ./compiler/test-project
       - name: "Build relay unit-tests"
         run: './compile-tests.sh'

--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -25,7 +25,6 @@ jobs:
           override: true
       - name: cargo check
         run: cargo check --features vendored --manifest-path=compiler/Cargo.toml
-        working-directory: compiler
       - name: pull-request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -23,9 +23,11 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - name: "cargo check"
-        run: cargo check --features vendored
-        working-directory: ./compiler/
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --features vendored
+          working-directory: ./compiler/
       - name: pull-request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -23,11 +23,9 @@ jobs:
         with:
           toolchain: 1.64.0
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features vendored --manifest-path=compiler/Cargo.toml
-          working-directory: compiler
+      - name: cargo check
+        run: cargo check --features vendored --manifest-path=compiler/Cargo.toml
+        working-directory: compiler
       - name: pull-request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -24,7 +24,7 @@ jobs:
           toolchain: 1.64.0
           override: true
       - name: "cargo check"
-        run: cargo check
+        run: cargo check --features vendored
         working-directory: ./compiler/
       - name: pull-request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features vendored
-          working-directory: ./compiler/
+          args: --features vendored --manifest-path=compiler/Cargo.toml
+          working-directory: compiler
       - name: pull-request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -344,13 +344,15 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "num_cpus",
- "parking_lot 0.12.1",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.4",
  "rayon",
  "serde",
 ]
@@ -990,10 +992,11 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -1044,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.0"
+version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c74e2173b2b31f8655d33724b4b45ac13f439386f66290f539c22b144c2212"
+checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
 dependencies = [
  "bitflags",
  "serde",
@@ -1152,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl"
@@ -1350,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
@@ -1408,26 +1411,23 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -1860,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
@@ -1891,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2037,9 +2037,9 @@ checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Summary: 

Our build is currently failing: https://github.com/facebook/relay/actions/runs/3754707530/jobs/6379159556

Two reasons, we need to update Cargo.lock file and when we try do this the job is failing on ubuntu with this error: https://github.com/facebook/relay/actions/runs/3753772949/jobs/6377345792#step:4:425

This PR:

- The fix is to add `--features vendored` when running compiler on ubuntu
- Additional updates in this PR:
  - split jobs for rust tests and validation of compiler output
  - compiler output validation is broken on windows due to some Relay Resolver issues (this can be fixed in a separate diff)
  - Updated Cargo.lock file
