### PR TITLE
Ignore vscode-extension in root eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,5 @@ website-prototyping-tools/node_modules
 *.md
 src/flow/
 packages/relay-flight-experimental/
+# The VSCode Extension gets linted with a separate setup
+vscode-extension


### PR DESCRIPTION
@ernieturner originally had this line in https://github.com/facebook/relay/pull/4275 but I thought it was safe to remove.

Because the `vscode-extension` is now not part of the Yarn workspace, its ESLint dependencies do not get installed by default. This means linting those files will fail (since the TypeScript-specific ESLint packages are not installed).

Here we add it back. The `vscode-extension` code gets linted with its own run. See https://github.com/facebook/relay/blob/7b5bee426ffc4fc5c9a3f9d06225020f7b7fe066/.github/workflows/ci.yml#L24