### PR TITLE
Bump vscode engine to match types

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -119,7 +119,7 @@
     "build-local": "vsce package"
   },
   "engines": {
-    "vscode": "^1.60.0"
+    "vscode": "^1.65.0"
   },
   "dependencies": {
     "semver": "^7.3.7",


### PR DESCRIPTION
Bumping the minimum VSCode engine in extension package.json to fix publishing step - https://github.com/facebook/relay/actions/runs/3831747693/jobs/6521246260