### PR TITLE
Fix version number parsing in cannotReadPropertyOfUndefined__DEPRECATED

### DIFF
--- a/packages/relay-test-utils-internal/index.js
+++ b/packages/relay-test-utils-internal/index.js
@@ -49,7 +49,7 @@ function cannotReadPropertyOfUndefined__DEPRECATED(
   propertyName: string,
 ): string {
   const matches = process.version.match(/^v(\d+)\./);
-  const majorVersion = matches == null ? null : parseInt(matches[0], 10);
+  const majorVersion = matches == null ? null : parseInt(matches[1], 10);
   if (majorVersion == null || majorVersion < 16) {
     return `Cannot read property '${propertyName}' of undefined`;
   }


### PR DESCRIPTION
`.match` is a super confusing API. The first value is the full match. To get the parenthesized full match, you need to look at the second value.

Originally added here: https://github.com/facebook/relay/commit/f5c48cdd9369646a14676d9170578bd0b4ab853b

Test Plan: Look at test run in Node version 14 GitHub CI and see that there are nolonger any instance of errors that look like this:

![Screenshot 2023-05-11 at 12 44 11 PM](https://github.com/facebook/relay/assets/162735/fb35dd55-4922-404d-a0b0-d08b78800618)

(Note that there are other errors in GitHub CI right now)

