### PR TITLE
If artifactDir doesn't exist, create it

### DIFF
--- a/compiler/crates/relay-compiler/src/errors.rs
+++ b/compiler/crates/relay-compiler/src/errors.rs
@@ -214,8 +214,11 @@ pub enum ConfigValidationError {
         error: regex::Error,
     },
 
-    #[error("The `artifactDirectory` does not exist at `{path}`.")]
-    ArtifactDirectoryNotExistent { path: PathBuf },
+    #[error("The `artifactDirectory` could not be created at `{path}`: {error}.")]
+    ArtifactDirectoryCreationError {
+        path: PathBuf,
+        error: std::io::Error,
+    },
 
     #[error("Unable to find common path for directories in the config file.")]
     CommonPathNotFound,


### PR DESCRIPTION
Closes #3782

This PR is in response to the comment https://github.com/facebook/relay/issues/3782#issuecomment-1029060702

With this change, the artifactDirectory is created instead of failing with `ArtifactDirectoryNotExistent`.

Note: I've removed the `ArtifactDirectoryNotExistent` case and used `unwrap` here instead since this case should be impossible with this change. If you prefer to keep the error variant, I'm happy to throw it back in.