### PR TITLE
Add missing relay-runtime to installation script

### DIFF
--- a/website/versioned_docs/version-v14.0.0/getting-started/installation-and-setup.md
+++ b/website/versioned_docs/version-v14.0.0/getting-started/installation-and-setup.md
@@ -38,7 +38,7 @@ More details about this script can be found at its [GitHub repository](https://g
 Install React and Relay using `yarn` or `npm`:
 
 ```sh
-yarn add react react-dom react-relay
+yarn add react react-dom react-relay relay-runtime
 ```
 
 ## Set up the compiler


### PR DESCRIPTION
Self-explanatory, it seems the `relay-runtime` dependency is missing in the installation instructions.

After following the ["Installing in a Project"](https://relay.dev/docs/getting-started/installation-and-setup/) guide, I jumped to the [tutorial docs](https://relay.dev/docs/tutorial/queries-1/) and noticed I didn't have the runtime installed.