### PR TITLE
Remove unused compiler option

### DIFF
--- a/scripts/config.tests.json
+++ b/scripts/config.tests.json
@@ -28,7 +28,6 @@
       "jsModuleFormat": "commonjs",
       "featureFlags": {
         "enable_relay_resolver_transform": true,
-        "use_named_imports_for_relay_resolvers": true,
         "relay_resolver_model_syntax_enabled": true,
         "enable_flight_transform": true,
         "no_inline": {


### PR DESCRIPTION
This config option was removed in a previous diff, but we forgot to clean it up in our 
OSS test config. This should return the "Compiler output check" back to green.
