### PR TITLE
Enable __token field based on compiler schema config

### DIFF
--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.expected
@@ -154,13 +154,6 @@ fragment fragmentOnNonNodeFetchableType_ProfilePicture on User {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "__token",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -204,7 +197,6 @@ fragment fragmentOnNonNodeFetchableType_RefetchableFragment on NonNodeStory {
     id
   }
   fetch_id
-  __token
 }
 
 
@@ -292,13 +284,6 @@ fragment fragmentOnNonNodeFetchableType_RefetchableFragment on NonNodeStory {
       "args": null,
       "kind": "ScalarField",
       "name": "fetch_id",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "__token",
       "storageKey": null
     }
   ],

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -181,6 +181,10 @@ pub struct SchemaConfig {
     /// The name of the directive indicating fields that cannot be selected
     #[serde(default = "default_unselectable_directive_name")]
     pub unselectable_directive_name: DirectiveName,
+
+    /// If we should select __token field on fetchable types
+    #[serde(default = "default_enable_token_field")]
+    pub enable_token_field: bool,
 }
 
 fn default_node_interface_id_field() -> StringKey {
@@ -195,6 +199,10 @@ fn default_unselectable_directive_name() -> DirectiveName {
     DirectiveName("unselectable".intern())
 }
 
+fn default_enable_token_field() -> bool {
+    false
+}
+
 impl Default for SchemaConfig {
     fn default() -> Self {
         Self {
@@ -203,6 +211,7 @@ impl Default for SchemaConfig {
             node_interface_id_variable_name: default_node_interface_id_variable_name(),
             non_node_id_fields: None,
             unselectable_directive_name: default_unselectable_directive_name(),
+            enable_token_field: default_enable_token_field(),
         }
     }
 }

--- a/compiler/crates/relay-transforms/src/refetchable_fragment/fetchable_query_generator.rs
+++ b/compiler/crates/relay-transforms/src/refetchable_fragment/fetchable_query_generator.rs
@@ -49,7 +49,6 @@ fn build_refetch_operation(
     query_name: OperationDefinitionName,
     variables_map: &VariableMap,
 ) -> DiagnosticsResult<Option<RefetchRoot>> {
-    
     let id_name = schema_config.node_interface_id_field;
 
     if let Some(identifier_field_name) = get_fetchable_field_name(fragment, schema)? {
@@ -60,7 +59,6 @@ fn build_refetch_operation(
             format!("fetch__{}", schema.get_type_name(fragment.type_condition)).intern();
         let (fetch_field_id, id_arg) =
             get_fetch_field_id_and_id_arg(fragment, schema, query_type, fetch_field_name)?;
-
 
         let fetch_token_field = match schema_config.enable_token_field {
             true => Some(schema.fetch_token_field()),
@@ -90,7 +88,7 @@ fn build_refetch_operation(
             selections: enforce_selections_with_id_field(
                 fragment,
                 identifier_field_id,
-                fetch_token_field
+                fetch_token_field,
             ),
         });
         let mut variable_definitions = build_operation_variable_definitions(&fragment);

--- a/compiler/crates/relay-transforms/src/refetchable_fragment/fetchable_query_generator.rs
+++ b/compiler/crates/relay-transforms/src/refetchable_fragment/fetchable_query_generator.rs
@@ -49,6 +49,7 @@ fn build_refetch_operation(
     query_name: OperationDefinitionName,
     variables_map: &VariableMap,
 ) -> DiagnosticsResult<Option<RefetchRoot>> {
+    
     let id_name = schema_config.node_interface_id_field;
 
     if let Some(identifier_field_name) = get_fetchable_field_name(fragment, schema)? {
@@ -59,6 +60,12 @@ fn build_refetch_operation(
             format!("fetch__{}", schema.get_type_name(fragment.type_condition)).intern();
         let (fetch_field_id, id_arg) =
             get_fetch_field_id_and_id_arg(fragment, schema, query_type, fetch_field_name)?;
+
+
+        let fetch_token_field = match schema_config.enable_token_field {
+            true => Some(schema.fetch_token_field()),
+            false => None,
+        };
 
         let fragment = Arc::new(FragmentDefinition {
             name: fragment.name,
@@ -83,7 +90,7 @@ fn build_refetch_operation(
             selections: enforce_selections_with_id_field(
                 fragment,
                 identifier_field_id,
-                schema.fetch_token_field(),
+                fetch_token_field
             ),
         });
         let mut variable_definitions = build_operation_variable_definitions(&fragment);
@@ -223,7 +230,7 @@ fn has_field(selections: &[Selection], field_id: FieldID) -> bool {
 fn enforce_selections_with_id_field(
     fragment: &FragmentDefinition,
     identifier_field_id: FieldID,
-    fetch_token_field_id: FieldID,
+    fetch_token_field_id: Option<FieldID>,
 ) -> Vec<Selection> {
     let mut next_selections = fragment.selections.clone();
     if !has_field(&next_selections, identifier_field_id) {
@@ -234,13 +241,18 @@ fn enforce_selections_with_id_field(
             directives: vec![],
         })));
     }
-    if !has_field(&next_selections, fetch_token_field_id) {
-        next_selections.push(Selection::ScalarField(Arc::new(ScalarField {
-            alias: None,
-            definition: WithLocation::generated(fetch_token_field_id),
-            arguments: vec![],
-            directives: vec![],
-        })));
+    match fetch_token_field_id {
+        Some(fetch_token_field_id) => {
+            if !has_field(&next_selections, fetch_token_field_id) {
+                next_selections.push(Selection::ScalarField(Arc::new(ScalarField {
+                    alias: None,
+                    definition: WithLocation::new(fragment.name.location, fetch_token_field_id),
+                    arguments: vec![],
+                    directives: vec![],
+                })));
+            }
+        }
+        None => {}
     }
     next_selections
 }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type-with-token-field.expected
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type-with-token-field.expected
@@ -1,0 +1,59 @@
+==================================== INPUT ====================================
+# // enable-token-field: true
+
+fragment RefetchableFragment on NonNodeStory
+  @refetchable(queryName: "RefetchableFragmentQuery") {
+  actor {
+    ...ProfilePicture
+  }
+}
+
+fragment ProfilePicture on User {
+  profilePicture(size: $size) {
+    uri
+  }
+}
+==================================== OUTPUT ===================================
+query RefetchableFragmentQuery(
+  $size: [Int]
+  $id: ID!
+) @__RefetchableDerivedFromMetadata
+# RefetchableDerivedFromMetadata(
+#     FragmentDefinitionName(
+#         "RefetchableFragment",
+#     ),
+# )
+ {
+  fetch__NonNodeStory(input_fetch_id: $id) {
+    ...RefetchableFragment
+  }
+}
+
+fragment ProfilePicture on User {
+  profilePicture(size: $size) {
+    uri
+  }
+}
+
+fragment RefetchableFragment on NonNodeStory @refetchable(queryName: "RefetchableFragmentQuery") @__RefetchableMetadata
+# RefetchableMetadata {
+#     operation_name: OperationDefinitionName(
+#         "RefetchableFragmentQuery",
+#     ),
+#     path: [
+#         "fetch__NonNodeStory",
+#     ],
+#     identifier_info: Some(
+#         RefetchableIdentifierInfo {
+#             identifier_field: "fetch_id",
+#             identifier_query_variable_name: "id",
+#         },
+#     ),
+# }
+ {
+  actor {
+    ...ProfilePicture
+  }
+  fetch_id
+  __token
+}

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type-with-token-field.graphql
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type-with-token-field.graphql
@@ -1,0 +1,14 @@
+# // enable-token-field: true
+
+fragment RefetchableFragment on NonNodeStory
+  @refetchable(queryName: "RefetchableFragmentQuery") {
+  actor {
+    ...ProfilePicture
+  }
+}
+
+fragment ProfilePicture on User {
+  profilePicture(size: $size) {
+    uri
+  }
+}

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type.expected
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type.expected
@@ -53,5 +53,4 @@ fragment RefetchableFragment on NonNodeStory @refetchable(queryName: "Refetchabl
     ...ProfilePicture
   }
   fetch_id
-  __token
 }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-interface-some-types-impl-node.expected
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-interface-some-types-impl-node.expected
@@ -53,5 +53,4 @@ fragment RefetchableFragment on RefetchableInterface @refetchable(queryName: "Re
 # }
  {
   id
-  __token
 }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-interface.expected
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-interface.expected
@@ -77,7 +77,6 @@ fragment RefetchableFragment on RefetchableInterface @refetchable(queryName: "Re
 # }
  {
   id
-  __token
 }
 
 fragment RefetchableFragment2 on RefetchableInterface2 @refetchable(queryName: "RefetchableFragmentQuery2") @__RefetchableMetadata
@@ -98,5 +97,4 @@ fragment RefetchableFragment2 on RefetchableInterface2 @refetchable(queryName: "
  {
   __typename
   not_id
-  __token
 }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/mod.rs
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/mod.rs
@@ -15,6 +15,13 @@ pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         let program = transform_connections(program, &ConnectionInterface::default());
         let base_fragments = Default::default();
-        transform_refetchable_fragment(&program, &Default::default(), &base_fragments, false)
+        let schema_config = if fixture.content.contains("// enable-token-field: true") {
+            let mut schema_config: relay_config::SchemaConfig = Default::default();
+            schema_config.enable_token_field = true;
+            schema_config
+        } else {
+            Default::default()
+        };
+        transform_refetchable_fragment(&program, &schema_config, &base_fragments, false)
     })
 }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment_test.rs
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment_test.rs
@@ -62,6 +62,13 @@ fn fragment_on_non_node_fetchable_type() {
 }
 
 #[test]
+fn fragment_on_non_node_fetchable_type_with_token_field() {
+    let input = include_str!("refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type-with-token-field.graphql");
+    let expected = include_str!("refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type-with-token-field.expected");
+    test_fixture(transform_fixture, "fragment-on-non-node-fetchable-type-with-token-field.graphql", "refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type-with-token-field.expected", input, expected);
+}
+
+#[test]
 fn fragment_on_object_implementing_node_interface() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface.expected");

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment_test.rs
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5d6010d9b0356775854a925e90881577>>
+ * @generated SignedSource<<f2a33e9f40621feaf83bba7d98a60d9b>>
  */
 
 mod refetchable_fragment;

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentTestStoryFragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentTestStoryFragment.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<78d2548c61fb6ef49166b87871b6e52c>>
+ * @generated SignedSource<<2e4ae25f68052d1b3f1d5a0327a06554>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -22,7 +22,6 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type usePaginationFragmentTestStoryFragment$fragmentType: FragmentType;
 type usePaginationFragmentTestStoryFragmentRefetchQuery$variables = any;
 export type usePaginationFragmentTestStoryFragment$data = {|
-  +__token: string,
   +comments: ?{|
     +edges: ?$ReadOnlyArray<?{|
       +node: ?{|
@@ -172,13 +171,6 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "fetch_id",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "__token",
       "storageKey": null
     }
   ],

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentTestStoryFragmentRefetchQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentTestStoryFragmentRefetchQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<93fed42485a145d595fb964db3e7d6f6>>
+ * @generated SignedSource<<b20479502bee7aa3b51ac271ec8efce0>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -221,13 +221,6 @@ return {
             "name": "fetch_id",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__token",
-            "storageKey": null
-          },
           (v3/*: any*/)
         ],
         "storageKey": null
@@ -235,12 +228,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "141601b4d00333b2f388709fff638ee6",
+    "cacheID": "16690aeca128c15136cb3c656e061799",
     "id": null,
     "metadata": {},
     "name": "usePaginationFragmentTestStoryFragmentRefetchQuery",
     "operationKind": "query",
-    "text": "query usePaginationFragmentTestStoryFragmentRefetchQuery(\n  $count: Int = 10\n  $cursor: ID\n  $id: ID!\n) {\n  fetch__NonNodeStory(input_fetch_id: $id) {\n    ...usePaginationFragmentTestStoryFragment_1G22uz\n    id\n  }\n}\n\nfragment usePaginationFragmentTestStoryFragment_1G22uz on NonNodeStory {\n  comments(first: $count, after: $cursor) {\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  fetch_id\n  __token\n}\n"
+    "text": "query usePaginationFragmentTestStoryFragmentRefetchQuery(\n  $count: Int = 10\n  $cursor: ID\n  $id: ID!\n) {\n  fetch__NonNodeStory(input_fetch_id: $id) {\n    ...usePaginationFragmentTestStoryFragment_1G22uz\n    id\n  }\n}\n\nfragment usePaginationFragmentTestStoryFragment_1G22uz on NonNodeStory {\n  comments(first: $count, after: $cursor) {\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  fetch_id\n}\n"
   }
 };
 })();

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentTestStoryQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentTestStoryQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<f1fc019d705bbceebe63c5c272af6c89>>
+ * @generated SignedSource<<6f9740295cde0d77668c74f29279d7cc>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -192,13 +192,6 @@ return {
             "name": "fetch_id",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__token",
-            "storageKey": null
-          },
           (v3/*: any*/)
         ],
         "storageKey": null
@@ -206,12 +199,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4f3e70176552d390bebe4d2886c17745",
+    "cacheID": "3cb446084b7d394d00b3150a5ce104cb",
     "id": null,
     "metadata": {},
     "name": "usePaginationFragmentTestStoryQuery",
     "operationKind": "query",
-    "text": "query usePaginationFragmentTestStoryQuery(\n  $id: ID!\n) {\n  nonNodeStory(id: $id) {\n    ...usePaginationFragmentTestStoryFragment\n    id\n  }\n}\n\nfragment usePaginationFragmentTestStoryFragment on NonNodeStory {\n  comments(first: 10) {\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  fetch_id\n  __token\n}\n"
+    "text": "query usePaginationFragmentTestStoryQuery(\n  $id: ID!\n) {\n  nonNodeStory(id: $id) {\n    ...usePaginationFragmentTestStoryFragment\n    id\n  }\n}\n\nfragment usePaginationFragmentTestStoryFragment on NonNodeStory {\n  comments(first: 10) {\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  fetch_id\n}\n"
   }
 };
 })();

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTest1Fragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTest1Fragment.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<7c2c05ec0d836f9fab77060b8dc4447e>>
+ * @generated SignedSource<<074e7dac8c97944de8b6ce60fd1eb626>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -22,7 +22,6 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type useRefetchableFragmentNodeTest1Fragment$fragmentType: FragmentType;
 type useRefetchableFragmentNodeTest1FragmentRefetchQuery$variables = any;
 export type useRefetchableFragmentNodeTest1Fragment$data = {|
-  +__token: string,
   +actor: ?{|
     +name: ?string,
   |},
@@ -77,13 +76,6 @@ var node/*: ReaderFragment*/ = {
       "args": null,
       "kind": "ScalarField",
       "name": "fetch_id",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "__token",
       "storageKey": null
     }
   ],

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTest1FragmentRefetchQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTest1FragmentRefetchQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<d5b50cb7bb64d0756748cafa6ee4b6b1>>
+ * @generated SignedSource<<f2064a3b2c8cf9665d0d9de963ac00b0>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -130,13 +130,6 @@ return {
             "name": "fetch_id",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__token",
-            "storageKey": null
-          },
           (v2/*: any*/)
         ],
         "storageKey": null
