### PR TITLE
Repro for queryCacheExpirationTime not working in hooks

### DIFF
--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useLazyLoadQueryQueryCacheExpirationTimeTestQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useLazyLoadQueryQueryCacheExpirationTimeTestQuery.graphql.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<3f685baaee25bec1486ec7ad50e8fd65>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type useLazyLoadQueryQueryCacheExpirationTimeTestQuery$variables = {||};
+export type useLazyLoadQueryQueryCacheExpirationTimeTestQuery$data = {|
+  +me: ?{|
+    +id: string,
+    +name: ?string,
+  |},
+|};
+export type useLazyLoadQueryQueryCacheExpirationTimeTestQuery = {|
+  response: useLazyLoadQueryQueryCacheExpirationTimeTestQuery$data,
+  variables: useLazyLoadQueryQueryCacheExpirationTimeTestQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "User",
+    "kind": "LinkedField",
+    "name": "me",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useLazyLoadQueryQueryCacheExpirationTimeTestQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "useLazyLoadQueryQueryCacheExpirationTimeTestQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "d2703389c91278aacb3dba085cac3260",
+    "id": null,
+    "metadata": {},
+    "name": "useLazyLoadQueryQueryCacheExpirationTimeTestQuery",
+    "operationKind": "query",
+    "text": "query useLazyLoadQueryQueryCacheExpirationTimeTestQuery {\n  me {\n    id\n    name\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "bc4f616133288fcfce806fe9d159b8a1";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  useLazyLoadQueryQueryCacheExpirationTimeTestQuery$variables,
+  useLazyLoadQueryQueryCacheExpirationTimeTestQuery$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/useLazyLoadQuery-queryCacheExpirationTime-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useLazyLoadQuery-queryCacheExpirationTime-test.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {CacheConfig, RequestParameters, Variables} from 'relay-runtime';
+
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
+const useLazyLoadQuery = require('../useLazyLoadQuery');
+const React = require('react');
+const ReactTestRenderer = require('react-test-renderer');
+const {
+  Environment,
+  Network,
+  Observable,
+  RecordSource,
+  Store,
+  graphql,
+} = require('relay-runtime');
+
+describe('useLazyLoadQuery with queryCacheExpirationTime', () => {
+  let environment;
+  let ParentQuery;
+  let source;
+  let store;
+  let fetchTime;
+  let fetch;
+  let networkSource;
+  let render;
+  const QUERY_CACHE_EXPIRATION_TIME = 1000;
+  const GC_RELEASE_BUFFER_SIZE = 1;
+
+  beforeEach(() => {
+    fetchTime = Date.now();
+    jest.spyOn(global.Date, 'now').mockImplementation(() => fetchTime);
+
+    ParentQuery = graphql`
+      query useLazyLoadQueryQueryCacheExpirationTimeTestQuery {
+        me {
+          id
+          name
+        }
+      }
+    `;
+
+    source = RecordSource.create();
+    store = new Store(source, {
+      queryCacheExpirationTime: QUERY_CACHE_EXPIRATION_TIME,
+      gcReleaseBufferSize: GC_RELEASE_BUFFER_SIZE,
+    });
+    fetch = jest.fn(
+      (
+        _query: RequestParameters,
+        _variables: Variables,
+        _cacheConfig: CacheConfig,
+      ) => {
+        return Observable.create<$FlowFixMe>(sink => {
+          networkSource = sink;
+        });
+      },
+    );
+    environment = new Environment({
+      network: Network.create((fetch: $FlowFixMe)),
+      store,
+    });
+
+    render = (env: Environment, children: React.Node) => {
+      const instance = ReactTestRenderer.create(
+        <RelayEnvironmentProvider environment={env}>
+          <React.Suspense fallback="Fallback">{children}</React.Suspense>
+        </RelayEnvironmentProvider>,
+      );
+      return [
+        instance,
+        (nextChildren: React.Node) => {
+          instance.update(
+            <RelayEnvironmentProvider environment={env}>
+              <React.Suspense fallback="Fallback">
+                {nextChildren}
+              </React.Suspense>
+            </RelayEnvironmentProvider>,
+          );
+        },
+      ];
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not refetch if the previous query has not expired', () => {
+    let data: string | void;
+    function Component() {
+      data = useLazyLoadQuery(
+        ParentQuery,
+        {},
+        {
+          fetchPolicy: 'store-or-network',
+        },
+      );
+      return data.me.name;
+    }
+    const [instance, rerender] = render(environment, <Component />);
+    expect(instance.toJSON()).toEqual('Fallback');
+    expect(data).toEqual(undefined);
+
+    ReactTestRenderer.act(() => {
+      networkSource.next({
+        data: {
+          me: {
+            id: '4',
+            name: 'Zuck',
+          },
+        },
+      });
+      jest.runAllTimers();
+    });
+    expect(instance.toJSON()).toEqual('Zuck');
+    expect(data).toEqual({
+      me: {
+        id: '4',
+        name: 'Zuck',
+      },
+    });
+    expect(fetch).toBeCalledTimes(1);
+    ReactTestRenderer.act(() => {
+      jest.runAllTimers();
+      rerender(<div />); // unmount the component
+      jest.runAllTimers();
+    });
+
+    // Advance time to just before query expiration
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => fetchTime + (QUERY_CACHE_EXPIRATION_TIME - 1));
+
+    rerender(<Component />);
+    expect(instance.toJSON()).toEqual('Zuck');
+    expect(fetch).toBeCalledTimes(1);
+    rerender(<div />); // unmount the component
+    jest.runAllTimers();
+
+    // Advance time to just after query expiration
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => fetchTime + (QUERY_CACHE_EXPIRATION_TIME + 1));
+
+    rerender(<Component />);
+    // TODO: This should suspend again and show the fallback.
+    // The fetchQueryInternal instance is incorrectly reused when it should have
+    // been cleared on unmount of the previous component.
+    expect(instance.toJSON()).toEqual('Zuck');
+    // TODO: This should fetch again, per above the previous cache entry should be
+    // cleared and this should fetch again (call count 2, not 1)
+    expect(fetch).toBeCalledTimes(1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,19 +4092,24 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hermes-eslint@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.14.0.tgz#d56426b0931a7ced99d08b4b6a06f798064b13ba"
-  integrity sha512-ORk7znDabvALzTbI3QRIQefCkxF1ukDm3dVut3e+cVmwdtsTC71BJetSvdh1jtgK10czwck1QiPZOVOVolhiqQ==
+hermes-eslint@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.15.0.tgz#4d7495cb5e0e9275a1fb0b465b88fccf0b6d8840"
+  integrity sha512-Rd12uW9FZdOTDDwpVdYUxZGEApskUzBfKYy9RMtczm2uprX8yviPb9QVSVn2hl+xuRTA7Z0FnqDwOwXGiinsRQ==
   dependencies:
     esrecurse "^4.3.0"
-    hermes-estree "0.14.0"
-    hermes-parser "0.14.0"
+    hermes-estree "0.15.0"
+    hermes-parser "0.15.0"
 
 hermes-estree@0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.14.0.tgz#c663eea1400980802283338a09d0087c448729e7"
   integrity sha512-L6M67+0/eSEbt6Ha2XOBFXL++7MR34EOJMgm+j7YCaI4L/jZqrVAg6zYQKzbs1ZCFDLvEQpOgLlapTX4gpFriA==
+
+hermes-estree@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.15.0.tgz#e32f6210ab18c7b705bdcb375f7700f2db15d6ba"
+  integrity sha512-lLYvAd+6BnOqWdnNbP/Q8xfl8LOGw4wVjfrNd9Gt8eoFzhNBRVD95n4l2ksfMVOoxuVyegs85g83KS9QOsxbVQ==
 
 hermes-parser@0.14.0:
   version "0.14.0"
@@ -4112,6 +4117,13 @@ hermes-parser@0.14.0:
   integrity sha512-pt+8uRiJhVlErY3fiXB3gKhZ72RxM6E1xRMpvfZ5n6Z5TQKQQXKorgRCRzoe02mmvLKBJFP5nPDGv75MWAgCTw==
   dependencies:
     hermes-estree "0.14.0"
+
+hermes-parser@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.15.0.tgz#f611a297c2a2dbbfbce8af8543242254f604c382"
+  integrity sha512-Q1uks5rjZlE9RjMMjSUCkGrEIPI5pKJILeCtK1VmTj7U4pf3wVPoo+cxfu+s4cBAPy2JzikIIdCZgBoR6x7U1Q==
+  dependencies:
+    hermes-estree "0.15.0"
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Repro for `queryCacheExpirationTime` not working in Relay Hooks (or at least not in useLazyLoadQuery). It appears that fetchQueryInternal's deduped entry isn't cleared even after the previous instance of the hook is unmounted, and the subsequent hook invocation reuses this fetch entry. Ie, the runtime correctly detects the query as stale and tries to refetch, but our network caching says no and reuses the previous query.