### PR TITLE
Rerun relay compiler

### DIFF
--- a/website/docs/tutorial/queries-1.md
+++ b/website/docs/tutorial/queries-1.md
@@ -83,7 +83,7 @@ Now that we’ve defined the query, we need to do two things.
 1. Run relay compiler so that it knows aboout the new Graphql query. [npm run relay.] 
 2. Modify our React component to fetch it and to use the data returned by the server.
 
-If you open package.json you will find the script relays is hooked up to run the relay-compiler. This is what npm run relay does. Once the compiler successfully updates/generated the new compiled query you will be able to find it in the __generated__ folder under src/components/ as NewsfeedQuery.graphql.ts. This project comes with precomputed fragments, so unless you do this step, you will not get the desired results.
+If you open package.json you will find the script `relay` is hooked up to run the relay-compiler. This is what npm run relay does. Once the compiler successfully updates/generated the new compiled query you will be able to find it in the __generated__ folder under src/components/ as NewsfeedQuery.graphql.ts. This project comes with precomputed fragments, so unless you do this step, you will not get the desired results.
 
 Next, Turn back to the `Newsfeed` component and start by deleting the placeholder data. Then replace it with this:
 

--- a/website/docs/tutorial/queries-1.md
+++ b/website/docs/tutorial/queries-1.md
@@ -79,9 +79,13 @@ This illustrates the part of the graph that this query is asking for:
 
 ![Parts of the GraphQL query](/img/docs/tutorial/query-breakdown.png)
 
-Now that we’ve defined the query, we need to modify our React component to fetch it and to use the data returned by the server.
+Now that we’ve defined the query, we need to do two things. 
+1. Run relay compiler so that it knows aboout the new Graphql query. [npm run relay.] 
+2. Modify our React component to fetch it and to use the data returned by the server.
 
-Turn back to the `Newsfeed` component and start by deleting the placeholder data. Then replace it with this:
+If you open package.json you will find the script relays is hooked up to run the relay-compiler. This is what npm run relay does. Once the compiler successfully updates/generated the new compiled query you will be able to find it in the __generated__ folder under src/components/ as NewsfeedQuery.graphql.ts. This project comes with precomputed fragments, so unless you do this step, you will not get the desired results.
+
+Next, Turn back to the `Newsfeed` component and start by deleting the placeholder data. Then replace it with this:
 
 ```
 import { useLazyLoadQuery } from "react-relay";


### PR DESCRIPTION
The project comes with precompiled relay fragments that do not work when the student who is just starting this tutorial tries to fetch the top query without having any fragments defined. To make it work, we need to delete the precompiled queries and re compile. The student also does not know the command to do that since it is not mentioned anywhere and they may not know to look for it in the `package.json` file. These specifics are important to unblock the student at this stage.