@@ -144,12 +137,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f90df4dc16ad217f9e91605e41c7bebe",
+    "cacheID": "3129a94c4b427c07b464a3e4b9f27849",
     "id": null,
     "metadata": {},
     "name": "useRefetchableFragmentNodeTest1FragmentRefetchQuery",
     "operationKind": "query",
-    "text": "query useRefetchableFragmentNodeTest1FragmentRefetchQuery(\n  $id: ID!\n) {\n  fetch__NonNodeStory(input_fetch_id: $id) {\n    ...useRefetchableFragmentNodeTest1Fragment\n    id\n  }\n}\n\nfragment useRefetchableFragmentNodeTest1Fragment on NonNodeStory {\n  actor {\n    __typename\n    name\n    id\n  }\n  fetch_id\n  __token\n}\n"
+    "text": "query useRefetchableFragmentNodeTest1FragmentRefetchQuery(\n  $id: ID!\n) {\n  fetch__NonNodeStory(input_fetch_id: $id) {\n    ...useRefetchableFragmentNodeTest1Fragment\n    id\n  }\n}\n\nfragment useRefetchableFragmentNodeTest1Fragment on NonNodeStory {\n  actor {\n    __typename\n    name\n    id\n  }\n  fetch_id\n}\n"
   }
 };
 })();

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTest1Query.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTest1Query.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<10e1a861ea49f1a624859dad7a53c95a>>
+ * @generated SignedSource<<2319a3d7450db8fb50d547d5a91ab33b>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -129,13 +129,6 @@ return {
             "name": "fetch_id",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__token",
-            "storageKey": null
-          },
           (v2/*: any*/)
         ],
         "storageKey": null
