### PR TITLE
Update commit-mutation.md

### DIFF
--- a/website/versioned_docs/version-v14.0.0/api-reference/relay-runtime/commit-mutation.md
+++ b/website/versioned_docs/version-v14.0.0/api-reference/relay-runtime/commit-mutation.md
@@ -22,7 +22,7 @@ See also the [`useMutation`](../use-mutation/) API and [Guide to Updating Data](
 import type {FeedbackLikeMutation} from 'FeedbackLikeMutation.graphql';
 const React = require('React');
 
-const {graphql, useMutation} = require('react-relay');
+const {graphql, commitMutation} = require('react-relay');
 
 function likeFeedback(environment: IEnvironment): Disposable {
   return commitMutation<FeedbackLikeMutation>(environment, {


### PR DESCRIPTION
This page describes how to use `commitMutation` and includes a code snippet. The snippet contains a typo. This PR fixes the typo by having the snippet import `commitMutation` instead of `useMutation`. 