### PR TITLE
Upgrade rustix to prevent build error

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -1031,9 +1031,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1801,16 +1801,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.3"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno 0.3.1",
  "io-lifetimes 1.0.10",
  "libc",
  "linux-raw-sys 0.3.7",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2150,7 +2150,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.3",
+ "rustix 0.37.19",
  "windows-sys 0.45.0",
 ]
 


### PR DESCRIPTION
Currently the compiler build is failing in GitHub CI with the following error:

```
error[E0425]: cannot find function `makedev` in module `c`
  --> /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/rustix-0.37.3/src/backend/libc/fs/makedev.rs:44:17
   |
44 |     unsafe { c::makedev(maj as i32, min as i32) }
   |                 ^^^^^^^ not found in `c`
   |
help: consider importing this function
   |
2  | use crate::fs::makedev;
   |
help: if you import `makedev`, refer to it directly
   |
44 -     unsafe { c::makedev(maj as i32, min as i32) }
44 +     unsafe { makedev(maj as i32, min as i32) }
   |
```

Update done with:

```
cargo update -p rustix@0.37.3 --precise 0.37.19
```

I'm not entirely sure what in this upgrade is resolving the error, but it does seem to resolve it locally. Will check CI on this PR to confirm it fixes it in CI as well.