### PR TITLE
Small fix on tutorial (interfaces-polymorphism.md)

### DIFF
--- a/website/versioned_docs/version-v14.0.0/tutorial/interfaces-polymorphism.md
+++ b/website/versioned_docs/version-v14.0.0/tutorial/interfaces-polymorphism.md
@@ -127,7 +127,7 @@ function PosterDetailsHovercardContentsBody({ poster }: Props): React.ReactEleme
       <Image image={data.profilePicture} width={128} height={128} className="posterHovercard__image" />
       <div className="posterHovercard__name">{data.name}</div>
       <ul className="posterHovercard__details">
-         <li>Joined <Timestamp time={poster.joined} /></li>
+         <li>Joined <Timestamp time={data.joined} /></li>
          // change
          {data.location != null && (
            <li>{data.location.name}</li>


### PR DESCRIPTION
Small error on getting poster.joined. Must use data.joined due to data masking.

The code is correct in the source. Error only in the doc.