### PR TITLE
Fix tutorial typos

### DIFF
--- a/website/docs/tutorial/connections-pagination.md
+++ b/website/docs/tutorial/connections-pagination.md
@@ -50,7 +50,7 @@ Now consider what we would need to model in our schema in order to support pagin
 
 How can we use the features of GraphQL to do these things? Specifying the page size is done with field arguments. In other words, instead of just `friends` the query will say `friends(first: 3)`, passing the page size an argument to the `friends` field.
 
-For the server to say whether there is a next page or not, we need to introduce a node in the graph that has information about the *list of friends itself,* just like we introduces a node for each edge to store information about the edge itself. This new node is called a *Connection*.
+For the server to say whether there is a next page or not, we need to introduce a node in the graph that has information about the *list of friends itself,* just like we are introducing a node for each edge to store information about the edge itself. This new node is called a *Connection*.
 
 The Connection node represents the connection itself between you and your friends. Metadata about the connection is stored there — for example, it could have a `totalCount` field that says how many friends you have. In addition, it always has two fields which represent the *current* page: a `pageInfo` field with metadata about the current page, such as whether there is another page available — and an `edges` field that points to the edges we saw before:
 

--- a/website/docs/tutorial/queries-2.md
+++ b/website/docs/tutorial/queries-2.md
@@ -16,7 +16,7 @@ In this section we’ll add a hovercard to `PosterByline` so that you can see mo
 <details>
 <summary>Deep dive: When to use a secondary query</summary>
 
-We've mentioned before that Relay is designed to help you fetch all of your data requirements for an entire screen up-front. But w can generalize this and say that it's a *user interaction* that should have at most one query. Navigating to another screen is just one common type of user intecation.
+We've mentioned before that Relay is designed to help you fetch all of your data requirements for an entire screen up-front. But we can generalize this and say that it's a *user interaction* that should have at most one query. Navigating to another screen is just one common type of user intecation.
 
 Within a screen, some interactions may disclose additional data from what was shown initially. If an interaction is performed relatively rarely, but needs a significant amount of additional data, it can be smart to fetch that additional data in a second query, performed when the interaction happens, rather than up-front when the screen is first loaded. This makes that initial load faster and less expensive.
 

--- a/website/versioned_docs/version-v14.0.0/tutorial/connections-pagination.md
+++ b/website/versioned_docs/version-v14.0.0/tutorial/connections-pagination.md
@@ -50,7 +50,7 @@ Now consider what we would need to model in our schema in order to support pagin
 
 How can we use the features of GraphQL to do these things? Specifying the page size is done with field arguments. In other words, instead of just `friends` the query will say `friends(first: 3)`, passing the page size an argument to the `friends` field.
 
-For the server to say whether there is a next page or not, we need to introduce a node in the graph that has information about the *list of friends itself,* just like we introduces a node for each edge to store information about the edge itself. This new node is called a *Connection*.
+For the server to say whether there is a next page or not, we need to introduce a node in the graph that has information about the *list of friends itself,* just like we are introducing a node for each edge to store information about the edge itself. This new node is called a *Connection*.
 
 The Connection node represents the connection itself between you and your friends. Metadata about the connection is stored there — for example, it could have a `totalCount` field that says how many friends you have. In addition, it always has two fields which represent the *current* page: a `pageInfo` field with metadata about the current page, such as whether there is another page available — and an `edges` field that points to the edges we saw before:
 

--- a/website/versioned_docs/version-v14.0.0/tutorial/queries-2.md
+++ b/website/versioned_docs/version-v14.0.0/tutorial/queries-2.md
@@ -16,7 +16,7 @@ In this section we’ll add a hovercard to `PosterByline` so that you can see mo
 <details>
 <summary>Deep dive: When to use a secondary query</summary>
 
-We've mentioned before that Relay is designed to help you fetch all of your data requirements for an entire screen up-front. But w can generalize this and say that it's a *user interaction* that should have at most one query. Navigating to another screen is just one common type of user intecation.
+We've mentioned before that Relay is designed to help you fetch all of your data requirements for an entire screen up-front. But we can generalize this and say that it's a *user interaction* that should have at most one query. Navigating to another screen is just one common type of user intecation.
 
 Within a screen, some interactions may disclose additional data from what was shown initially. If an interaction is performed relatively rarely, but needs a significant amount of additional data, it can be smart to fetch that additional data in a second query, performed when the interaction happens, rather than up-front when the screen is first loaded. This makes that initial load faster and less expensive.
 


### PR DESCRIPTION
Found some typos in the tutorial. The content seems to be defined in two places so I updated them both. Please let me know if only one should be updated.