### PR TITLE
Use same field name for pagination that compiler generates

### DIFF
--- a/packages/react-relay/relay-hooks/useLoadMoreFunction.js
+++ b/packages/react-relay/relay-hooks/useLoadMoreFunction.js
@@ -214,7 +214,7 @@ function useLoadMoreFunction<TVariables: Variables>(
             identifierValue,
           );
         }
-        paginationVariables.id = identifierValue;
+        paginationVariables[identifierField] = identifierValue;
       }
 
       const paginationQuery = createOperationDescriptor(


### PR DESCRIPTION
It looks like the compiler [generates the refetchable query](https://github.com/facebook/relay/blob/4b1b59eb06dae90ba3c6f9e5034ac7845fee0cf2/compiler/crates/relay-transforms/src/refetchable_fragment/fetchable_query_generator.rs#L94) using the `nodeInterfaceIdField` as the variable name, but the runtime always uses "id" as the variable name.

This should fix `usePaginationFragment` for users that set a custom `nodeInterfaceIdField` in their `schemaConfig`.