### PR TITLE
Can we migrate Relay from common js to es6 modules?

### DIFF
--- a/packages/relay-runtime/util/getFragmentIdentifier.js
+++ b/packages/relay-runtime/util/getFragmentIdentifier.js
@@ -18,7 +18,7 @@ const {
   getSelector,
   getVariablesFromFragment,
 } = require('../store/RelayModernSelector');
-const isEmptyObject = require('./isEmptyObject');
+const {isEmptyObject} = require('./isEmptyObject');
 const RelayFeatureFlags = require('./RelayFeatureFlags');
 const stableCopy = require('./stableCopy');
 const {intern} = require('./StringInterner');

--- a/packages/relay-runtime/util/isEmptyObject.js
+++ b/packages/relay-runtime/util/isEmptyObject.js
@@ -14,7 +14,7 @@
 // $FlowFixMe[method-unbinding] added when improving typing for this parameters
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-function isEmptyObject(obj: {+[key: string]: mixed}): boolean {
+export function isEmptyObject(obj: {+[key: string]: mixed}): boolean {
   for (const key in obj) {
     if (hasOwnProperty.call(obj, key)) {
       return false;
@@ -22,5 +22,3 @@ function isEmptyObject(obj: {+[key: string]: mixed}): boolean {
   }
   return true;
 }
-
-module.exports = isEmptyObject;


### PR DESCRIPTION
Differential Revision: D42580242

