### PR TITLE
Enable Flow LTI in relay

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -30,7 +30,7 @@ suppress_type=$FlowExpectedError
 format.bracket_spacing=false
 
 experimental.abstract_locations=true
-inference_mode=constrain_writes
+inference_mode=lti
 
 [lints]
 untyped-type-import=error

--- a/packages/react-relay/__tests__/LiveResolvers-test.js
+++ b/packages/react-relay/__tests__/LiveResolvers-test.js
@@ -925,7 +925,20 @@ describe.each([
         </RelayEnvironmentProvider>
       );
     }
-    const requiredFieldLogger = jest.fn();
+    const requiredFieldLogger = jest.fn<
+      | $FlowFixMe
+      | [
+          | {+fieldPath: string, +kind: 'missing_field.log', +owner: string}
+          | {+fieldPath: string, +kind: 'missing_field.throw', +owner: string}
+          | {
+              +error: Error,
+              +fieldPath: string,
+              +kind: 'relay_resolver.error',
+              +owner: string,
+            },
+        ],
+      void,
+    >();
     function createEnvironment(source: MutableRecordSource) {
       return new RelayModernEnvironment({
         network: RelayNetwork.create(jest.fn()),

--- a/packages/react-relay/__tests__/ReactRelayFragmentContainer-react-double-effects-test.js
+++ b/packages/react-relay/__tests__/ReactRelayFragmentContainer-react-double-effects-test.js
@@ -40,7 +40,7 @@ describe.skip('ReactRelayFragmentContainer-react-double-effects-test', () => {
     // Set up mocks
     jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
     jest.mock('warning');
-    renderSpy = jest.fn();
+    renderSpy = jest.fn<$ReadOnlyArray<mixed>, mixed>();
 
     // Set up environment and base data
     environment = createMockEnvironment();

--- a/packages/react-relay/__tests__/ReactRelayFragmentContainer-react-double-effects-test.js
+++ b/packages/react-relay/__tests__/ReactRelayFragmentContainer-react-double-effects-test.js
@@ -110,7 +110,6 @@ describe.skip('ReactRelayFragmentContainer-react-double-effects-test', () => {
             <FragmentContainer user={data?.node} />
           </RelayEnvironmentProvider>
         </React.StrictMode>,
-        // $FlowFixMe
         {unstable_isConcurrent: true, unstable_strictMode: true},
       );
     });

--- a/packages/react-relay/__tests__/ReactRelayPaginationContainer-react-double-effects-test.js
+++ b/packages/react-relay/__tests__/ReactRelayPaginationContainer-react-double-effects-test.js
@@ -40,7 +40,7 @@ describe.skip('ReactRelayFragmentContainer-react-double-effects-test', () => {
     // Set up mocks
     jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
     jest.mock('warning');
-    renderSpy = jest.fn();
+    renderSpy = jest.fn<$ReadOnlyArray<mixed>, mixed>();
 
     // Set up environment and base data
     environment = createMockEnvironment();

--- a/packages/react-relay/__tests__/ReactRelayPaginationContainer-react-double-effects-test.js
+++ b/packages/react-relay/__tests__/ReactRelayPaginationContainer-react-double-effects-test.js
@@ -129,7 +129,6 @@ describe.skip('ReactRelayFragmentContainer-react-double-effects-test', () => {
             <FragmentContainer user={data?.node} />
           </RelayEnvironmentProvider>
         </React.StrictMode>,
-        // $FlowFixMe
         {unstable_isConcurrent: true, unstable_strictMode: true},
       );
     });

--- a/packages/react-relay/__tests__/ReactRelayQueryRenderer-react-double-effects-test.js
+++ b/packages/react-relay/__tests__/ReactRelayQueryRenderer-react-double-effects-test.js
@@ -60,7 +60,7 @@ describe.skip('ReactRelayQueryRenderer-react-double-effects', () => {
     jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
 
     environment = createMockEnvironment();
-    release = jest.fn();
+    release = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalRetain = environment.retain;
     (environment: $FlowFixMe).retain = jest.fn(operation => {
@@ -73,7 +73,7 @@ describe.skip('ReactRelayQueryRenderer-react-double-effects', () => {
       };
     });
 
-    cancelNetworkRequest = jest.fn();
+    cancelNetworkRequest = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalExecute = environment.execute;
     (environment: $FlowFixMe).execute = jest.fn((...args) => {

--- a/packages/react-relay/__tests__/ReactRelayQueryRenderer-react-double-effects-test.js
+++ b/packages/react-relay/__tests__/ReactRelayQueryRenderer-react-double-effects-test.js
@@ -147,7 +147,6 @@ describe.skip('ReactRelayQueryRenderer-react-double-effects', () => {
         <React.StrictMode>
           <QueryContainer variables={variables} />
         </React.StrictMode>,
-        // $FlowFixMe
         {unstable_isConcurrent: true, unstable_strictMode: true},
       );
     });

--- a/packages/react-relay/__tests__/ReactRelayRefetchContainer-react-double-effects-test.js
+++ b/packages/react-relay/__tests__/ReactRelayRefetchContainer-react-double-effects-test.js
@@ -40,7 +40,7 @@ describe.skip('ReactRelayFragmentContainer-react-double-effects-test', () => {
     // Set up mocks
     jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
     jest.mock('warning');
-    renderSpy = jest.fn();
+    renderSpy = jest.fn<$ReadOnlyArray<mixed>, mixed>();
 
     // Set up environment and base data
     environment = createMockEnvironment();

--- a/packages/react-relay/__tests__/ReactRelayRefetchContainer-react-double-effects-test.js
+++ b/packages/react-relay/__tests__/ReactRelayRefetchContainer-react-double-effects-test.js
@@ -114,7 +114,6 @@ describe.skip('ReactRelayFragmentContainer-react-double-effects-test', () => {
             <FragmentContainer user={data?.node} />
           </RelayEnvironmentProvider>
         </React.StrictMode>,
-        // $FlowFixMe
         {unstable_isConcurrent: true, unstable_strictMode: true},
       );
     });

--- a/packages/react-relay/__tests__/RelayResolverModel-test.js
+++ b/packages/react-relay/__tests__/RelayResolverModel-test.js
@@ -330,7 +330,6 @@ describe.each([
         <TodoComponentWithInterfaceComponent todoID="todo-1" />
       </EnvironmentWrapper>,
     );
-    // $FlowFixMe[incompatible-call] Yes, it is compatible...
     const response = JSON.parse(renderer.toJSON() ?? '{}');
     jest.runAllImmediates();
 

--- a/packages/react-relay/__tests__/isRelayEnvironment-test.js
+++ b/packages/react-relay/__tests__/isRelayEnvironment-test.js
@@ -25,14 +25,14 @@ describe('isRelayEnvironment()', () => {
 
   it('returns true for objects that conform to the interface', () => {
     const environment = {
-      applyMutation: jest.fn(),
-      check: jest.fn(),
-      lookup: jest.fn(),
-      retain: jest.fn(),
-      sendMutation: jest.fn(),
-      sendQuery: jest.fn(),
-      execute: jest.fn(),
-      subscribe: jest.fn(),
+      applyMutation: jest.fn<$ReadOnlyArray<mixed>, mixed>(),
+      check: jest.fn<$ReadOnlyArray<mixed>, mixed>(),
+      lookup: jest.fn<$ReadOnlyArray<mixed>, mixed>(),
+      retain: jest.fn<$ReadOnlyArray<mixed>, mixed>(),
+      sendMutation: jest.fn<$ReadOnlyArray<mixed>, mixed>(),
+      sendQuery: jest.fn<$ReadOnlyArray<mixed>, mixed>(),
+      execute: jest.fn<$ReadOnlyArray<mixed>, mixed>(),
+      subscribe: jest.fn<$ReadOnlyArray<mixed>, mixed>(),
     };
     expect(isRelayEnvironment(environment)).toBe(true);
   });

--- a/packages/react-relay/multi-actor/__tests__/ActorChangeWithMutation-test.js
+++ b/packages/react-relay/multi-actor/__tests__/ActorChangeWithMutation-test.js
@@ -215,7 +215,7 @@ describe('ActorChange', () => {
     });
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const renderViewerActorName = jest.fn();
+    const renderViewerActorName = jest.fn<[?string], void>();
 
     ReactTestRenderer.create(
       <ComponentWrapper

--- a/packages/react-relay/multi-actor/__tests__/ActorChangeWithMutation-test.js
+++ b/packages/react-relay/multi-actor/__tests__/ActorChangeWithMutation-test.js
@@ -213,8 +213,6 @@ describe('ActorChange', () => {
     const renderFn = jest.fn(data => {
       actorRenders.push(data);
     });
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const renderViewerActorName = jest.fn<[?string], void>();
 
     ReactTestRenderer.create(

--- a/packages/react-relay/multi-actor/__tests__/ActorChangeWithMutation-test.js
+++ b/packages/react-relay/multi-actor/__tests__/ActorChangeWithMutation-test.js
@@ -209,9 +209,12 @@ describe('ActorChange', () => {
 
   it('should render a fragment for actor', () => {
     const actorRenders = [];
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     const renderFn = jest.fn(data => {
       actorRenders.push(data);
     });
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const renderViewerActorName = jest.fn();
 
     ReactTestRenderer.create(

--- a/packages/react-relay/relay-hooks/LazyLoadEntryPointContainer_DEPRECATED.react.js
+++ b/packages/react-relay/relay-hooks/LazyLoadEntryPointContainer_DEPRECATED.react.js
@@ -11,7 +11,6 @@
 
 'use strict';
 import type {OperationType} from '../../relay-runtime/util/RelayRuntimeTypes';
-
 import type {
   EntryPoint,
   EntryPointComponent,

--- a/packages/react-relay/relay-hooks/LazyLoadEntryPointContainer_DEPRECATED.react.js
+++ b/packages/react-relay/relay-hooks/LazyLoadEntryPointContainer_DEPRECATED.react.js
@@ -97,7 +97,6 @@ function prepareEntryPoint<
         environmentProviderOptions,
       );
 
-      // $FlowFixMe[underconstrained-implicit-instantiation]
       preloadedQueries[queryPropName] = preloadQuery_DEPRECATED<
         OperationType,
         mixed,
@@ -120,8 +119,6 @@ function prepareEntryPoint<
       }
       const {entryPoint: nestedEntryPoint, entryPointParams: nestedParams} =
         entryPointDescription;
-      // $FlowFixMe[incompatible-call]
-      // $FlowFixMe[underconstrained-implicit-instantiation]
       preloadedEntryPoints[entryPointPropName] = prepareEntryPoint<
         _,
         {...},

--- a/packages/react-relay/relay-hooks/LazyLoadEntryPointContainer_DEPRECATED.react.js
+++ b/packages/react-relay/relay-hooks/LazyLoadEntryPointContainer_DEPRECATED.react.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {OperationType} from '../../relay-runtime/util/RelayRuntimeTypes';
 
 import type {
   EntryPoint,
@@ -98,7 +99,10 @@ function prepareEntryPoint<
       );
 
       // $FlowFixMe[underconstrained-implicit-instantiation]
-      preloadedQueries[queryPropName] = preloadQuery_DEPRECATED(
+      preloadedQueries[queryPropName] = preloadQuery_DEPRECATED<
+        OperationType,
+        mixed,
+      >(
         environment,
         parameters,
         variables,
@@ -119,11 +123,15 @@ function prepareEntryPoint<
         entryPointDescription;
       // $FlowFixMe[incompatible-call]
       // $FlowFixMe[underconstrained-implicit-instantiation]
-      preloadedEntryPoints[entryPointPropName] = prepareEntryPoint(
-        environmentProvider,
-        nestedEntryPoint,
-        nestedParams,
-      );
+      preloadedEntryPoints[entryPointPropName] = prepareEntryPoint<
+        _,
+        {...},
+        {...},
+        {...},
+        mixed,
+        EntryPointComponent<{...}, {...}, {...}, mixed>,
+        _,
+      >(environmentProvider, nestedEntryPoint, nestedParams);
     });
   }
   return {

--- a/packages/react-relay/relay-hooks/__tests__/EntryPointContainer-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/EntryPointContainer-test.js
@@ -106,7 +106,9 @@ class FakeJSResource<T> {
 }
 
 beforeEach(() => {
+  // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
   fetch = jest.fn((_query, _variables, _cacheConfig) =>
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     Observable.create(sink => {
       dataSource = sink;
     }),

--- a/packages/react-relay/relay-hooks/__tests__/FragmentResource-ClientEdges-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResource-ClientEdges-test.js
@@ -84,7 +84,7 @@ describe('FragmentResource Client Edges behavior', () => {
       __fragmentOwner: query.request,
     };
 
-    release = jest.fn();
+    release = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     // eslint-disable-next-line ft-flow/no-flow-fix-me-comments
     // $FlowFixMe[method-unbinding]
     environment.retain.mockImplementation((...args) => {

--- a/packages/react-relay/relay-hooks/__tests__/FragmentResource-ClientEdges-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResource-ClientEdges-test.js
@@ -240,16 +240,13 @@ describe('FragmentResource Client Edges behavior', () => {
     const originalClearTimeout = global.clearTimeout;
     try {
       // eslint-disable-next-line ft-flow/no-flow-fix-me-comments
-      // $FlowFixMe[cannot-write]
       global.setTimeout = fn => {
         const id = nextTimeoutID++;
         timeouts.set(id, fn);
         return id;
       };
       // eslint-disable-next-line ft-flow/no-flow-fix-me-comments
-      // $FlowFixMe[cannot-write]
       global.clearTimeout = id => {
-        // $FlowFixMe[incompatible-call] Error found while enabling LTI on this file
         timeouts.delete(id);
       };
       function runAllTimeouts() {
@@ -316,10 +313,8 @@ describe('FragmentResource Client Edges behavior', () => {
       expect(release).toBeCalledTimes(1);
     } finally {
       // eslint-disable-next-line ft-flow/no-flow-fix-me-comments
-      // $FlowFixMe[cannot-write]
       global.setTimeout = originalSetTimeout;
       // eslint-disable-next-line ft-flow/no-flow-fix-me-comments
-      // $FlowFixMe[cannot-write]
       global.clearTimeout = originalClearTimeout;
     }
   });

--- a/packages/react-relay/relay-hooks/__tests__/FragmentResource-Resolver-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResource-Resolver-test.js
@@ -61,7 +61,19 @@ describe('FragmentResource RelayResolver behavior', () => {
   let mockRequiredFieldLogger;
 
   beforeEach(() => {
-    mockRequiredFieldLogger = jest.fn();
+    mockRequiredFieldLogger = jest.fn<
+      [
+        | {+fieldPath: string, +kind: 'missing_field.log', +owner: string}
+        | {+fieldPath: string, +kind: 'missing_field.throw', +owner: string}
+        | {
+            +error: Error,
+            +fieldPath: string,
+            +kind: 'relay_resolver.error',
+            +owner: string,
+          },
+      ],
+      void,
+    >();
     environment = createMockEnvironment({
       requiredFieldLogger: mockRequiredFieldLogger,
     });

--- a/packages/react-relay/relay-hooks/__tests__/FragmentResource-WithOperationTracker-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResource-WithOperationTracker-test.js
@@ -10,6 +10,10 @@
  */
 
 'use strict';
+import type {
+  NormalizationSplitOperation,
+  NormalizationRootNode,
+} from '../../../relay-runtime/util/NormalizationNode';
 
 import type {LogEvent} from 'relay-runtime/store/RelayStoreTypes';
 
@@ -44,8 +48,8 @@ describe('FragmentResource with Operation Tracker and Missing Data', () => {
 
   beforeEach(() => {
     operationLoader = {
-      load: jest.fn(),
-      get: jest.fn(),
+      load: jest.fn<[mixed], Promise<NormalizationSplitOperation>>(),
+      get: jest.fn<[mixed], ?NormalizationRootNode>(),
     };
     operationTracker = new RelayOperationTracker();
     logger = jest.fn<[LogEvent], void>();

--- a/packages/react-relay/relay-hooks/__tests__/FragmentResource-WithOperationTracker-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResource-WithOperationTracker-test.js
@@ -11,10 +11,9 @@
 
 'use strict';
 import type {
-  NormalizationSplitOperation,
   NormalizationRootNode,
+  NormalizationSplitOperation,
 } from '../../../relay-runtime/util/NormalizationNode';
-
 import type {LogEvent} from 'relay-runtime/store/RelayStoreTypes';
 
 const {createFragmentResource} = require('../FragmentResource');

--- a/packages/react-relay/relay-hooks/__tests__/FragmentResource-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResource-test.js
@@ -624,8 +624,6 @@ describe('FragmentResource', () => {
 
       expect(getMissigDataEvents()).toEqual([expectedLogEvent]);
 
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       const mockSubscription = jest.fn<[], void>();
       // Subscribing here will cause Fragment resource to write updated fragment
       // snapshots to its cache.
@@ -787,8 +785,6 @@ describe('FragmentResource', () => {
   describe('subscribe', () => {
     let callback;
     beforeEach(() => {
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       callback = jest.fn<[], void>();
     });
 
@@ -1056,11 +1052,7 @@ describe('FragmentResource', () => {
           },
           __fragmentOwner: query.request,
         };
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback1 = jest.fn<[], void>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback2 = jest.fn<[], void>();
 
         let result = FragmentResource.read(
@@ -1558,8 +1550,6 @@ describe('FragmentResource', () => {
     let unsubscribe;
     let callback: JestMockFn<$ReadOnlyArray<mixed>, void>;
     beforeEach(() => {
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       unsubscribe = jest.fn<$ReadOnlyArray<mixed>, mixed>();
       callback = jest.fn();
       jest.spyOn(environment, 'subscribe').mockImplementation(() => ({

--- a/packages/react-relay/relay-hooks/__tests__/FragmentResource-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResource-test.js
@@ -624,6 +624,8 @@ describe('FragmentResource', () => {
 
       expect(getMissigDataEvents()).toEqual([expectedLogEvent]);
 
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       const mockSubscription = jest.fn();
       // Subscribing here will cause Fragment resource to write updated fragment
       // snapshots to its cache.
@@ -785,6 +787,8 @@ describe('FragmentResource', () => {
   describe('subscribe', () => {
     let callback;
     beforeEach(() => {
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       callback = jest.fn();
     });
 
@@ -1052,7 +1056,11 @@ describe('FragmentResource', () => {
           },
           __fragmentOwner: query.request,
         };
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback1 = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback2 = jest.fn();
 
         let result = FragmentResource.read(
@@ -1550,6 +1558,8 @@ describe('FragmentResource', () => {
     let unsubscribe;
     let callback: JestMockFn<$ReadOnlyArray<mixed>, void>;
     beforeEach(() => {
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       unsubscribe = jest.fn();
       callback = jest.fn();
       jest.spyOn(environment, 'subscribe').mockImplementation(() => ({

--- a/packages/react-relay/relay-hooks/__tests__/FragmentResource-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResource-test.js
@@ -626,7 +626,7 @@ describe('FragmentResource', () => {
 
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      const mockSubscription = jest.fn();
+      const mockSubscription = jest.fn<[], void>();
       // Subscribing here will cause Fragment resource to write updated fragment
       // snapshots to its cache.
       const disposable = FragmentResource.subscribe(result, mockSubscription);
@@ -789,7 +789,7 @@ describe('FragmentResource', () => {
     beforeEach(() => {
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      callback = jest.fn();
+      callback = jest.fn<[], void>();
     });
 
     it('subscribes to the fragment that was `read`', () => {
@@ -1058,10 +1058,10 @@ describe('FragmentResource', () => {
         };
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback1 = jest.fn();
+        const callback1 = jest.fn<[], void>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback2 = jest.fn();
+        const callback2 = jest.fn<[], void>();
 
         let result = FragmentResource.read(
           fragmentNode,
@@ -1560,7 +1560,7 @@ describe('FragmentResource', () => {
     beforeEach(() => {
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      unsubscribe = jest.fn();
+      unsubscribe = jest.fn<$ReadOnlyArray<mixed>, mixed>();
       callback = jest.fn();
       jest.spyOn(environment, 'subscribe').mockImplementation(() => ({
         dispose: unsubscribe,

--- a/packages/react-relay/relay-hooks/__tests__/FragmentResourceRequiredField-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/FragmentResourceRequiredField-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {LogEvent} from '../../../relay-runtime/store/RelayStoreTypes';
 
 const {getFragmentResourceForEnvironment} = require('../FragmentResource');
 const {
@@ -35,8 +36,20 @@ let logger;
 let requiredFieldLogger;
 
 beforeEach(() => {
-  logger = jest.fn();
-  requiredFieldLogger = jest.fn();
+  logger = jest.fn<[LogEvent], void>();
+  requiredFieldLogger = jest.fn<
+    [
+      | {+fieldPath: string, +kind: 'missing_field.log', +owner: string}
+      | {+fieldPath: string, +kind: 'missing_field.throw', +owner: string}
+      | {
+          +error: Error,
+          +fieldPath: string,
+          +kind: 'relay_resolver.error',
+          +owner: string,
+        },
+    ],
+    void,
+  >();
 
   environment = createMockEnvironment({
     log: logger,
@@ -111,7 +124,7 @@ test('Logs if a @required(action: LOG) field is null', () => {
 });
 
 test('Throws if a @required(action: THROW) field is present and then goes missing', () => {
-  const callback = jest.fn();
+  const callback = jest.fn<[], void>();
   environment.commitPayload(query, {
     node: {
       __typename: 'User',

--- a/packages/react-relay/relay-hooks/__tests__/LazyLoadEntryPointContainer_DEEPRECATED-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/LazyLoadEntryPointContainer_DEEPRECATED-test.js
@@ -10,6 +10,17 @@
  */
 
 'use strict';
+import type {
+  Variables,
+  CacheConfig,
+} from '../../../relay-runtime/util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
+import type {ObservableFromValue} from '../../../relay-runtime/network/RelayObservable';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+  GraphQLResponse,
+} from '../../../relay-runtime/network/RelayNetworkTypes';
 
 const LazyLoadEntryPointContainer_DEPRECATED = require('../LazyLoadEntryPointContainer_DEPRECATED.react');
 const preloadQuery_DEPRECATED = require('../preloadQuery_DEPRECATED');
@@ -106,7 +117,9 @@ class FakeJSResource<T> {
 beforeEach(() => {
   PreloadableQueryRegistry.clear();
 
+  // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
   fetch = jest.fn((_query, _variables, _cacheConfig) =>
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     Observable.create(sink => {
       dataSource = sink;
     }),
@@ -122,6 +135,7 @@ beforeEach(() => {
     params: query.params,
   };
   entryPoint = {
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     getPreloadProps: jest.fn(entryPointParams => {
       return {
         queries: {
@@ -280,6 +294,7 @@ it('renders synchronously when the query and component are already loaded', () =
 });
 
 it('re-renders without reloading when non-prefetch props change', () => {
+  // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
   const Component = jest.fn(props => {
     const data = usePreloadedQuery(query, props.queries.prefetched);
     return data.node?.name;
@@ -321,6 +336,7 @@ it('re-renders without reloading when non-prefetch props change', () => {
 });
 
 it('re-renders and reloads when prefetch params change', () => {
+  // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
   const Component = jest.fn(props => {
     const data = usePreloadedQuery(query, props.queries.prefetched);
     return data.node?.name;
@@ -498,6 +514,7 @@ it('renders synchronously when the query data and ast are cached, without fetchi
 
 it('should use environment from `getEnvironment` prop to fetch a query', () => {
   entryPoint = {
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     getPreloadProps: jest.fn(entryPointParams => {
       return {
         queries: {
@@ -513,8 +530,26 @@ it('should use environment from `getEnvironment` prop to fetch a query', () => {
     }),
     root: (new FakeJSResource(): $FlowFixMe),
   };
-  const fetchFn = jest.fn();
-  const defaultFetchFn = jest.fn();
+  const fetchFn = jest.fn<
+    [
+      RequestParameters,
+      Variables,
+      CacheConfig,
+      ?UploadableMap,
+      ?LogRequestInfoFunction,
+    ],
+    ObservableFromValue<GraphQLResponse>,
+  >();
+  const defaultFetchFn = jest.fn<
+    [
+      RequestParameters,
+      Variables,
+      CacheConfig,
+      ?UploadableMap,
+      ?LogRequestInfoFunction,
+    ],
+    ObservableFromValue<GraphQLResponse>,
+  >();
   const defaultEnvironment = new Environment({
     network: Network.create(defaultFetchFn),
     store: new Store(new RecordSource()),

--- a/packages/react-relay/relay-hooks/__tests__/LazyLoadEntryPointContainer_DEEPRECATED-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/LazyLoadEntryPointContainer_DEEPRECATED-test.js
@@ -59,7 +59,6 @@ const query = graphql`
 `;
 
 // Only queries with an ID are preloadable
-// $FlowFixMe[cannot-write]
 query.params.id = '12345';
 
 const response = {

--- a/packages/react-relay/relay-hooks/__tests__/LazyLoadEntryPointContainer_DEEPRECATED-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/LazyLoadEntryPointContainer_DEEPRECATED-test.js
@@ -11,16 +11,16 @@
 
 'use strict';
 import type {
-  Variables,
-  CacheConfig,
-} from '../../../relay-runtime/util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
-import type {ObservableFromValue} from '../../../relay-runtime/network/RelayObservable';
-import type {
-  UploadableMap,
-  LogRequestInfoFunction,
   GraphQLResponse,
+  LogRequestInfoFunction,
+  UploadableMap,
 } from '../../../relay-runtime/network/RelayNetworkTypes';
+import type {ObservableFromValue} from '../../../relay-runtime/network/RelayObservable';
+import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
+import type {
+  CacheConfig,
+  Variables,
+} from '../../../relay-runtime/util/RelayRuntimeTypes';
 
 const LazyLoadEntryPointContainer_DEPRECATED = require('../LazyLoadEntryPointContainer_DEPRECATED.react');
 const preloadQuery_DEPRECATED = require('../preloadQuery_DEPRECATED');

--- a/packages/react-relay/relay-hooks/__tests__/MatchContainer-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/MatchContainer-test.js
@@ -53,13 +53,18 @@ describe('MatchContainer', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    loader = jest.fn();
+    loader = jest.fn<
+      [mixed],
+      React$AbstractComponent<any | {otherProp: string}, any>,
+    >();
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     UserComponent = jest.fn(props => (
       <div>
         <h1>User</h1>
         <pre>{JSON.stringify(props, null, 2)}</pre>
       </div>
     ));
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     ActorComponent = jest.fn(props => (
       <div>
         <h1>Actor</h1>

--- a/packages/react-relay/relay-hooks/__tests__/PreloadableQueryRegistry-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/PreloadableQueryRegistry-test.js
@@ -45,7 +45,7 @@ describe('PreloadableQueryRegistry', () => {
       jest.resetModules();
     });
     it('should synchronously execute a callback when the ConcreteRequest given by the same key is loaded', () => {
-      const callback = jest.fn();
+      const callback = jest.fn<[ConcreteRequest], void>();
       const id1 = generateUniqueId();
       const c1 = makeConcreteRequest();
       PreloadableQueryRegistry.onLoad(id1, callback);
@@ -59,7 +59,7 @@ describe('PreloadableQueryRegistry', () => {
 
     it('dedupes callbacks passed to onLoad', () => {
       // the internal representation is a set.
-      const callback = jest.fn();
+      const callback = jest.fn<[ConcreteRequest], void>();
       const id1 = generateUniqueId();
       const c1 = makeConcreteRequest();
       PreloadableQueryRegistry.onLoad(id1, callback);
@@ -69,7 +69,7 @@ describe('PreloadableQueryRegistry', () => {
     });
 
     it('should execute the callback passed to onLoad callback many times', () => {
-      const callback = jest.fn();
+      const callback = jest.fn<[ConcreteRequest], void>();
       const id1 = generateUniqueId();
       const c1 = makeConcreteRequest();
       PreloadableQueryRegistry.onLoad(id1, callback);
@@ -83,7 +83,7 @@ describe('PreloadableQueryRegistry', () => {
     });
 
     it('should return a Disposable that, if executed, prevents the callback from being executed', () => {
-      const callback = jest.fn();
+      const callback = jest.fn<[ConcreteRequest], void>();
       const id1 = generateUniqueId();
       const c1 = makeConcreteRequest();
       // $FlowFixMe[method-unbinding] added when improving typing for this parameters
@@ -95,8 +95,8 @@ describe('PreloadableQueryRegistry', () => {
     });
 
     it('should support multiple callbacks', () => {
-      const cb1 = jest.fn();
-      const cb2 = jest.fn();
+      const cb1 = jest.fn<[ConcreteRequest], void>();
+      const cb2 = jest.fn<[ConcreteRequest], void>();
       const id1 = generateUniqueId();
       const c1 = makeConcreteRequest();
       // $FlowFixMe[method-unbinding] added when improving typing for this parameters
@@ -115,10 +115,10 @@ describe('PreloadableQueryRegistry', () => {
     });
 
     it('should call a subsequent callback even if the previous threw an error', () => {
-      const cb1 = jest.fn().mockImplementation(() => {
+      const cb1 = jest.fn<[ConcreteRequest], empty>().mockImplementation(() => {
         throw new Error('error');
       });
-      const cb2 = jest.fn();
+      const cb2 = jest.fn<[ConcreteRequest], void>();
       const id1 = generateUniqueId();
       const c1 = makeConcreteRequest();
       PreloadableQueryRegistry.onLoad(id1, cb1);
@@ -130,7 +130,7 @@ describe('PreloadableQueryRegistry', () => {
     it('should throw an error in the next tick after an uncaught error', () => {
       jest.useFakeTimers();
       const error = new Error('Not the droids you were looking for');
-      const cb1 = jest.fn().mockImplementation(() => {
+      const cb1 = jest.fn<[ConcreteRequest], empty>().mockImplementation(() => {
         throw error;
       });
       const id1 = generateUniqueId();

--- a/packages/react-relay/relay-hooks/__tests__/QueryResource-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/QueryResource-test.js
@@ -114,7 +114,7 @@ describe('QueryResource', () => {
       liveQueryMissingData,
     );
 
-    release = jest.fn();
+    release = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     environment.retain.mockImplementation((...args) => {
       return {
@@ -285,7 +285,7 @@ describe('QueryResource', () => {
         it('should throw error if network request errors', () => {
           let thrown = false;
           let sink;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(s => {
             networkExecute();
             sink = s;
@@ -330,7 +330,7 @@ describe('QueryResource', () => {
             status: 'missing',
           });
 
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const syncFetchObservable = Observable.create<$FlowFixMe>(sink => {
             environment.commitPayload(queryMissingData, {
               node: {
@@ -374,7 +374,7 @@ describe('QueryResource', () => {
 
         it('should throw error if network request errors synchronously', () => {
           let thrown = false;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(sink => {
             networkExecute();
             sink.error(new Error('Oops'));
@@ -701,7 +701,7 @@ describe('QueryResource', () => {
         it('should throw error if network request errors', () => {
           let thrown = false;
           let sink;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(s => {
             networkExecute();
             sink = s;
@@ -752,7 +752,7 @@ describe('QueryResource', () => {
             status: 'missing',
           });
 
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const syncFetchObservable = Observable.create<$FlowFixMe>(sink => {
             environment.commitPayload(queryMissingData, {
               node: {
@@ -796,7 +796,7 @@ describe('QueryResource', () => {
 
         it('should throw error if network request errors synchronously', () => {
           let thrown = false;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(sink => {
             networkExecute();
             sink.error(new Error('Oops'));
@@ -1261,7 +1261,7 @@ describe('QueryResource', () => {
         it('should throw error if network request errors', () => {
           let thrown = false;
           let sink;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(s => {
             networkExecute();
             sink = s;
@@ -1305,7 +1305,7 @@ describe('QueryResource', () => {
             status: 'missing',
           });
 
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const syncFetchObservable = Observable.create<$FlowFixMe>(sink => {
             environment.commitPayload(queryMissingData, {
               node: {
@@ -1349,7 +1349,7 @@ describe('QueryResource', () => {
 
         it('should throw error if network request errors synchronously', () => {
           let thrown = false;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(sink => {
             networkExecute();
             sink.error(new Error('Oops'));
@@ -1499,7 +1499,7 @@ describe('QueryResource', () => {
         it('should throw error if network request errors', () => {
           let thrown = false;
           let sink;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(s => {
             networkExecute();
             sink = s;
@@ -1548,7 +1548,7 @@ describe('QueryResource', () => {
             status: 'missing',
           });
 
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const syncFetchObservable = Observable.create<$FlowFixMe>(sink => {
             environment.commitPayload(queryMissingData, {
               node: {
@@ -1592,7 +1592,7 @@ describe('QueryResource', () => {
 
         it('should throw error if network request errors synchronously', () => {
           let thrown = false;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(sink => {
             networkExecute();
             sink.error(new Error('Oops'));
@@ -1724,7 +1724,7 @@ describe('QueryResource', () => {
           let thrownPromise = false;
           let thrownError = false;
           let sink;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(s => {
             networkExecute();
             sink = s;
@@ -1771,7 +1771,7 @@ describe('QueryResource', () => {
         });
 
         it('should return result if network observable returns synchronously', () => {
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const syncFetchObservable = Observable.create<$FlowFixMe>(sink => {
             const snapshot = environment.lookup(query.fragment);
             networkExecute();
@@ -1809,7 +1809,7 @@ describe('QueryResource', () => {
 
         it('should throw error if network request errors synchronously', () => {
           let thrown = false;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(sink => {
             networkExecute();
             const error = new Error('Oops');
@@ -1906,7 +1906,7 @@ describe('QueryResource', () => {
           let thrownPromise = false;
           let thrownError = false;
           let sink;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(s => {
             networkExecute();
             sink = s;
@@ -1953,7 +1953,7 @@ describe('QueryResource', () => {
         });
 
         it('should return result if network observable returns synchronously', () => {
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const syncFetchObservable = Observable.create<$FlowFixMe>(sink => {
             const snapshot = environment.lookup(query.fragment);
             networkExecute();
@@ -1991,7 +1991,7 @@ describe('QueryResource', () => {
 
         it('should throw error if network request errors synchronously', () => {
           let thrown = false;
-          const networkExecute = jest.fn();
+          const networkExecute = jest.fn<[], mixed>();
           const errorFetchObservable = Observable.create<$FlowFixMe>(sink => {
             networkExecute();
             const error = new Error('Oops');
@@ -2922,7 +2922,7 @@ describe('QueryResource, with an environment meant for SSR', () => {
 
     fetchObservable = fetchQuery(environment, query);
 
-    release = jest.fn();
+    release = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     environment.retain.mockImplementation((...args) => {
       return {

--- a/packages/react-relay/relay-hooks/__tests__/loadEntryPoint-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadEntryPoint-test.js
@@ -94,9 +94,7 @@ test('it should preload entry point with queries', () => {
     entryPoint,
     {id: 'my-id'},
   );
-  // $FlowFixMe[method-unbinding] added when improving typing for this parameters
   expect(entryPoint.root.getModuleIfRequired).toBeCalledTimes(1);
-  // $FlowFixMe[method-unbinding] added when improving typing for this parameters
   expect(entryPoint.root.load).toBeCalledTimes(1);
   expect(networkSpy).toBeCalledTimes(1);
   expect(preloadedEntryPoint.queries.myTestQuery.name).toBe('MyPreloadedQuery');
@@ -384,9 +382,7 @@ test('it should preload entry point with nested entry points', () => {
     entryPoint,
     {id: 'my-id'},
   );
-  // $FlowFixMe[method-unbinding] added when improving typing for this parameters
   expect(entryPoint.root.getModuleIfRequired).toBeCalledTimes(1);
-  // $FlowFixMe[method-unbinding] added when improving typing for this parameters
   expect(entryPoint.root.load).toBeCalledTimes(1);
   expect(nestedEntryPoint.root.getModuleIfRequired).toBeCalledTimes(1);
   expect(nestedEntryPoint.root.load).toBeCalledTimes(1);
@@ -481,9 +477,7 @@ test('it should preload entry point with both queries and nested entry points', 
   expect(networkSpy).toBeCalledTimes(2);
   expect(nestedEntryPoint.root.getModuleIfRequired).toBeCalledTimes(1);
   expect(nestedEntryPoint.root.load).toBeCalledTimes(1);
-  // $FlowFixMe[method-unbinding] added when improving typing for this parameters
   expect(entryPoint.root.getModuleIfRequired).toBeCalledTimes(1);
-  // $FlowFixMe[method-unbinding] added when improving typing for this parameters
   expect(entryPoint.root.load).toBeCalledTimes(1);
   expect(preloadedEntryPoint.queries.myTestQuery.name).toBe('MyPreloadedQuery');
   expect(preloadedEntryPoint.queries.myTestQuery.variables).toEqual({
@@ -573,7 +567,6 @@ test('it should dispose nested entry points', () => {
     },
     // $FlowFixMe[prop-missing] Error found while enabling LTI on this file
     entryPoint,
-    // $FlowFixMe[prop-missing]
     {},
   );
   const nestedEntryPointDisposeSpy = jest.spyOn(

--- a/packages/react-relay/relay-hooks/__tests__/loadEntryPoint-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadEntryPoint-test.js
@@ -204,13 +204,17 @@ test('it should return the module from an entry point that just returns the modu
 
 describe('with respect to loadQuery', () => {
   let mockLoadedQuery;
-  const loadQuery = jest.fn().mockImplementation(() => {
-    return mockLoadedQuery;
-  });
+  const loadQuery = jest
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
+    .fn<_, {dispose: JestMockFn<$ReadOnlyArray<mixed>, mixed>}>()
+    .mockImplementation(() => {
+      return mockLoadedQuery;
+    });
   beforeEach(() => {
     jest.mock('../loadQuery', () => ({loadQuery}));
     mockLoadedQuery = {
-      dispose: jest.fn(),
+      dispose: jest.fn<$ReadOnlyArray<mixed>, mixed>(),
     };
   });
   afterEach(() => {

--- a/packages/react-relay/relay-hooks/__tests__/loadQuery-source-behavior-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadQuery-source-behavior-test.js
@@ -101,6 +101,7 @@ beforeEach(() => {
   });
   PreloadableQueryRegistry.clear();
 
+  // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
   fetch = jest.fn((_query, _variables, _cacheConfig) => {
     // $FlowFixMe[missing-local-annot] Error found while enabling LTI on this file
     const observable = Observable.create(_sink => {
@@ -108,6 +109,8 @@ beforeEach(() => {
     });
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalSubscribe = observable.subscribe.bind(observable);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     networkUnsubscribe = jest.fn();
     jest.spyOn(observable, 'subscribe').mockImplementation((...args) => {
       const subscription = originalSubscribe(...args);

--- a/packages/react-relay/relay-hooks/__tests__/loadQuery-source-behavior-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadQuery-source-behavior-test.js
@@ -109,8 +109,6 @@ beforeEach(() => {
     });
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalSubscribe = observable.subscribe.bind(observable);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     networkUnsubscribe = jest.fn<[], $FlowFixMe>();
     jest.spyOn(observable, 'subscribe').mockImplementation((...args) => {
       const subscription = originalSubscribe(...args);

--- a/packages/react-relay/relay-hooks/__tests__/loadQuery-source-behavior-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadQuery-source-behavior-test.js
@@ -111,7 +111,7 @@ beforeEach(() => {
     const originalSubscribe = observable.subscribe.bind(observable);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    networkUnsubscribe = jest.fn();
+    networkUnsubscribe = jest.fn<[], $FlowFixMe>();
     jest.spyOn(observable, 'subscribe').mockImplementation((...args) => {
       const subscription = originalSubscribe(...args);
       jest

--- a/packages/react-relay/relay-hooks/__tests__/loadQuery-store-behavior-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadQuery-store-behavior-test.js
@@ -10,6 +10,15 @@
  */
 
 'use strict';
+import type {
+  Variables,
+  CacheConfig,
+} from '../../../relay-runtime/util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+} from '../../../relay-runtime/network/RelayNetworkTypes';
 
 import type {
   loadQueryStoreBehaviorTestQuery$data,
@@ -95,7 +104,13 @@ let writeDataToStore;
 beforeEach(() => {
   operation = createOperationDescriptor(query, variables);
   fetch = jest.fn(
-    (_query, _variables, _cacheConfig, _uploadables, _logRequestInfo) => {
+    (
+      _query: RequestParameters,
+      _variables: Variables,
+      _cacheConfig: CacheConfig,
+      _uploadables: ?UploadableMap,
+      _logRequestInfo: ?LogRequestInfoFunction,
+    ) => {
       const observableCreate = Observable.create(
         (_sink: Sink<GraphQLSingularResponse>) => {
           sink = _sink;

--- a/packages/react-relay/relay-hooks/__tests__/loadQuery-store-behavior-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadQuery-store-behavior-test.js
@@ -11,15 +11,14 @@
 
 'use strict';
 import type {
-  Variables,
-  CacheConfig,
-} from '../../../relay-runtime/util/RelayRuntimeTypes';
+  LogRequestInfoFunction,
+  UploadableMap,
+} from '../../../relay-runtime/network/RelayNetworkTypes';
 import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
 import type {
-  UploadableMap,
-  LogRequestInfoFunction,
-} from '../../../relay-runtime/network/RelayNetworkTypes';
-
+  CacheConfig,
+  Variables,
+} from '../../../relay-runtime/util/RelayRuntimeTypes';
 import type {
   loadQueryStoreBehaviorTestQuery$data,
   loadQueryStoreBehaviorTestQuery$variables,

--- a/packages/react-relay/relay-hooks/__tests__/loadQuery-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadQuery-test.js
@@ -10,6 +10,15 @@
  */
 
 'use strict';
+import type {
+  Variables,
+  CacheConfig,
+} from '../../../relay-runtime/util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+} from '../../../relay-runtime/network/RelayNetworkTypes';
 
 import type {
   loadQueryTestQuery$data,
@@ -92,13 +101,19 @@ describe('loadQuery', () => {
 
   beforeEach(() => {
     fetch = jest.fn(
-      (_query, _variables, _cacheConfig, _uploadables, _logRequestInfo) => {
+      (
+        _query: RequestParameters,
+        _variables: Variables,
+        _cacheConfig: CacheConfig,
+        _uploadables: ?UploadableMap,
+        _logRequestInfo: ?LogRequestInfoFunction,
+      ) => {
         const observable = Observable.create<$FlowFixMe>(_sink => {
           sink = _sink;
         });
         // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         const originalSubscribe = observable.subscribe.bind(observable);
-        networkUnsubscribe = jest.fn();
+        networkUnsubscribe = jest.fn<[], $FlowFixMe>();
         jest.spyOn(observable, 'subscribe').mockImplementation((...args) => {
           const subscription = originalSubscribe(...args);
           jest
@@ -127,7 +142,7 @@ describe('loadQuery', () => {
       .spyOn(PreloadableQueryRegistry, 'onLoad')
       .mockImplementation((key, cb) => {
         executeOnloadCallback = cb;
-        disposeOnloadCallback = jest.fn();
+        disposeOnloadCallback = jest.fn<$ReadOnlyArray<mixed>, mixed>();
         return {dispose: disposeOnloadCallback};
       });
 

--- a/packages/react-relay/relay-hooks/__tests__/loadQuery-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadQuery-test.js
@@ -11,15 +11,14 @@
 
 'use strict';
 import type {
-  Variables,
-  CacheConfig,
-} from '../../../relay-runtime/util/RelayRuntimeTypes';
+  LogRequestInfoFunction,
+  UploadableMap,
+} from '../../../relay-runtime/network/RelayNetworkTypes';
 import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
 import type {
-  UploadableMap,
-  LogRequestInfoFunction,
-} from '../../../relay-runtime/network/RelayNetworkTypes';
-
+  CacheConfig,
+  Variables,
+} from '../../../relay-runtime/util/RelayRuntimeTypes';
 import type {
   loadQueryTestQuery$data,
   loadQueryTestQuery$variables,

--- a/packages/react-relay/relay-hooks/__tests__/preloadQuery_DEPRECATED-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/preloadQuery_DEPRECATED-test.js
@@ -78,7 +78,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         let operation;
 
         beforeEach(() => {
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           fetch = jest.fn((_query, _variables, _cacheConfig) => {
+            // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
             return Observable.create(_sink => {
               sink = _sink;
             });
@@ -105,6 +107,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
           // $FlowFixMe[method-unbinding] added when improving typing for this parameters
           const environmentCheck = environment.check;
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           check = jest.fn((...args) =>
             environmentCheck.apply(environment, args),
           );
@@ -793,7 +796,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         let variables;
 
         beforeEach(() => {
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           fetch = jest.fn((_query, _variables, _cacheConfig) => {
+            // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
             return Observable.create(_sink => {
               sink = _sink;
             });
@@ -942,7 +947,9 @@ describe('Preload queries that use provided variables', () => {
   let operation;
 
   beforeEach(() => {
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     fetch = jest.fn((_query, _variables, _cacheConfig) => {
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       return Observable.create(_sink => {});
     });
 

--- a/packages/react-relay/relay-hooks/__tests__/preloadQuery_DEPRECATED-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/preloadQuery_DEPRECATED-test.js
@@ -45,7 +45,6 @@ const query = graphql`
 `;
 
 // Only queries with an ID are preloadable
-// $FlowFixMe[cannot-write]
 query.params.id = '12345';
 
 const params = {
@@ -920,7 +919,6 @@ describe('Preload queries that use provided variables', () => {
   };
 
   // Only queries with an ID are preloadable
-  // $FlowFixMe[cannot-write]
   queryWithProvidedVar.params.id = '12346';
 
   const paramsWithProvidedVar = {

--- a/packages/react-relay/relay-hooks/__tests__/useBlockingPaginationFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useBlockingPaginationFragment-test.js
@@ -141,7 +141,9 @@ describe('useBlockingPaginationFragment', () => {
 
   beforeEach(() => {
     // Set up mocks
-    renderSpy = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
+    renderSpy = jest.fn<_, mixed>();
 
     // Set up environment and base data
     environment = createMockEnvironment({
@@ -716,7 +718,7 @@ describe('useBlockingPaginationFragment', () => {
     let release;
 
     beforeEach(() => {
-      release = jest.fn();
+      release = jest.fn<$ReadOnlyArray<mixed>, mixed>();
       // $FlowFixMe[method-unbinding] added when improving typing for this parameters
       environment.retain.mockImplementation((...args) => {
         return {
@@ -815,7 +817,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('does not load more if request is already in flight', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -861,7 +863,7 @@ describe('useBlockingPaginationFragment', () => {
       it('does not load more if parent query is already active (i.e. during streaming)', () => {
         fetchQuery(environment, query).subscribe({});
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         environment.execute.mockClear();
         renderFragment();
@@ -884,7 +886,7 @@ describe('useBlockingPaginationFragment', () => {
 
       describe('cancellation', () => {
         it('cancels load more if component unmounts', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -937,7 +939,7 @@ describe('useBlockingPaginationFragment', () => {
         });
 
         it('cancels load more if refetch is called', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -1019,7 +1021,7 @@ describe('useBlockingPaginationFragment', () => {
             },
           },
         });
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
 
         const renderer = renderFragment();
         const expectedUser = {
@@ -1090,7 +1092,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('loads and renders next items in connection', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -1212,7 +1214,7 @@ describe('useBlockingPaginationFragment', () => {
           },
         };
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment({owner: queryWithLiteralArgs});
         expectFragmentResults([
           {
@@ -1319,7 +1321,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('correctly loads and renders next items when paginating multiple times', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -1525,7 +1527,7 @@ describe('useBlockingPaginationFragment', () => {
       // TODO(T64875643): Re-enable after next React sync to fbsource
       // eslint-disable-next-line jest/no-disabled-tests
       it.skip('does not suspend if pagination update is interruped before it commits (unsuspends)', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment({isConcurrent: true});
         expectFragmentResults([
           {
@@ -1657,7 +1659,7 @@ describe('useBlockingPaginationFragment', () => {
           jest.requireActual<any>('../useLoadMoreFunction')(...args),
         );
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -1711,7 +1713,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('renders with latest updated data from any updates missed while suspended for pagination', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -1831,7 +1833,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('correctly updates when fragment data changes after pagination', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -2012,7 +2014,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('(currently) reset the pagination to the initial state (even after a successful `loadNext`) in cases when a payload with missing data for the connection is published to the store.', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -2149,7 +2151,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('loads more correctly when original variables do not include an id', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const viewer = environment.lookup(queryWithoutID.fragment).data?.viewer;
         const userRef =
           typeof viewer === 'object' && viewer != null ? viewer?.actor : null;
@@ -2276,7 +2278,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('loads more with correct id from refetchable fragment when using a nested fragment', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
 
         // Populate store with data for query using nested fragment
         environment.commitPayload(queryNestedFragment, {
@@ -2443,7 +2445,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('calls callback with error when error occurs during fetch', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -2494,7 +2496,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('preserves pagination request if re-rendered with same fragment ref', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -2614,7 +2616,7 @@ describe('useBlockingPaginationFragment', () => {
 
       describe('extra variables', () => {
         it('loads and renders the next items in the connection when passing extra variables', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2723,7 +2725,7 @@ describe('useBlockingPaginationFragment', () => {
         });
 
         it('loads the next items in the connection and ignores any pagination vars passed as extra vars', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2841,7 +2843,7 @@ describe('useBlockingPaginationFragment', () => {
 
       describe('disposing', () => {
         it('disposes ongoing request if environment changes', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2948,7 +2950,7 @@ describe('useBlockingPaginationFragment', () => {
         });
 
         it('disposes ongoing request if fragment ref changes', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -3066,7 +3068,7 @@ describe('useBlockingPaginationFragment', () => {
         });
 
         it('disposes ongoing request on unmount', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -3123,7 +3125,7 @@ describe('useBlockingPaginationFragment', () => {
         });
 
         it('disposes ongoing request if it is manually disposed', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -3514,7 +3516,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('updates after pagination if more results are available', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -3620,7 +3622,7 @@ describe('useBlockingPaginationFragment', () => {
       });
 
       it('updates after pagination if no more results are available', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {

--- a/packages/react-relay/relay-hooks/__tests__/useBlockingPaginationFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useBlockingPaginationFragment-test.js
@@ -444,7 +444,6 @@ describe('useBlockingPaginationFragment', () => {
               </ContextProvider>
             </React.Suspense>
           </ErrorBoundary>,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: isConcurrent},
         );
       });

--- a/packages/react-relay/relay-hooks/__tests__/useBlockingPaginationFragment-with-suspense-transition-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useBlockingPaginationFragment-with-suspense-transition-test.js
@@ -214,7 +214,7 @@ describe('useBlockingPaginationFragment with useTransition', () => {
       environment = createMockEnvironment({
         handlerProvider: () => ConnectionHandler,
       });
-      release = jest.fn();
+      release = jest.fn<$ReadOnlyArray<mixed>, mixed>();
       // $FlowFixMe[method-unbinding] added when improving typing for this parameters
       environment.retain.mockImplementation((...args) => {
         return {
@@ -491,7 +491,7 @@ describe('useBlockingPaginationFragment with useTransition', () => {
 
       // Sanity check test, should already be tested in useBlockingPagination test
       it('loads and renders next items in connection', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<$ReadOnlyArray<mixed>, mixed>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -595,7 +595,7 @@ describe('useBlockingPaginationFragment with useTransition', () => {
       });
 
       it('renders pending flag correctly if pagination update is interrupted before it commits (unsuspends)', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<$ReadOnlyArray<mixed>, mixed>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -724,7 +724,7 @@ describe('useBlockingPaginationFragment with useTransition', () => {
       });
 
       it('loads more correctly when original variables do not include an id', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<$ReadOnlyArray<mixed>, mixed>();
         const viewer = environment.lookup(queryWithoutID.fragment).data?.viewer;
         const userRef =
           typeof viewer === 'object' && viewer != null ? viewer?.actor : null;
@@ -851,7 +851,7 @@ describe('useBlockingPaginationFragment with useTransition', () => {
       });
 
       it('calls callback with error when error occurs during fetch', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<$ReadOnlyArray<mixed>, mixed>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -893,7 +893,7 @@ describe('useBlockingPaginationFragment with useTransition', () => {
       });
 
       it('preserves pagination request if re-rendered with same fragment ref', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<$ReadOnlyArray<mixed>, mixed>();
         const renderer = renderFragment();
         expectFragmentResults([
           {

--- a/packages/react-relay/relay-hooks/__tests__/useBlockingPaginationFragment-with-suspense-transition-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useBlockingPaginationFragment-with-suspense-transition-test.js
@@ -451,7 +451,6 @@ describe('useBlockingPaginationFragment with useTransition', () => {
               </ContextProvider>
             </React.Suspense>
           </ErrorBoundary>,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: isConcurrent},
         );
       };

--- a/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-react-double-effects-test.js
@@ -94,7 +94,7 @@ describe.skip('useEntryPointLoader-react-double-effects', () => {
       getEnvironment: () => environment,
     };
 
-    release = jest.fn();
+    release = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalRetain = environment.retain;
     (environment: $FlowFixMe).retain = jest.fn(operation => {
@@ -107,7 +107,7 @@ describe.skip('useEntryPointLoader-react-double-effects', () => {
       };
     });
 
-    cancelNetworkRequest = jest.fn();
+    cancelNetworkRequest = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalExecuteWithSource = environment.executeWithSource;
     (environment: $FlowFixMe).executeWithSource = jest.fn((...args) => {
@@ -163,17 +163,21 @@ describe.skip('useEntryPointLoader-react-double-effects', () => {
     loaderRenderLogs = [];
     LoaderComponent = function (props: any) {
       // $FlowFixMe[underconstrained-implicit-instantiation]
-      const [entryPointRef] = useEntryPointLoader(
-        environmentProvider,
-        props.entryPoint,
-        {
-          TEST_ONLY__initialEntryPointData: {
-            entryPointParams:
-              props.initialEntryPointRef != null ? variables : null,
-            entryPointReference: props.initialEntryPointRef,
-          },
+      const [entryPointRef] = useEntryPointLoader<
+        _,
+        {...},
+        {...},
+        {...},
+        mixed,
+        _,
+        _,
+      >(environmentProvider, props.entryPoint, {
+        TEST_ONLY__initialEntryPointData: {
+          entryPointParams:
+            props.initialEntryPointRef != null ? variables : null,
+          entryPointReference: props.initialEntryPointRef,
         },
-      );
+      });
 
       let entryPointRefId;
       if (entryPointRef == null) {

--- a/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-react-double-effects-test.js
@@ -136,7 +136,6 @@ describe.skip('useEntryPointLoader-react-double-effects', () => {
         }
       }
     `;
-    // $FlowFixMe
     gqlQuery.params.cacheID = 'TestQuery';
     variables = {id: '1'};
     query = createOperationDescriptor(gqlQuery, variables);
@@ -272,7 +271,6 @@ describe.skip('useEntryPointLoader-react-double-effects', () => {
               </React.Suspense>
             </RelayEnvironmentProvider>
           </React.StrictMode>,
-          // $FlowFixMe
           {unstable_isConcurrent: true},
         );
       });

--- a/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {EntryPointComponent} from '../EntryPointTypes.flow';
 import type {EnvironmentProviderOptions} from '../EntryPointTypes.flow';
 import type {IEnvironment} from 'relay-runtime/store/RelayStoreTypes';
 
@@ -32,12 +33,16 @@ let render;
 let Container;
 let defaultEntryPoint: any;
 
-const loadEntryPoint = jest.fn().mockImplementation(() => {
-  dispose = jest.fn();
-  return (loadEntryPointLastReturnValue = {
-    dispose,
+const loadEntryPoint = jest
+  /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+   * enabling Flow LTI mode */
+  .fn<_, {dispose: JestMockFn<$ReadOnlyArray<mixed>, mixed>}>()
+  .mockImplementation(() => {
+    dispose = jest.fn();
+    return (loadEntryPointLastReturnValue = {
+      dispose,
+    });
   });
-});
 jest.mock('../loadEntryPoint', () => loadEntryPoint);
 
 beforeEach(() => {
@@ -177,10 +182,15 @@ it('does not dispose the entry point before the new component tree unsuspends in
     function ComponentWithHook() {
       // $FlowFixMe[incompatible-call]
       // $FlowFixMe[underconstrained-implicit-instantiation]
-      [, entryPointLoaderCallback] = useEntryPointLoader(
-        defaultEnvironmentProvider,
-        defaultEntryPoint,
-      );
+      [, entryPointLoaderCallback] = useEntryPointLoader<
+        {...},
+        {...},
+        {...},
+        {...},
+        mixed,
+        EntryPointComponent<{...}, {...}, {...}, mixed>,
+        _,
+      >(defaultEnvironmentProvider, defaultEntryPoint);
       return null;
     }
 
@@ -283,10 +293,15 @@ it('disposes entry point references associated with previous suspensions when mu
     function Inner({promise}: {promise: ?Promise<any>}) {
       // $FlowFixMe[incompatible-call]
       // $FlowFixMe[underconstrained-implicit-instantiation]
-      [, entryPointLoaderCallback] = useEntryPointLoader(
-        defaultEnvironmentProvider,
-        defaultEntryPoint,
-      );
+      [, entryPointLoaderCallback] = useEntryPointLoader<
+        {...},
+        {...},
+        {...},
+        {...},
+        mixed,
+        EntryPointComponent<{...}, {...}, {...}, mixed>,
+        _,
+      >(defaultEnvironmentProvider, defaultEntryPoint);
       if (
         promise == null ||
         (promise === resolvableSuspensePromise && resolved)
@@ -384,10 +399,15 @@ it('disposes entry point references associated with subsequent suspensions when 
     function Inner({promise}: {promise: ?Promise<any>}) {
       // $FlowFixMe[incompatible-call]
       // $FlowFixMe[underconstrained-implicit-instantiation]
-      [, entryPointLoaderCallback] = useEntryPointLoader(
-        defaultEnvironmentProvider,
-        defaultEntryPoint,
-      );
+      [, entryPointLoaderCallback] = useEntryPointLoader<
+        {...},
+        {...},
+        {...},
+        {...},
+        mixed,
+        EntryPointComponent<{...}, {...}, {...}, mixed>,
+        _,
+      >(defaultEnvironmentProvider, defaultEntryPoint);
       if (
         promise == null ||
         (promise === resolvableSuspensePromise && resolved)

--- a/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-test.js
@@ -194,10 +194,9 @@ it('does not dispose the entry point before the new component tree unsuspends in
 
     function concurrentRender() {
       ReactTestRenderer.act(() => {
-        instance = ReactTestRenderer.create(
-          <ConcurrentWrapper />,
-          {unstable_isConcurrent: true},
-        );
+        instance = ReactTestRenderer.create(<ConcurrentWrapper />, {
+          unstable_isConcurrent: true,
+        });
       });
     }
 
@@ -262,10 +261,9 @@ it('disposes entry point references associated with previous suspensions when mu
 
     function concurrentRender() {
       ReactTestRenderer.act(() => {
-        instance = ReactTestRenderer.create(
-          <ConcurrentWrapper />,
-          {unstable_isConcurrent: true},
-        );
+        instance = ReactTestRenderer.create(<ConcurrentWrapper />, {
+          unstable_isConcurrent: true,
+        });
       });
     }
 
@@ -364,10 +362,9 @@ it('disposes entry point references associated with subsequent suspensions when 
 
     function concurrentRender() {
       ReactTestRenderer.act(() => {
-        instance = ReactTestRenderer.create(
-          <ConcurrentWrapper />,
-          {unstable_isConcurrent: true},
-        );
+        instance = ReactTestRenderer.create(<ConcurrentWrapper />, {
+          unstable_isConcurrent: true,
+        });
       });
     }
 

--- a/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useEntryPointLoader-test.js
@@ -180,8 +180,6 @@ it('does not dispose the entry point before the new component tree unsuspends in
     }
 
     function ComponentWithHook() {
-      // $FlowFixMe[incompatible-call]
-      // $FlowFixMe[underconstrained-implicit-instantiation]
       [, entryPointLoaderCallback] = useEntryPointLoader<
         {...},
         {...},
@@ -198,7 +196,6 @@ it('does not dispose the entry point before the new component tree unsuspends in
       ReactTestRenderer.act(() => {
         instance = ReactTestRenderer.create(
           <ConcurrentWrapper />,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: true},
         );
       });
@@ -267,7 +264,6 @@ it('disposes entry point references associated with previous suspensions when mu
       ReactTestRenderer.act(() => {
         instance = ReactTestRenderer.create(
           <ConcurrentWrapper />,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: true},
         );
       });
@@ -291,8 +287,6 @@ it('disposes entry point references associated with previous suspensions when mu
     }
 
     function Inner({promise}: {promise: ?Promise<any>}) {
-      // $FlowFixMe[incompatible-call]
-      // $FlowFixMe[underconstrained-implicit-instantiation]
       [, entryPointLoaderCallback] = useEntryPointLoader<
         {...},
         {...},
@@ -372,7 +366,6 @@ it('disposes entry point references associated with subsequent suspensions when 
       ReactTestRenderer.act(() => {
         instance = ReactTestRenderer.create(
           <ConcurrentWrapper />,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: true},
         );
       });
@@ -397,8 +390,6 @@ it('disposes entry point references associated with subsequent suspensions when 
 
     let innerUnsuspendedCorrectly = false;
     function Inner({promise}: {promise: ?Promise<any>}) {
-      // $FlowFixMe[incompatible-call]
-      // $FlowFixMe[underconstrained-implicit-instantiation]
       [, entryPointLoaderCallback] = useEntryPointLoader<
         {...},
         {...},

--- a/packages/react-relay/relay-hooks/__tests__/useFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragment-test.js
@@ -111,7 +111,10 @@ describe.each([
   }
 
   beforeEach(() => {
-    renderSpy = jest.fn();
+    renderSpy = jest.fn<
+      [useFragmentTestUserFragment$data | useFragmentTestUsersFragment$data],
+      mixed,
+    >();
 
     // Set up environment and base data
     environment = createMockEnvironment();

--- a/packages/react-relay/relay-hooks/__tests__/useFragmentNode-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragmentNode-react-double-effects-test.js
@@ -33,7 +33,7 @@ describe.skip('useFragmentNode-react-double-effects-test', () => {
     jest.mock('scheduler', () => require('scheduler/unstable_mock'));
     jest.mock('warning');
     jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
-    renderSpy = jest.fn();
+    renderSpy = jest.fn<$ReadOnlyArray<mixed>, mixed>();
 
     // Set up environment and base data
     environment = createMockEnvironment();

--- a/packages/react-relay/relay-hooks/__tests__/useFragmentNode-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragmentNode-react-double-effects-test.js
@@ -96,7 +96,6 @@ describe.skip('useFragmentNode-react-double-effects-test', () => {
             <FragmentComponent user={data?.node} />
           </RelayEnvironmentProvider>
         </React.StrictMode>,
-        // $FlowFixMe
         {unstable_isConcurrent: true},
       );
     });

--- a/packages/react-relay/relay-hooks/__tests__/useFragmentNode-required-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragmentNode-required-test.js
@@ -57,7 +57,9 @@ beforeEach(() => {
   jest.resetModules();
   jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
   jest.mock('warning');
-  renderSpy = jest.fn();
+  /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+   * enabling Flow LTI mode */
+  renderSpy = jest.fn<_, mixed>();
 
   // Set up environment and base data
   environment = createMockEnvironment();

--- a/packages/react-relay/relay-hooks/__tests__/useFragmentNode-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragmentNode-test.js
@@ -240,8 +240,8 @@ describe.each([
       jest.mock('scheduler', () => {
         return jest.requireActual('scheduler/unstable_mock');
       });
-      commitSpy = jest.fn();
-      renderSpy = jest.fn();
+      commitSpy = jest.fn<any | [any], mixed>();
+      renderSpy = jest.fn<[any], mixed>();
 
       // Set up environment and base data
       environment = createMockEnvironment();

--- a/packages/react-relay/relay-hooks/__tests__/useFragmentNode-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragmentNode-test.js
@@ -443,13 +443,10 @@ describe.each([
           existing.update(elements);
           return existing;
         } else {
-          return TestRenderer.create(
-            elements,
-            {
-              unstable_isConcurrent: isConcurrent,
-              unstable_concurrentUpdatesByDefault: true,
-            },
-          );
+          return TestRenderer.create(elements, {
+            unstable_isConcurrent: isConcurrent,
+            unstable_concurrentUpdatesByDefault: true,
+          });
         }
       };
     });

--- a/packages/react-relay/relay-hooks/__tests__/useFragmentNode-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragmentNode-test.js
@@ -415,7 +415,6 @@ describe.each([
               <SingularContainer owner={singularQuery} {...props} />
             </ContextProvider>
           </React.Suspense>,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {
             unstable_isConcurrent: isConcurrent,
             unstable_concurrentUpdatesByDefault: true,
@@ -446,7 +445,6 @@ describe.each([
         } else {
           return TestRenderer.create(
             elements,
-            // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
             {
               unstable_isConcurrent: isConcurrent,
               unstable_concurrentUpdatesByDefault: true,

--- a/packages/react-relay/relay-hooks/__tests__/useIsParentQueryActive-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useIsParentQueryActive-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Sink} from '../../../relay-runtime/network/RelayObservable';
 
 const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const useIsParentQueryActive = require('../useIsParentQueryActive');
@@ -44,10 +45,27 @@ let query;
 beforeEach(() => {
   const source = new RecordSource();
   const store = new Store(source);
-  fetch = jest.fn((_query, _variables, _cacheConfig) =>
-    Observable.create(sink => {
-      dataSource = sink;
-    }),
+  fetch = jest.fn(
+    (
+      _query: $FlowExpectedError,
+      _variables: $FlowExpectedError,
+      _cacheConfig: $FlowExpectedError,
+    ) =>
+      Observable.create(
+        (
+          sink: Sink<
+            | {
+                data: {__typename: string, id: string, name: string},
+                label: string,
+                path: Array<string>,
+              }
+            | {data: {node: {__typename: string, id: string}}}
+            | {data: {node: {__typename: string, id: string, name: string}}},
+          >,
+        ) => {
+          dataSource = sink;
+        },
+      ),
   );
   environment = new Environment({
     network: Network.create((fetch: $FlowFixMe)),
@@ -188,7 +206,7 @@ it('returns false when owner fetch completed', () => {
 });
 
 it('returns false when owner fetch errored', () => {
-  const onError = jest.fn();
+  const onError = jest.fn<[Error], mixed>();
   fetchQuery(environment, operation).subscribe({
     error: onError,
   });
@@ -295,7 +313,7 @@ it('updates the component when a pending owner fetch completes', () => {
 });
 
 it('updates the component when a pending owner fetch errors', () => {
-  const onError = jest.fn();
+  const onError = jest.fn<[Error], mixed>();
   fetchQuery(environment, operation).subscribe({
     error: onError,
   });

--- a/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-fast-refresh-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-fast-refresh-test.js
@@ -102,7 +102,7 @@ describe('useLazyLoadQueryNode-fast-refresh', () => {
     variables = {id: '1'};
     query = createOperationDescriptor(gqlQuery, variables);
     // $FlowFixMe[incompatible-use]
-    renderFn = jest.fn(result => result?.node?.name ?? 'Empty');
+    renderFn = jest.fn((result: mixed) => result?.node?.name ?? 'Empty');
   });
 
   afterEach(() => {

--- a/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-fast-refresh-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-fast-refresh-test.js
@@ -111,7 +111,6 @@ describe('useLazyLoadQueryNode-fast-refresh', () => {
   });
 
   it('force a refetch in fast refresh', () => {
-    // $FlowFixMe[cannot-resolve-module] This module is not available on www.
     const ReactRefreshRuntime = require('react-refresh/runtime');
     ReactRefreshRuntime.injectIntoGlobalHook(global);
     const V1 = function (props: {variables: {id: string}}) {

--- a/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-react-double-effects-test.js
@@ -97,7 +97,7 @@ describe.skip('useLazyLoadQueryNode-react-double-effects', () => {
 
     environment = createMockEnvironment();
 
-    release = jest.fn();
+    release = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalRetain = environment.retain;
     (environment: $FlowFixMe).retain = jest.fn(operation => {
@@ -110,7 +110,7 @@ describe.skip('useLazyLoadQueryNode-react-double-effects', () => {
       };
     });
 
-    cancelNetworkRequest = jest.fn();
+    cancelNetworkRequest = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalExecute = environment.execute;
     (environment: $FlowFixMe).execute = jest.fn((...args) => {

--- a/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-react-double-effects-test.js
@@ -166,7 +166,6 @@ describe.skip('useLazyLoadQueryNode-react-double-effects', () => {
             </React.Suspense>
           </RelayEnvironmentProvider>
         </React.StrictMode>,
-        // $FlowFixMe
         {unstable_isConcurrent: true},
       );
     });
@@ -301,7 +300,6 @@ describe.skip('useLazyLoadQueryNode-react-double-effects', () => {
             </React.Suspense>
           </RelayEnvironmentProvider>
         </React.StrictMode>,
-        // $FlowFixMe
         {unstable_isConcurrent: true},
       );
     });
@@ -426,7 +424,6 @@ describe.skip('useLazyLoadQueryNode-react-double-effects', () => {
               </React.Suspense>
             </RelayEnvironmentProvider>
           </React.StrictMode>,
-          // $FlowFixMe
           {unstable_isConcurrent: true},
         );
       });
@@ -610,7 +607,6 @@ describe.skip('useLazyLoadQueryNode-react-double-effects', () => {
               </React.Suspense>
             </RelayEnvironmentProvider>
           </React.StrictMode>,
-          // $FlowFixMe
           {unstable_isConcurrent: true},
         );
       });

--- a/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useLazyLoadQueryNode-test.js
@@ -115,7 +115,7 @@ describe('useLazyLoadQueryNode', () => {
   let errorBoundaryDidCatchFn;
 
   beforeEach(() => {
-    errorBoundaryDidCatchFn = jest.fn();
+    errorBoundaryDidCatchFn = jest.fn<[Error], mixed>();
 
     class ErrorBoundary extends React.Component<any, any> {
       state: any | {error: null} = {error: null};
@@ -172,10 +172,11 @@ describe('useLazyLoadQueryNode', () => {
       },
       store: new Store(new RecordSource(), {gcReleaseBufferSize: 0}),
     });
-    release = jest.fn();
+    release = jest.fn<[mixed], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalRetain = environment.retain.bind(environment);
     // $FlowFixMe[cannot-write]
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     environment.retain = jest.fn((...args) => {
       const originalDisposable = originalRetain(...args);
       return {
@@ -203,7 +204,7 @@ describe('useLazyLoadQueryNode', () => {
 
     variables = {id: '1'};
     query = createOperationDescriptor(gqlQuery, variables);
-    renderFn = jest.fn(result => result?.node?.name ?? 'Empty');
+    renderFn = jest.fn((result: any) => result?.node?.name ?? 'Empty');
   });
 
   afterEach(() => {

--- a/packages/react-relay/relay-hooks/__tests__/useMutation-fast-refresh-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useMutation-fast-refresh-test.js
@@ -68,7 +68,7 @@ describe('useLazyLoadQueryNode', () => {
         }
       }
     `;
-    isInFlightFn = jest.fn(val => val);
+    isInFlightFn = jest.fn((val: boolean) => val);
   });
 
   afterEach(() => {

--- a/packages/react-relay/relay-hooks/__tests__/useMutation-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useMutation-test.js
@@ -64,7 +64,7 @@ const variables = {
 
 beforeEach(() => {
   environment = createMockEnvironment();
-  isInFlightFn = jest.fn();
+  isInFlightFn = jest.fn<[boolean], mixed>();
 
   CommentCreateMutation = graphql`
     mutation useMutationTest1Mutation($input: CommentCreateInput) {
@@ -327,8 +327,8 @@ it('returns in-flight state that tracks all current mutations when disposed or e
 });
 
 it('calls onCompleted when mutation responses contains server errors', () => {
-  const onError = jest.fn();
-  const onCompleted = jest.fn();
+  const onError = jest.fn<$ReadOnlyArray<mixed>, mixed>();
+  const onCompleted = jest.fn<$ReadOnlyArray<mixed>, mixed>();
   render(environment, CommentCreateMutation);
   commit({variables, onError, onCompleted});
   // $FlowFixMe[method-unbinding] added when improving typing for this parameters
@@ -371,8 +371,8 @@ it('calls onCompleted when mutation responses contains server errors', () => {
   expect(isInFlightFn).toBeCalledWith(false);
 });
 it('calls onError when mutation errors in commitMutation', () => {
-  const onError = jest.fn();
-  const onCompleted = jest.fn();
+  const onError = jest.fn<$ReadOnlyArray<mixed>, mixed>();
+  const onCompleted = jest.fn<$ReadOnlyArray<mixed>, mixed>();
   const throwingUpdater = () => {
     throw new Error('<error0>');
   };
@@ -390,8 +390,8 @@ it('calls onError when mutation errors in commitMutation', () => {
 });
 
 it('calls onComplete when mutation successfully resolved', () => {
-  const onError = jest.fn();
-  const onCompleted = jest.fn();
+  const onError = jest.fn<$ReadOnlyArray<mixed>, mixed>();
+  const onCompleted = jest.fn<$ReadOnlyArray<mixed>, mixed>();
   render(environment, CommentCreateMutation);
   commit({variables, onError, onCompleted});
 
@@ -551,7 +551,7 @@ describe('unmount', () => {
   });
 
   it('does not dispose previous in-flight mutaiton ', () => {
-    const onCompleted = jest.fn();
+    const onCompleted = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     render(environment, CommentCreateMutation);
     commit({variables, onCompleted});
     ReactTestRenderer.act(() => instance.unmount());

--- a/packages/react-relay/relay-hooks/__tests__/usePaginationFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePaginationFragment-test.js
@@ -189,7 +189,6 @@ describe.each([
   }
 
   function resolveQuery(payload: mixed) {
-    // $FlowFixMe[incompatible-call]
     dataSource.next(payload);
     dataSource.complete();
   }
@@ -222,11 +221,9 @@ describe.each([
         _variables: Variables,
         _cacheConfig: CacheConfig,
       ) => {
-        // $FlowFixMe[incompatible-call]
         return Observable.create((sink: Sink<mixed>) => {
           dataSource = sink;
           unsubscribe = jest.fn<[], mixed>();
-          // $FlowFixMe[incompatible-call]
           return unsubscribe;
         });
       },
@@ -234,7 +231,6 @@ describe.each([
     const environment = new Environment({
       getDataID: (data: {[string]: mixed}, typename: string) => {
         // This is the default, but making it explicit in case we need to override
-        // $FlowFixMe[prop-missing]
         return data.id;
       },
       // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
@@ -568,7 +564,6 @@ describe.each([
           [ID_KEY]:
             owner.request.variables.id ?? owner.request.variables.nodeID,
           [FRAGMENTS_KEY]: {
-            // $FlowFixMe[invalid-computed-prop] Error found while enabling LTI on this file
             [fragment.name]: {},
           },
           [FRAGMENT_OWNER_KEY]: owner.request,
@@ -620,7 +615,6 @@ describe.each([
               </ContextProvider>
             </React.Suspense>
           </ErrorBoundary>,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: isConcurrent},
         );
       });
@@ -869,7 +863,6 @@ describe.each([
     });
 
     function expectRequestIsInFlight(expected: any) {
-      // $FlowFixMe[method-unbinding] added when improving typing for this parameters
       expect(fetch).toBeCalledTimes(expected.requestCount);
       const fetchCall = fetch.mock.calls.find(call => {
         return (
@@ -951,7 +944,6 @@ describe.each([
             'Relay: Unexpected fetch on unmounted component',
           ),
         ).toEqual(true);
-        // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         expect(fetch).toHaveBeenCalledTimes(0);
       });
 
@@ -981,7 +973,6 @@ describe.each([
             'Relay: Unexpected fetch while using a null fragment ref',
           ),
         ).toEqual(true);
-        // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         expect(fetch).toHaveBeenCalledTimes(0);
       });
 
@@ -1024,7 +1015,6 @@ describe.each([
         TestRenderer.act(() => {
           loadNext(1, {onComplete: callback});
         });
-        // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         expect(fetch).toBeCalledTimes(1);
         expect(callback).toBeCalledTimes(1);
         expect(renderSpy).toBeCalledTimes(0);
@@ -1040,7 +1030,6 @@ describe.each([
         fetchQuery(environment, query).subscribe({});
 
         const callback = jest.fn<[Error | null], void>();
-        // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         fetch.mockClear();
         renderFragment();
 
@@ -1057,7 +1046,6 @@ describe.each([
         TestRenderer.act(() => {
           loadNext(1, {onComplete: callback});
         });
-        // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         expect(fetch).toBeCalledTimes(0);
         expect(callback).toBeCalledTimes(1);
         expect(renderSpy).toBeCalledTimes(0);
@@ -1141,7 +1129,6 @@ describe.each([
               id: '1',
               name: 'Alice',
               friends: {
-                // $FlowFixMe[missing-empty-array-annot]
                 edges: [],
                 pageInfo: {
                   startCursor: null,
@@ -2208,7 +2195,6 @@ describe.each([
             jest.runAllTimers();
           });
           expect(unsubscribe).toHaveBeenCalledTimes(1);
-          // $FlowFixMe[method-unbinding] added when improving typing for this parameters
           expect(fetch).toBeCalledTimes(1);
           expect(callback).toBeCalledTimes(0);
           expect(renderSpy).toBeCalledTimes(0);
@@ -2254,11 +2240,9 @@ describe.each([
           TestRenderer.act(() => {
             refetch({id: '4'});
           });
-          // $FlowFixMe[method-unbinding] added when improving typing for this parameters
           expect(fetch).toBeCalledTimes(2); // loadNext and refetch
           expect(loadNextUnsubscribe).toHaveBeenCalledTimes(1); // loadNext is cancelled
           expect(unsubscribe).toHaveBeenCalledTimes(0); // refetch is not cancelled
-          // $FlowFixMe[method-unbinding] added when improving typing for this parameters
           expect(callback).toBeCalledTimes(0);
           expect(renderSpy).toBeCalledTimes(0);
         });
@@ -2732,7 +2716,6 @@ describe.each([
             },
           ]);
 
-          // $FlowFixMe[method-unbinding] added when improving typing for this parameters
           fetch.mockClear();
           renderSpy.mockClear();
           // Call `capturedLoadNext`, which should be a no-op since it's
@@ -2743,7 +2726,6 @@ describe.each([
           });
 
           // Assert that calling `capturedLoadNext` is a no-op
-          // $FlowFixMe[method-unbinding] added when improving typing for this parameters
           expect(fetch).toBeCalledTimes(0);
           expect(renderSpy).toBeCalledTimes(0);
 
@@ -2755,7 +2737,6 @@ describe.each([
           });
 
           // Assert that calling `loadNext` starts the request
-          // $FlowFixMe[method-unbinding] added when improving typing for this parameters
           expect(fetch).toBeCalledTimes(1);
           expect(renderSpy).toBeCalledTimes(1);
         });
@@ -3350,7 +3331,6 @@ describe.each([
         refetchVariables: Variables,
         requestCount: number,
       }) {
-        // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         expect(fetch).toBeCalledTimes(expected.requestCount);
         const fetchCall = fetch.mock.calls.find(call => {
           return (
@@ -3944,7 +3924,6 @@ describe.each([
         expect(environment.retain.mock.calls[0][0]).toEqual(paginationQuery);
 
         // Paginate after refetching
-        // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         fetch.mockClear();
         TestRenderer.act(() => {
           loadNext(1);
@@ -4060,8 +4039,6 @@ describe.each([
           }
         `;
 
-        // $FlowFixMe[prop-missing]
-        // $FlowFixMe[incompatible-type-arg]
         gqlFragment = graphql`
           fragment usePaginationFragmentTestStoryFragment on NonNodeStory
           @argumentDefinitions(

--- a/packages/react-relay/relay-hooks/__tests__/usePaginationFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePaginationFragment-test.js
@@ -10,10 +10,9 @@
  */
 
 'use strict';
-import type {CacheConfig} from '../../../relay-runtime/util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
 import type {Sink} from '../../../relay-runtime/network/RelayObservable';
-
+import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
+import type {CacheConfig} from '../../../relay-runtime/util/RelayRuntimeTypes';
 import type {
   usePaginationFragmentTestStoryFragmentRefetchQuery$data,
   usePaginationFragmentTestStoryFragmentRefetchQuery$variables,

--- a/packages/react-relay/relay-hooks/__tests__/usePaginationFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePaginationFragment-test.js
@@ -10,6 +10,9 @@
  */
 
 'use strict';
+import type {CacheConfig} from '../../../relay-runtime/util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
+import type {Sink} from '../../../relay-runtime/network/RelayObservable';
 
 import type {
   usePaginationFragmentTestStoryFragmentRefetchQuery$data,
@@ -134,6 +137,8 @@ describe.each([
   }
 
   function usePaginationFragment(fragmentNode: any, fragmentRef: any) {
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const {data, ...result} = usePaginationFragmentOriginal(
       fragmentNode,
       fragmentRef,
@@ -212,15 +217,21 @@ describe.each([
   function createMockEnvironment() {
     const source = RecordSource.create();
     const store = new Store(source);
-    const fetchFn = jest.fn((_query, _variables, _cacheConfig) => {
-      // $FlowFixMe[incompatible-call]
-      return Observable.create(sink => {
-        dataSource = sink;
-        unsubscribe = jest.fn();
+    const fetchFn = jest.fn(
+      (
+        _query: RequestParameters,
+        _variables: Variables,
+        _cacheConfig: CacheConfig,
+      ) => {
         // $FlowFixMe[incompatible-call]
-        return unsubscribe;
-      });
-    });
+        return Observable.create((sink: Sink<mixed>) => {
+          dataSource = sink;
+          unsubscribe = jest.fn<[], mixed>();
+          // $FlowFixMe[incompatible-call]
+          return unsubscribe;
+        });
+      },
+    );
     const environment = new Environment({
       getDataID: (data: {[string]: mixed}, typename: string) => {
         // This is the default, but making it explicit in case we need to override
@@ -228,6 +239,7 @@ describe.each([
         return data.id;
       },
       // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
+      // $FlowFixMe[incompatible-call] error found when enabling Flow LTI mode
       network: Network.create(fetchFn),
       store,
       handlerProvider: _name => {
@@ -237,7 +249,7 @@ describe.each([
     // $FlowFixMe[method-unbinding]
     const originalRetain = environment.retain;
     // $FlowFixMe[cannot-write]
-    environment.retain = jest.fn((...args) =>
+    environment.retain = jest.fn((...args: any) =>
       originalRetain.apply(environment, args),
     );
     return [environment, fetchFn];
@@ -247,7 +259,9 @@ describe.each([
     // Set up mocks
     jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
     jest.mock('warning');
-    renderSpy = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
+    renderSpy = jest.fn<_, mixed>();
     // Set up environment and base data
     [environment, fetch] = createMockEnvironment();
 
@@ -846,7 +860,7 @@ describe.each([
     let release;
 
     beforeEach(() => {
-      release = jest.fn();
+      release = jest.fn<$ReadOnlyArray<mixed>, mixed>();
       // $FlowFixMe[method-unbinding] added when improving typing for this parameters
       environment.retain.mockImplementation((...args) => {
         return {
@@ -973,7 +987,7 @@ describe.each([
       });
 
       it('does not load more if request is already in flight', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -1026,7 +1040,7 @@ describe.each([
 
         fetchQuery(environment, query).subscribe({});
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         fetch.mockClear();
         renderFragment();
@@ -1078,7 +1092,7 @@ describe.each([
             },
           },
         });
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
 
         const renderer = renderFragment();
         const expectedUser = {
@@ -1153,7 +1167,7 @@ describe.each([
       });
 
       it('loads and renders next items in connection', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -1288,7 +1302,7 @@ describe.each([
           },
         };
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment({owner: queryWithLiteralArgs});
         expectFragmentResults([
           {
@@ -1408,7 +1422,7 @@ describe.each([
       });
 
       it('loads more correctly when original variables do not include an id', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const viewer = environment.lookup(queryWithoutID.fragment).data?.viewer;
         const userRef =
           typeof viewer === 'object' && viewer != null ? viewer?.actor : null;
@@ -1548,7 +1562,7 @@ describe.each([
       });
 
       it('loads more with correct id from refetchable fragment when using a nested fragment', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
 
         // Populate store with data for query using nested fragment
         environment.commitPayload(queryNestedFragment, {
@@ -1731,7 +1745,7 @@ describe.each([
       });
 
       it('calls callback with error when error occurs during fetch', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -1776,7 +1790,7 @@ describe.each([
       });
 
       it('preserves pagination request if re-rendered with same fragment ref', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -1909,7 +1923,7 @@ describe.each([
 
       describe('extra variables', () => {
         it('loads and renders the next items in the connection when passing extra variables', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2031,7 +2045,7 @@ describe.each([
         });
 
         it('loads the next items in the connection and ignores any pagination vars passed as extra vars', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2156,7 +2170,7 @@ describe.each([
       describe('disposing', () => {
         it('cancels load more if component unmounts', () => {
           unsubscribe.mockClear();
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2203,7 +2217,7 @@ describe.each([
 
         it('cancels load more if refetch is called', () => {
           unsubscribe.mockClear();
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2251,7 +2265,7 @@ describe.each([
         });
 
         it('disposes ongoing request if environment changes', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2353,7 +2367,7 @@ describe.each([
         });
 
         it('disposes ongoing request if fragment ref changes', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2466,7 +2480,7 @@ describe.each([
         });
 
         it('disposes ongoing request on unmount', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -2512,7 +2526,7 @@ describe.each([
         });
 
         it('disposes ongoing request if it is manually disposed', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Error | null], void>();
           const renderer = renderFragment();
           expectFragmentResults([
             {
@@ -3085,7 +3099,7 @@ describe.each([
       });
 
       it('updates after pagination if more results are available', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -3205,7 +3219,7 @@ describe.each([
       });
 
       it('updates after pagination if no more results are available', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         expectFragmentResults([
           {
@@ -4097,7 +4111,7 @@ describe.each([
       });
 
       it('loads and renders next items in connection', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         const initialData = {
           fetch_id: 'fetch:a',

--- a/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-provided-variables-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-provided-variables-test.js
@@ -10,13 +10,12 @@
  */
 
 'use strict';
-import type {
-  Variables,
-  CacheConfig,
-} from '../../../relay-runtime/util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
-
 import type {Sink} from '../../../relay-runtime/network/RelayObservable';
+import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
+import type {
+  CacheConfig,
+  Variables,
+} from '../../../relay-runtime/util/RelayRuntimeTypes';
 import type {GraphQLResponse} from 'relay-runtime/network/RelayNetworkTypes';
 
 const {loadQuery} = require('../loadQuery');

--- a/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-provided-variables-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-provided-variables-test.js
@@ -10,6 +10,11 @@
  */
 
 'use strict';
+import type {
+  Variables,
+  CacheConfig,
+} from '../../../relay-runtime/util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../../relay-runtime/util/RelayConcreteNode';
 
 import type {Sink} from '../../../relay-runtime/network/RelayObservable';
 import type {GraphQLResponse} from 'relay-runtime/network/RelayNetworkTypes';
@@ -139,10 +144,15 @@ describe.each([
     };
     beforeEach(() => {
       dataSource = undefined;
-      fetch = jest.fn((_query, _variables, _cacheConfig) =>
-        Observable.create(sink => {
-          dataSource = sink;
-        }),
+      fetch = jest.fn(
+        (
+          _query: RequestParameters,
+          _variables: Variables,
+          _cacheConfig: CacheConfig,
+        ) =>
+          Observable.create((sink: Sink<GraphQLResponse>) => {
+            dataSource = sink;
+          }),
       );
       environment = new Environment({
         // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file

--- a/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-react-double-effects-test.js
@@ -92,7 +92,7 @@ describe.skip('usePreloadedQuery-react-double-effects', () => {
 
     environment = createMockEnvironment();
 
-    release = jest.fn();
+    release = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalRetain = environment.retain;
     (environment: $FlowFixMe).retain = jest.fn(operation => {
@@ -105,7 +105,7 @@ describe.skip('usePreloadedQuery-react-double-effects', () => {
       };
     });
 
-    cancelNetworkRequest = jest.fn();
+    cancelNetworkRequest = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalExecuteWithSource = environment.executeWithSource;
     (environment: $FlowFixMe).executeWithSource = jest.fn((...args) => {

--- a/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-react-double-effects-test.js
@@ -202,7 +202,6 @@ describe.skip('usePreloadedQuery-react-double-effects', () => {
               </React.Suspense>
             </RelayEnvironmentProvider>
           </React.StrictMode>,
-          // $FlowFixMe
           {unstable_isConcurrent: true},
         );
       });

--- a/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePreloadedQuery-test.js
@@ -137,7 +137,9 @@ describe.each([
 
   beforeEach(() => {
     dataSource = undefined;
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     fetch = jest.fn((_query, _variables, _cacheConfig) =>
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       Observable.create(sink => {
         dataSource = sink;
       }),
@@ -1008,7 +1010,9 @@ describe.each([
     describe('when environments do not match', () => {
       it('should fetch the data at render time, even if the query has already resolved', () => {
         let altDataSource;
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         const altFetch = jest.fn((_query, _variables, _cacheConfig) =>
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           Observable.create(sink => {
             altDataSource = sink;
           }),

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
@@ -335,7 +335,6 @@ it('does not release or cancel the query before the new component tree unsuspend
           <RelayEnvironmentProvider environment={environment}>
             <ConcurrentWrapper />
           </RelayEnvironmentProvider>,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: true},
         );
       });
@@ -406,7 +405,6 @@ it('releases and cancels query references associated with previous suspensions w
           <RelayEnvironmentProvider environment={environment}>
             <ConcurrentWrapper />
           </RelayEnvironmentProvider>,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: true},
         );
       });
@@ -418,8 +416,6 @@ it('releases and cancels query references associated with previous suspensions w
 
       triggerStateChange = (newPromise, newName) =>
         React.startTransition(() => {
-          /* $FlowFixMe[prop-missing] error exposed when improving flow typing
-           * of useQueryLoader */
           queryLoaderCallback({});
           setPromise(newPromise);
         });
@@ -503,7 +499,6 @@ it('releases and cancels query references associated with subsequent suspensions
       ReactTestRenderer.act(() => {
         instance = ReactTestRenderer.create(
           <ConcurrentWrapper />,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: true},
         );
       });
@@ -515,8 +510,6 @@ it('releases and cancels query references associated with subsequent suspensions
 
       triggerStateChange = (newPromise, newName) =>
         React.startTransition(() => {
-          /* $FlowFixMe[prop-missing] error exposed when improving flow typing
-           * of useQueryLoader */
           queryLoaderCallback({});
           setPromise(newPromise);
         });
@@ -582,12 +575,8 @@ it('should release and cancel prior queries if the callback is called multiple t
   render();
   let firstDispose;
   ReactTestRenderer.act(() => {
-    /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-     * useQueryLoader */
     queryLoaderCallback({});
     firstDispose = dispose;
-    /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-     * useQueryLoader */
     queryLoaderCallback({});
   });
   expect(loadQuery).toHaveBeenCalledTimes(2);
@@ -619,8 +608,6 @@ it('should release and cancel queries on unmount if the callback is called, the 
   const outerInstance = ReactTestRenderer.create(<Outer />);
   expect(renderCount).toEqual(1);
   ReactTestRenderer.act(() => {
-    /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-     * useQueryLoader */
     queryLoaderCallback({});
   });
   expect(renderCount).toEqual(2);
@@ -659,8 +646,6 @@ it('releases and cancels all queries if a the callback is called, the component 
   const outerInstance = ReactTestRenderer.create(<Outer />);
   expect(renderCount).toEqual(1);
   ReactTestRenderer.act(() => {
-    /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-     * useQueryLoader */
     queryLoaderCallback({});
   });
   expect(renderCount).toEqual(2);
@@ -673,8 +658,6 @@ it('releases and cancels all queries if a the callback is called, the component 
   expect(outerInstance.toJSON()).toEqual('fallback');
 
   ReactTestRenderer.act(() => {
-    /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-     * useQueryLoader */
     queryLoaderCallback({});
   });
   const secondDispose = dispose;
@@ -716,8 +699,6 @@ it('releases and cancels all queries if the component suspends, another query is
   expect(renderCount).toEqual(1);
   expect(outerInstance.toJSON()).toEqual('fallback');
   ReactTestRenderer.act(() => {
-    /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-     * useQueryLoader */
     queryLoaderCallback({});
   });
 
@@ -734,8 +715,6 @@ it('releases and cancels the query on unmount if the component unmounts and then
   expect(renderCount).toEqual(1);
   ReactTestRenderer.act(() => {
     instance.unmount();
-    /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-     * useQueryLoader */
     queryLoaderCallback({});
     expect(dispose).not.toHaveBeenCalled();
   });
@@ -748,8 +727,6 @@ it('releases and cancels the query on unmount if the callback is called and the 
   render();
   expect(renderCount).toEqual(1);
   ReactTestRenderer.act(() => {
-    /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-     * useQueryLoader */
     queryLoaderCallback({});
     expect(dispose).not.toHaveBeenCalled();
     instance.unmount();

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
@@ -44,11 +44,11 @@ let environment;
 /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
  * enabling Flow LTI mode */
 const loadQuery = jest.fn().mockImplementation(() => {
-    dispose = jest.fn();
-    return {
-      dispose,
-    };
-  });
+  dispose = jest.fn();
+  return {
+    dispose,
+  };
+});
 
 jest.mock('../loadQuery', () => ({
   loadQuery,
@@ -497,10 +497,9 @@ it('releases and cancels query references associated with subsequent suspensions
 
     function concurrentRender() {
       ReactTestRenderer.act(() => {
-        instance = ReactTestRenderer.create(
-          <ConcurrentWrapper />,
-          {unstable_isConcurrent: true},
-        );
+        instance = ReactTestRenderer.create(<ConcurrentWrapper />, {
+          unstable_isConcurrent: true,
+        });
       });
     }
 

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
@@ -41,6 +41,8 @@ let update;
 let Container;
 let environment;
 
+/* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+ * enabling Flow LTI mode */
 const loadQuery = jest.fn().mockImplementation(() => {
   dispose = jest.fn();
   return {

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
@@ -44,11 +44,11 @@ let environment;
 /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
  * enabling Flow LTI mode */
 const loadQuery = jest.fn().mockImplementation(() => {
-  dispose = jest.fn();
-  return {
-    dispose,
-  };
-});
+    dispose = jest.fn();
+    return {
+      dispose,
+    };
+  });
 
 jest.mock('../loadQuery', () => ({
   loadQuery,

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-multiple-calls-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-multiple-calls-test.js
@@ -77,7 +77,7 @@ beforeEach(() => {
     const originalSubscribe = observable.subscribe.bind(observable);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    networkUnsubscribe = jest.fn();
+    networkUnsubscribe = jest.fn<[], $FlowFixMe>();
     jest.spyOn(observable, 'subscribe').mockImplementation((...args) => {
       const subscription = originalSubscribe(...args);
       jest
@@ -108,7 +108,7 @@ beforeEach(() => {
           originalSubscribe(subscriptionCallbacks);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          const executeUnsubscribeFn = jest.fn();
+          const executeUnsubscribeFn = jest.fn<$ReadOnlyArray<mixed>, mixed>();
           return {unsubscribe: executeUnsubscribeFn};
         });
       return executeObservable;

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-multiple-calls-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-multiple-calls-test.js
@@ -75,8 +75,6 @@ beforeEach(() => {
     });
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalSubscribe = observable.subscribe.bind(observable);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     networkUnsubscribe = jest.fn<[], $FlowFixMe>();
     jest.spyOn(observable, 'subscribe').mockImplementation((...args) => {
       const subscription = originalSubscribe(...args);
@@ -106,8 +104,6 @@ beforeEach(() => {
         .spyOn(executeObservable, 'subscribe')
         .mockImplementation(subscriptionCallbacks => {
           originalSubscribe(subscriptionCallbacks);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           const executeUnsubscribeFn = jest.fn<$ReadOnlyArray<mixed>, mixed>();
           return {unsubscribe: executeUnsubscribeFn};
         });

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-multiple-calls-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-multiple-calls-test.js
@@ -67,6 +67,7 @@ beforeEach(() => {
 
   PreloadableQueryRegistry.clear();
 
+  // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
   fetch = jest.fn((_query, _variables, _cacheConfig) => {
     // $FlowFixMe[missing-local-annot] Error found while enabling LTI on this file
     const observable = Observable.create(_sink => {
@@ -74,6 +75,8 @@ beforeEach(() => {
     });
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalSubscribe = observable.subscribe.bind(observable);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     networkUnsubscribe = jest.fn();
     jest.spyOn(observable, 'subscribe').mockImplementation((...args) => {
       const subscription = originalSubscribe(...args);
@@ -103,6 +106,8 @@ beforeEach(() => {
         .spyOn(executeObservable, 'subscribe')
         .mockImplementation(subscriptionCallbacks => {
           originalSubscribe(subscriptionCallbacks);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           const executeUnsubscribeFn = jest.fn();
           return {unsubscribe: executeUnsubscribeFn};
         });

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-react-double-effects-test.js
@@ -80,7 +80,7 @@ describe.skip('useQueryLoader-react-double-effects', () => {
 
     environment = createMockEnvironment();
 
-    release = jest.fn();
+    release = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalRetain = environment.retain;
     (environment: $FlowFixMe).retain = jest.fn(operation => {
@@ -93,7 +93,7 @@ describe.skip('useQueryLoader-react-double-effects', () => {
       };
     });
 
-    cancelNetworkRequest = jest.fn();
+    cancelNetworkRequest = jest.fn<[], mixed>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const originalExecuteWithSource = environment.executeWithSource;
     (environment: $FlowFixMe).executeWithSource = jest.fn((...args) => {

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-react-double-effects-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-react-double-effects-test.js
@@ -122,7 +122,6 @@ describe.skip('useQueryLoader-react-double-effects', () => {
         }
       }
     `;
-    // $FlowFixMe
     gqlQuery.params.cacheID = 'TestQuery';
     variables = {id: '1'};
     query = createOperationDescriptor(gqlQuery, variables);
@@ -190,7 +189,6 @@ describe.skip('useQueryLoader-react-double-effects', () => {
               </React.Suspense>
             </RelayEnvironmentProvider>
           </React.StrictMode>,
-          // $FlowFixMe
           {unstable_isConcurrent: true},
         );
       });

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
@@ -41,6 +41,8 @@ let update;
 let Container;
 let environment;
 
+/* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+ * enabling Flow LTI mode */
 const loadQuery = jest.fn().mockImplementation(() => {
   releaseQuery = jest.fn();
   return (lastLoadQueryReturnValue = {

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
@@ -384,7 +384,6 @@ describe('useQueryLoader', () => {
             <RelayEnvironmentProvider environment={environment}>
               <ConcurrentWrapper />
             </RelayEnvironmentProvider>,
-            // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
             {unstable_isConcurrent: true},
           );
         });
@@ -455,7 +454,6 @@ describe('useQueryLoader', () => {
             <RelayEnvironmentProvider environment={environment}>
               <ConcurrentWrapper />
             </RelayEnvironmentProvider>,
-            // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
             {unstable_isConcurrent: true},
           );
         });
@@ -467,8 +465,6 @@ describe('useQueryLoader', () => {
 
         triggerStateChange = (newPromise, newName) =>
           React.startTransition(() => {
-            /* $FlowFixMe[prop-missing] error exposed when improving flow
-             * typing of useQueryLoader */
             queryLoaderCallback({});
             setPromise(newPromise);
           });
@@ -552,7 +548,6 @@ describe('useQueryLoader', () => {
         ReactTestRenderer.act(() => {
           instance = ReactTestRenderer.create(
             <ConcurrentWrapper />,
-            // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
             {unstable_isConcurrent: true},
           );
         });
@@ -564,8 +559,6 @@ describe('useQueryLoader', () => {
 
         triggerStateChange = (newPromise, newName) =>
           React.startTransition(() => {
-            /* $FlowFixMe[prop-missing] error exposed when improving flow
-             * typing of useQueryLoader */
             queryLoaderCallback({});
             setPromise(newPromise);
           });
@@ -631,12 +624,8 @@ describe('useQueryLoader', () => {
     render();
     let firstDispose;
     ReactTestRenderer.act(() => {
-      /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-       * useQueryLoader */
       queryLoaderCallback({});
       firstDispose = releaseQuery;
-      /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-       * useQueryLoader */
       queryLoaderCallback({});
     });
     expect(loadQuery).toHaveBeenCalledTimes(2);
@@ -668,8 +657,6 @@ describe('useQueryLoader', () => {
     const outerInstance = ReactTestRenderer.create(<Outer />);
     expect(renderCount).toEqual(1);
     ReactTestRenderer.act(() => {
-      /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-       * useQueryLoader */
       queryLoaderCallback({});
     });
     expect(renderCount).toEqual(2);
@@ -708,8 +695,6 @@ describe('useQueryLoader', () => {
     const outerInstance = ReactTestRenderer.create(<Outer />);
     expect(renderCount).toEqual(1);
     ReactTestRenderer.act(() => {
-      /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-       * useQueryLoader */
       queryLoaderCallback({});
     });
     expect(renderCount).toEqual(2);
@@ -722,8 +707,6 @@ describe('useQueryLoader', () => {
     expect(outerInstance.toJSON()).toEqual('fallback');
 
     ReactTestRenderer.act(() => {
-      /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-       * useQueryLoader */
       queryLoaderCallback({});
     });
     const secondDispose = releaseQuery;
@@ -765,8 +748,6 @@ describe('useQueryLoader', () => {
     expect(renderCount).toEqual(1);
     expect(outerInstance.toJSON()).toEqual('fallback');
     ReactTestRenderer.act(() => {
-      /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-       * useQueryLoader */
       queryLoaderCallback({});
     });
 
@@ -783,8 +764,6 @@ describe('useQueryLoader', () => {
     expect(renderCount).toEqual(1);
     ReactTestRenderer.act(() => {
       instance.unmount();
-      /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-       * useQueryLoader */
       queryLoaderCallback({});
       expect(releaseQuery).not.toHaveBeenCalled();
     });
@@ -797,8 +776,6 @@ describe('useQueryLoader', () => {
     render();
     expect(renderCount).toEqual(1);
     ReactTestRenderer.act(() => {
-      /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-       * useQueryLoader */
       queryLoaderCallback({});
       expect(releaseQuery).not.toHaveBeenCalled();
       instance.unmount();
@@ -810,8 +787,6 @@ describe('useQueryLoader', () => {
   it('does not call loadQuery if the callback is called after the component unmounts', () => {
     render();
     ReactTestRenderer.act(() => instance.unmount());
-    /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
-     * useQueryLoader */
     queryLoaderCallback({});
     expect(loadQuery).not.toHaveBeenCalled();
   });

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
@@ -44,11 +44,11 @@ let environment;
 /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
  * enabling Flow LTI mode */
 const loadQuery = jest.fn().mockImplementation(() => {
-  releaseQuery = jest.fn();
-  return (lastLoadQueryReturnValue = {
-    releaseQuery,
+    releaseQuery = jest.fn();
+    return (lastLoadQueryReturnValue = {
+      releaseQuery,
+    });
   });
-});
 
 jest.mock('../loadQuery', () => ({
   loadQuery,

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
@@ -44,11 +44,11 @@ let environment;
 /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
  * enabling Flow LTI mode */
 const loadQuery = jest.fn().mockImplementation(() => {
-    releaseQuery = jest.fn();
-    return (lastLoadQueryReturnValue = {
-      releaseQuery,
-    });
+  releaseQuery = jest.fn();
+  return (lastLoadQueryReturnValue = {
+    releaseQuery,
   });
+});
 
 jest.mock('../loadQuery', () => ({
   loadQuery,
@@ -546,10 +546,9 @@ describe('useQueryLoader', () => {
 
       function concurrentRender() {
         ReactTestRenderer.act(() => {
-          instance = ReactTestRenderer.create(
-            <ConcurrentWrapper />,
-            {unstable_isConcurrent: true},
-          );
+          instance = ReactTestRenderer.create(<ConcurrentWrapper />, {
+            unstable_isConcurrent: true,
+          });
         });
       }
 

--- a/packages/react-relay/relay-hooks/__tests__/useRefetchableFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useRefetchableFragment-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {RefetchFn} from '../useRefetchableFragment';
-
 import type {OperationDescriptor} from '../../../relay-runtime/store/RelayStoreTypes';
+import type {RefetchFn} from '../useRefetchableFragment';
 
 const useRefetchableFragmentOriginal = require('../useRefetchableFragment');
 const React = require('react');

--- a/packages/react-relay/relay-hooks/__tests__/useRefetchableFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useRefetchableFragment-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {RefetchFn} from '../useRefetchableFragment';
 
 import type {OperationDescriptor} from '../../../relay-runtime/store/RelayStoreTypes';
 
@@ -83,7 +84,7 @@ describe('useRefetchableFragment', () => {
     jest.resetModules();
     jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
     jest.mock('warning');
-    renderSpy = jest.fn();
+    renderSpy = jest.fn<[any, RefetchFn<any, any>], mixed>();
 
     // Set up environment and base data
     environment = createMockEnvironment();

--- a/packages/react-relay/relay-hooks/__tests__/useRefetchableFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useRefetchableFragment-test.js
@@ -176,7 +176,6 @@ describe('useRefetchableFragment', () => {
             <Container owner={query} {...props} />
           </ContextProvider>
         </React.Suspense>,
-        // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
         {unstable_isConcurrent: isConcurrent},
       );
     };

--- a/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-test.js
@@ -203,7 +203,9 @@ describe.each([
       jest.mock('scheduler', () =>
         jest.requireActual('scheduler/unstable_mock'),
       );
-      commitSpy = jest.fn();
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
+      commitSpy = jest.fn<_, mixed>();
 
       fetchPolicy = 'store-or-network';
       renderPolicy = 'partial';
@@ -672,7 +674,7 @@ describe.each([
       it('throws error when error occurs during refetch', () => {
         jest.spyOn(console, 'error').mockImplementationOnce(() => {});
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Error | null], void>();
         const renderer = renderFragment();
         const initialUser = {
           id: '1',
@@ -1633,7 +1635,7 @@ describe.each([
       describe('multiple refetches', () => {
         const internalRuntime = require('relay-runtime').__internal;
         const originalFetchQueryDeduped = internalRuntime.fetchQueryDeduped;
-        const fetchSpy = jest.fn();
+        const fetchSpy = jest.fn<Array<any>, mixed>();
         jest
           .spyOn(internalRuntime, 'fetchQueryDeduped')
           .mockImplementation((...args) => {
@@ -3072,7 +3074,7 @@ describe.each([
       });
 
       describe('disposing', () => {
-        const unsubscribe = jest.fn();
+        const unsubscribe = jest.fn<[], mixed>();
         jest.doMock('relay-runtime', () => {
           const originalRuntime = jest.requireActual<any>('relay-runtime');
           const originalInternal = originalRuntime.__internal;

--- a/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-test.js
@@ -352,7 +352,6 @@ describe.each([
             [ID_KEY]:
               owner.request.variables.id ?? owner.request.variables.nodeID,
             [FRAGMENTS_KEY]: {
-              // $FlowFixMe[invalid-computed-prop] Error found while enabling LTI on this file
               [fragment.name]: {},
             },
             [FRAGMENT_OWNER_KEY]: owner.request,
@@ -421,7 +420,6 @@ describe.each([
                 </ContextProvider>
               </React.Suspense>
             </ErrorBoundary>,
-            // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
             {unstable_isConcurrent: isConcurrent},
           );
           jest.runAllImmediates();
@@ -3432,8 +3430,6 @@ describe.each([
 
       describe('refetching @fetchable types', () => {
         beforeEach(() => {
-          // $FlowFixMe[prop-missing]
-          // $FlowFixMe[incompatible-type-arg]
           gqlFragment = graphql`
             fragment useRefetchableFragmentNodeTest1Fragment on NonNodeStory
             @refetchable(
@@ -3676,7 +3672,6 @@ describe.each([
               username
             }
           `;
-          // $FlowFixMe[incompatible-type-arg]
           gqlFragment = graphql`
             fragment useRefetchableFragmentNodeTest3Fragment on User
             @refetchable(

--- a/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-with-suspense-transition-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-with-suspense-transition-test.js
@@ -394,7 +394,7 @@ describe('useRefetchableFragmentNode with useTransition', () => {
       describe('multiple refetches', () => {
         let fetchSpy;
         beforeEach(() => {
-          fetchSpy = jest.fn();
+          fetchSpy = jest.fn<Array<any>, mixed>();
           const internalRuntime = require('relay-runtime').__internal;
           const originalFetchQueryDeduped = internalRuntime.fetchQueryDeduped;
           jest

--- a/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-with-suspense-transition-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-with-suspense-transition-test.js
@@ -262,7 +262,6 @@ describe('useRefetchableFragmentNode with useTransition', () => {
             [ID_KEY]:
               owner.request.variables.id ?? owner.request.variables.nodeID,
             [FRAGMENTS_KEY]: {
-              // $FlowFixMe[invalid-computed-prop] Error found while enabling LTI on this file
               [fragment.name]: {},
             },
             [FRAGMENT_OWNER_KEY]: owner.request,
@@ -315,7 +314,6 @@ describe('useRefetchableFragmentNode with useTransition', () => {
               <Container owner={query} {...props} />
             </ContextProvider>
           </React.Suspense>,
-          // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
           {unstable_isConcurrent: isConcurrent},
         );
       };

--- a/packages/react-relay/relay-hooks/__tests__/useStaticFragmentNodeWarning-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useStaticFragmentNodeWarning-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const mockWarning = jest.fn();
+const mockWarning = jest.fn<$FlowFixMe & $ReadOnlyArray<mixed>, mixed>();
 jest.mock('warning', () => mockWarning);
 
 const useStaticFragmentNodeWarning = require('../useStaticFragmentNodeWarning');

--- a/packages/react-relay/relay-hooks/__tests__/useSubscribeToInvalidationState-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useSubscribeToInvalidationState-test.js
@@ -65,7 +65,7 @@ beforeEach(() => {
   const store = new Store(source);
 
   environment = createMockEnvironment({store});
-  callback = jest.fn();
+  callback = jest.fn<$ReadOnlyArray<mixed>, void>();
 
   function Renderer({
     initialDataIDs,
@@ -365,7 +365,7 @@ it('re-establishes subscription when callback changes', () => {
 
   expect(callback).toHaveBeenCalledTimes(1);
 
-  const newCallback = jest.fn();
+  const newCallback = jest.fn<Array<mixed>, void>();
   ReactTestRenderer.act(() => {
     // $FlowFixMe[incompatible-call] Error found while enabling LTI on this file
     setCallback(newCallback);

--- a/packages/react-relay/relay-hooks/__tests__/useSubscribeToInvalidationState-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useSubscribeToInvalidationState-test.js
@@ -367,7 +367,6 @@ it('re-establishes subscription when callback changes', () => {
 
   const newCallback = jest.fn<Array<mixed>, void>();
   ReactTestRenderer.act(() => {
-    // $FlowFixMe[incompatible-call] Error found while enabling LTI on this file
     setCallback(newCallback);
   });
 

--- a/packages/react-relay/relay-hooks/__tests__/useSubscription-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useSubscription-test.js
@@ -41,10 +41,12 @@ describe('useSubscription', () => {
     variables: {},
     subscription: CommentCreateSubscription,
   };
-  const dispose = jest.fn();
-  const requestSubscription = jest.fn((_passedEnv, _passedConfig) => ({
-    dispose,
-  }));
+  const dispose = jest.fn<$ReadOnlyArray<mixed>, mixed>();
+  const requestSubscription = jest.fn(
+    (_passedEnv: any, _passedConfig: any) => ({
+      dispose,
+    }),
+  );
   const relayRuntime = require('relay-runtime');
   jest.mock('relay-runtime', () => {
     return {

--- a/packages/react-relay/relay-hooks/loadEntryPoint.js
+++ b/packages/react-relay/relay-hooks/loadEntryPoint.js
@@ -84,11 +84,15 @@ function loadEntryPoint<
         entryPointDescription;
       // $FlowFixMe[incompatible-call]
       // $FlowFixMe[underconstrained-implicit-instantiation]
-      preloadedEntryPoints[entryPointPropName] = loadEntryPoint(
-        environmentProvider,
-        nestedEntryPoint,
-        nestedParams,
-      );
+      preloadedEntryPoints[entryPointPropName] = loadEntryPoint<
+        _,
+        {...},
+        {...},
+        {...},
+        mixed,
+        EntryPointComponent<{...}, {...}, {...}, mixed>,
+        _,
+      >(environmentProvider, nestedEntryPoint, nestedParams);
     });
   }
 

--- a/packages/react-relay/relay-hooks/loadEntryPoint.js
+++ b/packages/react-relay/relay-hooks/loadEntryPoint.js
@@ -82,8 +82,6 @@ function loadEntryPoint<
       }
       const {entryPoint: nestedEntryPoint, entryPointParams: nestedParams} =
         entryPointDescription;
-      // $FlowFixMe[incompatible-call]
-      // $FlowFixMe[underconstrained-implicit-instantiation]
       preloadedEntryPoints[entryPointPropName] = loadEntryPoint<
         _,
         {...},

--- a/packages/react-relay/relay-hooks/loadQuery.js
+++ b/packages/react-relay/relay-hooks/loadQuery.js
@@ -119,7 +119,6 @@ function loadQuery<
   // allows us to capture the events that occur during the eager execution
   // of the operation, and then replay them to the Observable we
   // ultimately return.
-  // $FlowFixMe[underconstrained-implicit-instantiation]
   const executionSubject = new ReplaySubject<GraphQLResponse>();
   const returnedObservable = Observable.create<GraphQLResponse>(sink =>
     executionSubject.subscribe(sink),
@@ -144,7 +143,6 @@ function loadQuery<
     didMakeNetworkRequest = true;
 
     let observable;
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     const subject = new ReplaySubject<GraphQLResponse>();
     if (RelayFeatureFlags.ENABLE_LOAD_QUERY_REQUEST_DEDUPING === true) {
       // Here, we are calling fetchQueryDeduped at the network layer level,

--- a/packages/react-relay/relay-hooks/loadQuery.js
+++ b/packages/react-relay/relay-hooks/loadQuery.js
@@ -120,7 +120,7 @@ function loadQuery<
   // of the operation, and then replay them to the Observable we
   // ultimately return.
   // $FlowFixMe[underconstrained-implicit-instantiation]
-  const executionSubject = new ReplaySubject();
+  const executionSubject = new ReplaySubject<GraphQLResponse>();
   const returnedObservable = Observable.create<GraphQLResponse>(sink =>
     executionSubject.subscribe(sink),
   );
@@ -145,7 +145,7 @@ function loadQuery<
 
     let observable;
     // $FlowFixMe[underconstrained-implicit-instantiation]
-    const subject = new ReplaySubject();
+    const subject = new ReplaySubject<GraphQLResponse>();
     if (RelayFeatureFlags.ENABLE_LOAD_QUERY_REQUEST_DEDUPING === true) {
       // Here, we are calling fetchQueryDeduped at the network layer level,
       // which ensures that only a single network request is active for a given

--- a/packages/react-relay/relay-hooks/preloadQuery_DEPRECATED.js
+++ b/packages/react-relay/relay-hooks/preloadQuery_DEPRECATED.js
@@ -204,7 +204,6 @@ function preloadQueryDeduped<TQuery: OperationType>(
   } else if (prevQueryEntry == null || prevQueryEntry.kind !== 'network') {
     // Should fetch but we're not already fetching: fetch!
     const source = network.execute(params, variables, networkCacheConfig, null);
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     const subject = new ReplaySubject<GraphQLResponse>();
     nextQueryEntry = {
       cacheKey,

--- a/packages/react-relay/relay-hooks/preloadQuery_DEPRECATED.js
+++ b/packages/react-relay/relay-hooks/preloadQuery_DEPRECATED.js
@@ -205,7 +205,7 @@ function preloadQueryDeduped<TQuery: OperationType>(
     // Should fetch but we're not already fetching: fetch!
     const source = network.execute(params, variables, networkCacheConfig, null);
     // $FlowFixMe[underconstrained-implicit-instantiation]
-    const subject = new ReplaySubject();
+    const subject = new ReplaySubject<GraphQLResponse>();
     nextQueryEntry = {
       cacheKey,
       fetchKey,

--- a/packages/react-relay/relay-hooks/prepareEntryPoint_DEPRECATED.js
+++ b/packages/react-relay/relay-hooks/prepareEntryPoint_DEPRECATED.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {OperationType} from '../../relay-runtime/util/RelayRuntimeTypes';
 
 import type {
   EntryPoint,
@@ -57,7 +58,7 @@ function prepareEntryPoint<
       );
 
       // $FlowFixMe[underconstrained-implicit-instantiation]
-      preloadedQueries[queryPropName] = preloadQuery(
+      preloadedQueries[queryPropName] = preloadQuery<OperationType, mixed>(
         environment,
         parameters,
         variables,

--- a/packages/react-relay/relay-hooks/prepareEntryPoint_DEPRECATED.js
+++ b/packages/react-relay/relay-hooks/prepareEntryPoint_DEPRECATED.js
@@ -11,7 +11,6 @@
 
 'use strict';
 import type {OperationType} from '../../relay-runtime/util/RelayRuntimeTypes';
-
 import type {
   EntryPoint,
   EntryPointComponent,

--- a/packages/react-relay/relay-hooks/prepareEntryPoint_DEPRECATED.js
+++ b/packages/react-relay/relay-hooks/prepareEntryPoint_DEPRECATED.js
@@ -56,7 +56,6 @@ function prepareEntryPoint<
         environmentProviderOptions,
       );
 
-      // $FlowFixMe[underconstrained-implicit-instantiation]
       preloadedQueries[queryPropName] = preloadQuery<OperationType, mixed>(
         environment,
         parameters,

--- a/packages/react-relay/relay-hooks/react-cache/__tests__/useLazyLoadQuery_REACT_CACHE-test.js
+++ b/packages/react-relay/relay-hooks/react-cache/__tests__/useLazyLoadQuery_REACT_CACHE-test.js
@@ -10,6 +10,16 @@
  */
 
 'use strict';
+import type {
+  Variables,
+  CacheConfig,
+} from '../../../../relay-runtime/util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../../../relay-runtime/util/RelayConcreteNode';
+import type {Sink} from '../../../../relay-runtime/network/RelayObservable';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+} from '../../../../relay-runtime/network/RelayNetworkTypes';
 
 import type {FetchPolicy, GraphQLResponse, RenderPolicy} from 'relay-runtime';
 import type {LogEvent} from 'relay-runtime/store/RelayStoreTypes';
@@ -212,14 +222,38 @@ describe('useLazyLoadQuery_REACT_CACHE', () => {
 
       beforeEach(() => {
         jest.clearAllTimers();
-        errorBoundaryDidCatchFn = jest.fn();
+        errorBoundaryDidCatchFn = jest.fn<[Error], mixed>();
         logs = ([]: Array<LogEvent>);
         subject = new RelayReplaySubject();
-        fetch = jest.fn((_query, _vars, config) => {
-          return RelayObservable.create(sink => {
-            subject.subscribe(sink);
-          });
-        });
+        fetch = jest.fn(
+          (
+            _query: ?(
+              | LogRequestInfoFunction
+              | UploadableMap
+              | RequestParameters
+              | Variables
+              | CacheConfig
+            ),
+            _vars: ?(
+              | LogRequestInfoFunction
+              | UploadableMap
+              | RequestParameters
+              | Variables
+              | CacheConfig
+            ),
+            config: ?(
+              | LogRequestInfoFunction
+              | UploadableMap
+              | RequestParameters
+              | Variables
+              | CacheConfig
+            ),
+          ) => {
+            return RelayObservable.create((sink: Sink<GraphQLResponse>) => {
+              subject.subscribe(sink);
+            });
+          },
+        );
         environment = new Environment({
           // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
           network: RelayNetwork.create(fetch),

--- a/packages/react-relay/relay-hooks/react-cache/__tests__/useLazyLoadQuery_REACT_CACHE-test.js
+++ b/packages/react-relay/relay-hooks/react-cache/__tests__/useLazyLoadQuery_REACT_CACHE-test.js
@@ -11,16 +11,15 @@
 
 'use strict';
 import type {
-  Variables,
-  CacheConfig,
-} from '../../../../relay-runtime/util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../../../relay-runtime/util/RelayConcreteNode';
-import type {Sink} from '../../../../relay-runtime/network/RelayObservable';
-import type {
-  UploadableMap,
   LogRequestInfoFunction,
+  UploadableMap,
 } from '../../../../relay-runtime/network/RelayNetworkTypes';
-
+import type {Sink} from '../../../../relay-runtime/network/RelayObservable';
+import type {RequestParameters} from '../../../../relay-runtime/util/RelayConcreteNode';
+import type {
+  CacheConfig,
+  Variables,
+} from '../../../../relay-runtime/util/RelayRuntimeTypes';
 import type {FetchPolicy, GraphQLResponse, RenderPolicy} from 'relay-runtime';
 import type {LogEvent} from 'relay-runtime/store/RelayStoreTypes';
 

--- a/packages/relay-runtime/multi-actor-environment/__tests__/MultiActorEnvironment-ExecuteMutation-test.js
+++ b/packages/relay-runtime/multi-actor-environment/__tests__/MultiActorEnvironment-ExecuteMutation-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../../store/RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../../store/RelayStoreTypes';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const RelayObservable = require('../../network/RelayObservable');

--- a/packages/relay-runtime/multi-actor-environment/__tests__/MultiActorEnvironment-ExecuteMutation-test.js
+++ b/packages/relay-runtime/multi-actor-environment/__tests__/MultiActorEnvironment-ExecuteMutation-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../../store/RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const RelayObservable = require('../../network/RelayObservable');
@@ -103,7 +105,9 @@ describe('executeMutation()', () => {
     operation = createOperationDescriptor(CreateCommentMutation, variables);
     queryOperation = createOperationDescriptor(CommentQuery, queryVariables);
 
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     fetch = jest.fn((_query, _variables, _cacheConfig) =>
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       RelayObservable.create(sink => {
         subject = sink;
       }),
@@ -115,9 +119,9 @@ describe('executeMutation()', () => {
       // $FlowFixMe
       'actor:12345',
     );
-    complete = jest.fn();
-    error = jest.fn();
-    next = jest.fn();
+    complete = jest.fn<[], mixed>();
+    error = jest.fn<[Error], mixed>();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
   });
 
@@ -137,7 +141,7 @@ describe('executeMutation()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment
@@ -171,7 +175,7 @@ describe('executeMutation()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment
@@ -207,7 +211,7 @@ describe('executeMutation()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     const subscription = environment
@@ -238,7 +242,7 @@ describe('executeMutation()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment
@@ -288,7 +292,7 @@ describe('executeMutation()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment
@@ -346,7 +350,7 @@ describe('executeMutation()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment
@@ -384,7 +388,7 @@ describe('executeMutation()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment
@@ -422,7 +426,7 @@ describe('executeMutation()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     const subscription = environment
@@ -489,7 +493,7 @@ describe('executeMutation()', () => {
     );
 
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     expectWarningWillFire(

--- a/packages/relay-runtime/multi-actor-environment/__tests__/actorEnvironment_execute-test.js
+++ b/packages/relay-runtime/multi-actor-environment/__tests__/actorEnvironment_execute-test.js
@@ -29,6 +29,7 @@ test('send a network request with actor specific params', () => {
   const fetchFn = jest.fn(() => new Promise(jest.fn()));
   const multiActorEnvironment = new MultiActorEnvironment({
     // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
+    // $FlowFixMe[incompatible-call] error found when enabling Flow LTI mode
     createNetworkForActor: () => create(fetchFn),
     logFn: jest.fn(),
     requiredFieldLogger: jest.fn(),

--- a/packages/relay-runtime/multi-actor-environment/__tests__/forActor-test.js
+++ b/packages/relay-runtime/multi-actor-environment/__tests__/forActor-test.js
@@ -10,14 +10,14 @@
  */
 
 'use strict';
-import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../util/RelayConcreteNode';
-import type {ObservableFromValue} from '../../network/RelayObservable';
 import type {
-  UploadableMap,
-  LogRequestInfoFunction,
   GraphQLResponse,
+  LogRequestInfoFunction,
+  UploadableMap,
 } from '../../network/RelayNetworkTypes';
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {CacheConfig, Variables} from '../../util/RelayRuntimeTypes';
 
 const {create} = require('../../network/RelayNetwork');
 const {getActorIdentifier} = require('../ActorIdentifier');

--- a/packages/relay-runtime/multi-actor-environment/__tests__/forActor-test.js
+++ b/packages/relay-runtime/multi-actor-environment/__tests__/forActor-test.js
@@ -10,6 +10,14 @@
  */
 
 'use strict';
+import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+  GraphQLResponse,
+} from '../../network/RelayNetworkTypes';
 
 const {create} = require('../../network/RelayNetwork');
 const {getActorIdentifier} = require('../ActorIdentifier');
@@ -17,7 +25,16 @@ const MultiActorEnvironment = require('../MultiActorEnvironment');
 
 test('forActor: creates an environment', () => {
   const actorIdentifer = getActorIdentifier('actor:1234');
-  const fetchFn = jest.fn();
+  const fetchFn = jest.fn<
+    [
+      RequestParameters,
+      Variables,
+      CacheConfig,
+      ?UploadableMap,
+      ?LogRequestInfoFunction,
+    ],
+    ObservableFromValue<GraphQLResponse>,
+  >();
   const multiActorEnvironment = new MultiActorEnvironment({
     createNetworkForActor: () => create(fetchFn),
     logFn: jest.fn(),
@@ -31,7 +48,16 @@ test('forActor: creates an environment', () => {
 
 test('forActor: memoize an environment', () => {
   const actorIdentifer = getActorIdentifier('actor:1234');
-  const fetchFn = jest.fn();
+  const fetchFn = jest.fn<
+    [
+      RequestParameters,
+      Variables,
+      CacheConfig,
+      ?UploadableMap,
+      ?LogRequestInfoFunction,
+    ],
+    ObservableFromValue<GraphQLResponse>,
+  >();
   const multiActorEnvironment = new MultiActorEnvironment({
     createNetworkForActor: () => create(fetchFn),
     logFn: jest.fn(),

--- a/packages/relay-runtime/mutations/__tests__/commitMutation-test.js
+++ b/packages/relay-runtime/mutations/__tests__/commitMutation-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../../store/RelayStoreTypes';
-
 import type {GraphQLResponseWithoutData} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../../store/RelayStoreTypes';
 import type {RecordSourceSelectorProxy} from '../../store/RelayStoreTypes';
 import type {
   commitMutationTest4Query$data,

--- a/packages/relay-runtime/mutations/__tests__/commitMutation-test.js
+++ b/packages/relay-runtime/mutations/__tests__/commitMutation-test.js
@@ -122,7 +122,11 @@ describe('Configs: NODE_DELETE', () => {
         deletedIDFieldName: 'deletedCommentId',
       },
     ];
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const optimisticUpdater = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const updater = jest.fn();
     const operationDescriptor = createOperationDescriptor(
       FeedbackCommentQuery,
@@ -137,6 +141,8 @@ describe('Configs: NODE_DELETE', () => {
         operationDescriptor.request,
       ),
     );
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
@@ -270,7 +276,11 @@ describe('Configs: RANGE_DELETE', () => {
       {},
     );
     environment.commitPayload(operationDescriptor, payload);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const optimisticUpdater = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const updater = jest.fn();
     const snapshot = store.lookup(
       createReaderSelector(
@@ -280,6 +290,8 @@ describe('Configs: RANGE_DELETE', () => {
         operationDescriptor.request,
       ),
     );
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
@@ -316,7 +328,11 @@ describe('Configs: RANGE_DELETE', () => {
   });
 
   it('handles config with deletedIDFieldName as path', () => {
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const optimisticUpdater = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const updater = jest.fn();
     const mutation = graphql`
       mutation commitMutationTest3Mutation($input: UnfriendInput) {
@@ -405,6 +421,8 @@ describe('Configs: RANGE_DELETE', () => {
         operationDescriptor.request,
       ),
     );
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
@@ -537,7 +555,11 @@ describe('Configs: RANGE_ADD', () => {
         },
       },
     };
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     callback = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     optimisticUpdater = jest.fn();
     updater = jest.fn();
     data = {
@@ -1110,7 +1132,9 @@ describe('Required mutation roots', () => {
   let dataSource;
   let environment;
   beforeEach(() => {
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     const fetch = jest.fn((_query, _variables, _cacheConfig) => {
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       return RelayObservable.create(sink => {
         dataSource = sink;
       });
@@ -1192,10 +1216,18 @@ describe('commitMutation()', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     onCompleted = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     onError = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     onNext = jest.fn();
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     const fetch = jest.fn((_query, _variables, _cacheConfig) => {
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       return RelayObservable.create(sink => {
         dataSource = sink;
       });
@@ -1214,6 +1246,8 @@ describe('commitMutation()', () => {
     const initialSnapshot = environment.lookup(
       createReaderSelector(fragment, '1', {}, operation.request),
     );
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -1515,8 +1549,11 @@ describe('commitMutation() cacheConfig', () => {
     };
 
     cacheConfig = undefined;
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     const fetch = jest.fn((_query, _variables, _cacheConfig) => {
       cacheConfig = _cacheConfig;
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       return RelayObservable.create(() => {});
     });
     const source = RelayRecordSource.create({});
@@ -1533,6 +1570,8 @@ describe('commitMutation() cacheConfig', () => {
     const initialSnapshot = environment.lookup(
       createReaderSelector(fragment, '1', {}, operation.request),
     );
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -1560,6 +1599,8 @@ describe('commitMutation() cacheConfig', () => {
     const initialSnapshot = environment.lookup(
       createReaderSelector(fragment, '1', {}, operation.request),
     );
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/mutations/__tests__/commitMutation-test.js
+++ b/packages/relay-runtime/mutations/__tests__/commitMutation-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../../store/RelayStoreTypes';
 
 import type {GraphQLResponseWithoutData} from '../../network/RelayNetworkTypes';
 import type {RecordSourceSelectorProxy} from '../../store/RelayStoreTypes';
@@ -124,10 +125,13 @@ describe('Configs: NODE_DELETE', () => {
     ];
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const optimisticUpdater = jest.fn();
+    const optimisticUpdater = jest.fn<
+      [RecordSourceSelectorProxy, ?{...}],
+      void,
+    >();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const updater = jest.fn();
+    const updater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
     const operationDescriptor = createOperationDescriptor(
       FeedbackCommentQuery,
       {},
@@ -143,7 +147,7 @@ describe('Configs: NODE_DELETE', () => {
     );
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
       configs,
@@ -278,10 +282,13 @@ describe('Configs: RANGE_DELETE', () => {
     environment.commitPayload(operationDescriptor, payload);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const optimisticUpdater = jest.fn();
+    const optimisticUpdater = jest.fn<
+      [RecordSourceSelectorProxy, ?{...}],
+      void,
+    >();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const updater = jest.fn();
+    const updater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
     const snapshot = store.lookup(
       createReaderSelector(
         FeedbackCommentQuery.fragment,
@@ -292,7 +299,7 @@ describe('Configs: RANGE_DELETE', () => {
     );
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
       configs,
@@ -330,10 +337,13 @@ describe('Configs: RANGE_DELETE', () => {
   it('handles config with deletedIDFieldName as path', () => {
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const optimisticUpdater = jest.fn();
+    const optimisticUpdater = jest.fn<
+      [RecordSourceSelectorProxy, ?{...}],
+      void,
+    >();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const updater = jest.fn();
+    const updater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
     const mutation = graphql`
       mutation commitMutationTest3Mutation($input: UnfriendInput) {
         unfriend(input: $input) {
@@ -423,7 +433,7 @@ describe('Configs: RANGE_DELETE', () => {
     );
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
       configs,
@@ -557,10 +567,10 @@ describe('Configs: RANGE_ADD', () => {
     };
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    callback = jest.fn();
+    callback = jest.fn<[Snapshot], void>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    optimisticUpdater = jest.fn();
+    optimisticUpdater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
     updater = jest.fn();
     data = {
       data: {
@@ -1218,10 +1228,10 @@ describe('commitMutation()', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    onCompleted = jest.fn();
+    onCompleted = jest.fn<_, void>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    onError = jest.fn();
+    onError = jest.fn<[Error], void>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
     onNext = jest.fn();
@@ -1248,7 +1258,7 @@ describe('commitMutation()', () => {
     );
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     commitMutation(environment, {
@@ -1572,7 +1582,7 @@ describe('commitMutation() cacheConfig', () => {
     );
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     const metadata = {
@@ -1601,7 +1611,7 @@ describe('commitMutation() cacheConfig', () => {
     );
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     commitMutation(environment, {

--- a/packages/relay-runtime/mutations/__tests__/commitMutation-test.js
+++ b/packages/relay-runtime/mutations/__tests__/commitMutation-test.js
@@ -123,14 +123,10 @@ describe('Configs: NODE_DELETE', () => {
         deletedIDFieldName: 'deletedCommentId',
       },
     ];
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const optimisticUpdater = jest.fn<
       [RecordSourceSelectorProxy, ?{...}],
       void,
     >();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const updater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
     const operationDescriptor = createOperationDescriptor(
       FeedbackCommentQuery,
@@ -145,8 +141,6 @@ describe('Configs: NODE_DELETE', () => {
         operationDescriptor.request,
       ),
     );
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
@@ -280,14 +274,10 @@ describe('Configs: RANGE_DELETE', () => {
       {},
     );
     environment.commitPayload(operationDescriptor, payload);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const optimisticUpdater = jest.fn<
       [RecordSourceSelectorProxy, ?{...}],
       void,
     >();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const updater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
     const snapshot = store.lookup(
       createReaderSelector(
@@ -297,8 +287,6 @@ describe('Configs: RANGE_DELETE', () => {
         operationDescriptor.request,
       ),
     );
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
@@ -335,14 +323,10 @@ describe('Configs: RANGE_DELETE', () => {
   });
 
   it('handles config with deletedIDFieldName as path', () => {
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const optimisticUpdater = jest.fn<
       [RecordSourceSelectorProxy, ?{...}],
       void,
     >();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const updater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
     const mutation = graphql`
       mutation commitMutationTest3Mutation($input: UnfriendInput) {
@@ -431,8 +415,6 @@ describe('Configs: RANGE_DELETE', () => {
         operationDescriptor.request,
       ),
     );
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     store.subscribe(snapshot, callback);
     commitMutation(environment, {
@@ -565,11 +547,7 @@ describe('Configs: RANGE_ADD', () => {
         },
       },
     };
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     callback = jest.fn<[Snapshot], void>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     optimisticUpdater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
     updater = jest.fn();
     data = {
@@ -1229,8 +1207,6 @@ describe('commitMutation()', () => {
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
     onCompleted = jest.fn<_, void>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     onError = jest.fn<[Error], void>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
@@ -1256,8 +1232,6 @@ describe('commitMutation()', () => {
     const initialSnapshot = environment.lookup(
       createReaderSelector(fragment, '1', {}, operation.request),
     );
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -1580,8 +1554,6 @@ describe('commitMutation() cacheConfig', () => {
     const initialSnapshot = environment.lookup(
       createReaderSelector(fragment, '1', {}, operation.request),
     );
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -1609,8 +1581,6 @@ describe('commitMutation() cacheConfig', () => {
     const initialSnapshot = environment.lookup(
       createReaderSelector(fragment, '1', {}, operation.request),
     );
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/mutations/__tests__/readUpdatableFragment-test.js
+++ b/packages/relay-runtime/mutations/__tests__/readUpdatableFragment-test.js
@@ -10,15 +10,14 @@
  */
 
 'use strict';
-import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../util/RelayConcreteNode';
-import type {ObservableFromValue} from '../../network/RelayObservable';
 import type {
-  UploadableMap,
-  LogRequestInfoFunction,
   GraphQLResponse,
+  LogRequestInfoFunction,
+  UploadableMap,
 } from '../../network/RelayNetworkTypes';
-
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {CacheConfig, Variables} from '../../util/RelayRuntimeTypes';
 import type {readUpdatableFragmentTestRegularQuery} from './__generated__/readUpdatableFragmentTestRegularQuery.graphql';
 
 const RelayNetwork = require('../../network/RelayNetwork');

--- a/packages/relay-runtime/mutations/__tests__/readUpdatableFragment-test.js
+++ b/packages/relay-runtime/mutations/__tests__/readUpdatableFragment-test.js
@@ -10,6 +10,14 @@
  */
 
 'use strict';
+import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+  GraphQLResponse,
+} from '../../network/RelayNetworkTypes';
 
 import type {readUpdatableFragmentTestRegularQuery} from './__generated__/readUpdatableFragmentTestRegularQuery.graphql';
 
@@ -60,7 +68,16 @@ describe('readUpdatableFragment', () => {
     const source = RelayRecordSource.create();
     const store = new RelayModernStore(source);
 
-    const fetch = jest.fn();
+    const fetch = jest.fn<
+      [
+        RequestParameters,
+        Variables,
+        CacheConfig,
+        ?UploadableMap,
+        ?LogRequestInfoFunction,
+      ],
+      ObservableFromValue<GraphQLResponse>,
+    >();
     environment = new RelayModernEnvironment({
       network: RelayNetwork.create(fetch),
       store,

--- a/packages/relay-runtime/mutations/__tests__/readUpdatableQuery-test.js
+++ b/packages/relay-runtime/mutations/__tests__/readUpdatableQuery-test.js
@@ -10,21 +10,20 @@
  */
 
 'use strict';
-import type {ReaderLinkedField} from '../../util/ReaderNode';
 import type {
-  NormalizationScalarField,
-  NormalizationLinkedField,
-} from '../../util/NormalizationNode';
-import type {ReadOnlyRecordProxy} from '../../store/RelayStoreTypes';
-import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../util/RelayConcreteNode';
-import type {ObservableFromValue} from '../../network/RelayObservable';
-import type {
-  UploadableMap,
-  LogRequestInfoFunction,
   GraphQLResponse,
+  LogRequestInfoFunction,
+  UploadableMap,
 } from '../../network/RelayNetworkTypes';
-
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {ReadOnlyRecordProxy} from '../../store/RelayStoreTypes';
+import type {
+  NormalizationLinkedField,
+  NormalizationScalarField,
+} from '../../util/NormalizationNode';
+import type {ReaderLinkedField} from '../../util/ReaderNode';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {CacheConfig, Variables} from '../../util/RelayRuntimeTypes';
 import type {readUpdatableQueryTestRegularQuery} from './__generated__/readUpdatableQueryTestRegularQuery.graphql';
 import type {OpaqueScalarType} from './OpaqueScalarType';
 

--- a/packages/relay-runtime/mutations/__tests__/readUpdatableQuery-test.js
+++ b/packages/relay-runtime/mutations/__tests__/readUpdatableQuery-test.js
@@ -10,6 +10,20 @@
  */
 
 'use strict';
+import type {ReaderLinkedField} from '../../util/ReaderNode';
+import type {
+  NormalizationScalarField,
+  NormalizationLinkedField,
+} from '../../util/NormalizationNode';
+import type {ReadOnlyRecordProxy} from '../../store/RelayStoreTypes';
+import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+  GraphQLResponse,
+} from '../../network/RelayNetworkTypes';
 
 import type {readUpdatableQueryTestRegularQuery} from './__generated__/readUpdatableQueryTestRegularQuery.graphql';
 import type {OpaqueScalarType} from './OpaqueScalarType';
@@ -147,7 +161,16 @@ describe('readUpdatableQuery', () => {
     const source = RelayRecordSource.create();
     const store = new RelayModernStore(source);
 
-    const fetch = jest.fn();
+    const fetch = jest.fn<
+      [
+        RequestParameters,
+        Variables,
+        CacheConfig,
+        ?UploadableMap,
+        ?LogRequestInfoFunction,
+      ],
+      ObservableFromValue<GraphQLResponse>,
+    >();
     environment = new RelayModernEnvironment({
       network: RelayNetwork.create(fetch),
       store,
@@ -1136,36 +1159,59 @@ describe('readUpdatableQuery', () => {
     let handleScalarField;
 
     beforeEach(() => {
-      handleLinkedField = jest.fn((field, record, argValues) => {
-        if (
-          record != null &&
-          record.getType() === ROOT_TYPE &&
-          field.name === 'node' &&
-          argValues.hasOwnProperty('id')
-        ) {
-          return argValues.id;
-        }
-      });
-      handlePluralLinkedField = jest.fn((field, record, argValues) => {
-        if (
-          record != null &&
-          record.getType() === ROOT_TYPE &&
-          field.name === 'nodes' &&
-          argValues.hasOwnProperty('ids')
-        ) {
-          return argValues.ids;
-        }
-      });
-      handleScalarField = jest.fn((field, record) => {
-        if (field.name === 'lastName') {
-          return 'Hamill';
-        }
-      });
+      handleLinkedField = jest.fn(
+        (
+          field: NormalizationLinkedField | ReaderLinkedField,
+          record: ?ReadOnlyRecordProxy,
+          argValues: Variables,
+        ) => {
+          if (
+            record != null &&
+            record.getType() === ROOT_TYPE &&
+            field.name === 'node' &&
+            argValues.hasOwnProperty('id')
+          ) {
+            return argValues.id;
+          }
+        },
+      );
+      handlePluralLinkedField = jest.fn(
+        (
+          field: NormalizationLinkedField | ReaderLinkedField,
+          record: ?ReadOnlyRecordProxy,
+          argValues: Variables,
+        ) => {
+          if (
+            record != null &&
+            record.getType() === ROOT_TYPE &&
+            field.name === 'nodes' &&
+            argValues.hasOwnProperty('ids')
+          ) {
+            return argValues.ids;
+          }
+        },
+      );
+      handleScalarField = jest.fn(
+        (field: NormalizationScalarField, record: ?ReadOnlyRecordProxy) => {
+          if (field.name === 'lastName') {
+            return 'Hamill';
+          }
+        },
+      );
 
       const source = RelayRecordSource.create();
       const store = new RelayModernStore(source);
 
-      const fetch = jest.fn();
+      const fetch = jest.fn<
+        [
+          RequestParameters,
+          Variables,
+          CacheConfig,
+          ?UploadableMap,
+          ?LogRequestInfoFunction,
+        ],
+        ObservableFromValue<GraphQLResponse>,
+      >();
       environment = new RelayModernEnvironment({
         network: RelayNetwork.create(fetch),
         store,

--- a/packages/relay-runtime/mutations/__tests__/readUpdatableQuery-test.js
+++ b/packages/relay-runtime/mutations/__tests__/readUpdatableQuery-test.js
@@ -920,10 +920,10 @@ describe('readUpdatableQuery', () => {
     });
 
     commitLocalUpdate(environment, store => {
-      const updatableData = store.readUpdatableQuery(
-        updatableQuery2,
-        {id: '4', foo: 'bar'},
-      ).updatableData;
+      const updatableData = store.readUpdatableQuery(updatableQuery2, {
+        id: '4',
+        foo: 'bar',
+      }).updatableData;
       expect(updatableData.node?.__typename).toBe('Metahuman');
     });
   });

--- a/packages/relay-runtime/mutations/__tests__/readUpdatableQuery-test.js
+++ b/packages/relay-runtime/mutations/__tests__/readUpdatableQuery-test.js
@@ -263,19 +263,16 @@ describe('readUpdatableQuery', () => {
 
       expect(() => {
         if (updatableData.me != null) {
-          // $FlowFixMe[cannot-write] That's the point!
           updatableData.me.id = '5';
         }
       }).toThrowError();
       expect(() => {
         if (updatableData.me != null) {
-          // $FlowFixMe[cannot-write] That's the point!
           updatableData.me.__typename = 'Protoss';
         }
       }).toThrowError();
       expect(() => {
         if (updatableData.me != null) {
-          // $FlowFixMe[cannot-write] That's the point!
           updatableData.me.__id = '5';
         }
       }).toThrowError();
@@ -341,7 +338,6 @@ describe('readUpdatableQuery', () => {
         // descriptor.
         expect(() => {
           if (updatableData.node2 != null) {
-            // $FlowFixMe[prop-missing] that's the point!
             updatableData.node2.name = 'MetaZuck';
           }
         }).toThrowError();
@@ -762,7 +758,6 @@ describe('readUpdatableQuery', () => {
 
       if (updatableData.node2 != null) {
         if (updatableData.node2.__typename === 'User') {
-          // $FlowFixMe[prop-missing] Error found while enabling LTI on this file
           updatableData.node2.parents = [];
           expect(updatableData.node2.parents).toEqual([]);
           expect(
@@ -824,7 +819,6 @@ describe('readUpdatableQuery', () => {
             if (readOnlyData.node.__typename === 'User') {
               expect(() => {
                 /* eslint-disable-next-line ft-flow/no-flow-fix-me-comments */
-                // $FlowFixMe
                 updatableData.node2.parents = null;
               }).toThrowError();
             }
@@ -927,7 +921,6 @@ describe('readUpdatableQuery', () => {
 
     commitLocalUpdate(environment, store => {
       const updatableData = store.readUpdatableQuery(
-        // $FlowFixMe[prop-missing] Error found while enabling LTI on this file
         updatableQuery2,
         {id: '4', foo: 'bar'},
       ).updatableData;

--- a/packages/relay-runtime/network/RelayQueryResponseCache.js
+++ b/packages/relay-runtime/network/RelayQueryResponseCache.js
@@ -71,7 +71,6 @@ class RelayQueryResponseCache {
     if (Array.isArray(response.payload)) {
       return response.payload.map(
         payload =>
-          // $FlowFixMe[incompatible-cast]
           ({
             ...payload,
             extensions: {
@@ -81,7 +80,6 @@ class RelayQueryResponseCache {
           }: GraphQLSingularResponse),
       );
     }
-    // $FlowFixMe[incompatible-cast]
     return ({
       ...response.payload,
       extensions: {

--- a/packages/relay-runtime/query/__tests__/fetchQuery-test.js
+++ b/packages/relay-runtime/query/__tests__/fetchQuery-test.js
@@ -239,7 +239,19 @@ describe('fetchQuery', () => {
 
 describe('fetchQuery with missing @required value', () => {
   it('provides data snapshot on next', () => {
-    const requiredFieldLogger = jest.fn();
+    const requiredFieldLogger = jest.fn<
+      [
+        | {+fieldPath: string, +kind: 'missing_field.log', +owner: string}
+        | {+fieldPath: string, +kind: 'missing_field.throw', +owner: string}
+        | {
+            +error: Error,
+            +fieldPath: string,
+            +kind: 'relay_resolver.error',
+            +owner: string,
+          },
+      ],
+      void,
+    >();
     const environment = createMockEnvironment({
       requiredFieldLogger,
     });
@@ -251,7 +263,7 @@ describe('fetchQuery with missing @required value', () => {
       }
     `;
 
-    const observer = {next: jest.fn()};
+    const observer = {next: jest.fn<[$FlowFixMe], mixed>()};
     const subscription = fetchQuery(environment, query, {}).subscribe(observer);
     expect(observer.next).not.toHaveBeenCalled();
     const queryNode = getRequest(query);
@@ -274,7 +286,19 @@ describe('fetchQuery with missing @required value', () => {
   });
 
   it('throws on resolution', () => {
-    const requiredFieldLogger = jest.fn();
+    const requiredFieldLogger = jest.fn<
+      [
+        | {+fieldPath: string, +kind: 'missing_field.log', +owner: string}
+        | {+fieldPath: string, +kind: 'missing_field.throw', +owner: string}
+        | {
+            +error: Error,
+            +fieldPath: string,
+            +kind: 'relay_resolver.error',
+            +owner: string,
+          },
+      ],
+      void,
+    >();
     const environment = createMockEnvironment({requiredFieldLogger});
     const query = graphql`
       query fetchQueryTest3Query {
@@ -284,7 +308,10 @@ describe('fetchQuery with missing @required value', () => {
       }
     `;
 
-    const observer = {next: jest.fn(), error: jest.fn()};
+    const observer = {
+      next: jest.fn<[$FlowFixMe], mixed>(),
+      error: jest.fn<[Error], mixed>(),
+    };
     const subscription = fetchQuery(environment, query, {}).subscribe(observer);
     const queryNode = getRequest(query);
 
@@ -323,7 +350,10 @@ describe('fetchQuery with missing @required value', () => {
       }
     `;
 
-    const observer = {next: jest.fn(), error: jest.fn()};
+    const observer = {
+      next: jest.fn<[$FlowFixMe], mixed>(),
+      error: jest.fn<[Error], mixed>(),
+    };
     const subscription = fetchQuery(environment, query, {}).subscribe(observer);
     const queryNode = getRequest(query);
     environment.mock.nextValue(queryNode, {
@@ -353,7 +383,10 @@ test('client-only query with error', () => {
       client_root_field
     }
   `;
-  const observer = {next: jest.fn(), error: jest.fn()};
+  const observer = {
+    next: jest.fn<[empty], mixed>(),
+    error: jest.fn<[Error], mixed>(),
+  };
 
   // $FlowExpectedError[incompatible-call] - fetch query is expecting a fetchable query, `fetchQueryTest5Query` is client-only
   fetchQuery<{...}, empty, mixed>(environment, query, {}).subscribe(observer);

--- a/packages/relay-runtime/query/__tests__/fetchQuery-test.js
+++ b/packages/relay-runtime/query/__tests__/fetchQuery-test.js
@@ -388,7 +388,6 @@ test('client-only query with error', () => {
     error: jest.fn<[Error], mixed>(),
   };
 
-  // $FlowExpectedError[incompatible-call] - fetch query is expecting a fetchable query, `fetchQueryTest5Query` is client-only
   fetchQuery<{...}, empty, mixed>(environment, query, {}).subscribe(observer);
 
   expect(observer.next).not.toBeCalled();

--- a/packages/relay-runtime/query/__tests__/fetchQueryInternal-test.js
+++ b/packages/relay-runtime/query/__tests__/fetchQueryInternal-test.js
@@ -10,11 +10,10 @@
  */
 
 'use strict';
-import type {NormalizationSplitOperation} from '../../util/NormalizationNode';
-import type {Subscription} from '../../network/RelayObservable';
-
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Subscription} from '../../network/RelayObservable';
 import type {Observer} from '../../network/RelayObservable';
+import type {NormalizationSplitOperation} from '../../util/NormalizationNode';
 import type {
   fetchQueryInternalTest1Query$data,
   fetchQueryInternalTest1Query$variables,

--- a/packages/relay-runtime/query/__tests__/fetchQueryInternal-test.js
+++ b/packages/relay-runtime/query/__tests__/fetchQueryInternal-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {NormalizationSplitOperation} from '../../util/NormalizationNode';
+import type {Subscription} from '../../network/RelayObservable';
 
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {Observer} from '../../network/RelayObservable';
@@ -379,10 +381,10 @@ describe('isRequestActive', () => {
 
   it('returns false if request is not active', () => {
     const observer = {
-      complete: jest.fn(),
-      error: jest.fn(),
-      next: jest.fn(),
-      unsubscribe: jest.fn(),
+      complete: jest.fn<[], mixed>(),
+      error: jest.fn<[Error], mixed>(),
+      next: jest.fn<[GraphQLResponse], mixed>(),
+      unsubscribe: jest.fn<[Subscription], mixed>(),
     };
     fetchQuery(environment, query).subscribe(observer);
     environment.mock.nextValue(gqlQuery, response);
@@ -407,10 +409,10 @@ describe('getPromiseForActiveRequest', () => {
 
   it('returns null if request is not active', () => {
     const observer = {
-      complete: jest.fn(),
-      error: jest.fn(),
-      next: jest.fn(),
-      unsubscribe: jest.fn(),
+      complete: jest.fn<[], mixed>(),
+      error: jest.fn<[Error], mixed>(),
+      next: jest.fn<[GraphQLResponse], mixed>(),
+      unsubscribe: jest.fn<[Subscription], mixed>(),
     };
     fetchQuery(environment, query).subscribe(observer);
     environment.mock.nextValue(gqlQuery, response);
@@ -421,10 +423,10 @@ describe('getPromiseForActiveRequest', () => {
 
   it('returns null after request has completed', () => {
     const observer = {
-      complete: jest.fn(),
-      error: jest.fn(),
-      next: jest.fn(),
-      unsubscribe: jest.fn(),
+      complete: jest.fn<[], mixed>(),
+      error: jest.fn<[Error], mixed>(),
+      next: jest.fn<[GraphQLResponse], mixed>(),
+      unsubscribe: jest.fn<[Subscription], mixed>(),
     };
     fetchQuery(environment, query).subscribe(observer);
     environment.mock.resolve(gqlQuery, response);
@@ -435,10 +437,10 @@ describe('getPromiseForActiveRequest', () => {
 
   it('returns null after request has errored', () => {
     const observer = {
-      complete: jest.fn(),
-      error: jest.fn(),
-      next: jest.fn(),
-      unsubscribe: jest.fn(),
+      complete: jest.fn<[], mixed>(),
+      error: jest.fn<[Error], mixed>(),
+      next: jest.fn<[GraphQLResponse], mixed>(),
+      unsubscribe: jest.fn<[Subscription], mixed>(),
     };
     fetchQuery(environment, query).subscribe(observer);
     environment.mock.reject(gqlQuery, new Error('Oops'));
@@ -449,10 +451,10 @@ describe('getPromiseForActiveRequest', () => {
 
   it('returns null after request has unsubscribed (canceled)', () => {
     const observer = {
-      complete: jest.fn(),
-      error: jest.fn(),
-      next: jest.fn(),
-      unsubscribe: jest.fn(),
+      complete: jest.fn<[], mixed>(),
+      error: jest.fn<[Error], mixed>(),
+      next: jest.fn<[GraphQLResponse], mixed>(),
+      unsubscribe: jest.fn<[Subscription], mixed>(),
     };
     const subscription = fetchQuery(environment, query).subscribe(observer);
     subscription.unsubscribe();
@@ -466,10 +468,10 @@ describe('getPromiseForActiveRequest', () => {
     let subscription;
     beforeEach(() => {
       observer = {
-        complete: jest.fn(),
-        error: jest.fn(),
-        next: jest.fn(),
-        unsubscribe: jest.fn(),
+        complete: jest.fn<[], mixed>(),
+        error: jest.fn<[Error], mixed>(),
+        next: jest.fn<[GraphQLResponse], mixed>(),
+        unsubscribe: jest.fn<[Subscription], mixed>(),
       };
       subscription = fetchQuery(environment, query).subscribe(observer);
     });
@@ -482,7 +484,7 @@ describe('getPromiseForActiveRequest', () => {
       }
 
       // Assert that promise hasn't resolved
-      const spy = jest.fn();
+      const spy = jest.fn<[void] | [$FlowFixMe], mixed>();
       promise.then(spy).catch(spy);
       jest.runAllTimers();
       expect(spy).toHaveBeenCalledTimes(0);
@@ -507,7 +509,7 @@ describe('getPromiseForActiveRequest', () => {
       }
 
       // Assert that promise hasn't resolved
-      const spy = jest.fn();
+      const spy = jest.fn<[void] | [$FlowFixMe], mixed>();
       promise.then(spy).catch(spy);
       jest.runAllTimers();
       expect(spy).toHaveBeenCalledTimes(0);
@@ -531,7 +533,7 @@ describe('getPromiseForActiveRequest', () => {
       }
 
       // Assert that promise hasn't resolved
-      const spy = jest.fn();
+      const spy = jest.fn<[void] | [$FlowFixMe], mixed>();
       promise.then(spy).catch(spy);
       jest.runAllTimers();
       expect(spy).toHaveBeenCalledTimes(0);
@@ -563,7 +565,7 @@ describe('getPromiseForActiveRequest', () => {
         }
 
         // Assert that promise hasn't resolved
-        const spy = jest.fn();
+        const spy = jest.fn<[void] | [$FlowFixMe], mixed>();
         promise.then(spy).catch(spy);
         jest.runAllTimers();
         expect(spy).toHaveBeenCalledTimes(0);
@@ -587,7 +589,7 @@ describe('getPromiseForActiveRequest', () => {
         }
 
         // Assert that promise hasn't resolved
-        const spy = jest.fn();
+        const spy = jest.fn<[void] | [$FlowFixMe], mixed>();
         promise.then(spy).catch(spy);
         jest.runAllTimers();
         expect(spy).toHaveBeenCalledTimes(0);
@@ -623,7 +625,7 @@ describe('getPromiseForActiveRequest', () => {
 
         // Assert that promise hasn't resolved even if first call to
         // `next` has already occurred
-        const spy = jest.fn();
+        const spy = jest.fn<[void] | [$FlowFixMe], mixed>();
         promise.then(spy).catch(spy);
         jest.runAllTimers();
         expect(spy).toHaveBeenCalledTimes(0);
@@ -653,7 +655,7 @@ describe('getPromiseForActiveRequest', () => {
 
         // Assert that promise hasn't resolved even if first call to
         // `next` has already occurred
-        const spy = jest.fn();
+        const spy = jest.fn<[void] | [$FlowFixMe], mixed>();
         promise.then(spy).catch(spy);
         jest.runAllTimers();
         expect(spy).toHaveBeenCalledTimes(0);
@@ -678,7 +680,7 @@ describe('getPromiseForActiveRequest', () => {
 
         // Assert that promise hasn't resolved even if first call to
         // `next` has already occurred
-        const spy = jest.fn();
+        const spy = jest.fn<[void] | [$FlowFixMe], mixed>();
         promise.then(spy).catch(spy);
         jest.runAllTimers();
         expect(spy).toHaveBeenCalledTimes(0);
@@ -703,19 +705,20 @@ describe('getPromiseForActiveRequest', () => {
 
     beforeEach(() => {
       observer = {
-        complete: jest.fn(),
-        error: jest.fn(),
-        next: jest.fn(),
-        unsubscribe: jest.fn(),
+        complete: jest.fn<[], mixed>(),
+        error: jest.fn<[Error], mixed>(),
+        next: jest.fn<[GraphQLResponse], mixed>(),
+        unsubscribe: jest.fn<[Subscription], mixed>(),
       };
       operationLoader = {
-        load: jest.fn(moduleName => {
+        load: jest.fn((moduleName: mixed) => {
           return new Promise(resolve => {
             resolveModule = resolve;
           });
         }),
-        get: jest.fn(),
+        get: jest.fn<[mixed], NormalizationSplitOperation>(),
       };
+      // $FlowFixMe[incompatible-call] error found when enabling Flow LTI mode
       environment = createMockEnvironment({operationLoader});
       gqlQuery = graphql`
         query fetchQueryInternalTest2Query($id: ID!) {
@@ -1019,13 +1022,14 @@ describe('getObservableForActiveRequest', () => {
 
     beforeEach(() => {
       operationLoader = {
-        load: jest.fn(moduleName => {
+        load: jest.fn((moduleName: mixed) => {
           return new Promise(resolve => {
             resolveModule = resolve;
           });
         }),
-        get: jest.fn(),
+        get: jest.fn<[mixed], NormalizationSplitOperation>(),
       };
+      // $FlowFixMe[incompatible-call] error found when enabling Flow LTI mode
       environment = createMockEnvironment({operationLoader});
       gqlQuery = graphql`
         query fetchQueryInternalTest3Query($id: ID!) {

--- a/packages/relay-runtime/store/__tests__/DataChecker-test.js
+++ b/packages/relay-runtime/store/__tests__/DataChecker-test.js
@@ -782,7 +782,6 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(loader.get).toBeCalledTimes(1);
-      // $FlowFixMe[prop-missing]
       expect(loader.get.mock.calls[0][0]).toBe(
         'DataCheckerTestPlainUserNameRenderer_nameFragment$normalization.graphql',
       );
@@ -1249,7 +1248,6 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(loader.get).toBeCalledTimes(1);
-      // $FlowFixMe[prop-missing]
       expect(loader.get.mock.calls[0][0]).toBe(
         'DataCheckerTest5PlainUserNameRenderer_name$normalization.graphql',
       );
@@ -2538,7 +2536,6 @@ describe('check()', () => {
             __id: 'client:1',
             __typename: 'FriendsConnection',
             edges: {
-              // $FlowFixMe[incompatible-type]
               __refs: [],
             },
           },

--- a/packages/relay-runtime/store/__tests__/DataChecker-test.js
+++ b/packages/relay-runtime/store/__tests__/DataChecker-test.js
@@ -10,11 +10,10 @@
  */
 
 'use strict';
-import type {ReadOnlyRecordProxy} from '../RelayStoreTypes';
-import type {Variables} from '../../util/RelayRuntimeTypes';
-import type {ReaderLinkedField} from '../../util/ReaderNode';
 import type {NormalizationLinkedField} from '../../util/NormalizationNode';
-
+import type {ReaderLinkedField} from '../../util/ReaderNode';
+import type {Variables} from '../../util/RelayRuntimeTypes';
+import type {ReadOnlyRecordProxy} from '../RelayStoreTypes';
 import type {
   DataCheckerTest10Query$data,
   DataCheckerTest10Query$variables,

--- a/packages/relay-runtime/store/__tests__/DataChecker-test.js
+++ b/packages/relay-runtime/store/__tests__/DataChecker-test.js
@@ -10,6 +10,10 @@
  */
 
 'use strict';
+import type {ReadOnlyRecordProxy} from '../RelayStoreTypes';
+import type {Variables} from '../../util/RelayRuntimeTypes';
+import type {ReaderLinkedField} from '../../util/ReaderNode';
+import type {NormalizationLinkedField} from '../../util/NormalizationNode';
 
 import type {
   DataCheckerTest10Query$data,
@@ -717,9 +721,9 @@ describe('check()', () => {
 
       loader = {
         get: jest.fn(
-          moduleName => nodes[String(moduleName).replace(/\$.*/, '')],
+          (moduleName: mixed) => nodes[String(moduleName).replace(/\$.*/, '')],
         ),
-        load: jest.fn(moduleName =>
+        load: jest.fn((moduleName: mixed) =>
           Promise.resolve(nodes[String(moduleName).replace(/\$.*/, '')]),
         ),
       };
@@ -1187,9 +1191,9 @@ describe('check()', () => {
 
       loader = {
         get: jest.fn(
-          moduleName => nodes[String(moduleName).replace(/\$.*/, '')],
+          (moduleName: mixed) => nodes[String(moduleName).replace(/\$.*/, '')],
         ),
-        load: jest.fn(moduleName =>
+        load: jest.fn((moduleName: mixed) =>
           Promise.resolve(nodes[String(moduleName).replace(/\$.*/, '')]),
         ),
       };
@@ -1946,9 +1950,15 @@ describe('check()', () => {
             }
           }
         `;
-        const handle = jest.fn((field, record, argValues) => {
-          return handleReturnValue;
-        });
+        const handle = jest.fn(
+          (
+            field: NormalizationLinkedField | ReaderLinkedField,
+            record: ?ReadOnlyRecordProxy,
+            argValues: Variables,
+          ) => {
+            return handleReturnValue;
+          },
+        );
         const status = check(
           () => source,
           () => target,
@@ -2099,9 +2109,15 @@ describe('check()', () => {
             }
           }
         `;
-        const handle = jest.fn((field, record, argValues) => {
-          return handleReturnValue;
-        });
+        const handle = jest.fn(
+          (
+            field: NormalizationLinkedField | ReaderLinkedField,
+            record: ?ReadOnlyRecordProxy,
+            argValues: Variables,
+          ) => {
+            return handleReturnValue;
+          },
+        );
         const status = check(
           () => source,
           () => target,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ApplyMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ApplyMutation-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,
@@ -130,7 +131,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment.applyMutation({
@@ -162,7 +163,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         const disposable = environment.applyMutation({
@@ -195,7 +196,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment.applyMutation({

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ApplyUpdate-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ApplyUpdate-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {RecordSourceProxy} from 'relay-runtime/store/RelayStoreTypes';
 
 const {
@@ -81,7 +82,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           {},
           operation.request,
         );
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         const snapshot = environment.lookup(selector);
         environment.subscribe(snapshot, callback);
 
@@ -106,7 +107,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           {},
           operation.request,
         );
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         const snapshot = environment.lookup(selector);
         environment.subscribe(snapshot, callback);
 
@@ -130,7 +131,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           {},
           operation.request,
         );
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         const snapshot = environment.lookup(selector);
         environment.subscribe(snapshot, callback);
 
@@ -166,7 +167,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           {},
           operation.request,
         );
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         const snapshot = environment.lookup(selector);
         expect(snapshot.data).toEqual(undefined);
         environment.subscribe(snapshot, callback);
@@ -267,7 +268,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             {},
             operation.request,
           );
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           const snapshot = environment.lookup(selector);
           environment.subscribe(snapshot, callback);
 
@@ -298,7 +299,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             {},
             operation.request,
           );
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           const snapshot = environment.lookup(selector);
           environment.subscribe(snapshot, callback);
 
@@ -334,7 +335,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             {},
             operation.request,
           );
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           const snapshot = environment.lookup(selector);
           environment.subscribe(snapshot, callback);
 
@@ -377,7 +378,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             {},
             operation.request,
           );
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           const snapshot = environment.lookup(selector);
           expect(snapshot.data).toEqual(undefined);
           environment.subscribe(snapshot, callback);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithGlobalInvalidation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithGlobalInvalidation-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,
@@ -67,13 +68,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        complete = jest.fn();
+        complete = jest.fn<[], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        error = jest.fn();
+        error = jest.fn<[Error], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        next = jest.fn();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
           _query: RequestParameters,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithGlobalInvalidation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithGlobalInvalidation-test.js
@@ -66,14 +66,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         `;
         operation = createOperationDescriptor(ParentQuery, {size: 32});
 
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         complete = jest.fn<[], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         error = jest.fn<[Error], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithGlobalInvalidation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithGlobalInvalidation-test.js
@@ -65,8 +65,14 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         `;
         operation = createOperationDescriptor(ParentQuery, {size: 32});
 
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         complete = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         error = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         next = jest.fn();
         callbacks = {complete, error, next};
         fetch = (

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithLocalInvalidation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithLocalInvalidation-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,
@@ -67,13 +68,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        complete = jest.fn();
+        complete = jest.fn<[], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        error = jest.fn();
+        error = jest.fn<[Error], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        next = jest.fn();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
           _query: RequestParameters,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithLocalInvalidation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithLocalInvalidation-test.js
@@ -66,14 +66,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         `;
         operation = createOperationDescriptor(ParentQuery, {size: 32});
 
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         complete = jest.fn<[], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         error = jest.fn<[Error], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithLocalInvalidation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CheckWithLocalInvalidation-test.js
@@ -65,8 +65,14 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         `;
         operation = createOperationDescriptor(ParentQuery, {size: 32});
 
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         complete = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         error = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         next = jest.fn();
         callbacks = {complete, error, next};
         fetch = (

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
@@ -10,6 +10,15 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+  GraphQLResponse,
+} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -55,7 +64,16 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         (store: $FlowFixMe).notify = jest.fn(store.notify.bind(store));
         // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         (store: $FlowFixMe).publish = jest.fn(store.publish.bind(store));
-        const fetch = jest.fn();
+        const fetch = jest.fn<
+          [
+            RequestParameters,
+            Variables,
+            CacheConfig,
+            ?UploadableMap,
+            ?LogRequestInfoFunction,
+          ],
+          ObservableFromValue<GraphQLResponse>,
+        >();
         const multiActorEnvironment = new MultiActorEnvironment({
           createNetworkForActor: _actorID => RelayNetwork.create(fetch),
           createStoreForActor: _actorID => store,
@@ -70,7 +88,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
       });
 
       it('applies server updates', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         const snapshot = environment.lookup(operation.fragment);
         environment.subscribe(snapshot, callback);
 
@@ -103,7 +121,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           }
         `;
         operation = createOperationDescriptor(query, {});
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         const snapshot = environment.lookup(operation.fragment);
         environment.subscribe(snapshot, callback);
 
@@ -149,7 +167,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           }
         `;
         operation = createOperationDescriptor(query, {});
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         const snapshot = environment.lookup(operation.fragment);
         environment.subscribe(snapshot, callback);
 
@@ -173,7 +191,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
       });
 
       it('rebases optimistic updates', () => {
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         const snapshot = environment.lookup(operation.fragment);
         environment.subscribe(snapshot, callback);
 
@@ -229,8 +247,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
 
-        const queryCallback = jest.fn();
-        const fragmentCallback = jest.fn();
+        const queryCallback = jest.fn<[Snapshot], void>();
+        const fragmentCallback = jest.fn<[Snapshot], void>();
         const querySnapshot = environment.lookup(operation.fragment);
         const fragmentSnapshot = environment.lookup(selector);
         environment.subscribe(querySnapshot, queryCallback);
@@ -310,8 +328,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
 
-        const queryCallback = jest.fn();
-        const fragmentCallback = jest.fn();
+        const queryCallback = jest.fn<[Snapshot], void>();
+        const fragmentCallback = jest.fn<[Snapshot], void>();
         const querySnapshot = environment.lookup(operation.fragment);
         const fragmentSnapshot = environment.lookup(selector);
         environment.subscribe(querySnapshot, queryCallback);
@@ -375,7 +393,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         });
 
         it('applies server updates', () => {
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           const snapshot = environment.lookup(operation.fragment);
           environment.subscribe(snapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitPayload-test.js
@@ -10,15 +10,15 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
-import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../util/RelayConcreteNode';
-import type {ObservableFromValue} from '../../network/RelayObservable';
 import type {
-  UploadableMap,
-  LogRequestInfoFunction,
   GraphQLResponse,
+  LogRequestInfoFunction,
+  UploadableMap,
 } from '../../network/RelayNetworkTypes';
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {CacheConfig, Variables} from '../../util/RelayRuntimeTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitUpdate-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitUpdate-test.js
@@ -10,6 +10,15 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+  GraphQLResponse,
+} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -57,7 +66,16 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         source = RelayRecordSource.create();
         store = new RelayModernStore(source);
-        const fetch = jest.fn();
+        const fetch = jest.fn<
+          [
+            RequestParameters,
+            Variables,
+            CacheConfig,
+            ?UploadableMap,
+            ?LogRequestInfoFunction,
+          ],
+          ObservableFromValue<GraphQLResponse>,
+        >();
         const multiActorEnvironment = new MultiActorEnvironment({
           createNetworkForActor: _actorID => RelayNetwork.create(fetch),
           createStoreForActor: _actorID => store,
@@ -79,7 +97,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           {},
           operation.request,
         );
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         const snapshot = environment.lookup(selector);
         environment.subscribe(snapshot, callback);
 
@@ -135,7 +153,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             {},
             operation.request,
           );
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           const snapshot = environment.lookup(selector);
           environment.subscribe(snapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitUpdate-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-CommitUpdate-test.js
@@ -10,15 +10,15 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
-import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../util/RelayConcreteNode';
-import type {ObservableFromValue} from '../../network/RelayObservable';
 import type {
-  UploadableMap,
-  LogRequestInfoFunction,
   GraphQLResponse,
+  LogRequestInfoFunction,
+  UploadableMap,
 } from '../../network/RelayNetworkTypes';
+import type {ObservableFromValue} from '../../network/RelayObservable';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {CacheConfig, Variables} from '../../util/RelayRuntimeTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Connection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Connection-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Connection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Connection-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -95,11 +97,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         };
         operation = createOperationDescriptor(query, variables);
 
-        complete = jest.fn();
-        error = jest.fn();
-        next = jest.fn();
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetch = jest.fn((_query, _variables, _cacheConfig) => {
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           return RelayObservable.create(sink => {
             dataSource = sink;
           });
@@ -124,7 +128,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('publishes initial results to the store', () => {
         const operationSnapshot = environment.lookup(operation.fragment);
-        const operationCallback = jest.fn();
+        const operationCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(operationSnapshot, operationCallback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -243,7 +247,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             getSingularSelector(fragment, operationSnapshot.data?.node),
           );
           const snapshot = environment.lookup(selector);
-          callback = jest.fn();
+          callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
         });
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ConnectionAndRequired-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ConnectionAndRequired-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ConnectionAndRequired-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ConnectionAndRequired-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -77,11 +79,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         };
         operation = createOperationDescriptor(query, variables);
 
-        const complete = jest.fn();
-        const error = jest.fn();
-        const next = jest.fn();
+        const complete = jest.fn<[], mixed>();
+        const error = jest.fn<[Error], mixed>();
+        const next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         const fetch = jest.fn((_query, _variables, _cacheConfig) => {
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           return RelayObservable.create(sink => {
             dataSource = sink;
           });
@@ -105,7 +109,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('When a field is @required and a @connection _and_ null, it bubbles null up to its parent', () => {
         const operationSnapshot = environment.lookup(operation.fragment);
-        const operationCallback = jest.fn();
+        const operationCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(operationSnapshot, operationCallback);
 
         environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-DynamicConnectionKey-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-DynamicConnectionKey-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-DynamicConnectionKey-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-DynamicConnectionKey-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -102,11 +104,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         };
         operation = createOperationDescriptor(query, variables);
 
-        complete = jest.fn();
-        error = jest.fn();
-        next = jest.fn();
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetch = jest.fn((_query, _variables, _cacheConfig) => {
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           return RelayObservable.create(sink => {
             dataSource = sink;
           });
@@ -134,7 +138,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('publishes initial results to the store', () => {
         const operationSnapshot = environment.lookup(operation.fragment);
-        const operationCallback = jest.fn();
+        const operationCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(operationSnapshot, operationCallback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -254,7 +258,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             getSingularSelector(fragment, operationSnapshot.data?.node),
           );
           const snapshot = environment.lookup(selector);
-          callback = jest.fn();
+          callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
         });
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutation-WithLocalInvalidation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutation-WithLocalInvalidation-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,
@@ -101,7 +102,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryVariables,
         );
 
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetch = jest.fn((_query, _variables, _cacheConfig) =>
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           RelayObservable.create(sink => {
             subject = sink;
           }),
@@ -127,8 +130,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
                 network: RelayNetwork.create(fetch),
                 store,
               });
-        complete = jest.fn();
-        error = jest.fn();
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
         callbacks = {complete, error};
       });
 
@@ -140,7 +143,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -177,7 +180,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             queryOperation.request,
           );
           const snapshot = environment.lookup(selector);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -250,7 +253,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             queryOperation.request,
           );
           const snapshot = environment.lookup(selector);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -309,7 +312,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             queryOperation.request,
           );
           const snapshot = environment.lookup(selector);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutation-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutation-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -119,7 +121,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryVariables,
         );
 
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetch = jest.fn((_query, _variables, _cacheConfig) =>
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           RelayObservable.create(sink => {
             subject = sink;
           }),
@@ -139,9 +143,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
                 network: RelayNetwork.create(fetch),
                 store,
               });
-        complete = jest.fn();
-        error = jest.fn();
-        next = jest.fn();
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
       });
 
@@ -161,7 +165,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -195,7 +199,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -231,7 +235,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         const subscription = environment
@@ -262,7 +266,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -312,7 +316,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -370,7 +374,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -408,7 +412,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -446,7 +450,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         const subscription = environment
@@ -511,7 +515,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         });
 
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         expectWarningWillFire(

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithDeclarativeMutation-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -97,7 +99,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             queryVariables,
           );
 
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           fetch = jest.fn((_query, _variables, _cacheConfig) =>
+            // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
             RelayObservable.create(sink => {
               subject = sink;
             }),
@@ -117,9 +121,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
                   network: RelayNetwork.create(fetch),
                   store,
                 });
-          complete = jest.fn();
-          error = jest.fn();
-          next = jest.fn();
+          complete = jest.fn<[], mixed>();
+          error = jest.fn<[Error], mixed>();
+          next = jest.fn<[GraphQLResponse], mixed>();
           callbacks = {complete, error, next};
 
           environment.execute({operation: queryOperation}).subscribe({});
@@ -147,7 +151,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
               },
             },
           });
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -182,7 +186,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
               },
             },
           });
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -237,8 +241,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
               },
             },
           });
-          const serverCallback = jest.fn();
-          const clientCallback = jest.fn();
+          const serverCallback = jest.fn<[Snapshot], void>();
+          const clientCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(serverSnapshot, serverCallback);
           environment.subscribe(clientSnapshot, clientCallback);
 
@@ -365,7 +369,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             },
           );
 
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           fetch = jest.fn((_query, _variables, _cacheConfig) =>
+            // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
             RelayObservable.create(sink => {
               subject = sink;
             }),
@@ -385,9 +391,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
                   network: RelayNetwork.create(fetch),
                   store,
                 });
-          complete = jest.fn();
-          error = jest.fn();
-          next = jest.fn();
+          complete = jest.fn<[], mixed>();
+          error = jest.fn<[Error], mixed>();
+          next = jest.fn<[GraphQLResponse], mixed>();
           callbacks = {complete, error, next};
 
           environment
@@ -445,8 +451,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             },
           });
 
-          const firstCallback = jest.fn();
-          const secondCallback = jest.fn();
+          const firstCallback = jest.fn<[Snapshot], void>();
+          const secondCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(firstCommentSnapshot, firstCallback);
           environment.subscribe(firstCommentSnapshot, secondCallback);
 
@@ -499,8 +505,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             },
           });
 
-          const firstCallback = jest.fn();
-          const secondCallback = jest.fn();
+          const firstCallback = jest.fn<[Snapshot], void>();
+          const secondCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(firstCommentSnapshot, firstCallback);
           environment.subscribe(firstCommentSnapshot, secondCallback);
 
@@ -560,8 +566,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
               },
             },
           });
-          const serverCallback = jest.fn();
-          const clientCallback = jest.fn();
+          const serverCallback = jest.fn<[Snapshot], void>();
+          const clientCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(serverSnapshot, serverCallback);
           environment.subscribe(clientSnapshot, clientCallback);
 
@@ -829,11 +835,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         );
 
-        complete = jest.fn();
-        error = jest.fn();
-        next = jest.fn();
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetch = jest.fn((_query, _variables, _cacheConfig) => {
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           return RelayObservable.create(sink => {
             subject = sink;
           });
@@ -925,7 +933,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
       describe('append and prepend edges', () => {
         it('commits the mutation and inserts comment edges into the connection', () => {
           const snapshot = environment.lookup(operation.fragment);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -1042,7 +1050,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('does not insert nodes into connections where that node already exists', () => {
           const snapshot = environment.lookup(operation.fragment);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -1095,7 +1103,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('commits the mutation and inserts multiple comment edges into the connection', () => {
           const snapshot = environment.lookup(operation.fragment);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -1258,7 +1266,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('commits the mutation and inserts multiple comment edges on a field with args into the connection', () => {
           const snapshot = environment.lookup(operation.fragment);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -1424,7 +1432,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('inserts an comment edge during optmistic update, and reverts and inserts new edge when server payload resolves', () => {
           const snapshot = environment.lookup(operation.fragment);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -1525,7 +1533,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
       describe('delete edges', () => {
         it('commits the mutation and deletes comment edges from the connection from a single id', () => {
           const snapshot = environment.lookup(operation.fragment);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -1562,7 +1570,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('commits the mutation and deletes comment edges from the connection from a list of ids', () => {
           const snapshot = environment.lookup(operation.fragment);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
 
           environment
@@ -1768,11 +1776,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         );
 
-        complete = jest.fn();
-        error = jest.fn();
-        next = jest.fn();
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetch = jest.fn((_query, _variables, _cacheConfig) => {
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           return RelayObservable.create(sink => {
             subject = sink;
           });
@@ -1855,7 +1865,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('commits the mutation, creates edges for the comment and inserts the edges into the connection', () => {
         const snapshot = environment.lookup(operation.fragment);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -1967,7 +1977,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('does not insert nodes into connections where that node already exists', () => {
         const snapshot = environment.lookup(operation.fragment);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -2017,7 +2027,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('works when the edge name is a literal', () => {
         const snapshot = environment.lookup(operation.fragment);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -2128,7 +2138,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('handles lists of nodes', () => {
         const snapshot = environment.lookup(operation.fragment);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -2275,7 +2285,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('creates and inserts a comment edge during optmistic update', () => {
         const snapshot = environment.lookup(operation.fragment);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment
@@ -2368,7 +2378,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('warns when the server returns an null for the node', () => {
         const snapshot = environment.lookup(operation.fragment);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithFlight-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithFlight-test.js
@@ -11,12 +11,11 @@
 
 'use strict';
 import type {
-  ReactFlightServerTree,
   ReactFlightServerError,
+  ReactFlightServerTree,
 } from '../../network/RelayNetworkTypes';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
+import type {Snapshot} from '../RelayStoreTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithFlight-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithFlight-test.js
@@ -10,6 +10,12 @@
  */
 
 'use strict';
+import type {
+  ReactFlightServerTree,
+  ReactFlightServerError,
+} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
@@ -123,16 +129,18 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           id: '2',
         };
 
-        reactFlightPayloadDeserializer = jest.fn(payload => {
-          return {
-            readRoot() {
-              return payload;
-            },
-          };
-        });
-        complete = jest.fn();
-        error = jest.fn();
-        next = jest.fn();
+        reactFlightPayloadDeserializer = jest.fn(
+          (payload: ReactFlightServerTree) => {
+            return {
+              readRoot() {
+                return payload;
+              },
+            };
+          },
+        );
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
           _query: RequestParameters,
@@ -239,7 +247,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         it('updates Flight fields that were previously queried for', () => {
           // precondition - FlightQuery
           const snapshot = environment.lookup(queryOperation.fragment);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
           // $FlowFixMe[incompatible-use] readRoot() to verify that it updated
           expect(snapshot.data.node.flightComponent.readRoot()).toEqual([
@@ -250,7 +258,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           const innerSnapshot = environment.lookup(
             innerQueryOperation.fragment,
           );
-          const innerCallback = jest.fn();
+          const innerCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(innerSnapshot, innerCallback);
           expect(innerSnapshot.data).toEqual({node: {name: 'Lauren'}});
 
@@ -337,11 +345,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         describe('and ReactFlightServerErrorHandler is specified', () => {
           let reactFlightServerErrorHandler;
           beforeEach(() => {
-            reactFlightServerErrorHandler = jest.fn((status, errors) => {
-              const err = new Error(`${status}: ${errors[0].message}`);
-              err.stack = errors[0].stack;
-              throw err;
-            });
+            reactFlightServerErrorHandler = jest.fn(
+              (status: string, errors: Array<ReactFlightServerError>) => {
+                const err = new Error(`${status}: ${errors[0].message}`);
+                err.stack = errors[0].stack;
+                throw err;
+              },
+            );
             const multiActorEnvironment = new MultiActorEnvironment({
               createNetworkForActor: _actorID => RelayNetwork.create(fetch),
               createStoreForActor: _actorID => store,
@@ -367,7 +377,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           it('calls ReactFlightServerErrorHandler', () => {
             // precondition - FlightQuery
             const snapshot = environment.lookup(queryOperation.fragment);
-            const callback = jest.fn();
+            const callback = jest.fn<[Snapshot], void>();
             environment.subscribe(snapshot, callback);
             // $FlowFixMe[incompatible-use] readRoot() to verify that it updated
             expect(snapshot.data.node.flightComponent.readRoot()).toEqual([
@@ -378,7 +388,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             const innerSnapshot = environment.lookup(
               innerQueryOperation.fragment,
             );
-            const innerCallback = jest.fn();
+            const innerCallback = jest.fn<[Snapshot], void>();
             environment.subscribe(innerSnapshot, innerCallback);
             expect(innerSnapshot.data).toEqual({node: {name: 'Lauren'}});
 
@@ -429,7 +439,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           it('warns', () => {
             // precondition - FlightQuery
             const snapshot = environment.lookup(queryOperation.fragment);
-            const callback = jest.fn();
+            const callback = jest.fn<[Snapshot], void>();
             environment.subscribe(snapshot, callback);
             // $FlowFixMe[incompatible-use] readRoot() to verify that it updated
             expect(snapshot.data.node.flightComponent.readRoot()).toEqual([
@@ -440,7 +450,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             const innerSnapshot = environment.lookup(
               innerQueryOperation.fragment,
             );
-            const innerCallback = jest.fn();
+            const innerCallback = jest.fn<[Snapshot], void>();
             environment.subscribe(innerSnapshot, innerCallback);
             expect(innerSnapshot.data).toEqual({node: {name: 'Lauren'}});
 
@@ -493,7 +503,7 @@ Error
         it('warns when the row protocol is null', () => {
           // precondition - FlightQuery
           const snapshot = environment.lookup(queryOperation.fragment);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(snapshot, callback);
           // $FlowFixMe[incompatible-use] readRoot() to verify that it updated
           expect(snapshot.data.node.flightComponent.readRoot()).toEqual([
@@ -504,7 +514,7 @@ Error
           const innerSnapshot = environment.lookup(
             innerQueryOperation.fragment,
           );
-          const innerCallback = jest.fn();
+          const innerCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(innerSnapshot, innerCallback);
           expect(innerSnapshot.data).toEqual({node: {name: 'Lauren'}});
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithGlobalInvalidation-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithGlobalInvalidation-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const RelayObservable = require('../../network/RelayObservable');
@@ -92,7 +93,9 @@ describe('executeMutation() with global invalidation', () => {
       queryVariables,
     );
 
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     fetch = jest.fn((_query, _variables, _cacheConfig) =>
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       RelayObservable.create(sink => {
         subject = sink;
       }),
@@ -110,8 +113,8 @@ describe('executeMutation() with global invalidation', () => {
       network: RelayNetwork.create(fetch),
       store,
     });
-    complete = jest.fn();
-    error = jest.fn();
+    complete = jest.fn<[], mixed>();
+    error = jest.fn<[Error], mixed>();
     callbacks = {complete, error};
   });
 
@@ -123,7 +126,7 @@ describe('executeMutation() with global invalidation', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment
@@ -160,7 +163,7 @@ describe('executeMutation() with global invalidation', () => {
         queryOperation.request,
       );
       const snapshot = environment.lookup(selector);
-      const callback = jest.fn();
+      const callback = jest.fn<[Snapshot], void>();
       environment.subscribe(snapshot, callback);
 
       environment
@@ -232,7 +235,7 @@ describe('executeMutation() with global invalidation', () => {
         queryOperation.request,
       );
       const snapshot = environment.lookup(selector);
-      const callback = jest.fn();
+      const callback = jest.fn<[Snapshot], void>();
       environment.subscribe(snapshot, callback);
 
       environment
@@ -290,7 +293,7 @@ describe('executeMutation() with global invalidation', () => {
         queryOperation.request,
       );
       const snapshot = environment.lookup(selector);
-      const callback = jest.fn();
+      const callback = jest.fn<[Snapshot], void>();
       environment.subscribe(snapshot, callback);
 
       environment

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.js
@@ -173,14 +173,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         };
 
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         complete = jest.fn<[], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         error = jest.fn<[Error], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
@@ -237,13 +231,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const fragmentSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         fragmentCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(fragmentSnapshot, fragmentCallback);
         const operationSnapshot = environment.lookup(operation.fragment);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         operationCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(operationSnapshot, operationCallback);
       });
@@ -425,8 +415,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         );
         const initialMatchSnapshot = environment.lookup(matchSelector);
         expect(initialMatchSnapshot.isMissingData).toBe(true);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const matchCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.js
@@ -171,8 +171,14 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         };
 
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         complete = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         error = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         next = jest.fn();
         callbacks = {complete, error, next};
         fetch = (
@@ -229,9 +235,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const fragmentSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         fragmentCallback = jest.fn();
         environment.subscribe(fragmentSnapshot, fragmentCallback);
         const operationSnapshot = environment.lookup(operation.fragment);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         operationCallback = jest.fn();
         environment.subscribe(operationSnapshot, operationCallback);
       });
@@ -413,6 +423,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         );
         const initialMatchSnapshot = environment.lookup(matchSelector);
         expect(initialMatchSnapshot.isMissingData).toBe(true);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const matchCallback = jest.fn();
         environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.js
@@ -10,10 +10,9 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteMutationWithMatch-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {
@@ -173,13 +175,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        complete = jest.fn();
+        complete = jest.fn<[], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        error = jest.fn();
+        error = jest.fn<[Error], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        next = jest.fn();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
           _query: RequestParameters,
@@ -237,12 +239,12 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const fragmentSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        fragmentCallback = jest.fn();
+        fragmentCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(fragmentSnapshot, fragmentCallback);
         const operationSnapshot = environment.lookup(operation.fragment);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        operationCallback = jest.fn();
+        operationCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(operationSnapshot, operationCallback);
       });
 
@@ -425,7 +427,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         expect(initialMatchSnapshot.isMissingData).toBe(true);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const matchCallback = jest.fn();
+        const matchCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialMatchSnapshot, matchCallback);
 
         resolveFragment(markdownRendererNormalizationFragment);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscription-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscription-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const RelayObservable = require('../../network/RelayObservable');
@@ -88,10 +89,14 @@ describe('execute()', () => {
     operation = createOperationDescriptor(CommentCreateSubscription, variables);
     queryOperation = createOperationDescriptor(CommentQuery, queryVariables);
 
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     fetchFn = jest.fn((_query, _variables, _cacheConfig) =>
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       RelayObservable.create(sink => {}),
     );
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     subscribeFn = jest.fn((_query, _variables, _cacheConfig) =>
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       RelayObservable.create(sink => {
         dataSource = sink;
       }),
@@ -103,8 +108,8 @@ describe('execute()', () => {
       network: RelayNetwork.create(fetchFn, subscribeFn),
       store,
     });
-    complete = jest.fn();
-    error = jest.fn();
+    complete = jest.fn<[], mixed>();
+    error = jest.fn<[Error], mixed>();
     callbacks = {complete, error};
   });
 
@@ -125,7 +130,7 @@ describe('execute()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment
@@ -190,7 +195,7 @@ describe('execute()', () => {
       queryOperation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     const subscription = environment

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithDefer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithDefer-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {
   HandleFieldPayload,
@@ -117,14 +119,18 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         };
 
-        complete = jest.fn();
-        error = jest.fn();
-        next = jest.fn();
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetchFn = jest.fn((_query, _variables, _cacheConfig) =>
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           RelayObservable.create(sink => {}),
         );
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         subscribeFn = jest.fn((_query, _variables, _cacheConfig) =>
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           RelayObservable.create(sink => {
             dataSource = sink;
           }),
@@ -163,7 +169,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const fragmentSnapshot = environment.lookup(selector);
-        fragmentCallback = jest.fn();
+        fragmentCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(fragmentSnapshot, fragmentCallback);
       });
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithDefer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithDefer-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
@@ -171,14 +171,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         };
 
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         complete = jest.fn<[], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         error = jest.fn<[Error], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
@@ -240,13 +234,9 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const fragmentSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         fragmentCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(fragmentSnapshot, fragmentCallback);
         const operationSnapshot = environment.lookup(operation.fragment);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         operationCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(operationSnapshot, operationCallback);
       });
@@ -415,8 +405,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialMatchSnapshot = environment.lookup(matchSelector);
         // TODO T96653810: Correctly detect reading from root of mutation/subscription
         expect(initialMatchSnapshot.isMissingData).toBe(false); // should be true
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const matchCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
@@ -10,10 +10,9 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {
@@ -171,13 +173,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        complete = jest.fn();
+        complete = jest.fn<[], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        error = jest.fn();
+        error = jest.fn<[Error], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        next = jest.fn();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetchFn = jest.fn((_query, _variables, _cacheConfig) =>
@@ -240,12 +242,12 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const fragmentSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        fragmentCallback = jest.fn();
+        fragmentCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(fragmentSnapshot, fragmentCallback);
         const operationSnapshot = environment.lookup(operation.fragment);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        operationCallback = jest.fn();
+        operationCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(operationSnapshot, operationCallback);
       });
 
@@ -415,7 +417,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         expect(initialMatchSnapshot.isMissingData).toBe(false); // should be true
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const matchCallback = jest.fn();
+        const matchCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialMatchSnapshot, matchCallback);
 
         resolveFragment(markdownRendererNormalizationFragment);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithMatch-test.js
@@ -169,14 +169,24 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         };
 
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         complete = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         error = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         next = jest.fn();
         callbacks = {complete, error, next};
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetchFn = jest.fn((_query, _variables, _cacheConfig) =>
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           RelayObservable.create(sink => {}),
         );
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         subscribeFn = jest.fn((_query, _variables, _cacheConfig) =>
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           RelayObservable.create(sink => {
             dataSource = sink;
           }),
@@ -228,9 +238,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           queryOperation.request,
         );
         const fragmentSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         fragmentCallback = jest.fn();
         environment.subscribe(fragmentSnapshot, fragmentCallback);
         const operationSnapshot = environment.lookup(operation.fragment);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         operationCallback = jest.fn();
         environment.subscribe(operationSnapshot, operationCallback);
       });
@@ -399,6 +413,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialMatchSnapshot = environment.lookup(matchSelector);
         // TODO T96653810: Correctly detect reading from root of mutation/subscription
         expect(initialMatchSnapshot.isMissingData).toBe(false); // should be true
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const matchCallback = jest.fn();
         environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithStream-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {
   HandleFieldPayload,
@@ -107,14 +109,18 @@ describe('executeSubscrption() with @stream', () => {
       },
     };
 
-    complete = jest.fn();
-    error = jest.fn();
-    next = jest.fn();
+    complete = jest.fn<[], mixed>();
+    error = jest.fn<[Error], mixed>();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     fetchFn = jest.fn((_query, _variables, _cacheConfig) =>
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       RelayObservable.create(sink => {}),
     );
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     subscribeFn = jest.fn((_query, _variables, _cacheConfig) =>
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       RelayObservable.create(sink => {
         dataSource = sink;
       }),
@@ -140,7 +146,7 @@ describe('executeSubscrption() with @stream', () => {
       queryOperation.request,
     );
     const fragmentSnapshot = environment.lookup(selector);
-    fragmentCallback = jest.fn();
+    fragmentCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(fragmentSnapshot, fragmentCallback);
   });
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteSubscriptionWithStream-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,
@@ -93,13 +95,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        complete = jest.fn();
+        complete = jest.fn<[], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        error = jest.fn();
+        error = jest.fn<[Error], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        next = jest.fn();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
           _query: RequestParameters,
@@ -141,7 +143,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -172,7 +174,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -215,7 +217,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -308,7 +310,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           const initialSnapshot = environment.lookup(selector);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(initialSnapshot, callback);
 
           environment.execute({operation}).subscribe(callbacks);
@@ -364,7 +366,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           const initialSnapshot = environment.lookup(selector);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(initialSnapshot, callback);
 
           environment.execute({operation}).subscribe(callbacks);
@@ -416,7 +418,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           const initialSnapshot = environment.lookup(selector);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(initialSnapshot, callback);
 
           const subscription = environment
@@ -467,7 +469,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -509,7 +511,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -540,7 +542,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -584,7 +586,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -617,7 +619,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -662,7 +664,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
@@ -91,8 +91,14 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         };
 
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         complete = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         error = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         next = jest.fn();
         callbacks = {complete, error, next};
         fetch = (
@@ -133,6 +139,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls next() and publishes the initial payload to the store', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -162,6 +170,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('processes deferred payloads', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -203,6 +213,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('processes deferred payloads mixed with extensions-only payloads', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -294,6 +306,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('processes deferred payloads with scheduling', () => {
           const initialSnapshot = environment.lookup(selector);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           const callback = jest.fn();
           environment.subscribe(initialSnapshot, callback);
 
@@ -348,6 +362,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('processes deferred payloads that are available synchronously within the same scheduler step', () => {
           const initialSnapshot = environment.lookup(selector);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           const callback = jest.fn();
           environment.subscribe(initialSnapshot, callback);
 
@@ -398,6 +414,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('cancels processing of deferred payloads with scheduling', () => {
           const initialSnapshot = environment.lookup(selector);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           const callback = jest.fn();
           environment.subscribe(initialSnapshot, callback);
 
@@ -447,6 +465,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls complete() when server completes after deferred payload resolves', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -487,6 +507,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls complete() when server completes before deferred payload resolves', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -516,6 +538,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls error() when server errors after deferred payload resolves', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -558,6 +582,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls error() when server errors before deferred payload resolves', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -589,6 +615,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls error() when deferred payload is missing data', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -632,6 +660,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('warns if executed in non-streaming mode and processes deferred selections', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
@@ -93,14 +93,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         };
 
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         complete = jest.fn<[], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         error = jest.fn<[Error], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
@@ -141,8 +135,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls next() and publishes the initial payload to the store', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -172,8 +164,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('processes deferred payloads', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -215,8 +205,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('processes deferred payloads mixed with extensions-only payloads', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -308,8 +296,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('processes deferred payloads with scheduling', () => {
           const initialSnapshot = environment.lookup(selector);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(initialSnapshot, callback);
 
@@ -364,8 +350,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('processes deferred payloads that are available synchronously within the same scheduler step', () => {
           const initialSnapshot = environment.lookup(selector);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(initialSnapshot, callback);
 
@@ -416,8 +400,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         it('cancels processing of deferred payloads with scheduling', () => {
           const initialSnapshot = environment.lookup(selector);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           const callback = jest.fn<[Snapshot], void>();
           environment.subscribe(initialSnapshot, callback);
 
@@ -467,8 +449,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls complete() when server completes after deferred payload resolves', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -509,8 +489,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls complete() when server completes before deferred payload resolves', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -540,8 +518,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls error() when server errors after deferred payload resolves', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -584,8 +560,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls error() when server errors before deferred payload resolves', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -617,8 +591,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('calls error() when deferred payload is missing data', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -662,8 +634,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('warns if executed in non-streaming mode and processes deferred selections', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferAndModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferAndModule-test.js
@@ -10,12 +10,12 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
-import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {IActorEnvironment} from '../../multi-actor-environment/MultiActorEnvironmentTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {ReaderFragment} from '../../util/ReaderNode';
 import type {ConcreteRequest} from '../../util/RelayConcreteNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferAndModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferAndModule-test.js
@@ -98,14 +98,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
 
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         complete = jest.fn<[], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         error = jest.fn<[Error], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
@@ -150,8 +144,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
               });
 
         const operationSnapshot = environment.lookup(operation.fragment);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         operationCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(operationSnapshot, operationCallback);
       });
@@ -159,8 +151,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
       it('calls next() and publishes the initial payload to the store', () => {
         const initialSnapshot = environment.lookup(selector);
 
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
         environment.execute({operation}).subscribe(callbacks);
@@ -190,8 +180,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('processes deferred payloads', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -248,8 +236,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('synchronously normalizes the deferred payload if the normalization fragment is available synchronously', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
@@ -300,8 +286,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('processes deferred payloads if the normalization fragment is delivered in same network response', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferAndModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferAndModule-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {IActorEnvironment} from '../../multi-actor-environment/MultiActorEnvironmentTypes';
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {ReaderFragment} from '../../util/ReaderNode';
@@ -98,13 +100,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        complete = jest.fn();
+        complete = jest.fn<[], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        error = jest.fn();
+        error = jest.fn<[Error], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        next = jest.fn();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
           _query: RequestParameters,
@@ -150,7 +152,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const operationSnapshot = environment.lookup(operation.fragment);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        operationCallback = jest.fn();
+        operationCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(operationSnapshot, operationCallback);
       });
 
@@ -159,7 +161,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
         environment.execute({operation}).subscribe(callbacks);
         const payload = {
@@ -190,7 +192,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -248,7 +250,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);
@@ -300,7 +302,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferAndModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferAndModule-test.js
@@ -96,8 +96,14 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
 
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         complete = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         error = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         next = jest.fn();
         callbacks = {complete, error, next};
         fetch = (
@@ -142,6 +148,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
               });
 
         const operationSnapshot = environment.lookup(operation.fragment);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         operationCallback = jest.fn();
         environment.subscribe(operationSnapshot, operationCallback);
       });
@@ -149,6 +157,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
       it('calls next() and publishes the initial payload to the store', () => {
         const initialSnapshot = environment.lookup(selector);
 
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
         environment.execute({operation}).subscribe(callbacks);
@@ -178,6 +188,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('processes deferred payloads', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -234,6 +246,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('synchronously normalizes the deferred payload if the normalization fragment is available synchronously', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 
@@ -284,6 +298,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('processes deferred payloads if the normalization fragment is delivered in same network response', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         const callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferWithinModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferWithinModule-test.js
@@ -10,13 +10,12 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
 import type {
   NormalizationRootNode,
   NormalizationSplitOperation,
 } from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferWithinModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferWithinModule-test.js
@@ -73,7 +73,6 @@ function createOperationLoader() {
       if (entry == null) {
         let resolveFn = (_x: NormalizationSplitOperation) => undefined;
         const promise = new Promise(resolve_ => {
-          // $FlowFixMe[incompatible-type]
           resolveFn = resolve_;
         });
         // $FlowFixMe[incompatible-type] Error found while enabling LTI on this file
@@ -169,14 +168,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         `;
         variables = {id: '1'};
         operation = createOperationDescriptor(query, variables);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         complete = jest.fn<[], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         error = jest.fn<[Error], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
@@ -185,7 +178,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           _cacheConfig: CacheConfig,
         ) => {
           // $FlowFixMe[missing-local-annot] Error found while enabling LTI on this file
-          // $FlowFixMe[underconstrained-implicit-instantiation]
           return RelayObservable.create(sink => {
             dataSource = sink;
           });
@@ -217,8 +209,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
         const userSnapshot = environment.lookup(userSelector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         userCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(userSnapshot, userCallback);
 
@@ -229,8 +219,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
         const actorSnapshot = environment.lookup(actorSelector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         actorCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(actorSnapshot, actorCallback);
       });

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferWithinModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferWithinModule-test.js
@@ -58,12 +58,14 @@ function createOperationLoader() {
     cache.set(moduleName, {kind: 'value', operation: operation});
   };
   const loader = {
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     get: jest.fn(moduleName => {
       const entry = cache.get(moduleName);
       if (entry && entry.kind === 'value') {
         return entry.operation;
       }
     }),
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     load: jest.fn(moduleName => {
       let entry = cache.get(moduleName);
       if (entry == null) {
@@ -165,8 +167,14 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         `;
         variables = {id: '1'};
         operation = createOperationDescriptor(query, variables);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         complete = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         error = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         next = jest.fn();
         callbacks = {complete, error, next};
         fetch = (
@@ -207,6 +215,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
         const userSnapshot = environment.lookup(userSelector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         userCallback = jest.fn();
         environment.subscribe(userSnapshot, userCallback);
 
@@ -217,6 +227,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
         const actorSnapshot = environment.lookup(actorSelector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         actorCallback = jest.fn();
         environment.subscribe(actorSnapshot, actorCallback);
       });

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferWithinModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferWithinModule-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {
   NormalizationRootNode,
@@ -169,13 +171,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         operation = createOperationDescriptor(query, variables);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        complete = jest.fn();
+        complete = jest.fn<[], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        error = jest.fn();
+        error = jest.fn<[Error], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        next = jest.fn();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
           _query: RequestParameters,
@@ -217,7 +219,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const userSnapshot = environment.lookup(userSelector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        userCallback = jest.fn();
+        userCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(userSnapshot, userCallback);
 
         const actorSelector = createReaderSelector(
@@ -229,7 +231,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const actorSnapshot = environment.lookup(actorSelector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        actorCallback = jest.fn();
+        actorCallback = jest.fn<[Snapshot], void>();
         environment.subscribe(actorSnapshot, actorCallback);
       });
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferredStreamedConnection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferredStreamedConnection-test.js
@@ -128,14 +128,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         };
 
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         complete = jest.fn<[], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         error = jest.fn<[Error], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
@@ -180,8 +174,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('does not initialize the connection with the root payload', () => {
         const initialSnapshot = environment.lookup(selector);
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferredStreamedConnection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferredStreamedConnection-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferredStreamedConnection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferredStreamedConnection-test.js
@@ -126,8 +126,14 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           },
         };
 
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         complete = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         error = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         next = jest.fn();
         callbacks = {complete, error, next};
         fetch = (
@@ -172,6 +178,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
       it('does not initialize the connection with the root payload', () => {
         const initialSnapshot = environment.lookup(selector);
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         callback = jest.fn();
         environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferredStreamedConnection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDeferredStreamedConnection-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,
@@ -128,13 +130,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
 
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        complete = jest.fn();
+        complete = jest.fn<[], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        error = jest.fn();
+        error = jest.fn<[Error], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        next = jest.fn();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
           _query: RequestParameters,
@@ -180,7 +182,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         const initialSnapshot = environment.lookup(selector);
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        callback = jest.fn();
+        callback = jest.fn<[Snapshot], void>();
         environment.subscribe(initialSnapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlight-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlight-test.js
@@ -11,11 +11,10 @@
 
 'use strict';
 import type {
-  ReactFlightServerTree,
   ReactFlightServerError,
+  ReactFlightServerTree,
 } from '../../network/RelayNetworkTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlightAndClientFragment-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlightAndClientFragment-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
@@ -106,13 +108,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         });
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        complete = jest.fn();
+        complete = jest.fn<[], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        error = jest.fn();
+        error = jest.fn<[Error], mixed>();
         /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
          * enabling Flow LTI mode */
-        next = jest.fn();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
           _query: RequestParameters,
@@ -133,7 +135,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           }),
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          get: jest.fn(),
+          get: jest.fn<[mixed], ?NormalizationRootNode>(),
         };
         source = RelayRecordSource.create();
         // DataChecker receives its operationLoader from the store, not the

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlightAndClientFragment-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlightAndClientFragment-test.js
@@ -96,6 +96,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           }
         `;
 
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         reactFlightPayloadDeserializer = jest.fn(payload => {
           return {
             readRoot() {
@@ -103,8 +104,14 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             },
           };
         });
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         complete = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         error = jest.fn();
+        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+         * enabling Flow LTI mode */
         next = jest.fn();
         callbacks = {complete, error, next};
         fetch = (
@@ -118,23 +125,28 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           });
         };
         operationLoader = {
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           load: jest.fn(moduleName => {
             return new Promise(resolve => {
               resolveFragment = resolve;
             });
           }),
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           get: jest.fn(),
         };
         source = RelayRecordSource.create();
         // DataChecker receives its operationLoader from the store, not the
         // environment. So we have to pass it here as well.
         store = new RelayModernStore(source, {
+          // $FlowFixMe[incompatible-call] error found when enabling Flow LTI mode
           operationLoader,
           gcReleaseBufferSize: 0,
         });
         const multiActorEnvironment = new MultiActorEnvironment({
           createNetworkForActor: _actorID => RelayNetwork.create(fetch),
           createStoreForActor: _actorID => store,
+          // $FlowFixMe[incompatible-call] error found when enabling Flow LTI mode
           operationLoader,
           reactFlightPayloadDeserializer,
         });
@@ -143,6 +155,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             ? multiActorEnvironment.forActor(getActorIdentifier('actor:1234'))
             : new RelayModernEnvironment({
                 network: RelayNetwork.create(fetch),
+                // $FlowFixMe[incompatible-call] error found when enabling Flow LTI mode
                 operationLoader,
                 store,
                 reactFlightPayloadDeserializer,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlightAndClientFragment-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlightAndClientFragment-test.js
@@ -106,14 +106,8 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             },
           };
         });
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         complete = jest.fn<[], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         error = jest.fn<[Error], mixed>();
-        /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-         * enabling Flow LTI mode */
         next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
         fetch = (
@@ -133,8 +127,6 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
               resolveFragment = resolve;
             });
           }),
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           get: jest.fn<[mixed], ?NormalizationRootNode>(),
         };
         source = RelayRecordSource.create();

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlightAndClientFragment-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithFlightAndClientFragment-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
+import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithHandlerAndUpdater-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithHandlerAndUpdater-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {RecordSourceSelectorProxy} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {
   HandleFieldPayload,
@@ -55,11 +57,13 @@ describe('execute() with handler and updater', () => {
     `;
     operation = createOperationDescriptor(query, {});
 
-    complete = jest.fn();
-    error = jest.fn();
-    next = jest.fn();
+    complete = jest.fn<[], mixed>();
+    error = jest.fn<[Error], mixed>();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
+    // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
     fetch = jest.fn((_query, _variables, _cacheConfig) =>
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       RelayObservable.create(sink => {
         subject = sink;
       }),
@@ -93,7 +97,7 @@ describe('execute() with handler and updater', () => {
   });
 
   it('calls next() and runs updater when payloads return', () => {
-    const updater = jest.fn();
+    const updater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
     environment.executeSubscription({operation, updater}).subscribe(callbacks);
     subject.next({
       data: {

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithHandlerAndUpdater-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithHandlerAndUpdater-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {RecordSourceSelectorProxy} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
+import type {RecordSourceSelectorProxy} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatch-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {
@@ -122,13 +123,13 @@ describe('execute() a query with @match', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<$ReadOnlyArray<Error>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -165,7 +166,7 @@ describe('execute() a query with @match', () => {
     const operationSnapshot = environment.lookup(operation.fragment);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    operationCallback = jest.fn();
+    operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
 
@@ -279,7 +280,7 @@ describe('execute() a query with @match', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     resolveFragment(markdownRendererNormalizationFragment);
@@ -646,7 +647,7 @@ describe('execute() a query with @match', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     subscription.unsubscribe();
@@ -744,7 +745,7 @@ describe('execute() a query with @match', () => {
       expect(initialMatchSnapshot.isMissingData).toBe(true);
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      const matchCallback = jest.fn();
+      const matchCallback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialMatchSnapshot, matchCallback);
 
       resolveFragment(markdownRendererNormalizationFragment);
@@ -817,7 +818,7 @@ describe('execute() a query with @match', () => {
       expect(initialMatchSnapshot.isMissingData).toBe(true);
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      const matchCallback = jest.fn();
+      const matchCallback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialMatchSnapshot, matchCallback);
 
       resolveFragment(markdownRendererNormalizationFragment);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatch-test.js
@@ -121,14 +121,8 @@ describe('execute() a query with @match', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<$ReadOnlyArray<Error>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -164,8 +158,6 @@ describe('execute() a query with @match', () => {
     });
 
     const operationSnapshot = environment.lookup(operation.fragment);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -278,8 +270,6 @@ describe('execute() a query with @match', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -645,8 +635,6 @@ describe('execute() a query with @match', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -743,8 +731,6 @@ describe('execute() a query with @match', () => {
       // initial results tested above
       const initialMatchSnapshot = environment.lookup(matchSelector);
       expect(initialMatchSnapshot.isMissingData).toBe(true);
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       const matchCallback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -816,8 +802,6 @@ describe('execute() a query with @match', () => {
       // initial results tested above
       const initialMatchSnapshot = environment.lookup(matchSelector);
       expect(initialMatchSnapshot.isMissingData).toBe(true);
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       const matchCallback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatch-test.js
@@ -120,8 +120,14 @@ describe('execute() a query with @match', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -157,6 +163,8 @@ describe('execute() a query with @match', () => {
     });
 
     const operationSnapshot = environment.lookup(operation.fragment);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     operationCallback = jest.fn();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -269,6 +277,8 @@ describe('execute() a query with @match', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -634,6 +644,8 @@ describe('execute() a query with @match', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -730,6 +742,8 @@ describe('execute() a query with @match', () => {
       // initial results tested above
       const initialMatchSnapshot = environment.lookup(matchSelector);
       expect(initialMatchSnapshot.isMissingData).toBe(true);
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       const matchCallback = jest.fn();
       environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -801,6 +815,8 @@ describe('execute() a query with @match', () => {
       // initial results tested above
       const initialMatchSnapshot = environment.lookup(matchSelector);
       expect(initialMatchSnapshot.isMissingData).toBe(true);
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       const matchCallback = jest.fn();
       environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatch-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
-
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatchAdditionalArguments-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatchAdditionalArguments-test.js
@@ -122,14 +122,8 @@ describe('execute() a query with @match with additional arguments', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<$ReadOnlyArray<Error>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -165,8 +159,6 @@ describe('execute() a query with @match with additional arguments', () => {
     });
 
     const operationSnapshot = environment.lookup(operation.fragment);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -280,8 +272,6 @@ describe('execute() a query with @match with additional arguments', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -435,8 +425,6 @@ describe('execute() a query with @match with additional arguments', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -536,8 +524,6 @@ describe('execute() a query with @match with additional arguments', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -806,8 +792,6 @@ describe('execute() a query with @match with additional arguments', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatchAdditionalArguments-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatchAdditionalArguments-test.js
@@ -121,8 +121,14 @@ describe('execute() a query with @match with additional arguments', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -158,6 +164,8 @@ describe('execute() a query with @match with additional arguments', () => {
     });
 
     const operationSnapshot = environment.lookup(operation.fragment);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     operationCallback = jest.fn();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -271,6 +279,8 @@ describe('execute() a query with @match with additional arguments', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -424,6 +434,8 @@ describe('execute() a query with @match with additional arguments', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -523,6 +535,8 @@ describe('execute() a query with @match with additional arguments', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -791,6 +805,8 @@ describe('execute() a query with @match with additional arguments', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatchAdditionalArguments-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatchAdditionalArguments-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {
@@ -123,13 +124,13 @@ describe('execute() a query with @match with additional arguments', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<$ReadOnlyArray<Error>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -166,7 +167,7 @@ describe('execute() a query with @match with additional arguments', () => {
     const operationSnapshot = environment.lookup(operation.fragment);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    operationCallback = jest.fn();
+    operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
 
@@ -281,7 +282,7 @@ describe('execute() a query with @match with additional arguments', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     resolveFragment(markdownRendererNormalizationFragment);
@@ -436,7 +437,7 @@ describe('execute() a query with @match with additional arguments', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     resolveFragment(markdownRendererNormalizationFragment);
@@ -537,7 +538,7 @@ describe('execute() a query with @match with additional arguments', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     resolveFragment(markdownRendererNormalizationFragment);
@@ -807,7 +808,7 @@ describe('execute() a query with @match with additional arguments', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     subscription.unsubscribe();

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatchAdditionalArguments-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithMatchAdditionalArguments-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
-
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModule-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModule-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {
   HandleFieldPayload,
@@ -122,13 +123,13 @@ describe('execute() a query with @module', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<$ReadOnlyArray<Error>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -164,7 +165,7 @@ describe('execute() a query with @module', () => {
     const operationSnapshot = environment.lookup(operation.fragment);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    operationCallback = jest.fn();
+    operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
 
@@ -278,7 +279,7 @@ describe('execute() a query with @module', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     resolveFragment(markdownRendererNormalizationFragment);
@@ -610,7 +611,7 @@ describe('execute() a query with @module', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     subscription.unsubscribe();

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModule-test.js
@@ -120,8 +120,14 @@ describe('execute() a query with @module', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -156,6 +162,8 @@ describe('execute() a query with @module', () => {
       },
     });
     const operationSnapshot = environment.lookup(operation.fragment);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     operationCallback = jest.fn();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -268,6 +276,8 @@ describe('execute() a query with @module', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -598,6 +608,8 @@ describe('execute() a query with @module', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModule-test.js
@@ -121,14 +121,8 @@ describe('execute() a query with @module', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<$ReadOnlyArray<Error>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -163,8 +157,6 @@ describe('execute() a query with @module', () => {
       },
     });
     const operationSnapshot = environment.lookup(operation.fragment);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -277,8 +269,6 @@ describe('execute() a query with @module', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -609,8 +599,6 @@ describe('execute() a query with @module', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleOnConcreteField-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleOnConcreteField-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
@@ -82,13 +84,13 @@ describe('execute() a query with @module on a field with a nullable concrete typ
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<any | [Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -118,7 +120,7 @@ describe('execute() a query with @module on a field with a nullable concrete typ
     const operationSnapshot = environment.lookup(operation.fragment);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    operationCallback = jest.fn();
+    operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
 
@@ -224,7 +226,7 @@ describe('execute() a query with @module on a field with a nullable concrete typ
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     resolveFragment(authorNormalizationFragment);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleOnConcreteField-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleOnConcreteField-test.js
@@ -10,10 +10,9 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleOnConcreteField-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleOnConcreteField-test.js
@@ -80,8 +80,14 @@ describe('execute() a query with @module on a field with a nullable concrete typ
     variables = {id: '1'};
     operation = createOperationDescriptor(query, variables);
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -110,6 +116,8 @@ describe('execute() a query with @module on a field with a nullable concrete typ
       operationLoader,
     });
     const operationSnapshot = environment.lookup(operation.fragment);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     operationCallback = jest.fn();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -214,6 +222,8 @@ describe('execute() a query with @module on a field with a nullable concrete typ
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleOnConcreteField-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleOnConcreteField-test.js
@@ -82,14 +82,8 @@ describe('execute() a query with @module on a field with a nullable concrete typ
     variables = {id: '1'};
     operation = createOperationDescriptor(query, variables);
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<any | [Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -118,8 +112,6 @@ describe('execute() a query with @module on a field with a nullable concrete typ
       operationLoader,
     });
     const operationSnapshot = environment.lookup(operation.fragment);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -224,8 +216,6 @@ describe('execute() a query with @module on a field with a nullable concrete typ
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleWithKey-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleWithKey-test.js
@@ -125,14 +125,8 @@ describe('execute() a query with @module', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<$ReadOnlyArray<Error>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -167,8 +161,6 @@ describe('execute() a query with @module', () => {
       },
     });
     const operationSnapshot = environment.lookup(operation.fragment);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -281,8 +273,6 @@ describe('execute() a query with @module', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -613,8 +603,6 @@ describe('execute() a query with @module', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleWithKey-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleWithKey-test.js
@@ -124,8 +124,14 @@ describe('execute() a query with @module', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -160,6 +166,8 @@ describe('execute() a query with @module', () => {
       },
     });
     const operationSnapshot = environment.lookup(operation.fragment);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     operationCallback = jest.fn();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -272,6 +280,8 @@ describe('execute() a query with @module', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
@@ -602,6 +612,8 @@ describe('execute() a query with @module', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleWithKey-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleWithKey-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {
@@ -126,13 +127,13 @@ describe('execute() a query with @module', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<$ReadOnlyArray<Error>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -168,7 +169,7 @@ describe('execute() a query with @module', () => {
     const operationSnapshot = environment.lookup(operation.fragment);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    operationCallback = jest.fn();
+    operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
 
@@ -282,7 +283,7 @@ describe('execute() a query with @module', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     resolveFragment(markdownRendererNormalizationFragment);
@@ -614,7 +615,7 @@ describe('execute() a query with @module', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     subscription.unsubscribe();

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleWithKey-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithModuleWithKey-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
-
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedMatch-test.js
@@ -129,8 +129,14 @@ describe('execute() a query with nested @match', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -165,6 +171,8 @@ describe('execute() a query with nested @match', () => {
       },
     });
     const operationSnapshot = environment.lookup(operation.fragment);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     operationCallback = jest.fn();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -307,6 +315,8 @@ describe('execute() a query with nested @match', () => {
     // initial outer fragment snapshot is tested above
     const initialOuterMatchSnapshot = environment.lookup(outerMatchSelector);
     expect(initialOuterMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const outerMatchCallback = jest.fn();
     environment.subscribe(initialOuterMatchSnapshot, outerMatchCallback);
 
@@ -351,6 +361,8 @@ describe('execute() a query with nested @match', () => {
     );
     const initialInnerMatchSnapshot = environment.lookup(innerMatchSelector);
     expect(initialInnerMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const innerMatchCallback = jest.fn();
     environment.subscribe(initialInnerMatchSnapshot, innerMatchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedMatch-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {
@@ -131,13 +132,13 @@ describe('execute() a query with nested @match', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<$ReadOnlyArray<Error>, mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -173,7 +174,7 @@ describe('execute() a query with nested @match', () => {
     const operationSnapshot = environment.lookup(operation.fragment);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    operationCallback = jest.fn();
+    operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
 
@@ -317,7 +318,7 @@ describe('execute() a query with nested @match', () => {
     expect(initialOuterMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const outerMatchCallback = jest.fn();
+    const outerMatchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialOuterMatchSnapshot, outerMatchCallback);
 
     resolveFragment(markdownRendererNormalizationFragment);
@@ -363,7 +364,7 @@ describe('execute() a query with nested @match', () => {
     expect(initialInnerMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const innerMatchCallback = jest.fn();
+    const innerMatchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialInnerMatchSnapshot, innerMatchCallback);
 
     resolveFragment(plaintextRendererNormalizationFragment);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedMatch-test.js
@@ -130,14 +130,8 @@ describe('execute() a query with nested @match', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<$ReadOnlyArray<Error>, mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -172,8 +166,6 @@ describe('execute() a query with nested @match', () => {
       },
     });
     const operationSnapshot = environment.lookup(operation.fragment);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -316,8 +308,6 @@ describe('execute() a query with nested @match', () => {
     // initial outer fragment snapshot is tested above
     const initialOuterMatchSnapshot = environment.lookup(outerMatchSelector);
     expect(initialOuterMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const outerMatchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialOuterMatchSnapshot, outerMatchCallback);
 
@@ -362,8 +352,6 @@ describe('execute() a query with nested @match', () => {
     );
     const initialInnerMatchSnapshot = environment.lookup(innerMatchSelector);
     expect(initialInnerMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const innerMatchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialInnerMatchSnapshot, innerMatchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedMatch-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
-
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedStream-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedStream-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,
@@ -118,13 +120,13 @@ describe('execute() a query with nested @stream', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -153,7 +155,7 @@ describe('execute() a query with nested @stream', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    callback = jest.fn();
+    callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedStream-test.js
@@ -118,14 +118,8 @@ describe('execute() a query with nested @stream', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -153,8 +147,6 @@ describe('execute() a query with nested @stream', () => {
 
     // Publish an initial root payload and a parent nested stream payload
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithNestedStream-test.js
@@ -116,8 +116,14 @@ describe('execute() a query with nested @stream', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -145,6 +151,8 @@ describe('execute() a query with nested @stream', () => {
 
     // Publish an initial root payload and a parent nested stream payload
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithObservableNetwork-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithObservableNetwork-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot, RecordSourceSelectorProxy} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {RecordSourceSelectorProxy, Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithObservableNetwork-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithObservableNetwork-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot, RecordSourceSelectorProxy} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -66,11 +68,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           foo: 'bar', // should be filtered from network fetch
         });
 
-        complete = jest.fn();
-        error = jest.fn();
-        next = jest.fn();
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetch = jest.fn((_query, _variables, _cacheConfig) =>
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           RelayObservable.create(sink => {
             subject = sink;
           }),
@@ -146,7 +150,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
       });
 
       it('calls next() and runs updater when payloads return', () => {
-        const updater = jest.fn();
+        const updater = jest.fn<[RecordSourceSelectorProxy, ?{...}], void>();
         environment
           .executeSubscription({operation, updater})
           .subscribe(callbacks);
@@ -204,7 +208,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOptimisticResponse-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOptimisticResponse-test.js
@@ -81,8 +81,14 @@ describe('execute() with network that returns optimistic response', () => {
       foo: 'bar', // should be filtered from network fetch
     });
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -111,6 +117,8 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(snapshot, callback);
 
@@ -151,6 +159,8 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(snapshot, callback);
 
@@ -210,6 +220,8 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(snapshot, callback);
 
@@ -252,6 +264,8 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(snapshot, callback);
 
@@ -296,6 +310,8 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(snapshot, callback);
 
@@ -338,6 +354,8 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(snapshot, callback);
 
@@ -391,6 +409,8 @@ describe('execute() with network that returns optimistic response', () => {
     );
 
     const snapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(snapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOptimisticResponse-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOptimisticResponse-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   RelayModernEnvironmentExecuteWithOptimisticResponseTestActor2Query$data,
   RelayModernEnvironmentExecuteWithOptimisticResponseTestActor2Query$variables,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOptimisticResponse-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOptimisticResponse-test.js
@@ -83,14 +83,8 @@ describe('execute() with network that returns optimistic response', () => {
       foo: 'bar', // should be filtered from network fetch
     });
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -119,8 +113,6 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
@@ -161,8 +153,6 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
@@ -222,8 +212,6 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
@@ -266,8 +254,6 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
@@ -312,8 +298,6 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
@@ -356,8 +340,6 @@ describe('execute() with network that returns optimistic response', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
@@ -411,8 +393,6 @@ describe('execute() with network that returns optimistic response', () => {
     );
 
     const snapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOptimisticResponse-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOptimisticResponse-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {
   RelayModernEnvironmentExecuteWithOptimisticResponseTestActor2Query$data,
   RelayModernEnvironmentExecuteWithOptimisticResponseTestActor2Query$variables,
@@ -83,13 +85,13 @@ describe('execute() with network that returns optimistic response', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -119,7 +121,7 @@ describe('execute() with network that returns optimistic response', () => {
     const snapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -161,7 +163,7 @@ describe('execute() with network that returns optimistic response', () => {
     const snapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -222,7 +224,7 @@ describe('execute() with network that returns optimistic response', () => {
     const snapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -266,7 +268,7 @@ describe('execute() with network that returns optimistic response', () => {
     const snapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -312,7 +314,7 @@ describe('execute() with network that returns optimistic response', () => {
     const snapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     const subscription = environment.execute({operation}).subscribe(callbacks);
@@ -356,7 +358,7 @@ describe('execute() with network that returns optimistic response', () => {
     const snapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     const subscription = environment.execute({operation}).subscribe(callbacks);
@@ -411,7 +413,7 @@ describe('execute() with network that returns optimistic response', () => {
     const snapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingModule-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {NormalizationRootNode} from '../../util/NormalizationNode';
 
 import type {
   HandleFieldPayload,
@@ -144,7 +146,7 @@ describe('execute() multiple queries with overlapping @module-s', () => {
       }),
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      get: jest.fn(),
+      get: jest.fn<[mixed], ?NormalizationRootNode>(),
     };
     source = RelayRecordSource.create();
     store = new RelayModernStore(source);
@@ -162,12 +164,12 @@ describe('execute() multiple queries with overlapping @module-s', () => {
     const actorOperationSnapshot = environment.lookup(actorOperation.fragment);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    actorOperationCallback = jest.fn();
+    actorOperationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(actorOperationSnapshot, actorOperationCallback);
     const userOperationSnapshot = environment.lookup(userOperation.fragment);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    userOperationCallback = jest.fn();
+    userOperationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(userOperationSnapshot, userOperationCallback);
   });
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingModule-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
-
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingModule-test.js
@@ -138,9 +138,12 @@ describe('execute() multiple queries with overlapping @module-s', () => {
       });
     };
     operationLoader = {
+      // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
       load: jest.fn(moduleName => {
         return Promise.resolve();
       }),
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       get: jest.fn(),
     };
     source = RelayRecordSource.create();
@@ -157,9 +160,13 @@ describe('execute() multiple queries with overlapping @module-s', () => {
       },
     });
     const actorOperationSnapshot = environment.lookup(actorOperation.fragment);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     actorOperationCallback = jest.fn();
     environment.subscribe(actorOperationSnapshot, actorOperationCallback);
     const userOperationSnapshot = environment.lookup(userOperation.fragment);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     userOperationCallback = jest.fn();
     environment.subscribe(userOperationSnapshot, userOperationCallback);
   });

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingModule-test.js
@@ -144,8 +144,6 @@ describe('execute() multiple queries with overlapping @module-s', () => {
       load: jest.fn(moduleName => {
         return Promise.resolve();
       }),
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       get: jest.fn<[mixed], ?NormalizationRootNode>(),
     };
     source = RelayRecordSource.create();
@@ -162,13 +160,9 @@ describe('execute() multiple queries with overlapping @module-s', () => {
       },
     });
     const actorOperationSnapshot = environment.lookup(actorOperation.fragment);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     actorOperationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(actorOperationSnapshot, actorOperationCallback);
     const userOperationSnapshot = environment.lookup(userOperation.fragment);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     userOperationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(userOperationSnapshot, userOperationCallback);
   });

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingStream-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingStream-test.js
@@ -121,8 +121,14 @@ describe('execute() a query with multiple @stream selections on the same record'
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -153,6 +159,8 @@ describe('execute() a query with multiple @stream selections on the same record'
 
   it('calls next() and publishes the initial payload to the store', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -197,7 +205,11 @@ describe('execute() a query with multiple @stream selections on the same record'
 
   it('processes sequential payloads (all actors, then all viewedBy)', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const deferCallback = jest.fn();
 
     environment.subscribe(initialSnapshot, callback);
@@ -335,7 +347,11 @@ describe('execute() a query with multiple @stream selections on the same record'
 
   it('processes interleaved streamed payloads (actor/viewedBy/actor/viewedBy)', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const deferCallback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingStream-test.js
@@ -123,14 +123,8 @@ describe('execute() a query with multiple @stream selections on the same record'
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -161,8 +155,6 @@ describe('execute() a query with multiple @stream selections on the same record'
 
   it('calls next() and publishes the initial payload to the store', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -207,11 +199,7 @@ describe('execute() a query with multiple @stream selections on the same record'
 
   it('processes sequential payloads (all actors, then all viewedBy)', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const deferCallback = jest.fn<[Snapshot], void>();
 
     environment.subscribe(initialSnapshot, callback);
@@ -349,11 +337,7 @@ describe('execute() a query with multiple @stream selections on the same record'
 
   it('processes interleaved streamed payloads (actor/viewedBy/actor/viewedBy)', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const deferCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithOverlappingStream-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,
@@ -123,13 +125,13 @@ describe('execute() a query with multiple @stream selections on the same record'
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -161,7 +163,7 @@ describe('execute() a query with multiple @stream selections on the same record'
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -207,10 +209,10 @@ describe('execute() a query with multiple @stream selections on the same record'
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const deferCallback = jest.fn();
+    const deferCallback = jest.fn<[Snapshot], void>();
 
     environment.subscribe(initialSnapshot, callback);
 
@@ -349,10 +351,10 @@ describe('execute() a query with multiple @stream selections on the same record'
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const deferCallback = jest.fn();
+    const deferCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPluralMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPluralMatch-test.js
@@ -115,14 +115,8 @@ describe('execute() a query with plural @match', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -158,8 +152,6 @@ describe('execute() a query with plural @match', () => {
     });
 
     const operationSnapshot = environment.lookup(operation.fragment);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -279,8 +271,6 @@ describe('execute() a query with plural @match', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPluralMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPluralMatch-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {
@@ -115,13 +117,13 @@ describe('execute() a query with plural @match', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -158,7 +160,7 @@ describe('execute() a query with plural @match', () => {
     const operationSnapshot = environment.lookup(operation.fragment);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    operationCallback = jest.fn();
+    operationCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(operationSnapshot, operationCallback);
   });
 
@@ -279,7 +281,7 @@ describe('execute() a query with plural @match', () => {
     expect(initialMatchSnapshot.isMissingData).toBe(true);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const matchCallback = jest.fn();
+    const matchCallback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 
     resolveFragment(markdownRendererNormalizationFragment);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPluralMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPluralMatch-test.js
@@ -113,8 +113,14 @@ describe('execute() a query with plural @match', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -150,6 +156,8 @@ describe('execute() a query with plural @match', () => {
     });
 
     const operationSnapshot = environment.lookup(operation.fragment);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     operationCallback = jest.fn();
     environment.subscribe(operationSnapshot, operationCallback);
   });
@@ -269,6 +277,8 @@ describe('execute() a query with plural @match', () => {
     // initial results tested above
     const initialMatchSnapshot = environment.lookup(matchSelector);
     expect(initialMatchSnapshot.isMissingData).toBe(true);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const matchCallback = jest.fn();
     environment.subscribe(initialMatchSnapshot, matchCallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPluralMatch-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPluralMatch-test.js
@@ -10,10 +10,9 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPromiseNetwork-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPromiseNetwork-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const {graphql} = require('../../query/GraphQLTag');

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPromiseNetwork-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithPromiseNetwork-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const {graphql} = require('../../query/GraphQLTag');
@@ -58,9 +60,9 @@ describe('execute() with Promise network', () => {
       foo: 'bar', // should be filtered from network fetch
     });
 
-    complete = jest.fn();
-    error = jest.fn();
-    next = jest.fn();
+    complete = jest.fn<[], mixed>();
+    error = jest.fn<[Error], mixed>();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = jest.fn(
       () =>
@@ -143,7 +145,7 @@ describe('execute() with Promise network', () => {
       operation.request,
     );
     const snapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithProvidedVariable-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithProvidedVariable-test.js
@@ -11,7 +11,6 @@
 
 'use strict';
 import type {Sink} from '../../network/RelayObservable';
-
 import type {ReaderFragment} from '../../util/ReaderNode';
 import type {OperationDescriptor, Snapshot} from '../RelayStoreTypes';
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithProvidedVariable-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithProvidedVariable-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Sink} from '../../network/RelayObservable';
 
 import type {ReaderFragment} from '../../util/ReaderNode';
 import type {OperationDescriptor, Snapshot} from '../RelayStoreTypes';
@@ -33,10 +34,31 @@ function getEnvironment(
   operation: OperationDescriptor,
 ): RelayModernEnvironment {
   let subject;
-  const fetch = jest.fn((_query, _variables, _cacheConfig) =>
-    RelayObservable.create(sink => {
-      subject = sink;
-    }),
+  const fetch = jest.fn(
+    (
+      _query: $FlowExpectedError,
+      _variables: $FlowExpectedError,
+      _cacheConfig: $FlowExpectedError,
+    ) =>
+      RelayObservable.create(
+        (
+          sink: Sink<{
+            data: {
+              node: {
+                __typename: string,
+                alternate_name: string,
+                id: string,
+                name: string,
+                profilePicture: {uri: string},
+                profile_picture: {uri: string},
+                username: string,
+              },
+            },
+          }>,
+        ) => {
+          subject = sink;
+        },
+      ),
   );
   const source = RelayRecordSource.create();
   const store = new RelayModernStore(source);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithRelayClientComponent-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithRelayClientComponent-test.js
@@ -73,8 +73,14 @@ describe('execute() with @relay_client_component', () => {
       }
     `;
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -90,7 +96,11 @@ describe('execute() with @relay_client_component', () => {
     network = RelayNetwork.create(fetch);
     source = RelayRecordSource.create();
     operationLoader = {
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       load: jest.fn(),
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       get: jest.fn(),
     };
     operation = createOperationDescriptor(Query, {id: '1'});

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithRelayClientComponent-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithRelayClientComponent-test.js
@@ -75,14 +75,8 @@ describe('execute() with @relay_client_component', () => {
       }
     `;
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -98,11 +92,7 @@ describe('execute() with @relay_client_component', () => {
     network = RelayNetwork.create(fetch);
     source = RelayRecordSource.create();
     operationLoader = {
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       load: jest.fn<[mixed], Promise<?NormalizationRootNode>>(),
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       get: jest.fn<[mixed], ?NormalizationRootNode>(),
     };
     operation = createOperationDescriptor(Query, {id: '1'});

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithRelayClientComponent-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithRelayClientComponent-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
-
+import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithRelayClientComponent-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithRelayClientComponent-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
@@ -75,13 +77,13 @@ describe('execute() with @relay_client_component', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -98,10 +100,10 @@ describe('execute() with @relay_client_component', () => {
     operationLoader = {
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      load: jest.fn(),
+      load: jest.fn<[mixed], Promise<?NormalizationRootNode>>(),
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      get: jest.fn(),
+      get: jest.fn<[mixed], ?NormalizationRootNode>(),
     };
     operation = createOperationDescriptor(Query, {id: '1'});
   });

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSiblingAndNestedModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSiblingAndNestedModule-test.js
@@ -141,8 +141,14 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
           variables = {id: '1'};
           operation = createOperationDescriptor(query, variables);
 
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           complete = jest.fn();
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           error = jest.fn();
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           next = jest.fn();
           callbacks = {complete, error, next};
           fetch = (
@@ -164,6 +170,8 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             get: jest.fn(),
           };
           source = RelayRecordSource.create();
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           logger = jest.fn();
           store = new RelayModernStore(source, {
             log: logger,
@@ -184,6 +192,8 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
                 });
 
           const operationSnapshot = environment.lookup(operation.fragment);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           operationCallback = jest.fn();
           environment.subscribe(operationSnapshot, operationCallback);
         });
@@ -250,6 +260,8 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererASelector,
           );
           expect(outerRendererASnapshot.isMissingData).toBe(true);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           const outerRendererACallback = jest.fn();
           environment.subscribe(outerRendererASnapshot, outerRendererACallback);
 
@@ -263,6 +275,8 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererBSelector,
           );
           expect(outerRendererBSnapshot.isMissingData).toBe(true);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           const outerRendererBCallback = jest.fn();
           environment.subscribe(outerRendererBSnapshot, outerRendererBCallback);
 
@@ -395,6 +409,8 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererASelector,
           );
           expect(outerRendererASnapshot.isMissingData).toBe(true);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           const outerRendererACallback = jest.fn();
           environment.subscribe(outerRendererASnapshot, outerRendererACallback);
 
@@ -408,6 +424,8 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererBSelector,
           );
           expect(outerRendererBSnapshot.isMissingData).toBe(true);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           const outerRendererBCallback = jest.fn();
           environment.subscribe(outerRendererBSnapshot, outerRendererBCallback);
 
@@ -632,6 +650,8 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererASelector,
           );
           expect(outerRendererASnapshot.isMissingData).toBe(true);
+          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
+           * when enabling Flow LTI mode */
           const outerRendererACallback = jest.fn();
           environment.subscribe(outerRendererASnapshot, outerRendererACallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSiblingAndNestedModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSiblingAndNestedModule-test.js
@@ -142,14 +142,8 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
           variables = {id: '1'};
           operation = createOperationDescriptor(query, variables);
 
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           error = jest.fn<$ReadOnlyArray<Error>, mixed>();
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
           callbacks = {complete, error, next};
           fetch = (
@@ -171,8 +165,6 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             get: jest.fn(),
           };
           source = RelayRecordSource.create();
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           logger = jest.fn<[LogEvent], void>();
           store = new RelayModernStore(source, {
             log: logger,
@@ -193,8 +185,6 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
                 });
 
           const operationSnapshot = environment.lookup(operation.fragment);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           operationCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(operationSnapshot, operationCallback);
         });
@@ -261,8 +251,6 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererASelector,
           );
           expect(outerRendererASnapshot.isMissingData).toBe(true);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           const outerRendererACallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererASnapshot, outerRendererACallback);
 
@@ -276,8 +264,6 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererBSelector,
           );
           expect(outerRendererBSnapshot.isMissingData).toBe(true);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           const outerRendererBCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererBSnapshot, outerRendererBCallback);
 
@@ -410,8 +396,6 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererASelector,
           );
           expect(outerRendererASnapshot.isMissingData).toBe(true);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           const outerRendererACallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererASnapshot, outerRendererACallback);
 
@@ -425,8 +409,6 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererBSelector,
           );
           expect(outerRendererBSnapshot.isMissingData).toBe(true);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           const outerRendererBCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererBSnapshot, outerRendererBCallback);
 
@@ -651,8 +633,6 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
             outerRendererASelector,
           );
           expect(outerRendererASnapshot.isMissingData).toBe(true);
-          /* $FlowFixMe[underconstrained-implicit-instantiation] error found
-           * when enabling Flow LTI mode */
           const outerRendererACallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererASnapshot, outerRendererACallback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSiblingAndNestedModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSiblingAndNestedModule-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot, LogEvent} from '../RelayStoreTypes';
 import type {NormalizationSplitOperation} from '../../util/NormalizationNode';
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
@@ -143,13 +144,13 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
 
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          complete = jest.fn();
+          complete = jest.fn<$ReadOnlyArray<mixed>, mixed>();
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          error = jest.fn();
+          error = jest.fn<$ReadOnlyArray<Error>, mixed>();
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          next = jest.fn();
+          next = jest.fn<$ReadOnlyArray<mixed>, mixed>();
           callbacks = {complete, error, next};
           fetch = (
             _query: RequestParameters,
@@ -172,7 +173,7 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
           source = RelayRecordSource.create();
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          logger = jest.fn();
+          logger = jest.fn<[LogEvent], void>();
           store = new RelayModernStore(source, {
             log: logger,
           });
@@ -194,7 +195,7 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
           const operationSnapshot = environment.lookup(operation.fragment);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          operationCallback = jest.fn();
+          operationCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(operationSnapshot, operationCallback);
         });
 
@@ -262,7 +263,7 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
           expect(outerRendererASnapshot.isMissingData).toBe(true);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          const outerRendererACallback = jest.fn();
+          const outerRendererACallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererASnapshot, outerRendererACallback);
 
           const outerRendererBSelector = nullthrows(
@@ -277,7 +278,7 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
           expect(outerRendererBSnapshot.isMissingData).toBe(true);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          const outerRendererBCallback = jest.fn();
+          const outerRendererBCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererBSnapshot, outerRendererBCallback);
 
           logger.mockClear();
@@ -411,7 +412,7 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
           expect(outerRendererASnapshot.isMissingData).toBe(true);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          const outerRendererACallback = jest.fn();
+          const outerRendererACallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererASnapshot, outerRendererACallback);
 
           const outerRendererBSelector = nullthrows(
@@ -426,7 +427,7 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
           expect(outerRendererBSnapshot.isMissingData).toBe(true);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          const outerRendererBCallback = jest.fn();
+          const outerRendererBCallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererBSnapshot, outerRendererBCallback);
 
           logger.mockClear();
@@ -652,7 +653,7 @@ function runWithFeatureFlags(setFlags: (typeof RelayFeatureFlags) => void) {
           expect(outerRendererASnapshot.isMissingData).toBe(true);
           /* $FlowFixMe[underconstrained-implicit-instantiation] error found
            * when enabling Flow LTI mode */
-          const outerRendererACallback = jest.fn();
+          const outerRendererACallback = jest.fn<[Snapshot], void>();
           environment.subscribe(outerRendererASnapshot, outerRendererACallback);
 
           next.mockClear();

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSiblingAndNestedModule-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSiblingAndNestedModule-test.js
@@ -10,9 +10,9 @@
  */
 
 'use strict';
-import type {Snapshot, LogEvent} from '../RelayStoreTypes';
 import type {NormalizationSplitOperation} from '../../util/NormalizationNode';
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {LogEvent, Snapshot} from '../RelayStoreTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSource-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSource-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSource-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithSource-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -67,11 +69,13 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           foo: 'bar', // should be filtered from network fetch
         });
 
-        complete = jest.fn();
-        error = jest.fn();
-        next = jest.fn();
+        complete = jest.fn<[], mixed>();
+        error = jest.fn<[Error], mixed>();
+        next = jest.fn<[GraphQLResponse], mixed>();
         callbacks = {complete, error, next};
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetch = jest.fn((_query, _variables, _cacheConfig) =>
+          // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
           RelayObservable.create(sink => {
             subject = sink;
           }),
@@ -91,6 +95,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
                 network: RelayNetwork.create(fetch),
                 store,
               });
+        // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
         fetchSourceMock = jest.fn(sink =>
           // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
           fetch(
@@ -169,7 +174,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           operation.request,
         );
         const snapshot = environment.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         environment.subscribe(snapshot, callback);
 
         environment

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStream-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStream-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStream-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,
@@ -106,9 +108,9 @@ describe('execute() a query with @stream', () => {
       return data.id;
     }
 
-    complete = jest.fn();
-    error = jest.fn();
-    next = jest.fn();
+    complete = jest.fn<[], mixed>();
+    error = jest.fn<[Error], mixed>();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -136,7 +138,7 @@ describe('execute() a query with @stream', () => {
 
   it('calls next() and publishes the initial payload to the store', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -166,7 +168,7 @@ describe('execute() a query with @stream', () => {
 
   it('processes streamed payloads', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -227,7 +229,7 @@ describe('execute() a query with @stream', () => {
 
   it('processes streamed payloads mixed with extensions-only payloads', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -276,7 +278,7 @@ describe('execute() a query with @stream', () => {
 
   it('processes batched streamed payloads (with use_customized_batch)', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -328,7 +330,7 @@ describe('execute() a query with @stream', () => {
 
   it('process error payloads in batched steaming responses', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -378,7 +380,7 @@ describe('execute() a query with @stream', () => {
 
   it('process batched steaming responses with the mix of initial and incremental payloads', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
     environment.execute({operation}).subscribe(callbacks);
     dataSource.next([
@@ -453,7 +455,7 @@ describe('execute() a query with @stream', () => {
 
   it('process batched steaming responses with the batch that has final payload', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
     environment.execute({operation}).subscribe(callbacks);
     expectToWarn(
@@ -532,7 +534,7 @@ describe('execute() a query with @stream', () => {
     });
 
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -633,7 +635,7 @@ describe('execute() a query with @stream', () => {
     });
 
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     const subscription = environment.execute({operation}).subscribe(callbacks);
@@ -674,7 +676,7 @@ describe('execute() a query with @stream', () => {
 
   it('processes @stream payloads when the parent record has been deleted', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -728,7 +730,7 @@ describe('execute() a query with @stream', () => {
 
   it('processes @stream payloads when the streamed field has been deleted on the parent record', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -791,7 +793,7 @@ describe('execute() a query with @stream', () => {
       'target index has changed on the parent record ()',
     () => {
       const initialSnapshot = environment.lookup(selector);
-      const callback = jest.fn();
+      const callback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialSnapshot, callback);
 
       environment.execute({operation}).subscribe(callbacks);
@@ -859,7 +861,7 @@ describe('execute() a query with @stream', () => {
       'an index other than the target has changed on the parent record ()',
     () => {
       const initialSnapshot = environment.lookup(selector);
-      const callback = jest.fn();
+      const callback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialSnapshot, callback);
 
       environment.execute({operation}).subscribe(callbacks);
@@ -946,7 +948,7 @@ describe('execute() a query with @stream', () => {
 
   it('processes streamed payloads that arrive out of order', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1009,7 +1011,7 @@ describe('execute() a query with @stream', () => {
 
   it('processes streamed payloads relative to the most recent root payload', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1071,7 +1073,7 @@ describe('execute() a query with @stream', () => {
 
   it('calls complete() when server completes after streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1112,7 +1114,7 @@ describe('execute() a query with @stream', () => {
 
   it('calls complete() when server completes before streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1142,7 +1144,7 @@ describe('execute() a query with @stream', () => {
 
   it('calls next() with extensions-only payloads', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1178,7 +1180,7 @@ describe('execute() a query with @stream', () => {
 
   it('calls error() when server errors after streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1221,7 +1223,7 @@ describe('execute() a query with @stream', () => {
 
   it('calls error() when server errors before streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1253,7 +1255,7 @@ describe('execute() a query with @stream', () => {
 
   it('calls error() when streamed payload is missing data', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1297,7 +1299,7 @@ describe('execute() a query with @stream', () => {
 
   it('calls error() when streamed payload has error', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1359,7 +1361,7 @@ describe('execute() a query with @stream', () => {
 
   it('uses user-defined getDataID to generate ID from streamed payload.', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -1425,7 +1427,7 @@ describe('execute() a query with @stream', () => {
 
   it('warns if executed in non-streaming mode', () => {
     const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamAndRequired-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamAndRequired-test.js
@@ -64,8 +64,14 @@ describe('execute() a query with @stream and @required', () => {
     `;
     const variables = {id: '1', enableStream: true};
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const next = jest.fn();
 
     operation = createOperationDescriptor(query, variables);
@@ -92,6 +98,8 @@ describe('execute() a query with @stream and @required', () => {
 
   it('bubbles @required @stream nodes up to the parent', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamAndRequired-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamAndRequired-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamAndRequired-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamAndRequired-test.js
@@ -66,14 +66,8 @@ describe('execute() a query with @stream and @required', () => {
     `;
     const variables = {id: '1', enableStream: true};
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const next = jest.fn<[GraphQLResponse], mixed>();
 
     operation = createOperationDescriptor(query, variables);
@@ -100,8 +94,6 @@ describe('execute() a query with @stream and @required', () => {
 
   it('bubbles @required @stream nodes up to the parent', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamAndRequired-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamAndRequired-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,
@@ -66,13 +68,13 @@ describe('execute() a query with @stream and @required', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const complete = jest.fn();
+    const complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const error = jest.fn();
+    const error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const next = jest.fn();
+    const next = jest.fn<[GraphQLResponse], mixed>();
 
     operation = createOperationDescriptor(query, variables);
     selector = createReaderSelector(fragment, '1', {}, operation.request);
@@ -100,7 +102,7 @@ describe('execute() a query with @stream and @required', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamWithHandler-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamWithHandler-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamWithHandler-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamWithHandler-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,
@@ -115,13 +117,13 @@ describe('execute() a query with @stream with handler', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -153,7 +155,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -185,7 +187,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -248,7 +250,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -304,7 +306,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -371,7 +373,7 @@ describe('execute() a query with @stream with handler', () => {
       const initialSnapshot = environment.lookup(selector);
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      const callback = jest.fn();
+      const callback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialSnapshot, callback);
 
       environment.execute({operation}).subscribe(callbacks);
@@ -444,7 +446,7 @@ describe('execute() a query with @stream with handler', () => {
       const initialSnapshot = environment.lookup(selector);
       /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
        * enabling Flow LTI mode */
-      const callback = jest.fn();
+      const callback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialSnapshot, callback);
 
       environment.execute({operation}).subscribe(callbacks);
@@ -534,7 +536,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -599,7 +601,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -663,7 +665,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -706,7 +708,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -738,7 +740,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -783,7 +785,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);
@@ -817,7 +819,7 @@ describe('execute() a query with @stream with handler', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamWithHandler-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamWithHandler-test.js
@@ -113,8 +113,14 @@ describe('execute() a query with @stream with handler', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -145,6 +151,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls next() and publishes the initial payload to the store', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -175,6 +183,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes streamed payloads', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -236,6 +246,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes @stream payloads when the parent record has been deleted', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -290,6 +302,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes @stream payloads when the streamed field has been deleted on the parent record', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -355,6 +369,8 @@ describe('execute() a query with @stream with handler', () => {
       'target index has changed on the parent record ()',
     () => {
       const initialSnapshot = environment.lookup(selector);
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       const callback = jest.fn();
       environment.subscribe(initialSnapshot, callback);
 
@@ -426,6 +442,8 @@ describe('execute() a query with @stream with handler', () => {
       'an index other than the target has changed on the parent record ()',
     () => {
       const initialSnapshot = environment.lookup(selector);
+      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+       * enabling Flow LTI mode */
       const callback = jest.fn();
       environment.subscribe(initialSnapshot, callback);
 
@@ -514,6 +532,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes streamed payloads that arrive out of order', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -577,6 +597,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes streamed payloads relative to the most recent root payload', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -639,6 +661,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls complete() when server completes after streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -680,6 +704,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls complete() when server completes before streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -710,6 +736,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls error() when server errors after streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -753,6 +781,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls error() when server errors before streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 
@@ -785,6 +815,8 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls error() when streamed payload is missing data', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamWithHandler-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamWithHandler-test.js
@@ -115,14 +115,8 @@ describe('execute() a query with @stream with handler', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -153,8 +147,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls next() and publishes the initial payload to the store', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -185,8 +177,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes streamed payloads', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -248,8 +238,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes @stream payloads when the parent record has been deleted', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -304,8 +292,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes @stream payloads when the streamed field has been deleted on the parent record', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -371,8 +357,6 @@ describe('execute() a query with @stream with handler', () => {
       'target index has changed on the parent record ()',
     () => {
       const initialSnapshot = environment.lookup(selector);
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       const callback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialSnapshot, callback);
 
@@ -444,8 +428,6 @@ describe('execute() a query with @stream with handler', () => {
       'an index other than the target has changed on the parent record ()',
     () => {
       const initialSnapshot = environment.lookup(selector);
-      /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-       * enabling Flow LTI mode */
       const callback = jest.fn<[Snapshot], void>();
       environment.subscribe(initialSnapshot, callback);
 
@@ -534,8 +516,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes streamed payloads that arrive out of order', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -599,8 +579,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('processes streamed payloads relative to the most recent root payload', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -663,8 +641,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls complete() when server completes after streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -706,8 +682,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls complete() when server completes before streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -738,8 +712,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls error() when server errors after streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -783,8 +755,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls error() when server errors before streamed payload resolves', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
@@ -817,8 +787,6 @@ describe('execute() a query with @stream with handler', () => {
 
   it('calls error() when streamed payload is missing data', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamedConnection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamedConnection-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,
@@ -118,13 +120,13 @@ describe('execute() fetches a @stream-ed @connection', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
       _query: RequestParameters,
@@ -155,7 +157,7 @@ describe('execute() fetches a @stream-ed @connection', () => {
     const initialSnapshot = environment.lookup(selector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    callback = jest.fn();
+    callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 
     environment.execute({operation}).subscribe(callbacks);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamedConnection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamedConnection-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   HandleFieldPayload,
   RecordSourceProxy,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamedConnection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamedConnection-test.js
@@ -116,8 +116,14 @@ describe('execute() fetches a @stream-ed @connection', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
     fetch = (
@@ -147,6 +153,8 @@ describe('execute() fetches a @stream-ed @connection', () => {
 
   it('initializes the connection with the first edge (0 => 1 edges)', () => {
     const initialSnapshot = environment.lookup(selector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     callback = jest.fn();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamedConnection-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithStreamedConnection-test.js
@@ -118,14 +118,8 @@ describe('execute() fetches a @stream-ed @connection', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
     fetch = (
@@ -155,8 +149,6 @@ describe('execute() fetches a @stream-ed @connection', () => {
 
   it('initializes the connection with the first edge (0 => 1 edges)', () => {
     const initialSnapshot = environment.lookup(selector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     callback = jest.fn<[Snapshot], void>();
     environment.subscribe(initialSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithUndeclaredUnusedArgument-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithUndeclaredUnusedArgument-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Sink} from '../../network/RelayObservable';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const RelayObservable = require('../../network/RelayObservable');
@@ -75,10 +76,28 @@ describe('query with undeclared, unused fragment argument', () => {
       }
     `;
     operation = createOperationDescriptor(query, {id: '4'});
-    fetch = jest.fn((_query, _variables, _cacheConfig) =>
-      RelayObservable.create(sink => {
-        subject = sink;
-      }),
+    fetch = jest.fn(
+      (
+        _query: $FlowExpectedError,
+        _variables: $FlowExpectedError,
+        _cacheConfig: $FlowExpectedError,
+      ) =>
+        RelayObservable.create(
+          (
+            sink: Sink<{
+              data: {
+                node: {
+                  __typename: string,
+                  id: string,
+                  name: string,
+                  profilePicture: {uri: string},
+                },
+              },
+            }>,
+          ) => {
+            subject = sink;
+          },
+        ),
     );
     source = RelayRecordSource.create();
     store = new RelayModernStore(source);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-NoInline-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-NoInline-test.js
@@ -10,6 +10,13 @@
  */
 
 'use strict';
+import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {
+  UploadableMap,
+  LogRequestInfoFunction,
+} from '../../network/RelayNetworkTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const {
   MultiActorEnvironment,
@@ -94,15 +101,39 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
       let callbacks;
 
       beforeEach(() => {
-        fetch = jest.fn((_query, _variables, _cacheConfig) =>
-          RelayObservable.create(sink => {
-            subject = sink;
-          }),
+        fetch = jest.fn(
+          (
+            _query: ?(
+              | LogRequestInfoFunction
+              | UploadableMap
+              | RequestParameters
+              | Variables
+              | CacheConfig
+            ),
+            _variables: ?(
+              | LogRequestInfoFunction
+              | UploadableMap
+              | RequestParameters
+              | Variables
+              | CacheConfig
+            ),
+            _cacheConfig: ?(
+              | LogRequestInfoFunction
+              | UploadableMap
+              | RequestParameters
+              | Variables
+              | CacheConfig
+            ),
+          ) =>
+            // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
+            RelayObservable.create(sink => {
+              subject = sink;
+            }),
         );
         callbacks = {
-          complete: jest.fn(),
-          error: jest.fn(),
-          next: jest.fn(),
+          complete: jest.fn<[], mixed>(),
+          error: jest.fn<[Error], mixed>(),
+          next: jest.fn<[GraphQLResponse], mixed>(),
         };
         source = RelayRecordSource.create();
         store = new RelayModernStore(source, {gcReleaseBufferSize: 0});
@@ -1079,7 +1110,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
         beforeEach(() => {
           fragmentToReturn = null;
           operationLoader = {
-            load: jest.fn(moduleName => {
+            load: jest.fn((moduleName: mixed) => {
               return new Promise(resolve => {
                 resolveFragment = resolve;
               });
@@ -1089,6 +1120,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
           store = new RelayModernStore(source, {
             gcReleaseBufferSize: 0,
             // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
+            // $FlowFixMe[incompatible-call] error found when enabling Flow LTI mode
             operationLoader,
           });
           environment = new RelayModernEnvironment({
@@ -1096,6 +1128,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
             network: RelayNetwork.create(fetch),
             store,
             // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
+            // $FlowFixMe[incompatible-call] error found when enabling Flow LTI mode
             operationLoader,
           });
         });

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-NoInline-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-NoInline-test.js
@@ -10,13 +10,13 @@
  */
 
 'use strict';
-import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../util/RelayConcreteNode';
 import type {
-  UploadableMap,
   LogRequestInfoFunction,
+  UploadableMap,
 } from '../../network/RelayNetworkTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {CacheConfig, Variables} from '../../util/RelayRuntimeTypes';
 
 const {
   MultiActorEnvironment,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-PartiallyNormalizedDataObservabilityWithBatchedUpdates-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-PartiallyNormalizedDataObservabilityWithBatchedUpdates-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
@@ -115,13 +117,13 @@ describe('execute() a query with @module if the module fragment is available syn
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
 
     // set up a subscription for the observation fragment.
@@ -131,7 +133,7 @@ describe('execute() a query with @module if the module fragment is available syn
     observationSnapshot = environment.lookup(observationSelector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    callback = jest.fn();
+    callback = jest.fn<[Snapshot], void>();
     environment.subscribe(observationSnapshot, callback);
 
     // ensure that the normalization fragment is available synchronously
@@ -250,13 +252,13 @@ describe('execute() a query with @module in @defer if the deferred fragment and 
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
 
     // set up a subscription for the observation fragment.
@@ -266,7 +268,7 @@ describe('execute() a query with @module in @defer if the deferred fragment and 
     observationSnapshot = environment.lookup(observationSelector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    callback = jest.fn();
+    callback = jest.fn<[Snapshot], void>();
     environment.subscribe(observationSnapshot, callback);
 
     // ensure that the normalization fragment is available synchronously
@@ -399,13 +401,13 @@ describe('execute() a query with nested @module fragments, where the inner @modu
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    complete = jest.fn();
+    complete = jest.fn<[], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    error = jest.fn();
+    error = jest.fn<[Error], mixed>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    next = jest.fn();
+    next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
 
     // set up a subscription for the observation fragment.
@@ -415,7 +417,7 @@ describe('execute() a query with nested @module fragments, where the inner @modu
     observationSnapshot = environment.lookup(observationSelector);
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    callback = jest.fn();
+    callback = jest.fn<[Snapshot], void>();
     environment.subscribe(observationSnapshot, callback);
 
     // ensure that the nested normalization fragment is available synchronously

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-PartiallyNormalizedDataObservabilityWithBatchedUpdates-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-PartiallyNormalizedDataObservabilityWithBatchedUpdates-test.js
@@ -10,9 +10,9 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 import type {NormalizationRootNode} from '../../util/NormalizationNode';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-PartiallyNormalizedDataObservabilityWithBatchedUpdates-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-PartiallyNormalizedDataObservabilityWithBatchedUpdates-test.js
@@ -115,14 +115,8 @@ describe('execute() a query with @module if the module fragment is available syn
       }
     `;
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
 
@@ -131,8 +125,6 @@ describe('execute() a query with @module if the module fragment is available syn
     // this subscription) the fragment in a partially-complete
     // state.
     observationSnapshot = environment.lookup(observationSelector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     callback = jest.fn<[Snapshot], void>();
     environment.subscribe(observationSnapshot, callback);
 
@@ -250,14 +242,8 @@ describe('execute() a query with @module in @defer if the deferred fragment and 
       }
     `;
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
 
@@ -266,8 +252,6 @@ describe('execute() a query with @module in @defer if the deferred fragment and 
     // this subscription) the fragment in a partially-complete
     // state.
     observationSnapshot = environment.lookup(observationSelector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     callback = jest.fn<[Snapshot], void>();
     environment.subscribe(observationSnapshot, callback);
 
@@ -399,14 +383,8 @@ describe('execute() a query with nested @module fragments, where the inner @modu
       operation.request,
     );
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     complete = jest.fn<[], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     error = jest.fn<[Error], mixed>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     next = jest.fn<[GraphQLResponse], mixed>();
     callbacks = {complete, error, next};
 
@@ -415,8 +393,6 @@ describe('execute() a query with nested @module fragments, where the inner @modu
     // this subscription) the fragment in a partially-complete
     // state.
     observationSnapshot = environment.lookup(observationSelector);
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     callback = jest.fn<[Snapshot], void>();
     environment.subscribe(observationSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-PartiallyNormalizedDataObservabilityWithBatchedUpdates-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-PartiallyNormalizedDataObservabilityWithBatchedUpdates-test.js
@@ -113,8 +113,14 @@ describe('execute() a query with @module if the module fragment is available syn
       }
     `;
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
 
@@ -123,6 +129,8 @@ describe('execute() a query with @module if the module fragment is available syn
     // this subscription) the fragment in a partially-complete
     // state.
     observationSnapshot = environment.lookup(observationSelector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     callback = jest.fn();
     environment.subscribe(observationSnapshot, callback);
 
@@ -240,8 +248,14 @@ describe('execute() a query with @module in @defer if the deferred fragment and 
       }
     `;
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
 
@@ -250,6 +264,8 @@ describe('execute() a query with @module in @defer if the deferred fragment and 
     // this subscription) the fragment in a partially-complete
     // state.
     observationSnapshot = environment.lookup(observationSelector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     callback = jest.fn();
     environment.subscribe(observationSnapshot, callback);
 
@@ -381,8 +397,14 @@ describe('execute() a query with nested @module fragments, where the inner @modu
       operation.request,
     );
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     complete = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     error = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     next = jest.fn();
     callbacks = {complete, error, next};
 
@@ -391,6 +413,8 @@ describe('execute() a query with nested @module fragments, where the inner @modu
     // this subscription) the fragment in a partially-complete
     // state.
     observationSnapshot = environment.lookup(observationSelector);
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     callback = jest.fn();
     environment.subscribe(observationSnapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Subscribe-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Subscribe-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const {graphql} = require('../../query/GraphQLTag');
@@ -78,7 +79,7 @@ describe('subscribe()', () => {
         operation.request,
       ),
     );
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(snapshot, callback);
     setName('4', 'Mark'); // Zuck -> Mark
     expect(callback.mock.calls.length).toBe(1);
@@ -100,7 +101,7 @@ describe('subscribe()', () => {
         operation.request,
       ),
     );
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     // $FlowFixMe[method-unbinding] added when improving typing for this parameters
     const {dispose} = environment.subscribe(snapshot, callback);
     dispose();

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-TypeRefinement-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-TypeRefinement-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   RelayModernEnvironmentTypeRefinementTest1Query$data,
   RelayModernEnvironmentTypeRefinementTest1Query$variables,
@@ -572,7 +573,7 @@ describe('missing data detection', () => {
     expect(environment.check(operation).status).toBe('missing');
 
     // Subscriptions are not notified of discriminator-only changes
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(fragmentSnapshot, callback);
     environment.commitUpdate(store => {
       const typeRecord = nullthrows(store.get(generateTypeID('User')));
@@ -629,7 +630,7 @@ describe('missing data detection', () => {
     expect(environment.check(operation).status).toBe('missing');
 
     // Subscriptions are not notified of discriminator-only changes
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(fragmentSnapshot, callback);
     environment.commitUpdate(store => {
       const typeRecord = nullthrows(store.get(generateTypeID('User')));
@@ -774,7 +775,7 @@ describe('missing data detection', () => {
     expect(environment.check(operation).status).toBe('missing');
 
     // Subscriptions are not notified of discriminator-only changes
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(fragmentSnapshot, callback);
     environment.commitUpdate(store => {
       const typeRecord = nullthrows(store.get(generateTypeID('User')));
@@ -831,7 +832,7 @@ describe('missing data detection', () => {
     expect(environment.check(operation).status).toBe('missing');
 
     // Subscriptions are not notified of discriminator-only changes
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     environment.subscribe(fragmentSnapshot, callback);
     environment.commitUpdate(store => {
       const typeRecord = nullthrows(store.get(generateTypeID('User')));

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Viewer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Viewer-test.js
@@ -68,11 +68,7 @@ describe('Mutations on viewer', () => {
       },
     };
 
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     onCompleted = jest.fn<[{...}, ?Array<PayloadError>], void>();
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     onError = jest.fn<[Error], void>();
     const fetch = (
       _query: RequestParameters,
@@ -117,8 +113,6 @@ describe('Mutations on viewer', () => {
       {},
       operationDescriptor.request,
     );
-    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
-     * enabling Flow LTI mode */
     const callback = jest.fn<[Snapshot], void>();
     const snapshot = environment.lookup(selector);
     environment.subscribe(snapshot, callback);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Viewer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Viewer-test.js
@@ -10,6 +10,8 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {PayloadError} from '../../network/RelayNetworkTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,
@@ -68,10 +70,10 @@ describe('Mutations on viewer', () => {
 
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    onCompleted = jest.fn();
+    onCompleted = jest.fn<[{...}, ?Array<PayloadError>], void>();
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    onError = jest.fn();
+    onError = jest.fn<[Error], void>();
     const fetch = (
       _query: RequestParameters,
       _variables: Variables,
@@ -117,7 +119,7 @@ describe('Mutations on viewer', () => {
     );
     /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
      * enabling Flow LTI mode */
-    const callback = jest.fn();
+    const callback = jest.fn<[Snapshot], void>();
     const snapshot = environment.lookup(selector);
     environment.subscribe(snapshot, callback);
 

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Viewer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Viewer-test.js
@@ -66,7 +66,11 @@ describe('Mutations on viewer', () => {
       },
     };
 
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     onCompleted = jest.fn();
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     onError = jest.fn();
     const fetch = (
       _query: RequestParameters,
@@ -111,6 +115,8 @@ describe('Mutations on viewer', () => {
       {},
       operationDescriptor.request,
     );
+    /* $FlowFixMe[underconstrained-implicit-instantiation] error found when
+     * enabling Flow LTI mode */
     const callback = jest.fn();
     const snapshot = environment.lookup(selector);
     environment.subscribe(snapshot, callback);

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Viewer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-Viewer-test.js
@@ -10,8 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
 import type {PayloadError} from '../../network/RelayNetworkTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
 import type {
   CacheConfig,

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-WithOperationTracker-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-WithOperationTracker-test.js
@@ -299,7 +299,7 @@ describe('RelayModernEnvironment with RelayOperationTracker', () => {
     );
 
     invariant(result != null, 'Expected to have promise for operation');
-    const promiseCallback = jest.fn();
+    const promiseCallback = jest.fn<[void], mixed>();
     result.promise.then(promiseCallback);
     expect(promiseCallback).not.toBeCalled();
     environment.mock.complete(MutationOperation.request.node);

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-Subscriptions-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-Subscriptions-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 import type {
   RelayModernStoreSubscriptionsTest1Fragment$data,
@@ -168,7 +169,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         const nextSource = getRecordSourceImplementation({
@@ -223,7 +224,7 @@ function cloneEventWithSets(event: LogEvent) {
         const snapshot = store.lookup(selector);
         expect(snapshot.selector).toBe(selector);
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         const nextSource = getRecordSourceImplementation({
@@ -259,7 +260,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         const nextSource = getRecordSourceImplementation({
@@ -287,7 +288,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         let nextSource = getRecordSourceImplementation({
@@ -352,7 +353,7 @@ function cloneEventWithSets(event: LogEvent) {
         const snapshot = store.lookup(selector);
         expect(snapshot.isMissingData).toEqual(true);
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         // Record does not exist when subscribed
         store.subscribe(snapshot, callback);
         const nextSource = getRecordSourceImplementation({
@@ -392,7 +393,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         // Record does not exist when subscribed
         store.subscribe(snapshot, callback);
         const nextSource = getRecordSourceImplementation({
@@ -431,7 +432,7 @@ function cloneEventWithSets(event: LogEvent) {
         // Initially delete the record
         source.delete('842472');
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         // Record does not exist when subscribed
         store.subscribe(snapshot, callback);
         // Create it again
@@ -468,7 +469,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         const nextSource = getRecordSourceImplementation({
@@ -493,7 +494,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         const {dispose} = store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
@@ -567,7 +568,7 @@ function cloneEventWithSets(event: LogEvent) {
             owner.request,
           );
           const snapshot = store.lookup(selector);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           store.subscribe(snapshot, callback);
           // Publish a change to profilePicture.uri
           const nextSource = getRecordSourceImplementation({
@@ -601,7 +602,7 @@ function cloneEventWithSets(event: LogEvent) {
             owner.request,
           );
           const snapshot = store.lookup(selector);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           store.subscribe(snapshot, callback);
           // Publish a change to profilePicture.uri
           const nextSource = getRecordSourceImplementation({
@@ -637,7 +638,7 @@ function cloneEventWithSets(event: LogEvent) {
             owner.request,
           );
           const snapshot = store.lookup(selector);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           store.subscribe(snapshot, callback);
           // Publish a change to profilePicture.uri
           const nextSource = getRecordSourceImplementation({
@@ -671,7 +672,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn(nextSnapshot => {
+        const callback = jest.fn((nextSnapshot: Snapshot) => {
           logEvents.push({
             kind: 'test_only_callback',
             data: nextSnapshot.data,
@@ -734,7 +735,7 @@ function cloneEventWithSets(event: LogEvent) {
             owner.request,
           );
           const snapshot = store.lookup(selector);
-          const callback = jest.fn(nextSnapshot => {
+          const callback = jest.fn((nextSnapshot: Snapshot) => {
             logEvents.push({
               kind: 'test_only_callback',
               data: nextSnapshot.data,

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-Subscriptions-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-Subscriptions-test.js
@@ -11,7 +11,6 @@
 
 'use strict';
 import type {Snapshot} from '../RelayStoreTypes';
-
 import type {
   RelayModernStoreSubscriptionsTest1Fragment$data,
   RelayModernStoreSubscriptionsTest1Fragment$fragmentType,

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 import type {Disposable} from '../../util/RelayRuntimeTypes';
 import type {
@@ -481,7 +482,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         const nextSource = getRecordSourceImplementation({
@@ -535,7 +536,7 @@ function cloneEventWithSets(event: LogEvent) {
         const snapshot = store.lookup(selector);
         expect(snapshot.selector).toBe(selector);
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         const nextSource = getRecordSourceImplementation({
@@ -571,7 +572,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         const nextSource = getRecordSourceImplementation({
@@ -599,7 +600,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         let nextSource = getRecordSourceImplementation({
@@ -664,7 +665,7 @@ function cloneEventWithSets(event: LogEvent) {
         const snapshot = store.lookup(selector);
         expect(snapshot.isMissingData).toEqual(true);
 
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         // Record does not exist when subscribed
         store.subscribe(snapshot, callback);
         const nextSource = getRecordSourceImplementation({
@@ -704,7 +705,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         // Record does not exist when subscribed
         store.subscribe(snapshot, callback);
         const nextSource = getRecordSourceImplementation({
@@ -744,7 +745,7 @@ function cloneEventWithSets(event: LogEvent) {
         // Initially delete the record
         source.delete('842472');
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         // Record does not exist when subscribed
         store.subscribe(snapshot, callback);
         // Create it again
@@ -781,7 +782,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
         const nextSource = getRecordSourceImplementation({
@@ -806,7 +807,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn();
+        const callback = jest.fn<[Snapshot], void>();
         // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         const {dispose} = store.subscribe(snapshot, callback);
         // Publish a change to profilePicture.uri
@@ -880,7 +881,7 @@ function cloneEventWithSets(event: LogEvent) {
             owner.request,
           );
           const snapshot = store.lookup(selector);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           store.subscribe(snapshot, callback);
           // Publish a change to profilePicture.uri
           const nextSource = getRecordSourceImplementation({
@@ -914,7 +915,7 @@ function cloneEventWithSets(event: LogEvent) {
             owner.request,
           );
           const snapshot = store.lookup(selector);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           store.subscribe(snapshot, callback);
           // Publish a change to profilePicture.uri
           const nextSource = getRecordSourceImplementation({
@@ -950,7 +951,7 @@ function cloneEventWithSets(event: LogEvent) {
             owner.request,
           );
           const snapshot = store.lookup(selector);
-          const callback = jest.fn();
+          const callback = jest.fn<[Snapshot], void>();
           store.subscribe(snapshot, callback);
           // Publish a change to profilePicture.uri
           const nextSource = getRecordSourceImplementation({
@@ -984,7 +985,7 @@ function cloneEventWithSets(event: LogEvent) {
           owner.request,
         );
         const snapshot = store.lookup(selector);
-        const callback = jest.fn(nextSnapshot => {
+        const callback = jest.fn((nextSnapshot: Snapshot) => {
           logEvents.push({
             kind: 'test_only_callback',
             data: nextSnapshot.data,
@@ -1047,7 +1048,7 @@ function cloneEventWithSets(event: LogEvent) {
             owner.request,
           );
           const snapshot = store.lookup(selector);
-          const callback = jest.fn(nextSnapshot => {
+          const callback = jest.fn((nextSnapshot: Snapshot) => {
             logEvents.push({
               kind: 'test_only_callback',
               data: nextSnapshot.data,
@@ -1757,7 +1758,7 @@ function cloneEventWithSets(event: LogEvent) {
         const dataIDs = ['4', 'client:1'];
 
         beforeEach(() => {
-          callback = jest.fn();
+          callback = jest.fn<[], void>();
         });
 
         it('notifies when invalidation state changes due to global invalidation', () => {

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
@@ -10,9 +10,8 @@
  */
 
 'use strict';
-import type {Snapshot} from '../RelayStoreTypes';
-
 import type {Disposable} from '../../util/RelayRuntimeTypes';
+import type {Snapshot} from '../RelayStoreTypes';
 import type {
   RelayModernStoreTest2Fragment$data,
   RelayModernStoreTest2Fragment$fragmentType,

--- a/packages/relay-runtime/store/__tests__/RelayOperationTracker-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayOperationTracker-test.js
@@ -175,7 +175,7 @@ describe('RelayOperationTracker', () => {
       const result =
         tracker.getPendingOperationsAffectingOwner(QueryOperation1);
       invariant(result != null, 'Expected to find operations for owner.');
-      const callback = jest.fn();
+      const callback = jest.fn<[void], mixed>();
       result.promise.then(callback);
       expect(callback).not.toBeCalled();
       tracker.complete(MutationOperation1);
@@ -191,7 +191,7 @@ describe('RelayOperationTracker', () => {
       const result =
         tracker.getPendingOperationsAffectingOwner(QueryOperation1);
       invariant(result != null, 'Expected to find operations for owner.');
-      const callback = jest.fn();
+      const callback = jest.fn<[void], mixed>();
       result.promise.then(callback);
       expect(callback).not.toBeCalled();
       tracker.update(MutationOperation2, new Set([QueryOperation1]));
@@ -221,7 +221,7 @@ describe('RelayOperationTracker', () => {
       const result =
         tracker.getPendingOperationsAffectingOwner(QueryOperation1);
       invariant(result != null, 'Expected to find operations for owner.');
-      const callback = jest.fn();
+      const callback = jest.fn<[void], mixed>();
       result.promise.then(callback);
       expect(callback).not.toBeCalled();
       tracker.complete(MutationOperation1);

--- a/packages/relay-runtime/store/__tests__/RelayReader-Resolver-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-Resolver-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
 
 const {
   constant_dependent: UserConstantDependentResolver,
@@ -336,7 +337,7 @@ describe('Relay Resolver', () => {
       }
     `;
 
-    const cb = jest.fn();
+    const cb = jest.fn<[Snapshot], void>();
     const operation = createOperationDescriptor(FooQuery, {});
     const snapshot = store.lookup(operation.fragment);
     const subscription = store.subscribe(snapshot, cb);
@@ -394,7 +395,7 @@ describe('Relay Resolver', () => {
       (UserConstantDependentResolver: any);
 
     expect(resolverInternals._relayResolverTestCallCount).toBe(undefined);
-    const cb = jest.fn();
+    const cb = jest.fn<[Snapshot], void>();
     const operation = createOperationDescriptor(FooQuery, {});
     const snapshot = store.lookup(operation.fragment);
     const subscription = store.subscribe(snapshot, cb);
@@ -444,7 +445,7 @@ describe('Relay Resolver', () => {
       }
     `;
 
-    const cb = jest.fn();
+    const cb = jest.fn<[Snapshot], void>();
     const operation = createOperationDescriptor(FooQuery, {});
     const snapshot = store.lookup(operation.fragment);
     const subscription = store.subscribe(snapshot, cb);
@@ -520,7 +521,7 @@ describe('Relay Resolver', () => {
       },
     });
 
-    const cb = jest.fn();
+    const cb = jest.fn<[Snapshot], void>();
     const operation = createOperationDescriptor(FooQuery, {});
     const snapshot = store.lookup(operation.fragment);
     const subscription = store.subscribe(snapshot, cb);
@@ -602,7 +603,7 @@ describe('Relay Resolver', () => {
       }
     `;
 
-    const cb = jest.fn();
+    const cb = jest.fn<[Snapshot], void>();
     const operation = createOperationDescriptor(FooQuery, {});
     const snapshot = store.lookup(operation.fragment);
     const subscription = store.subscribe(snapshot, cb);
@@ -659,7 +660,7 @@ describe('Relay Resolver', () => {
       }
     `;
 
-    const cb = jest.fn();
+    const cb = jest.fn<[Snapshot], void>();
     const operation = createOperationDescriptor(FooQuery, {});
     const snapshot = store.lookup(operation.fragment);
     const subscription = store.subscribe(snapshot, cb);
@@ -732,7 +733,7 @@ describe('Relay Resolver', () => {
       }
     `;
 
-    const cb = jest.fn();
+    const cb = jest.fn<[Snapshot], void>();
     const operation = createOperationDescriptor(FooQuery, {});
     const snapshot = store.lookup(operation.fragment);
     const subscription = store.subscribe(snapshot, cb);

--- a/packages/relay-runtime/store/__tests__/RelayReferenceMarker-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReferenceMarker-test.js
@@ -511,9 +511,9 @@ describe('RelayReferenceMarker', () => {
       `;
       loader = {
         get: jest.fn(
-          moduleName => nodes[String(moduleName).replace(/\$.*/, '')],
+          (moduleName: mixed) => nodes[String(moduleName).replace(/\$.*/, '')],
         ),
-        load: jest.fn(moduleName =>
+        load: jest.fn((moduleName: mixed) =>
           Promise.resolve(nodes[String(moduleName).replace(/\$.*/, '')]),
         ),
       };
@@ -888,9 +888,9 @@ describe('RelayReferenceMarker', () => {
       const references = new Set<DataID>();
       const loader = {
         get: jest.fn(
-          moduleName => nodes[String(moduleName).replace(/\$.*/, '')],
+          (moduleName: mixed) => nodes[String(moduleName).replace(/\$.*/, '')],
         ),
-        load: jest.fn(moduleName =>
+        load: jest.fn((moduleName: mixed) =>
           Promise.resolve(nodes[String(moduleName).replace(/\$.*/, '')]),
         ),
       };
@@ -937,9 +937,9 @@ describe('RelayReferenceMarker', () => {
       const references = new Set<DataID>();
       const loader = {
         get: jest.fn(
-          moduleName => nodes[String(moduleName).replace(/\$.*/, '')],
+          (moduleName: mixed) => nodes[String(moduleName).replace(/\$.*/, '')],
         ),
-        load: jest.fn(moduleName =>
+        load: jest.fn((moduleName: mixed) =>
           Promise.resolve(nodes[String(moduleName).replace(/\$.*/, '')]),
         ),
       };
@@ -985,9 +985,9 @@ describe('RelayReferenceMarker', () => {
       const references = new Set<DataID>();
       const loader = {
         get: jest.fn(
-          moduleName => nodes[String(moduleName).replace(/\$.*/, '')],
+          (moduleName: mixed) => nodes[String(moduleName).replace(/\$.*/, '')],
         ),
-        load: jest.fn(moduleName =>
+        load: jest.fn((moduleName: mixed) =>
           Promise.resolve(nodes[String(moduleName).replace(/\$.*/, '')]),
         ),
       };
@@ -1077,9 +1077,9 @@ describe('RelayReferenceMarker', () => {
       `;
       loader = {
         get: jest.fn(
-          moduleName => nodes[String(moduleName).replace(/\$.*/, '')],
+          (moduleName: mixed) => nodes[String(moduleName).replace(/\$.*/, '')],
         ),
-        load: jest.fn(moduleName =>
+        load: jest.fn((moduleName: mixed) =>
           Promise.resolve(nodes[String(moduleName).replace(/\$.*/, '')]),
         ),
       };

--- a/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {ReactFlightServerError} from '../../network/RelayNetworkTypes';
 
 const {
   getActorIdentifier,
@@ -1845,15 +1846,25 @@ describe('RelayResponseNormalizer', () => {
   describe('User-defined getDataID', () => {
     let recordSource;
 
-    const getDataID = jest.fn((fieldValue, typename) => {
-      return `${
-        typeof fieldValue === 'string' ? fieldValue : String(fieldValue.id)
-      }:${String(typename)}`;
-    });
+    const getDataID = jest.fn(
+      (
+        fieldValue: string | {[string]: mixed},
+        typename: string | {[string]: mixed},
+      ) => {
+        return `${
+          typeof fieldValue === 'string' ? fieldValue : String(fieldValue.id)
+        }:${String(typename)}`;
+      },
+    );
 
-    const getNullAsDataID = jest.fn((fieldValue, typename) => {
-      return null;
-    });
+    const getNullAsDataID = jest.fn(
+      (
+        fieldValue: string | {[string]: mixed},
+        typename: string | {[string]: mixed},
+      ) => {
+        return null;
+      },
+    );
 
     beforeEach(() => {
       recordSource = new RelayRecordSource();
@@ -3700,7 +3711,10 @@ describe('RelayResponseNormalizer', () => {
 
     describe('when server errors are encountered', () => {
       describe('and ReactFlightServerErrorHandler is specified', () => {
-        const reactFlightServerErrorHandler = jest.fn();
+        const reactFlightServerErrorHandler = jest.fn<
+          [string, Array<ReactFlightServerError>],
+          void,
+        >();
         it('calls ReactFlightServerErrorHandler', () => {
           const payload: $FlowFixMe = {
             node: {

--- a/packages/relay-runtime/store/__tests__/cloneRelayHandleSourceField-test.js
+++ b/packages/relay-runtime/store/__tests__/cloneRelayHandleSourceField-test.js
@@ -34,31 +34,24 @@ describe('cloneRelayHandleSourceField()', () => {
   });
 
   it('returns a clone of the source, with the same name as the handle', () => {
-    // $FlowFixMe[incompatible-use]
     const handleField = selections.find(node => node.kind === LINKED_HANDLE);
-    // $FlowFixMe[incompatible-use]
     const sourceField = selections.find(node => node.kind === LINKED_FIELD);
     const clone = cloneRelayHandleSourceField(
       (handleField: $FlowFixMe),
-      // $FlowFixMe[incompatible-call]
       selections,
       {},
     );
 
     expect(clone.kind).toBe(LINKED_FIELD);
     expect(clone.name).toBe(getRelayHandleKey('test', null, 'address'));
-    // $FlowFixMe[incompatible-use]
     expect(clone.selections).toEqual(sourceField.selections);
   });
 
   it('throws if the source field is not present', () => {
-    // $FlowFixMe[incompatible-use]
     const handleField = selections.find(node => node.kind === LINKED_HANDLE);
-    // $FlowFixMe[incompatible-use]
     selections = selections.filter(node => node.kind === LINKED_HANDLE);
 
     expect(() =>
-      // $FlowFixMe[incompatible-call]
       cloneRelayHandleSourceField((handleField: $FlowFixMe), selections, {}),
     ).toThrowError(
       'cloneRelayHandleSourceField: Expected a corresponding source field ' +

--- a/packages/relay-runtime/store/__tests__/cloneRelayScalarHandleSourceField-test.js
+++ b/packages/relay-runtime/store/__tests__/cloneRelayScalarHandleSourceField-test.js
@@ -30,16 +30,13 @@ describe('cloneRelayScalarHandleSourceField()', () => {
       }
     `;
     // Get the selections on `me.addresss`.
-    // $FlowFixMe
     selections = TestQuery.operation.selections[0].selections[0].selections;
   });
 
   it('returns a clone of the source, with the same name as the handle', () => {
-    // $FlowFixMe[incompatible-use]
     const handleField = selections.find(node => node.kind === SCALAR_HANDLE);
     const clone = cloneRelayScalarHandleSourceField(
       (handleField: $FlowFixMe),
-      // $FlowFixMe[incompatible-call]
       selections,
       {},
     );
@@ -50,15 +47,12 @@ describe('cloneRelayScalarHandleSourceField()', () => {
   });
 
   it('throws if the source field is not present', () => {
-    // $FlowFixMe[incompatible-use]
     const handleField = selections.find(node => node.kind === SCALAR_HANDLE);
-    // $FlowFixMe[incompatible-use]
     selections = selections.filter(node => node.kind === SCALAR_HANDLE);
 
     expect(() =>
       cloneRelayScalarHandleSourceField(
         (handleField: $FlowFixMe),
-        // $FlowFixMe[incompatible-call]
         selections,
         {},
       ),

--- a/packages/relay-runtime/store/__tests__/registerEnvironmentWithDevTools-test.js
+++ b/packages/relay-runtime/store/__tests__/registerEnvironmentWithDevTools-test.js
@@ -28,7 +28,7 @@ describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
   environmentType => {
     describe(environmentType, () => {
       it('should register environment with DevTools', () => {
-        const registerEnvironment = jest.fn();
+        const registerEnvironment = jest.fn<$ReadOnlyArray<mixed>, mixed>();
         global.__RELAY_DEVTOOLS_HOOK__ = {
           registerEnvironment,
         };

--- a/packages/relay-runtime/store/__tests__/resolvers/ExampleTodoStore.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/ExampleTodoStore.js
@@ -76,7 +76,7 @@ class TodoStore {
             description: action.payload,
             isCompleted: false,
             // $FlowFixMe[underconstrained-implicit-instantiation]
-            blockedBy: new Set(),
+            blockedBy: new Set<TodoID>(),
           },
         ];
         this._notify([COLLECTION_SUBSCRIBERS]);

--- a/packages/relay-runtime/store/__tests__/resolvers/ExampleTodoStore.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/ExampleTodoStore.js
@@ -75,7 +75,6 @@ class TodoStore {
             todoID: `todo-${this._state.length + 1}`,
             description: action.payload,
             isCompleted: false,
-            // $FlowFixMe[underconstrained-implicit-instantiation]
             blockedBy: new Set<TodoID>(),
           },
         ];

--- a/packages/relay-runtime/store/__tests__/resolvers/LiveResolvers-test.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/LiveResolvers-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {Snapshot} from '../../RelayStoreTypes';
 
 const {
   live_external_greeting: LiveExternalGreeting,
@@ -159,7 +160,7 @@ test('Updates can be batched', () => {
 
   const snapshot = environment.lookup(operation.fragment);
 
-  const handler = jest.fn();
+  const handler = jest.fn<[Snapshot], void>();
   environment.subscribe(snapshot, handler);
 
   expect(handler.mock.calls.length).toBe(0);

--- a/packages/relay-runtime/store/__tests__/resolvers/ResolverGC-test.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/ResolverGC-test.js
@@ -10,8 +10,6 @@
  */
 
 'use strict';
-import type {LogEvent} from '../../RelayStoreTypes';
-
 import type {GraphQLResponse} from '../../../network/RelayNetworkTypes';
 import type {ConcreteRequest} from '../../../util/RelayConcreteNode';
 import type {
@@ -19,6 +17,7 @@ import type {
   OperationType,
   VariablesOf,
 } from '../../../util/RelayRuntimeTypes';
+import type {LogEvent} from '../../RelayStoreTypes';
 import type {IEnvironment, Snapshot} from '../../RelayStoreTypes';
 
 const {HOUSE_ORDER} = require('./AstrologicalSignUtils');

--- a/packages/relay-runtime/store/__tests__/resolvers/ResolverGC-test.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/ResolverGC-test.js
@@ -10,6 +10,7 @@
  */
 
 'use strict';
+import type {LogEvent} from '../../RelayStoreTypes';
 
 import type {GraphQLResponse} from '../../../network/RelayNetworkTypes';
 import type {ConcreteRequest} from '../../../util/RelayConcreteNode';
@@ -869,7 +870,7 @@ async function testResolverGC<T: OperationType>({
   );
   const operation = createOperationDescriptor(query, variables);
 
-  const mockLogger = jest.fn();
+  const mockLogger = jest.fn<[LogEvent], void>();
 
   const store = new LiveResolverStore(source, {
     gcReleaseBufferSize: 0,

--- a/packages/relay-runtime/subscription/__tests__/requestSubscription-test.js
+++ b/packages/relay-runtime/subscription/__tests__/requestSubscription-test.js
@@ -10,10 +10,10 @@
  */
 
 'use strict';
-import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
-import type {RequestParameters} from '../../util/RelayConcreteNode';
-import type {RecordSourceSelectorProxy} from '../../store/RelayStoreTypes';
 import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
+import type {RecordSourceSelectorProxy} from '../../store/RelayStoreTypes';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {CacheConfig, Variables} from '../../util/RelayRuntimeTypes';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const RelayObservable = require('../../network/RelayObservable');

--- a/packages/relay-runtime/subscription/__tests__/requestSubscription-test.js
+++ b/packages/relay-runtime/subscription/__tests__/requestSubscription-test.js
@@ -10,6 +10,10 @@
  */
 
 'use strict';
+import type {Variables, CacheConfig} from '../../util/RelayRuntimeTypes';
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {RecordSourceSelectorProxy} from '../../store/RelayStoreTypes';
+import type {GraphQLResponse} from '../../network/RelayNetworkTypes';
 
 const RelayNetwork = require('../../network/RelayNetwork');
 const RelayObservable = require('../../network/RelayObservable');
@@ -224,10 +228,16 @@ describe('requestSubscription-test', () => {
       `;
 
       cacheMetadata = undefined;
-      const fetch = jest.fn((_query, _variables, _cacheConfig) => {
-        cacheMetadata = _cacheConfig.metadata;
-        return RelayObservable.create(() => {});
-      });
+      const fetch = jest.fn(
+        (
+          _query: RequestParameters,
+          _variables: Variables,
+          _cacheConfig: CacheConfig,
+        ) => {
+          cacheMetadata = _cacheConfig.metadata;
+          return RelayObservable.create<GraphQLResponse>(() => {});
+        },
+      );
       const source = RelayRecordSource.create({});
       const store = new RelayModernStore(source);
       environment = new RelayModernEnvironment({
@@ -309,7 +319,7 @@ describe('requestSubscription-test', () => {
       {},
       operationDescriptor.request,
     );
-    const onNext = jest.fn();
+    const onNext = jest.fn<[?$FlowFixMe], void>();
 
     let id = 0;
     requestSubscription(environment, {
@@ -456,8 +466,8 @@ describe('requestSubscription-test', () => {
       },
     });
 
-    const onNext = jest.fn();
-    const updater = jest.fn();
+    const onNext = jest.fn<[?$FlowFixMe], void>();
+    const updater = jest.fn<[RecordSourceSelectorProxy, ?$FlowFixMe], void>();
 
     requestSubscription(environment, {
       subscription,

--- a/packages/relay-runtime/util/__tests__/RelayReplaySubject-test.js
+++ b/packages/relay-runtime/util/__tests__/RelayReplaySubject-test.js
@@ -18,7 +18,6 @@ const RelayReplaySubject = require('../RelayReplaySubject');
 let subject;
 
 beforeEach(() => {
-  // $FlowFixMe[underconstrained-implicit-instantiation]
   subject = new RelayReplaySubject<string>();
 });
 

--- a/packages/relay-runtime/util/__tests__/RelayReplaySubject-test.js
+++ b/packages/relay-runtime/util/__tests__/RelayReplaySubject-test.js
@@ -19,7 +19,7 @@ let subject;
 
 beforeEach(() => {
   // $FlowFixMe[underconstrained-implicit-instantiation]
-  subject = new RelayReplaySubject();
+  subject = new RelayReplaySubject<string>();
 });
 
 type Observer = {

--- a/packages/relay-test-utils-internal/trackRetentionForEnvironment.js
+++ b/packages/relay-test-utils-internal/trackRetentionForEnvironment.js
@@ -28,7 +28,7 @@ function trackRetentionForEnvironment(environment: IEnvironment): {
 } {
   const retainCountsByOperation = new Map<mixed, number>();
 
-  const release = jest.fn(id => {
+  const release = jest.fn((id: mixed) => {
     const existing = retainCountsByOperation.get(id) ?? NaN;
     if (existing === 1) {
       retainCountsByOperation.delete(id);
@@ -38,6 +38,7 @@ function trackRetentionForEnvironment(environment: IEnvironment): {
   });
 
   // $FlowFixMe[cannot-write] safe to do for mocking
+  // $FlowFixMe[missing-local-annot] error found when enabling Flow LTI mode
   environment.retain = jest.fn(operation => {
     const id = operation.request.identifier;
     const existing = retainCountsByOperation.get(id) ?? 0;

--- a/packages/relay-test-utils/RelayMockPayloadGenerator.js
+++ b/packages/relay-test-utils/RelayMockPayloadGenerator.js
@@ -189,14 +189,11 @@ class RelayMockPayloadGenerator {
     +mockClientData: ?boolean,
   }) {
     this._variables = options.variables;
-    // $FlowFixMe[cannot-spread-inexact]
-    // $FlowFixMe[incompatible-type]
     this._mockResolvers = {
       ...DEFAULT_MOCK_RESOLVERS,
       ...(options.mockResolvers ?? {}),
     };
     this._selectionMetadata = options.selectionMetadata ?? {};
-    // $FlowFixMe[incompatible-call]
     this._resolveValue = createValueResolver(this._mockResolvers);
     this._mockClientData = options.mockClientData ?? false;
   }
@@ -472,7 +469,6 @@ class RelayMockPayloadGenerator {
             if (mockData == null) {
               mockData = {};
             }
-            // $FlowFixMe[cannot-spread-indexer]
             mockData = {
               ...mockData,
               [TYPENAME_KEY]: typeName,
@@ -755,7 +751,6 @@ class RelayMockPayloadGenerator {
             data[applicationName]
           : null,
         // $FlowFixMe[incompatible-call]
-        // $FlowFixMe[incompatible-variance]
         fieldDefaultValue,
       );
     };


### PR DESCRIPTION
Flow is moving to a new inference paradigm called Local Type Inference ([source](https://medium.com/flow-type/local-type-inference-for-flow-aaa65d071347)). This PR prepares the relay codebase for the new requirements. 

Repro step:

* Ran the following codemods
```
flow codemod annotate-functions-and-classes --include-lti
flow codemod annotate-implicit-instantiations --include-lti
```
* Reverted files where the above created errors
* Suppressed the remaining errors with `inference_mode=lti` set in .flowconfig