### PR TITLE
docs: noFutureProofEnums supported in typescript

### DIFF
--- a/packages/relay-compiler/README.md
+++ b/packages/relay-compiler/README.md
@@ -77,7 +77,7 @@ file sources, and "listen" to the file changes in the "watch" mode. If
   - `nonNodeIdFields` Restricts the type of all fields named `id` to `ID`.
     - `allowedIdTypes` Mappings from types in your schema to allowed types
       for their fields named `id` (e.g. "ObjectType": "CustomIdType"). [object]
-- `noFutureProofEnums` For `flow` only. This option controls whether or not a
+- `noFutureProofEnums` This option controls whether or not a
   catch-all entry is added to enum type definitions values that may be added in
   the future. Enabling this means you will have to update your application
   whenever the GraphQL server schema adds new enum values to prevent it from


### PR DESCRIPTION
`noFutureProofEnums` in the single project configuration is supported for typescript (we've been using it for a while). Updating the readme.