### PR TITLE
update fbjs to address ReDOS from ua-parser-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-relay": "1.8.3",
     "eslint-plugin-relay-internal": "link:./packages/eslint-plugin-relay-internal",
-    "fbjs": "^3.0.2",
+    "fbjs": "^3.0.5",
     "flow-bin": "^0.207.0",
     "glob": "^7.1.1",
     "graphql": "15.3.0",

--- a/packages/react-relay/package.json
+++ b/packages/react-relay/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "fbjs": "^3.0.2",
+    "fbjs": "^3.0.5",
     "invariant": "^2.2.4",
     "nullthrows": "^1.1.1",
     "relay-runtime": "15.0.0"

--- a/packages/relay-runtime/package.json
+++ b/packages/relay-runtime/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "fbjs": "^3.0.2",
+    "fbjs": "^3.0.5",
     "invariant": "^2.2.4"
   },
   "directories": {

--- a/packages/relay-test-utils-internal/package.json
+++ b/packages/relay-test-utils-internal/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "fbjs": "^3.0.2",
+    "fbjs": "^3.0.5",
     "relay-runtime": "15.0.0"
   },
   "directories": {

--- a/packages/relay-test-utils/package.json
+++ b/packages/relay-test-utils/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "fbjs": "^3.0.2",
+    "fbjs": "^3.0.5",
     "invariant": "^2.2.4",
     "relay-runtime": "15.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3455,10 +3455,10 @@ fbjs-css-vars@^1.0.0:
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
 
-fbjs@^3.0.2:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-3.0.4.tgz#e1871c6bd3083bac71ff2da868ad5067d37716c6"
-  integrity sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==
+fbjs@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-3.0.5.tgz#aa0edb7d5caa6340011790bd9249dbef8a81128d"
+  integrity sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==
   dependencies:
     cross-fetch "^3.1.5"
     fbjs-css-vars "^1.0.0"
@@ -3466,7 +3466,7 @@ fbjs@^3.0.2:
     object-assign "^4.1.0"
     promise "^7.1.1"
     setimmediate "^1.0.5"
-    ua-parser-js "^0.7.30"
+    ua-parser-js "^1.0.35"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -7692,10 +7692,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-ua-parser-js@^0.7.30:
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
-  integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
+ua-parser-js@^1.0.35:
+  version "1.0.35"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.35.tgz#c4ef44343bc3db0a3cbefdf21822f1b1fc1ab011"
+  integrity sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR bumps `fbjs` from `3.0.4` to `3.0.5`. `3.0.5` contains a fix for the [Regular Expression Denial of Service (ReDoS)](https://security.snyk.io/vuln/SNYK-JS-UAPARSERJS-3244450) vulnerability found in `ua-parser-js` and resolved [here](https://github.com/facebook/fbjs/pull/507)