### PR TITLE
Fix unexpected bold texts

### DIFF
--- a/packages/relay-compiler/README.md
+++ b/packages/relay-compiler/README.md
@@ -68,7 +68,7 @@ file sources, and "listen" to the file changes in the "watch" mode. If
   enabling this the babel plugin needs `artifactDirectory` to be set as well.
   [string]
 - `excludes` Directories to ignore under `src`. [array] [default:
-  ["**/node_modules/**", "**/__mocks__/**", "**/__generated__/**"]]
+  ["\*\*/node_modules/\*\*", "\*\*/__mocks__/\*\*", "\*\*/__generated__/\*\*"]]
 - `schemaExtensions` List of directories with schema extensions. [array]
 - `schemaConfig`
   - `nodeInterfaceIdField` Configure the name of the globally unique ID field on


### PR DESCRIPTION
There was a case where an asterisk was intended to be printed but was treated as a special character for bold.

You can check the issue at the following URL.

- https://github.com/facebook/relay/blob/10e20cc7344cb9130308fb5e5b3bb6f5e95e3514/packages/relay-compiler/README.md
- <img width="873" alt="image" src="https://user-images.githubusercontent.com/9639995/213429286-e2d068c4-b0fc-4ffb-9b7c-5928eab97050.png">
