### PR TITLE
Remove recommendation to commit generated files to source control

### DIFF
--- a/website/docs/getting-started/step-by-step-guide.md
+++ b/website/docs/getting-started/step-by-step-guide.md
@@ -205,7 +205,7 @@ cd your-app-name
 yarn start
 ```
 
-If it works, your app will open at [localhost:3000](http://localhost:3000). Now when we write GraphQL in our app, Relay will detect it and generate code to represent our queries in `your-app-name/src/__generated__/`. We recommend checking in these generated files to source control.
+If it works, your app will open at [localhost:3000](http://localhost:3000). Now when we write GraphQL in our app, Relay will detect it and generate code to represent our queries in `your-app-name/src/__generated__/`.
 
 ### 4.2 Configure Relay Runtime
 


### PR DESCRIPTION
This recommendation seems to be anecdotal, and doesn't have any reason to back it up.

It would be good to remove this as a recommendation (even suggesting to gitignore?) Or providing a reason why we should hold onto these files.

Related PR: https://github.com/facebook/relay/issues/4045