### PR TITLE
Use same toolchain for build and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-06-26
+          toolchain: 1.72.0
           override: true
           components: rustfmt
       - name: "rustfmt"

--- a/compiler/crates/common/src/diagnostic_check.rs
+++ b/compiler/crates/common/src/diagnostic_check.rs
@@ -124,11 +124,9 @@ mod escalate_tests {
 
         escalate(DiagnosticSeverity::WARNING, &mut diagnostics);
 
-        assert!(
-            diagnostics
-                .iter()
-                .all(|d| d.severity() == DiagnosticSeverity::HINT)
-        );
+        assert!(diagnostics
+            .iter()
+            .all(|d| d.severity() == DiagnosticSeverity::HINT));
     }
 
     #[test]
@@ -142,11 +140,9 @@ mod escalate_tests {
 
         escalate(DiagnosticSeverity::WARNING, &mut diagnostics);
 
-        assert!(
-            diagnostics
-                .iter()
-                .all(|d| d.severity() == DiagnosticSeverity::ERROR)
-        );
+        assert!(diagnostics
+            .iter()
+            .all(|d| d.severity() == DiagnosticSeverity::ERROR));
     }
 
     #[test]

--- a/compiler/crates/graphql-ir/src/build.rs
+++ b/compiler/crates/graphql-ir/src/build.rs
@@ -440,18 +440,16 @@ impl<'schema, 'signatures, 'options> Builder<'schema, 'signatures, 'options> {
         let mut seen_variables = StringKeyMap::default();
         for variable in definitions {
             if let Some(other_variable_span) = seen_variables.get(&variable.name.name) {
-                return Err(vec![
-                    Diagnostic::error(
-                        ValidationMessage::DuplicateVariable {
-                            name: variable.name.name,
-                        },
-                        self.location.with_span(variable.span),
-                    )
-                    .annotate(
-                        "conflicts with",
-                        self.location.with_span(*other_variable_span),
-                    ),
-                ]);
+                return Err(vec![Diagnostic::error(
+                    ValidationMessage::DuplicateVariable {
+                        name: variable.name.name,
+                    },
+                    self.location.with_span(variable.span),
+                )
+                .annotate(
+                    "conflicts with",
+                    self.location.with_span(*other_variable_span),
+                )]);
             }
             seen_variables.insert(variable.name.name, variable.span);
         }
@@ -1186,15 +1184,13 @@ impl<'schema, 'signatures, 'options> Builder<'schema, 'signatures, 'options> {
             for (i, arg) in arguments.items.iter().enumerate() {
                 for other_arg in arguments.items.iter().skip(i + 1) {
                     if arg.name.value == other_arg.name.value {
-                        return Err(vec![
-                            Diagnostic::error(
-                                ValidationMessage::DuplicateArgument {
-                                    name: arg.name.value,
-                                },
-                                self.location.with_span(arg.span),
-                            )
-                            .annotate("conflicts with", self.location.with_span(other_arg.span)),
-                        ]);
+                        return Err(vec![Diagnostic::error(
+                            ValidationMessage::DuplicateArgument {
+                                name: arg.name.value,
+                            },
+                            self.location.with_span(arg.span),
+                        )
+                        .annotate("conflicts with", self.location.with_span(other_arg.span))]);
                     }
                 }
             }
@@ -1285,15 +1281,13 @@ impl<'schema, 'signatures, 'options> Builder<'schema, 'signatures, 'options> {
                     .skip(index + 1)
                     .find(|other_directive| other_directive.name.item == directive.name.item)
                 {
-                    return Err(vec![
-                        Diagnostic::error(
-                            ValidationMessage::RepeatedNonRepeatableDirective {
-                                name: directive.name.item,
-                            },
-                            repeated_directive.name.location,
-                        )
-                        .annotate("previously used here", directive.name.location),
-                    ]);
+                    return Err(vec![Diagnostic::error(
+                        ValidationMessage::RepeatedNonRepeatableDirective {
+                            name: directive.name.item,
+                        },
+                        repeated_directive.name.location,
+                    )
+                    .annotate("previously used here", directive.name.location)]);
                 }
             }
         }
@@ -1424,16 +1418,14 @@ impl<'schema, 'signatures, 'options> Builder<'schema, 'signatures, 'options> {
                 let next_type = self.schema.get_type_string(used_as_type);
                 let next_span = self.location.with_span(variable.span);
                 let prev_span = self.location.with_span(prev_usage.span);
-                return Err(vec![
-                    Diagnostic::error(
-                        ValidationMessage::IncompatibleVariableUsage {
-                            prev_type,
-                            next_type,
-                        },
-                        next_span,
-                    )
-                    .annotate("is incompatible with", prev_span),
-                ]);
+                return Err(vec![Diagnostic::error(
+                    ValidationMessage::IncompatibleVariableUsage {
+                        prev_type,
+                        next_type,
+                    },
+                    next_span,
+                )
+                .annotate("is incompatible with", prev_span)]);
             }
             // If the currently used type is a subtype of the previous usage, then it could
             // be a narrower type. Update our inference to reflect the stronger requirements.
@@ -1558,16 +1550,11 @@ impl<'schema, 'signatures, 'options> Builder<'schema, 'signatures, 'options> {
                         required_fields.remove(&x.name.value);
                         let prev_span = seen_fields.insert(x.name.value, x.name.span);
                         if let Some(prev_span) = prev_span {
-                            return Err(vec![
-                                Diagnostic::error(
-                                    ValidationMessage::DuplicateInputField(x.name.value),
-                                    self.location.with_span(prev_span),
-                                )
-                                .annotate(
-                                    "also defined here",
-                                    self.location.with_span(x.name.span),
-                                ),
-                            ]);
+                            return Err(vec![Diagnostic::error(
+                                ValidationMessage::DuplicateInputField(x.name.value),
+                                self.location.with_span(prev_span),
+                            )
+                            .annotate("also defined here", self.location.with_span(x.name.span))]);
                         };
 
                         let value_span = x.value.span();
@@ -1702,16 +1689,11 @@ impl<'schema, 'signatures, 'options> Builder<'schema, 'signatures, 'options> {
                         required_fields.remove(&x.name.value);
                         let prev_span = seen_fields.insert(x.name.value, x.name.span);
                         if let Some(prev_span) = prev_span {
-                            return Err(vec![
-                                Diagnostic::error(
-                                    ValidationMessage::DuplicateInputField(x.name.value),
-                                    self.location.with_span(prev_span),
-                                )
-                                .annotate(
-                                    "also defined here",
-                                    self.location.with_span(x.name.span),
-                                ),
-                            ]);
+                            return Err(vec![Diagnostic::error(
+                                ValidationMessage::DuplicateInputField(x.name.value),
+                                self.location.with_span(prev_span),
+                            )
+                            .annotate("also defined here", self.location.with_span(x.name.span))]);
                         };
 
                         let value_span = x.value.span();

--- a/compiler/crates/intern/src/intern.rs
+++ b/compiler/crates/intern/src/intern.rs
@@ -308,6 +308,7 @@ impl<Id: InternId> InternTable<Id, Id::Intern> {
     fn serdes_type_index_slow(&'static self) -> u32 {
         let i = NEXT_SERDES_TYPE_INDEX.fetch_add(1, Ordering::Relaxed);
         assert!(i != u32::MAX); // Or we've overflowed.
+
         // Now, we might be racing another thread to assign self.type_index.
         // So CAS it in, keeping any entry that was already there (since it's
         // already being used).

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -570,7 +570,11 @@ impl fmt::Debug for Config {
         } = self;
 
         fn option_fn_to_string<T>(option: &Option<T>) -> &'static str {
-            if option.is_some() { "Some(Fn)" } else { "None" }
+            if option.is_some() {
+                "Some(Fn)"
+            } else {
+                "None"
+            }
         }
 
         f.debug_struct("Config")

--- a/compiler/crates/relay-docblock/src/docblock_ir.rs
+++ b/compiler/crates/relay-docblock/src/docblock_ir.rs
@@ -353,19 +353,17 @@ fn parse_terse_relay_resolver_ir(
 
     if let Some(fragment_type_condition) = fragment_type_condition {
         if fragment_type_condition.item != type_name.value {
-            return Err(vec![
-                Diagnostic::error(
-                    IrParsingErrorMessages::MismatchRootFragmentTypeConditionTerseSyntax {
-                        fragment_type_condition: fragment_type_condition.item,
-                        type_name: type_name.value,
-                    },
-                    type_str.location.with_span(type_name.span),
-                )
-                .annotate(
-                    "with fragment type condition",
-                    fragment_type_condition.location,
-                ),
-            ]);
+            return Err(vec![Diagnostic::error(
+                IrParsingErrorMessages::MismatchRootFragmentTypeConditionTerseSyntax {
+                    fragment_type_condition: fragment_type_condition.item,
+                    type_name: type_name.value,
+                },
+                type_str.location.with_span(type_name.span),
+            )
+            .annotate(
+                "with fragment type condition",
+                fragment_type_condition.location,
+            )]);
         }
     }
 
@@ -481,16 +479,14 @@ fn combine_edge_to_and_output_type(
         (None, Some(output_type)) => {
             parse_type_annotation(output_type.value).map(|val| Some(OutputType::Output(val)))
         }
-        (Some(edge_to), Some(output_type)) => Err(vec![
-            Diagnostic::error(
-                IrParsingErrorMessages::IncompatibleFields {
-                    field_1: AllowedFieldName::EdgeToField,
-                    field_2: AllowedFieldName::OutputTypeField,
-                },
-                edge_to.key_location,
-            )
-            .annotate("@outputType", output_type.key_location),
-        ]),
+        (Some(edge_to), Some(output_type)) => Err(vec![Diagnostic::error(
+            IrParsingErrorMessages::IncompatibleFields {
+                field_1: AllowedFieldName::EdgeToField,
+                field_2: AllowedFieldName::OutputTypeField,
+            },
+            edge_to.key_location,
+        )
+        .annotate("@outputType", output_type.key_location)]),
     }
 }
 
@@ -604,18 +600,16 @@ fn parse_fragment_definition(
     {
         for field_arg in &field_arguments.items {
             if let Some(fragment_arg) = fragment_arguments.named(field_arg.name.value) {
-                return Err(vec![
-                    Diagnostic::error(
-                        IrParsingErrorMessages::ConflictingArguments,
-                        Location::new(source_location, field_arg.name.span),
-                    )
-                    .annotate(
-                        "conflicts with this fragment argument",
-                        fragment_definition
-                            .location
-                            .with_span(fragment_arg.name.span),
-                    ),
-                ]);
+                return Err(vec![Diagnostic::error(
+                    IrParsingErrorMessages::ConflictingArguments,
+                    Location::new(source_location, field_arg.name.span),
+                )
+                .annotate(
+                    "conflicts with this fragment argument",
+                    fragment_definition
+                        .location
+                        .with_span(fragment_arg.name.span),
+                )]);
             }
         }
     }

--- a/compiler/crates/relay-transforms/src/assignable_fragment_spread/validate_updatable_directive.rs
+++ b/compiler/crates/relay-transforms/src/assignable_fragment_spread/validate_updatable_directive.rs
@@ -318,13 +318,11 @@ impl<'a> Validator for UpdatableDirective<'a> {
             .named(*RELAY_RESOLVER_DIRECTIVE_NAME)
             .is_some()
         {
-            return Err(vec![
-                Diagnostic::error(
-                    ValidationMessage::UpdatableDisallowRelayResolvers,
-                    field.definition.location,
-                )
-                .annotate("The field is defined here:", field_def.name.location),
-            ]);
+            return Err(vec![Diagnostic::error(
+                ValidationMessage::UpdatableDisallowRelayResolvers,
+                field.definition.location,
+            )
+            .annotate("The field is defined here:", field_def.name.location)]);
         }
         self.default_validate_scalar_field(field)
     }
@@ -339,13 +337,11 @@ impl<'a> Validator for UpdatableDirective<'a> {
             .named(*RELAY_RESOLVER_DIRECTIVE_NAME)
             .is_some()
         {
-            return Err(vec![
-                Diagnostic::error(
-                    ValidationMessage::UpdatableDisallowRelayResolvers,
-                    linked_field.definition.location,
-                )
-                .annotate("The field is defined here:", field_def.name.location),
-            ]);
+            return Err(vec![Diagnostic::error(
+                ValidationMessage::UpdatableDisallowRelayResolvers,
+                linked_field.definition.location,
+            )
+            .annotate("The field is defined here:", field_def.name.location)]);
         }
 
         validate!(

--- a/compiler/crates/relay-transforms/src/inline_data_fragment.rs
+++ b/compiler/crates/relay-transforms/src/inline_data_fragment.rs
@@ -145,15 +145,13 @@ impl<'s> Transformer for InlineDataFragmentsTransform<'s> {
 
             let inline_fragment = InlineFragment {
                 type_condition: None,
-                directives: vec![
-                    InlineDirectiveMetadata {
-                        fragment_name: name,
-                        arguments: spread.arguments.clone(),
-                        variable_definitions: fragment.variable_definitions.clone(),
-                        used_global_variables: fragment.used_global_variables.clone(),
-                    }
-                    .into(),
-                ],
+                directives: vec![InlineDirectiveMetadata {
+                    fragment_name: name,
+                    arguments: spread.arguments.clone(),
+                    variable_definitions: fragment.variable_definitions.clone(),
+                    used_global_variables: fragment.used_global_variables.clone(),
+                }
+                .into()],
                 selections: vec![Selection::InlineFragment(Arc::new(InlineFragment {
                     type_condition: Some(fragment.type_condition),
                     directives: vec![],

--- a/compiler/crates/relay-transforms/src/match_/match_transform.rs
+++ b/compiler/crates/relay-transforms/src/match_/match_transform.rs
@@ -500,24 +500,22 @@ impl<'program, 'flag> MatchTransform<'program, 'flag> {
                     directives: vec![],
                     selections: vec![Selection::InlineFragment(Arc::new(InlineFragment {
                         type_condition: Some(fragment.type_condition),
-                        directives: vec![
-                            ModuleMetadata {
-                                key: match_directive_key_argument,
-                                module_id,
-                                module_name: module_directive_name_argument,
-                                source_document_name: self.document_name,
-                                fragment_name: spread.fragment.item,
-                                fragment_source_location: self
-                                    .program
-                                    .fragment(spread.fragment.item)
-                                    .unwrap()
-                                    .name
-                                    .location,
-                                location: module_directive.name.location,
-                                no_inline: should_use_no_inline,
-                            }
-                            .into(),
-                        ],
+                        directives: vec![ModuleMetadata {
+                            key: match_directive_key_argument,
+                            module_id,
+                            module_name: module_directive_name_argument,
+                            source_document_name: self.document_name,
+                            fragment_name: spread.fragment.item,
+                            fragment_source_location: self
+                                .program
+                                .fragment(spread.fragment.item)
+                                .unwrap()
+                                .name
+                                .location,
+                            location: module_directive.name.location,
+                            no_inline: should_use_no_inline,
+                        }
+                        .into()],
                         selections: next_selections,
                         spread_location: Location::generated(),
                     }))],

--- a/compiler/crates/relay-transforms/src/match_/subscription_transform.rs
+++ b/compiler/crates/relay-transforms/src/match_/subscription_transform.rs
@@ -188,29 +188,27 @@ impl<'program> SubscriptionTransform<'program> {
             directives: vec![],
             selections: vec![Selection::InlineFragment(Arc::new(InlineFragment {
                 type_condition,
-                directives: vec![
-                    ModuleMetadata {
-                        key: operation_name_with_suffix.intern(),
-                        module_id: format!(
-                            "{}.{}",
-                            operation.name.item.0,
-                            linked_field.alias_or_name(&self.program.schema).lookup()
-                        )
-                        .intern(),
-                        module_name: normalization_operation_name,
-                        source_document_name: operation.name.item.into(),
-                        fragment_name: fragment_spread.fragment.item,
-                        fragment_source_location: self
-                            .program
-                            .fragment(fragment_spread.fragment.item)
-                            .unwrap()
-                            .name
-                            .location,
-                        location: name_location,
-                        no_inline: false,
-                    }
-                    .into(),
-                ],
+                directives: vec![ModuleMetadata {
+                    key: operation_name_with_suffix.intern(),
+                    module_id: format!(
+                        "{}.{}",
+                        operation.name.item.0,
+                        linked_field.alias_or_name(&self.program.schema).lookup()
+                    )
+                    .intern(),
+                    module_name: normalization_operation_name,
+                    source_document_name: operation.name.item.into(),
+                    fragment_name: fragment_spread.fragment.item,
+                    fragment_source_location: self
+                        .program
+                        .fragment(fragment_spread.fragment.item)
+                        .unwrap()
+                        .name
+                        .location,
+                    location: name_location,
+                    no_inline: false,
+                }
+                .into()],
                 selections,
                 spread_location: Location::generated(),
             }))],

--- a/compiler/crates/relay-transforms/src/no_inline/mod.rs
+++ b/compiler/crates/relay-transforms/src/no_inline/mod.rs
@@ -161,15 +161,13 @@ impl<'f, 'p> Validator for RequiredNoInlineValidator<'f, 'p> {
                 .iter()
                 .any(|directive| directive.name.item == MATCH_CONSTANTS.module_directive_name)
         {
-            Err(vec![
-                Diagnostic::error(
-                    ValidationMessage::RequiredExplicitNoInlineDirective {
-                        fragment_name: spread.fragment.item,
-                    },
-                    spread.fragment.location,
-                )
-                .annotate("fragment definition", fragment.name.location),
-            ])
+            Err(vec![Diagnostic::error(
+                ValidationMessage::RequiredExplicitNoInlineDirective {
+                    fragment_name: spread.fragment.item,
+                },
+                spread.fragment.location,
+            )
+            .annotate("fragment definition", fragment.name.location)])
         } else {
             Ok(())
         }

--- a/compiler/crates/relay-transforms/src/refetchable_fragment/mod.rs
+++ b/compiler/crates/relay-transforms/src/refetchable_fragment/mod.rs
@@ -234,17 +234,15 @@ impl<'program, 'sc> RefetchableFragment<'program, 'sc> {
             } else {
                 (fragment_name, previous_fragment)
             };
-            return Err(vec![
-                Diagnostic::error(
-                    ValidationMessage::DuplicateRefetchableOperation {
-                        query_name: refetchable_directive.query_name.item,
-                        first_fragment_name: first_fragment.item,
-                        second_fragment_name: second_fragment.item,
-                    },
-                    first_fragment.location,
-                )
-                .annotate("also defined here", second_fragment.location),
-            ]);
+            return Err(vec![Diagnostic::error(
+                ValidationMessage::DuplicateRefetchableOperation {
+                    query_name: refetchable_directive.query_name.item,
+                    first_fragment_name: first_fragment.item,
+                    second_fragment_name: second_fragment.item,
+                },
+                first_fragment.location,
+            )
+            .annotate("also defined here", second_fragment.location)]);
         }
 
         // check for conflict with operations
@@ -252,18 +250,16 @@ impl<'program, 'sc> RefetchableFragment<'program, 'sc> {
             .program
             .operation(refetchable_directive.query_name.item)
         {
-            return Err(vec![
-                Diagnostic::error(
-                    ValidationMessage::RefetchableQueryConflictWithQuery {
-                        query_name: refetchable_directive.query_name.item,
-                    },
-                    refetchable_directive.query_name.location,
-                )
-                .annotate(
-                    "an operation with that name is already defined here",
-                    existing_query.name.location,
-                ),
-            ]);
+            return Err(vec![Diagnostic::error(
+                ValidationMessage::RefetchableQueryConflictWithQuery {
+                    query_name: refetchable_directive.query_name.item,
+                },
+                refetchable_directive.query_name.location,
+            )
+            .annotate(
+                "an operation with that name is already defined here",
+                existing_query.name.location,
+            )]);
         }
 
         Ok(())

--- a/compiler/crates/relay-transforms/src/validations/validate_connections.rs
+++ b/compiler/crates/relay-transforms/src/validations/validate_connections.rs
@@ -194,18 +194,16 @@ impl<'s> ConnectionValidation<'s> {
             edges_selection_name,
             |_, edges_type| edges_type.is_list() && edges_type.inner().is_object_or_interface(),
             || {
-                vec![
-                    Diagnostic::error(
-                        ValidationMessage::ExpectedConnectionToExposeValidEdgesField {
-                            connection_directive_name,
-                            connection_field_name,
-                            connection_type_name,
-                            edges_selection_name,
-                        },
-                        connection_field.definition.location,
-                    )
-                    .annotate("invalid field type", edges_field.definition.location),
-                ]
+                vec![Diagnostic::error(
+                    ValidationMessage::ExpectedConnectionToExposeValidEdgesField {
+                        connection_directive_name,
+                        connection_field_name,
+                        connection_type_name,
+                        edges_selection_name,
+                    },
+                    connection_field.definition.location,
+                )
+                .annotate("invalid field type", edges_field.definition.location)]
             },
         )?;
 
@@ -222,19 +220,17 @@ impl<'s> ConnectionValidation<'s> {
                         && (node_type.inner().is_abstract_type() || node_type.inner().is_object())
                 },
                 || {
-                    vec![
-                        Diagnostic::error(
-                            ValidationMessage::ExpectedConnectionToExposeValidNodeField {
-                                connection_directive_name,
-                                connection_field_name,
-                                connection_type_name,
-                                edges_selection_name,
-                                node_selection_name,
-                            },
-                            connection_field.definition.location,
-                        )
-                        .annotate("field with invalid type", edges_field.definition.location),
-                    ]
+                    vec![Diagnostic::error(
+                        ValidationMessage::ExpectedConnectionToExposeValidNodeField {
+                            connection_directive_name,
+                            connection_field_name,
+                            connection_type_name,
+                            edges_selection_name,
+                            node_selection_name,
+                        },
+                        connection_field.definition.location,
+                    )
+                    .annotate("field with invalid type", edges_field.definition.location)]
                 },
             ),
             // Validate edges.cursor selection
@@ -243,19 +239,17 @@ impl<'s> ConnectionValidation<'s> {
                 cursor_selection_name,
                 |_, cursor_type| !cursor_type.is_list() && cursor_type.inner().is_scalar(),
                 || {
-                    vec![
-                        Diagnostic::error(
-                            ValidationMessage::ExpectedConnectionToExposeValidCursorField {
-                                connection_directive_name,
-                                connection_field_name,
-                                connection_type_name,
-                                cursor_selection_name,
-                                edges_selection_name,
-                            },
-                            connection_field.definition.location,
-                        )
-                        .annotate("field with invalid type", edges_field.definition.location),
-                    ]
+                    vec![Diagnostic::error(
+                        ValidationMessage::ExpectedConnectionToExposeValidCursorField {
+                            connection_directive_name,
+                            connection_field_name,
+                            connection_type_name,
+                            cursor_selection_name,
+                            edges_selection_name,
+                        },
+                        connection_field.definition.location,
+                    )
+                    .annotate("field with invalid type", edges_field.definition.location)]
                 },
             )
         )
@@ -392,17 +386,15 @@ impl<'s> ConnectionValidation<'s> {
             match handler_val {
                 ConstantValue::String(_) => {}
                 _ => {
-                    return Err(vec![
-                        Diagnostic::error(
-                            ValidationMessage::InvalidConnectionHandlerArg {
-                                connection_directive_name: connection_directive.name.item,
-                                connection_field_name: connection_schema_field.name.item,
-                                handler_arg_name: *CONNECTION_HANDLER_ARG_NAME,
-                            },
-                            arg.value.location,
-                        )
-                        .annotate("on connection field", connection_field.definition.location),
-                    ]);
+                    return Err(vec![Diagnostic::error(
+                        ValidationMessage::InvalidConnectionHandlerArg {
+                            connection_directive_name: connection_directive.name.item,
+                            connection_field_name: connection_schema_field.name.item,
+                            handler_arg_name: *CONNECTION_HANDLER_ARG_NAME,
+                        },
+                        arg.value.location,
+                    )
+                    .annotate("on connection field", connection_field.definition.location)]);
                 }
             }
         }
@@ -425,33 +417,29 @@ impl<'s> ConnectionValidation<'s> {
                     };
                     let postfix = format!("_{}", field_alias_or_name);
                     if !string_val.lookup().ends_with(postfix.as_str()) {
-                        return Err(vec![
-                            Diagnostic::error(
-                                ValidationMessage::InvalidConnectionKeyArgPostfix {
-                                    connection_directive_name: connection_directive.name.item,
-                                    connection_field_name: connection_schema_field.name.item,
-                                    key_arg_name: *KEY_ARG_NAME,
-                                    key_arg_value: *string_val,
-                                    postfix,
-                                },
-                                arg.value.location,
-                            )
-                            .annotate("related location", connection_field.definition.location),
-                        ]);
-                    }
-                }
-                _ => {
-                    return Err(vec![
-                        Diagnostic::error(
-                            ValidationMessage::InvalidConnectionKeyArg {
+                        return Err(vec![Diagnostic::error(
+                            ValidationMessage::InvalidConnectionKeyArgPostfix {
                                 connection_directive_name: connection_directive.name.item,
                                 connection_field_name: connection_schema_field.name.item,
                                 key_arg_name: *KEY_ARG_NAME,
+                                key_arg_value: *string_val,
+                                postfix,
                             },
                             arg.value.location,
                         )
-                        .annotate("related location", connection_field.definition.location),
-                    ]);
+                        .annotate("related location", connection_field.definition.location)]);
+                    }
+                }
+                _ => {
+                    return Err(vec![Diagnostic::error(
+                        ValidationMessage::InvalidConnectionKeyArg {
+                            connection_directive_name: connection_directive.name.item,
+                            connection_field_name: connection_schema_field.name.item,
+                            key_arg_name: *KEY_ARG_NAME,
+                        },
+                        arg.value.location,
+                    )
+                    .annotate("related location", connection_field.definition.location)]);
                 }
             },
             None => {
@@ -510,17 +498,15 @@ impl<'s> ConnectionValidation<'s> {
                     })?;
                 }
                 _ => {
-                    return Err(vec![
-                        Diagnostic::error(
-                            ValidationMessage::InvalidConnectionFiltersArg {
-                                connection_directive_name: connection_directive.name.item,
-                                connection_field_name: connection_schema_field.name.item,
-                                filters_arg_name: *FILTERS_ARG_NAME,
-                            },
-                            arg.value.location,
-                        )
-                        .annotate("related location", connection_field.definition.location),
-                    ]);
+                    return Err(vec![Diagnostic::error(
+                        ValidationMessage::InvalidConnectionFiltersArg {
+                            connection_directive_name: connection_directive.name.item,
+                            connection_field_name: connection_schema_field.name.item,
+                            filters_arg_name: *FILTERS_ARG_NAME,
+                        },
+                        arg.value.location,
+                    )
+                    .annotate("related location", connection_field.definition.location)]);
                 }
             }
         }
@@ -538,17 +524,15 @@ impl<'s> ConnectionValidation<'s> {
             match value {
                 Value::Variable(_) => {}
                 _ => {
-                    return Err(vec![
-                        Diagnostic::error(
-                            ValidationMessage::InvalidConnectionDynamicKeyArg {
-                                connection_directive_name: connection_directive.name.item,
-                                connection_field_name: connection_schema_field.name.item,
-                                dynamic_key_arg_name: *DYNAMIC_KEY_ARG_NAME,
-                            },
-                            dynamic_key_arg.value.location,
-                        )
-                        .annotate("related location", connection_field.definition.location),
-                    ]);
+                    return Err(vec![Diagnostic::error(
+                        ValidationMessage::InvalidConnectionDynamicKeyArg {
+                            connection_directive_name: connection_directive.name.item,
+                            connection_field_name: connection_schema_field.name.item,
+                            dynamic_key_arg_name: *DYNAMIC_KEY_ARG_NAME,
+                        },
+                        dynamic_key_arg.value.location,
+                    )
+                    .annotate("related location", connection_field.definition.location)]);
                 }
             }
         }

--- a/compiler/crates/relay-transforms/src/validations/validate_no_inline_with_raw_response_type.rs
+++ b/compiler/crates/relay-transforms/src/validations/validate_no_inline_with_raw_response_type.rs
@@ -73,18 +73,16 @@ impl<'a> Validator for NoInlineRawResponseTypeValidator<'a> {
     fn validate_fragment(&mut self, fragment: &FragmentDefinition) -> DiagnosticsResult<()> {
         if let Some(directive) = fragment.directives.named(*NO_INLINE_DIRECTIVE_NAME) {
             if !is_raw_response_type_enabled(directive) {
-                return Err(vec![
-                    Diagnostic::error(
-                        ValidationMessage::RequiredRawResponseTypeOnNoInline {
-                            fragment_name: fragment.name.item,
-                        },
-                        fragment.name.location,
-                    )
-                    .annotate(
-                        "The query with @raw_response_type",
-                        self.current_query_location,
-                    ),
-                ]);
+                return Err(vec![Diagnostic::error(
+                    ValidationMessage::RequiredRawResponseTypeOnNoInline {
+                        fragment_name: fragment.name.item,
+                    },
+                    fragment.name.location,
+                )
+                .annotate(
+                    "The query with @raw_response_type",
+                    self.current_query_location,
+                )]);
             }
         }
         self.default_validate_fragment(fragment)

--- a/compiler/crates/relay-transforms/src/validations/validate_relay_directives.rs
+++ b/compiler/crates/relay-transforms/src/validations/validate_relay_directives.rs
@@ -80,7 +80,11 @@ impl<'program> RelayDirectiveValidation<'program> {
 
         self.current_reachable_arguments
             .extend(&fragment.used_global_variables);
-        if errs.is_empty() { Ok(()) } else { Err(errs) }
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(errs)
+        }
     }
 
     /// For all reachable arguments in the unmaksed fragments, validate that for the variables with the same name:
@@ -125,7 +129,11 @@ impl<'program> RelayDirectiveValidation<'program> {
                 map.insert(arg.name.item, ArgumentDefinition::Global(arg));
             }
         }
-        if errs.is_empty() { Ok(()) } else { Err(errs) }
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(errs)
+        }
     }
 
     fn validate_relay_directives(&self, directives: &[Directive]) -> DiagnosticsResult<()> {
@@ -144,7 +152,11 @@ impl<'program> RelayDirectiveValidation<'program> {
                 }
             }
         }
-        if errs.is_empty() { Ok(()) } else { Err(errs) }
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(errs)
+        }
     }
 }
 
@@ -206,13 +218,11 @@ impl Validator for RelayDirectiveValidation<'_> {
                             }
                         }
                         Value::Constant(ConstantValue::Null()) => Ok(()),
-                        _ => Err(vec![
-                            Diagnostic::error(
-                                ValidationMessage::InvalidRelayDirectiveArg(arg.name.item),
-                                spread.fragment.location,
-                            )
-                            .annotate("related location", arg.value.location),
-                        ]),
+                        _ => Err(vec![Diagnostic::error(
+                            ValidationMessage::InvalidRelayDirectiveArg(arg.name.item),
+                            spread.fragment.location,
+                        )
+                        .annotate("related location", arg.value.location)]),
                     }
                 } else {
                     Ok(())

--- a/compiler/crates/relay-transforms/src/validations/validate_required_arguments.rs
+++ b/compiler/crates/relay-transforms/src/validations/validate_required_arguments.rs
@@ -133,18 +133,16 @@ impl ValidateRequiredArguments<'_> {
                         .map(|arg| arg.name.item)
                         .any(|x| x == def.name)
                 {
-                    return Err(vec![
-                        Diagnostic::error(
-                            ValidationMessage::MissingRequiredArgument {
-                                argument_name: def.name,
-                                node_name,
-                                root_name: root_name_with_location.item,
-                                type_string: self.program.schema.get_type_string(&def.type_),
-                            },
-                            node_location,
-                        )
-                        .annotate("Root definition:", root_name_with_location.location),
-                    ]);
+                    return Err(vec![Diagnostic::error(
+                        ValidationMessage::MissingRequiredArgument {
+                            argument_name: def.name,
+                            node_name,
+                            root_name: root_name_with_location.item,
+                            type_string: self.program.schema.get_type_string(&def.type_),
+                        },
+                        node_location,
+                    )
+                    .annotate("Root definition:", root_name_with_location.location)]);
                 }
             }
         }

