### PR TITLE
Add descriptions to invariant calls

### DIFF
--- a/packages/react-relay/relay-hooks/__tests__/FragmentResource-WithOperationTracker-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResource-WithOperationTracker-test.js
@@ -275,7 +275,10 @@ describe('FragmentResource with Operation Tracker and Missing Data', () => {
 
     expect(pendingOperationFoundEvents.length).toBe(1);
     const event = pendingOperationFoundEvents[0];
-    invariant(event.name === 'pendingoperation.found');
+    invariant(
+      event.name === 'pendingoperation.found',
+      "Expected log event to be 'pendingoperation.found'",
+    );
     expect(event.fragment.name).toBe(
       'FragmentResourceWithOperationTrackerTestPlainUserNameRenderer_name',
     );

--- a/packages/relay-runtime/store/__tests__/resolvers/ResolverGC-test.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/ResolverGC-test.js
@@ -602,7 +602,7 @@ test('Resolver reading a client-edge to a client type (resolver marked dirty)', 
       /* Here we update the user to invalidate the astrological_sign resolver */
       environment.commitUpdate(store => {
         const user = store.get('1');
-        invariant(user != null);
+        invariant(user != null, 'Expected to find a user');
         user.setValue('some_value', 'some_field');
       });
     },


### PR DESCRIPTION
It looks like there's a difference in behavior between OSS invariant and internal. In OSS, invariant needs this second argument. 