### PR TITLE
Fix LSP on Windows

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -400,6 +400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1512,7 @@ dependencies = [
  "dashmap",
  "dependency-analyzer",
  "docblock-syntax",
+ "dunce",
  "errors",
  "extract-graphql",
  "fixture-tests",

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1602,6 +1602,7 @@ dependencies = [
  "crossbeam",
  "dashmap",
  "docblock-syntax",
+ "dunce",
  "extract-graphql",
  "fixture-tests",
  "fnv",

--- a/compiler/crates/relay-compiler/Cargo.toml
+++ b/compiler/crates/relay-compiler/Cargo.toml
@@ -22,6 +22,7 @@ common-path = "1.0.0"
 dashmap = { version = "5.4", features = ["raw-api", "rayon", "serde"] }
 dependency-analyzer = { path = "../dependency-analyzer" }
 docblock-syntax = { path = "../docblock-syntax" }
+dunce = "1.0.3"
 errors = { path = "../errors" }
 extract-graphql = { path = "../extract-graphql" }
 fnv = "1.0"

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use common::FeatureFlags;
 use common::Rollout;
 use common::ScalarName;
+use dunce::canonicalize;
 use fnv::FnvBuildHasher;
 use fnv::FnvHashSet;
 use graphql_ir::OperationDefinition;
@@ -161,8 +162,7 @@ fn normalize_path_from_config(
 ) -> PathBuf {
     let mut src = current_dir.join(path_from_config.clone());
 
-    src = src
-        .canonicalize()
+    src = canonicalize(src.clone())
         .unwrap_or_else(|err| panic!("Unable to canonicalize file {:?}. Error: {:?}", &src, err));
 
     src.strip_prefix(common_path.clone())
@@ -370,8 +370,9 @@ Example file:
             .collect::<Result<FnvIndexMap<_, _>>>()?;
 
         let config_file_dir = config_path.parent().unwrap();
+
         let root_dir = if let Some(config_root) = config_file.root {
-            config_file_dir.join(config_root).canonicalize().unwrap()
+            canonicalize(config_file_dir.join(config_root)).unwrap()
         } else {
             config_file_dir.to_owned()
         };
@@ -754,41 +755,36 @@ impl SingleProjectConfigFile {
         let mut paths = vec![];
         if let Some(artifact_directory_path) = self.artifact_directory.clone() {
             paths.push(
-                root_dir
-                    .join(artifact_directory_path.clone())
-                    .canonicalize()
-                    .map_err(|_| ConfigValidationError::ArtifactDirectoryNotExistent {
+                canonicalize(root_dir.clone().join(artifact_directory_path.clone())).map_err(
+                    |_| ConfigValidationError::ArtifactDirectoryNotExistent {
                         path: artifact_directory_path,
-                    })?,
+                    },
+                )?,
             );
         }
         paths.push(
-            root_dir
-                .join(self.src.clone())
-                .canonicalize()
-                .map_err(|_| ConfigValidationError::SourceNotExistent {
+            canonicalize(root_dir.clone().join(self.src.clone())).map_err(|_| {
+                ConfigValidationError::SourceNotExistent {
                     source_dir: self.src.clone(),
-                })?,
+                }
+            })?,
         );
         paths.push(
-            root_dir
-                .join(self.schema.clone())
-                .canonicalize()
-                .map_err(|_| ConfigValidationError::SchemaFileNotExistent {
+            canonicalize(root_dir.clone().join(self.schema.clone())).map_err(|_| {
+                ConfigValidationError::SchemaFileNotExistent {
                     project_name: self.project_name,
                     schema_file: self.schema.clone(),
-                })?,
+                }
+            })?,
         );
         for extension_dir in self.schema_extensions.iter() {
             paths.push(
-                root_dir
-                    .clone()
-                    .join(extension_dir.clone())
-                    .canonicalize()
-                    .map_err(|_| ConfigValidationError::ExtensionDirNotExistent {
+                canonicalize(root_dir.clone().join(extension_dir.clone())).map_err(|_| {
+                    ConfigValidationError::ExtensionDirNotExistent {
                         project_name: self.project_name,
                         extension_dir: extension_dir.clone(),
-                    })?,
+                    }
+                })?,
             );
         }
         common_path::common_path_all(paths.iter().map(|path| path.as_path()))

--- a/compiler/crates/relay-lsp/Cargo.toml
+++ b/compiler/crates/relay-lsp/Cargo.toml
@@ -15,6 +15,7 @@ common = { path = "../common" }
 crossbeam = "0.8"
 dashmap = { version = "5.4", features = ["raw-api", "rayon", "serde"] }
 docblock-syntax = { path = "../docblock-syntax" }
+dunce = "1.0.3"
 extract-graphql = { path = "../extract-graphql" }
 fnv = "1.0"
 graphql-ir = { path = "../graphql-ir" }

--- a/compiler/crates/relay-lsp/src/code_action/mod.rs
+++ b/compiler/crates/relay-lsp/src/code_action/mod.rs
@@ -39,17 +39,15 @@ use serde_json::Value;
 use crate::lsp_runtime_error::LSPRuntimeError;
 use crate::lsp_runtime_error::LSPRuntimeResult;
 use crate::server::GlobalState;
+use crate::utils::is_file_uri_in_dir;
 
 pub(crate) fn on_code_action(
     state: &impl GlobalState,
     params: <CodeActionRequest as Request>::Params,
 ) -> LSPRuntimeResult<<CodeActionRequest as Request>::Result> {
     let uri = params.text_document.uri.clone();
-    let file_path = uri.to_file_path().map_err(|_| {
-        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to file path: {:?}", uri))
-    })?;
 
-    if !file_path.starts_with(state.root_dir()) {
+    if !is_file_uri_in_dir(state.root_dir(), &uri) {
         return Err(LSPRuntimeError::ExpectedError);
     }
 

--- a/compiler/crates/relay-lsp/src/code_action/mod.rs
+++ b/compiler/crates/relay-lsp/src/code_action/mod.rs
@@ -45,10 +45,11 @@ pub(crate) fn on_code_action(
     params: <CodeActionRequest as Request>::Params,
 ) -> LSPRuntimeResult<<CodeActionRequest as Request>::Result> {
     let uri = params.text_document.uri.clone();
-    if !uri
-        .path()
-        .starts_with(state.root_dir().to_string_lossy().as_ref())
-    {
+    let file_path = uri.to_file_path().map_err(|_| {
+        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to file path: {:?}", uri))
+    })?;
+
+    if !file_path.starts_with(state.root_dir()) {
         return Err(LSPRuntimeError::ExpectedError);
     }
 

--- a/compiler/crates/relay-lsp/src/diagnostic_reporter.rs
+++ b/compiler/crates/relay-lsp/src/diagnostic_reporter.rs
@@ -16,6 +16,7 @@ use common::TextSource;
 use crossbeam::channel::Sender;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
+use dunce::canonicalize;
 use extract_graphql::JavaScriptSourceFeature;
 use lsp_server::Message;
 use lsp_server::Notification as ServerNotification;
@@ -42,7 +43,7 @@ use crate::lsp_process_error::LSPProcessResult;
 /// Returns None if we are unable to do the conversion
 fn url_from_location(location: Location, root_dir: &PathBuf) -> Option<Url> {
     let file_path = location.source_location().path();
-    let canonical_path = std::fs::canonicalize(root_dir.join(file_path)).ok()?;
+    let canonical_path = canonicalize(root_dir.join(file_path)).ok()?;
     Url::from_file_path(canonical_path).ok()
 }
 

--- a/compiler/crates/relay-lsp/src/server/lsp_request_dispatch.rs
+++ b/compiler/crates/relay-lsp/src/server/lsp_request_dispatch.rs
@@ -79,15 +79,12 @@ fn convert_to_lsp_response(
             result: Some(result),
             error: None,
         },
+        Err(LSPRuntimeError::ExpectedError) => ServerResponse {
+            id,
+            result: Some(Value::Null),
+            error: None,
+        },
         Err(runtime_error) => {
-            if let LSPRuntimeError::ExpectedError = runtime_error {
-                return ServerResponse {
-                    id,
-                    result: Some(Value::Null),
-                    error: None,
-                };
-            }
-
             let response_error: Option<ResponseError> = runtime_error.into();
             let response_error = response_error.unwrap_or_else(|| ResponseError {
                 code: ErrorCode::UnknownErrorCode as i32,

--- a/compiler/crates/relay-lsp/src/server/lsp_request_dispatch.rs
+++ b/compiler/crates/relay-lsp/src/server/lsp_request_dispatch.rs
@@ -14,6 +14,7 @@ use lsp_server::RequestId as ServerRequestId;
 use lsp_server::Response as ServerResponse;
 use lsp_server::ResponseError;
 use lsp_types::request::Request;
+use serde_json::Value;
 
 use crate::lsp_runtime_error::LSPRuntimeError;
 use crate::lsp_runtime_error::LSPRuntimeResult;
@@ -79,6 +80,14 @@ fn convert_to_lsp_response(
             error: None,
         },
         Err(runtime_error) => {
+            if let LSPRuntimeError::ExpectedError = runtime_error {
+                return ServerResponse {
+                    id,
+                    result: Some(Value::Null),
+                    error: None,
+                };
+            }
+
             let response_error: Option<ResponseError> = runtime_error.into();
             let response_error = response_error.unwrap_or_else(|| ResponseError {
                 code: ErrorCode::UnknownErrorCode as i32,

--- a/compiler/crates/relay-lsp/src/text_documents.rs
+++ b/compiler/crates/relay-lsp/src/text_documents.rs
@@ -19,6 +19,7 @@ use lsp_types::TextDocumentItem;
 
 use crate::lsp_runtime_error::LSPRuntimeResult;
 use crate::server::GlobalState;
+use crate::LSPRuntimeError;
 
 pub fn on_did_open_text_document(
     lsp_state: &impl GlobalState,
@@ -26,10 +27,11 @@ pub fn on_did_open_text_document(
 ) -> LSPRuntimeResult<()> {
     let DidOpenTextDocumentParams { text_document } = params;
     let TextDocumentItem { text, uri, .. } = text_document;
-    if !uri
-        .path()
-        .starts_with(lsp_state.root_dir().to_string_lossy().as_ref())
-    {
+    let file_path = uri.to_file_path().map_err(|_| {
+        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to file path: {:?}", uri))
+    })?;
+
+    if !file_path.starts_with(lsp_state.root_dir()) {
         return Ok(());
     }
 
@@ -42,10 +44,11 @@ pub fn on_did_close_text_document(
     params: <DidCloseTextDocument as Notification>::Params,
 ) -> LSPRuntimeResult<()> {
     let uri = params.text_document.uri;
-    if !uri
-        .path()
-        .starts_with(lsp_state.root_dir().to_string_lossy().as_ref())
-    {
+    let file_path = uri.to_file_path().map_err(|_| {
+        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to file path: {:?}", uri))
+    })?;
+
+    if !file_path.starts_with(lsp_state.root_dir()) {
         return Ok(());
     }
 
@@ -61,10 +64,11 @@ pub fn on_did_change_text_document(
         text_document,
     } = params;
     let uri = text_document.uri;
-    if !uri
-        .path()
-        .starts_with(lsp_state.root_dir().to_string_lossy().as_ref())
-    {
+    let file_path = uri.to_file_path().map_err(|_| {
+        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to file path: {:?}", uri))
+    })?;
+
+    if !file_path.starts_with(lsp_state.root_dir()) {
         return Ok(());
     }
 

--- a/compiler/crates/relay-lsp/src/text_documents.rs
+++ b/compiler/crates/relay-lsp/src/text_documents.rs
@@ -19,7 +19,7 @@ use lsp_types::TextDocumentItem;
 
 use crate::lsp_runtime_error::LSPRuntimeResult;
 use crate::server::GlobalState;
-use crate::LSPRuntimeError;
+use crate::utils::is_file_uri_in_dir;
 
 pub fn on_did_open_text_document(
     lsp_state: &impl GlobalState,
@@ -27,11 +27,8 @@ pub fn on_did_open_text_document(
 ) -> LSPRuntimeResult<()> {
     let DidOpenTextDocumentParams { text_document } = params;
     let TextDocumentItem { text, uri, .. } = text_document;
-    let file_path = uri.to_file_path().map_err(|_| {
-        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to file path: {:?}", uri))
-    })?;
 
-    if !file_path.starts_with(lsp_state.root_dir()) {
+    if !is_file_uri_in_dir(lsp_state.root_dir(), &uri) {
         return Ok(());
     }
 
@@ -44,11 +41,8 @@ pub fn on_did_close_text_document(
     params: <DidCloseTextDocument as Notification>::Params,
 ) -> LSPRuntimeResult<()> {
     let uri = params.text_document.uri;
-    let file_path = uri.to_file_path().map_err(|_| {
-        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to file path: {:?}", uri))
-    })?;
 
-    if !file_path.starts_with(lsp_state.root_dir()) {
+    if !is_file_uri_in_dir(lsp_state.root_dir(), &uri) {
         return Ok(());
     }
 
@@ -64,11 +58,8 @@ pub fn on_did_change_text_document(
         text_document,
     } = params;
     let uri = text_document.uri;
-    let file_path = uri.to_file_path().map_err(|_| {
-        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to file path: {:?}", uri))
-    })?;
 
-    if !file_path.starts_with(lsp_state.root_dir()) {
+    if !is_file_uri_in_dir(lsp_state.root_dir(), &uri) {
         return Ok(());
     }
 

--- a/compiler/crates/relay-lsp/src/utils.rs
+++ b/compiler/crates/relay-lsp/src/utils.rs
@@ -67,7 +67,7 @@ pub fn extract_project_name_from_url(
     root_dir: &PathBuf,
 ) -> LSPRuntimeResult<StringKey> {
     let absolute_file_path = url.to_file_path().map_err(|_| {
-        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to fiel path: {:?}", url))
+        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to file path: {:?}", url))
     })?;
 
     let file_path = absolute_file_path.strip_prefix(root_dir).map_err(|_e| {

--- a/compiler/crates/relay-lsp/src/utils.rs
+++ b/compiler/crates/relay-lsp/src/utils.rs
@@ -30,6 +30,15 @@ use crate::lsp_runtime_error::LSPRuntimeError;
 use crate::lsp_runtime_error::LSPRuntimeResult;
 use crate::Feature;
 
+pub fn is_file_uri_in_dir(root_dir: PathBuf, file_uri: &Url) -> bool {
+    let file_path_result = file_uri.to_file_path();
+
+    match file_path_result {
+        Ok(file_path) => file_path.starts_with(root_dir),
+        Err(()) => false,
+    }
+}
+
 pub fn extract_executable_definitions_from_text_document(
     text_document_uri: &Url,
     source_feature_cache: &DashMap<Url, Vec<JavaScriptSourceFeature>>,

--- a/compiler/crates/relay-lsp/src/utils.rs
+++ b/compiler/crates/relay-lsp/src/utils.rs
@@ -66,7 +66,10 @@ pub fn extract_project_name_from_url(
     url: &Url,
     root_dir: &PathBuf,
 ) -> LSPRuntimeResult<StringKey> {
-    let absolute_file_path = PathBuf::from(url.path());
+    let absolute_file_path = url.to_file_path().map_err(|_| {
+        LSPRuntimeError::UnexpectedError(format!("Unable to convert URL to fiel path: {:?}", url))
+    })?;
+
     let file_path = absolute_file_path.strip_prefix(root_dir).map_err(|_e| {
         LSPRuntimeError::UnexpectedError(format!(
             "Failed to strip prefix {:?} from {:?}",


### PR DESCRIPTION
For every language server endpoint dealing with documents the code previously checked, whether the incoming file URI was part of the root directory:

```rust
uri.path().starts_with(state.root_dir().to_string_lossy().as_ref())
```

This works fine on Unix, since paths and URIs are "the same":

Root directory: `/home/user/my-app/`
File URI: `/home/user/my-app/subdir/file.ts`

For Windows you can see why the simple string `startsWith` might not suffice:

Root directory: `C:\user\my-app\`
File URI: `/c/user/my-app/subdir/file.ts`

In order to address this we now first convert the URI to a OS specific file path before doing the `startsWith`.

Furthermore [dunce](https://docs.rs/dunce/latest/dunce/) is being used to canonicalize paths, preventing paths to be converted to their UNC variant.

Closes #3918 