@@ -143,12 +136,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "48452883758b52f03c316637a58a7bf9",
+    "cacheID": "2b1fe038fd3a80f4e81b56e3b864e547",
     "id": null,
     "metadata": {},
     "name": "useRefetchableFragmentNodeTest1Query",
     "operationKind": "query",
-    "text": "query useRefetchableFragmentNodeTest1Query(\n  $id: ID!\n) {\n  nonNodeStory(id: $id) {\n    ...useRefetchableFragmentNodeTest1Fragment\n    id\n  }\n}\n\nfragment useRefetchableFragmentNodeTest1Fragment on NonNodeStory {\n  actor {\n    __typename\n    name\n    id\n  }\n  fetch_id\n  __token\n}\n"
+    "text": "query useRefetchableFragmentNodeTest1Query(\n  $id: ID!\n) {\n  nonNodeStory(id: $id) {\n    ...useRefetchableFragmentNodeTest1Fragment\n    id\n  }\n}\n\nfragment useRefetchableFragmentNodeTest1Fragment on NonNodeStory {\n  actor {\n    __typename\n    name\n    id\n  }\n  fetch_id\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This fixes #3941 so that fetchable directive is usable in OSS. 

# Why is this needed?

fields starting with `__` is reserved in the GraphQL spec and since this field isn't part of the spec any attempt of using the field on a server that is spec compliant will result in an error. 

# What changed?

* Added a new opt-in `enableTokenField`  config option.
* Conditionally include the `__token` field in refetchable fragment selections based on the config option.

# How has this been tested?

One could argue we should add a new test asserting the old behavior, I wasn't too sure how to go about adding a special fixture though.

The tests now assert that `__token` is not being generated. 

cc @captbaritone 