### PR TITLE
update fragment tutorial documentation

### DIFF
--- a/website/versioned_docs/version-v14.0.0/tutorial/fragments-1.md
+++ b/website/versioned_docs/version-v14.0.0/tutorial/fragments-1.md
@@ -468,6 +468,8 @@ const PosterBylineFragment = graphql`
 
 Now if you look at the images that our app downloads, you’ll see they’re of the smaller size, saving network bandwidth. Note that although we used integer literals for the value of our fragment arguments, we can also use variables supplied at runtime, as we'll see in later sections.
 
+_Note: The development server provided does not do actual image resizing, it will only append the size as integer to returned image URL as query parameter._
+
 Field arguments (e.g. `url(height: 100)`) are a feature of GraphQL itself, while fragment arguments (as in `@argumentDefinitions` and `@arguments`) are Relay-specific features. The Relay compiler processes these fragment arguments when it combines fragments into queries.
 
 ---


### PR DESCRIPTION
Clear up the (possible) misconception that the development server won't resize static assets.