### PR TITLE
Recommend Babel extension to fix VSCode syntax highlighting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,9 @@
 		"dbaeumer.vscode-eslint",
 		"rust-lang.rust-analyzer",
 		"meta.relay",
-		"flowtype.flow-for-vscode"
+		"flowtype.flow-for-vscode",
+		// https://github.com/flow/flow-for-vscode#known-issues
+		"mgmcdermott.vscode-language-babel"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [


### PR DESCRIPTION
The built in syntax highlighting for JS files does not correctly support all Flow syntax. This extension includes a syntax highlighter that does.

https://github.com/flow/flow-for-vscode#known-issues


## Before

<img width="1837" alt="Screenshot 2023-05-24 at 3 24 43 PM" src="https://github.com/facebook/relay/assets/162735/61ffda64-7c77-4357-b12e-1c31b7461d2f">

## After

<img width="1837" alt="Screenshot 2023-05-24 at 3 24 55 PM" src="https://github.com/facebook/relay/assets/162735/1c4f03ff-248d-4915-9e4d-31dcc674d404">
