### PR TITLE
Clarify hasPreviousPage/hasNextPage algorithms

### DIFF
--- a/website/spec/Connections.md
+++ b/website/spec/Connections.md
@@ -344,11 +344,13 @@ client may return {true} if edges prior to `after` exist, if it can do so
 efficiently, otherwise may return {false}. More formally:
 
 HasPreviousPage(allEdges, before, after, first, last):
+  * Let {edges} be the result of calling {ApplyCursorsToEdges(allEdges, before, after)}.
+  * If {edges} is empty return {false}.
   * If {last} is set:
-    * Let {edges} be the result of calling {ApplyCursorsToEdges(allEdges, before, after)}.
     * If {edges} contains more than {last} elements return {true}, otherwise {false}.
   * If {after} is set:
-    * If the server can efficiently determine that elements exist prior to {after}, return {true}.
+    * If elements exist before the first member of {edges}, and the server can efficiently
+      determine this, return {true}.
   * Return {false}.
 
 `hasNextPage` is used to indicate whether more edges exist following the set
@@ -359,11 +361,13 @@ client may return {true} if edges further from `before` exist, if it can do
 so efficiently, otherwise may return {false}. More formally:
 
 HasNextPage(allEdges, before, after, first, last):
+  * Let {edges} be the result of calling {ApplyCursorsToEdges(allEdges, before, after)}.
+  * If {edges} is empty return {false}.
   * If {first} is set:
-    * Let {edges} be the result of calling {ApplyCursorsToEdges(allEdges, before, after)}.
     * If {edges} contains more than {first} elements return {true}, otherwise {false}.
   * If {before} is set:
-    * If the server can efficiently determine that elements exist following {before}, return {true}.
+    * If elements exist after the last member of {edges}, and the server can efficiently
+      determine this, return {true}.
   * Return {false}.
 
 NOTE When both `first` and `last` are included, both of the fields should be set


### PR DESCRIPTION

Relates to Issue #2787 (closest I could find in a search)

Proposing a change to the wording of this part of the connection spec.

Given a data set as a simple array:

```
["a", "b", "c", "d"]
```

Let the cursors is the 0-based index into the array

```
connection (first: 1, after: 0)
```

Should intuitively return 

```
edges: [
  { cursor: 1, node: "b" }
],
pageInfo: {
  startCursor: 1,
  endCursor: 1,
  hasPreviousPage: true,
  hasNextPage: true
}
```

As there are edges both before and after the result set.

As written, the spec says that hasPreviousPage should be false, because the `after` cursor (0) refers to the first element in a fixed list and we can efficiently determine that there are therefore no elements before it. We would have a corresponding issue with `hasNextPage` if we requested `(before: 3, last: 1)`.

Intuitively, its probably intended that the hasPrevious/NextPage algorithms mean to refer to the first/last member of the result set, rather than the edge corresponding to the `after`/`before` cursor which is intended to be excluded from the result set.