### PR TITLE
Replace invalid variable characters for import name

### DIFF
--- a/compiler/crates/relay-codegen/src/build_ast.rs
+++ b/compiler/crates/relay-codegen/src/build_ast.rs
@@ -1860,12 +1860,14 @@ impl<'schema, 'builder, 'config> CodegenBuilder<'schema, 'builder, 'config> {
                             provider.module_path().to_str().unwrap().intern(),
                         )
                     };
+                
+                let variable_name = (provider.original_variable_name.to_string() + "_provider").intern();
 
                 Some(ObjectEntry {
                     key: def.name.item.0,
                     value: Primitive::JSModuleDependency(JSModuleDependency {
                         path: provider_module,
-                        import_name: ModuleImportName::Default(provider.module_name),
+                        import_name: ModuleImportName::Default(variable_name),
                     }),
                 })
             })


### PR DESCRIPTION
Closes: #4294 

When using provided variables, with ESM, the Relay compiler incorrectly assumes that the module path can also be reused for the default import name.

This is not valid Javascript as variables cannot use '.' or '-' characters.

To fix, simply replace '.' and '-' with underscores.

Before:
```
import include-can-edit-providers-three.relayprovider from './../include-can-edit-providers-three.relayprovider';
import include-can-edit-providers.relayprovider from './../include-can-edit-providers.relayprovider';
const providedVariablesDefinition: ProvidedVariablesType = {
  "__relay_internal__pv__includecaneditprovidersrelayprovider": include-can-edit-providers-three.relayprovider,
  "__relay_internal__pv__includecaneditprovidersthreerelayprovider": include-can-edit-providers.relayprovider
};
```

After:
```
import include_can_edit_providers_two_relayprovider from './../include-can-edit-providers-two.relayprovider';
import include_can_edit_providers_relayprovider from './../include-can-edit-providers.relayprovider';
const providedVariablesDefinition: ProvidedVariablesType = {
  "__relay_internal__pv__includecaneditprovidersrelayprovider": include_can_edit_providers_relayprovider,
  "__relay_internal__pv__includecaneditproviderstworelayprovider": include_can_edit_providers_two_relayprovider
};
```

I'm unfamiliar with Rust so am unsure if there is a better approach.