### PR TITLE
Avoid reusing AST nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@babel/core": "^7.18.6",
     "@babel/generator": "^7.18.6",
+    "@babel/helper-check-duplicate-nodes": "^7.18.6",
     "@babel/parser": "^7.18.6",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
     "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",

--- a/packages/babel-plugin-relay/__tests__/transformerWithOptions.js
+++ b/packages/babel-plugin-relay/__tests__/transformerWithOptions.js
@@ -12,6 +12,8 @@
 
 const BabelPluginRelay = require('../BabelPluginRelay');
 const babel = require('@babel/core');
+const checkDuplicatedNodes =
+  require('@babel/helper-check-duplicate-nodes').default;
 const prettier = require('prettier');
 
 function transformerWithOptions(
@@ -23,14 +25,16 @@ function transformerWithOptions(
     const previousEnv = process.env.BABEL_ENV;
     try {
       process.env.BABEL_ENV = environment;
-      const code = babel.transform(text, {
+      const {code, ast} = babel.transformSync(text, {
         compact: false,
         cwd: '/',
         filename: filename || providedFileName || 'test.js',
         highlightCode: false,
         parserOpts: {plugins: ['jsx']},
         plugins: [[BabelPluginRelay, options]],
-      }).code;
+        ast: true,
+      });
+      checkDuplicatedNodes(ast);
       return prettier.format(code, {
         bracketSameLine: true,
         bracketSpacing: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,13 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-check-duplicate-nodes@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-check-duplicate-nodes/-/helper-check-duplicate-nodes-7.18.6.tgz#776dcf6834a9ea1162530069000218bc44e1c11e"
+  integrity sha512-gQkMniJ8+GfcRk98xGNlBXSEuWOJpEb7weoHDJpw4xxQrikPRvO1INlqbCM6LynKYKVZ/suN869xudV5DzAkzQ==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz#69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf"


### PR DESCRIPTION
Reusing AST nodes can result in subtle bugs, for example [this issue](https://github.com/facebook/relay/issues/3856) is caused by AST node reuse breaking [memoization](https://github.com/babel/babel/blob/main/packages/babel-helper-module-transforms/src/rewrite-live-references.ts#L275-L276) in the `@babel/plugin-transform-modules-commonjs` plugin.

The first commit here introduces [@babel/helper-check-duplicated-nodes](https://github.com/babel/babel/tree/main/packages/babel-helper-check-duplicate-nodes) which breaks a number of tests. The second commit fixes those tests.

Fixes https://github.com/facebook/relay/issues/3856.