### PR TITLE
[relay-compiler] Fix LocalPersister repersist

### DIFF
--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_flow.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_flow.expected
@@ -15,9 +15,6 @@ graphql`
   }
 }
 
-//- operations.json
-{}
-
 //- schema.graphql
 type Query { userName: String }
 ==================================== OUTPUT ===================================
@@ -127,3 +124,8 @@ export default ((node/*: any*/)/*: Query<
   fooQuery$variables,
   fooQuery$data,
 >*/);
+
+//- operations.json
+{
+  "ae6874c86ce5db2df8d6b253a6a0ec13": "query fooQuery {\n  userName\n}\n"
+}

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_flow.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_flow.input
@@ -14,8 +14,5 @@ graphql`
   }
 }
 
-//- operations.json
-{}
-
 //- schema.graphql
 type Query { userName: String }

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_javascript.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_javascript.expected
@@ -15,9 +15,6 @@ graphql`
   }
 }
 
-//- operations.json
-{}
-
 //- schema.graphql
 type Query { userName: String }
 ==================================== OUTPUT ===================================
@@ -105,3 +102,8 @@ import { PreloadableQueryRegistry } from 'relay-runtime';
 PreloadableQueryRegistry.set(node.params.id, node);
 
 export default node;
+
+//- operations.json
+{
+  "ae6874c86ce5db2df8d6b253a6a0ec13": "query fooQuery {\n  userName\n}\n"
+}

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_javascript.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_javascript.input
@@ -14,8 +14,5 @@ graphql`
   }
 }
 
-//- operations.json
-{}
-
 //- schema.graphql
 type Query { userName: String }

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_typescript.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_typescript.expected
@@ -15,9 +15,6 @@ graphql`
   }
 }
 
-//- operations.json
-{}
-
 //- schema.graphql
 type Query { userName: String }
 ==================================== OUTPUT ===================================
@@ -118,3 +115,8 @@ import { PreloadableQueryRegistry } from 'relay-runtime';
 PreloadableQueryRegistry.set(node.params.id, node);
 
 export default node;
+
+//- operations.json
+{
+  "ae6874c86ce5db2df8d6b253a6a0ec13": "query fooQuery {\n  userName\n}\n"
+}

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_typescript.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/preloadable_query_typescript.input
@@ -14,8 +14,5 @@ graphql`
   }
 }
 
-//- operations.json
-{}
-
 //- schema.graphql
 type Query { userName: String }

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/mod.rs
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/mod.rs
@@ -54,7 +54,7 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
                             Box::new(RemotePersister::new(remote_config.clone()))
                         }
                         PersistConfig::Local(local_config) => {
-                            Box::new(LocalPersister::new(local_config.clone()))
+                            Box::new(LocalPersister::new(local_config.clone(), false))
                         }
                     }
                 },

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -128,16 +128,7 @@ impl<'de> Deserialize<'de> for PersistConfig {
         match RemotePersistConfig::deserialize(value.clone()) {
             Ok(remote_config) => Ok(PersistConfig::Remote(remote_config)),
             Err(remote_error) => match LocalPersistConfig::deserialize(value) {
-                Ok(local_config) => {
-                    if !local_config.file.exists() {
-                        Err(Error::custom(format!(
-                            "The file `{}` for the local query persisting does not exist. Please, make sure the file path is correct.",
-                            local_config.file.display()
-                        )))
-                    } else {
-                        Ok(PersistConfig::Local(local_config))
-                    }
-                }
+                Ok(local_config) => Ok(PersistConfig::Local(local_config)),
                 Err(local_error) => {
                     let error_message = format!(
                         r#"Persist configuration cannot be parsed as a remote configuration due to:


### PR DESCRIPTION
Currently the `--repersist` with the LocalPersister only adds new operations without cleaning up old operations. My expectation of a repersist would be to persist the currently active operations and getting rid of the outdated operations.

## Changes

- Do not panic if LocalPersister file doesn't exist yet and just print a warning
- Do not initialize LocalPersister when repersisting as to remove outdated operations