### PR TITLE
Small fix on queries-2.md

### DIFF
--- a/website/versioned_docs/version-v14.0.0/tutorial/queries-2.md
+++ b/website/versioned_docs/version-v14.0.0/tutorial/queries-2.md
@@ -39,7 +39,7 @@ export default function PosterByline({ poster }: Props): React.ReactElement {
   return (
     <div className="byline">
       <Image image={data.profilePicture} width={60} height={60} className="byline__image" />
-      <div className="byline__name" ref={hoverRef}>{data.name}</div>
+      <div className="byline__name">{data.name}</div>
     </div>
   );
 }


### PR DESCRIPTION
The attribute `ref={hoverRef}` is not added in the previous exercice. It is added just after in the tutorial.

Moreover the attribute is added on the `<div className="byline">`tag and not on the `<div className="byline__name"` tag