--- a/compiler/crates/relay-transforms/src/validations/validate_server_only_directives.rs
+++ b/compiler/crates/relay-transforms/src/validations/validate_server_only_directives.rs
@@ -224,15 +224,13 @@ impl<'s> Validator for ServerOnlyDirectivesValidation<'s> {
         {
             self.current_client_invalid_directives.push(directive.name);
             if let Some(location) = self.current_root_client_selection {
-                Err(vec![
-                    Diagnostic::error(
-                        ValidationMessage::InvalidServerOnlyDirectiveInClientFields(
-                            directive.name.item,
-                        ),
-                        directive.name.location,
-                    )
-                    .annotate("related location", location),
-                ])
+                Err(vec![Diagnostic::error(
+                    ValidationMessage::InvalidServerOnlyDirectiveInClientFields(
+                        directive.name.item,
+                    ),
+                    directive.name.location,
+                )
+                .annotate("related location", location)])
             } else {
                 Ok(())
             }

--- a/compiler/crates/schema/src/flatbuffer/mod.rs
+++ b/compiler/crates/schema/src/flatbuffer/mod.rs
@@ -628,37 +628,25 @@ mod tests {
         assert!(fb_schema.read_type("Aaaa".intern()).is_none());
         assert!(fb_schema.read_type("Zzzz".intern()).is_none());
 
-        assert!(
-            fb_schema
-                .read_directive(DirectiveName("ref_type".intern()))
-                .is_some()
-        );
-        assert!(
-            fb_schema
-                .read_directive(DirectiveName("extern_type".intern()))
-                .is_some()
-        );
-        assert!(
-            fb_schema
-                .read_directive(DirectiveName("fetchable".intern()))
-                .is_some()
-        );
+        assert!(fb_schema
+            .read_directive(DirectiveName("ref_type".intern()))
+            .is_some());
+        assert!(fb_schema
+            .read_directive(DirectiveName("extern_type".intern()))
+            .is_some());
+        assert!(fb_schema
+            .read_directive(DirectiveName("fetchable".intern()))
+            .is_some());
 
-        assert!(
-            fb_schema
-                .read_directive(DirectiveName("goto".intern()))
-                .is_none()
-        );
-        assert!(
-            fb_schema
-                .read_directive(DirectiveName("aaaa".intern()))
-                .is_none()
-        );
-        assert!(
-            fb_schema
-                .read_directive(DirectiveName("zzzz".intern()))
-                .is_none()
-        );
+        assert!(fb_schema
+            .read_directive(DirectiveName("goto".intern()))
+            .is_none());
+        assert!(fb_schema
+            .read_directive(DirectiveName("aaaa".intern()))
+            .is_none());
+        assert!(fb_schema
+            .read_directive(DirectiveName("zzzz".intern()))
+            .is_none());
 
         Ok(())
     }

--- a/compiler/crates/schema/src/in_memory/mod.rs
+++ b/compiler/crates/schema/src/in_memory/mod.rs
@@ -1610,10 +1610,11 @@ impl InMemorySchema {
                 let field_name = field_def.name.value;
                 let field_location = Location::new(source_location_key, field_def.name.span);
                 if let Some(prev_location) = existing_fields.insert(field_name, field_location) {
-                    return Err(vec![
-                        Diagnostic::error(SchemaError::DuplicateField(field_name), field_location)
-                            .annotate("previously defined here", prev_location),
-                    ]);
+                    return Err(vec![Diagnostic::error(
+                        SchemaError::DuplicateField(field_name),
+                        field_location,
+                    )
+                    .annotate("previously defined here", prev_location)]);
                 }
                 let arguments = self.build_arguments(&field_def.arguments)?;
                 let directives = self.build_directive_values(&field_def.directives);

--- a/compiler/rustfmt.toml
+++ b/compiler/rustfmt.toml
@@ -1,8 +1,5 @@
 # Get help on options with `rustfmt --help=config`
 # Please keep these in alphabetical order.
 edition = "2021"
-group_imports = "StdExternalCrate"
-imports_granularity = "Item"
 merge_derives = false
 use_field_init_shorthand = true
-version = "Two"


### PR DESCRIPTION
While building this codebase, I noticed several stumbling blocks that might confuse and discourage first-time contributors coming from other Rust projects, which I would like to help address in the near future.

The first one I'll bring up is that we're using different toolchains for formatting (nightly) and building (stable). I assume nightly is used for formatting/linting because some nice rules such as `group_imports` are unfortunately still unstable. The current setup means that:

- if people use a stable toolchain like they're used to from most projects, their IDE might apply formatting that doesn't respect these nightly-only rules, which they only notice once CI fails and might have trouble figuring out
- if they use nightly they won't have this problem, but will have to deal with the usual inconveniences of working with nightly builds, such as compiler panics and other unstable strangeness

As much as I like `group_imports = "StdExternalCrate"`, I'm not sure if it's worth the toolchain hassle. So I opened this PR to show what it would look like with stable-only and get your opinion. It doesn't actually change much in the existing files because the default behavior for the rules in question is mostly preserving existing formatting, the biggest downside I see is that we're no longer able to enforce the order of the imports for new files in CI. If consistency is a priority here, that would have to be maintained through the regular code review process. But in exchange we'd get a more streamlined development setup.