### PR TITLE
docs: Fix typo in `getting-started/installation-and-setup.md`

### DIFF
--- a/website/docs/getting-started/installation-and-setup.md
+++ b/website/docs/getting-started/installation-and-setup.md
@@ -69,7 +69,7 @@ module.exports = {
   src: "./src",
   language: "javascript", // "javascript" | "typescript" | "flow"
   schema: "./data/schema.graphql",
-  exclude: ["**/node_modules/**", "**/__mocks__/**", "**/__generated__/**"],
+  excludes: ["**/node_modules/**", "**/__mocks__/**", "**/__generated__/**"],
 }
 ```
 


### PR DESCRIPTION
Fix a typo in the relay config file,
should be `excludes` instead of `exclude`.