### PR TITLE
Enable goto def in LSP to goto the actual schema definition

### DIFF
--- a/compiler/crates/relay-bin/src/main.rs
+++ b/compiler/crates/relay-bin/src/main.rs
@@ -351,9 +351,10 @@ impl LSPExtraDataProvider for ExtraDataProvider {
         let result_trimmed = result.trim();
         let result = result_trimmed.split(':').collect::<Vec<_>>();
         if result.len() != 3 {
-            return Err(
-                format!("Result '{}' did not match expected format. Please return 'file_path:line_number:column_number'", result_trimmed),
-            );
+            return Err(format!(
+                "Result '{}' did not match expected format. Please return 'file_path:line_number:column_number'",
+                result_trimmed
+            ));
         }
         let file_path = result[0];
         let line_number = result[1].parse::<u64>().unwrap() - 1;

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -70,6 +70,13 @@ Path to a Relay config relative to the `rootDirectory`. Without this, the compil
 
 An array of project configuration in the form `{name: string, rootDirectory: string, pathToConfig: string}`. If omitted, it is assumed your workspace uses a single Relay config and the compiler will search for your config file. But you can also use this configuration if your Relay config is in a nested directory. This configuration must be used if your workspace has multiple Relay projects, each with their own config file.
 
+#### `relay.pathToExtraDataProviderScript` (default: `null`)
+
+Path to a script to look up the actual definition for a GraphQL entity for implementation-first GraphQL schemas. This script will be called for "goto definition" requests to the LSP instead of opening the schema.
+The script will be called with 2 arguments. The first will be the relay project name, the second will be either "Type" or "Type.field" (a type or the field of a type, repectively).
+The script must respond with a single line out putput matching "/absolute/file/path:1:2" where "1" is the line number in the file and "2" is the character on that line that the definition starts with. If it fails
+to match this pattern (or the script fails to execute for some reason) the GraphQL schema will be opened as a fallback.
+
 ## Features
 
 - IntelliSense

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -70,12 +70,14 @@ Path to a Relay config relative to the `rootDirectory`. Without this, the compil
 
 An array of project configuration in the form `{name: string, rootDirectory: string, pathToConfig: string}`. If omitted, it is assumed your workspace uses a single Relay config and the compiler will search for your config file. But you can also use this configuration if your Relay config is in a nested directory. This configuration must be used if your workspace has multiple Relay projects, each with their own config file.
 
-#### `relay.pathToExtraDataProviderScript` (default: `null`)
+#### `relay.pathToLocateCommand` (default: `null`)
 
 Path to a script to look up the actual definition for a GraphQL entity for implementation-first GraphQL schemas. This script will be called for "goto definition" requests to the LSP instead of opening the schema.
 The script will be called with 2 arguments. The first will be the relay project name, the second will be either "Type" or "Type.field" (a type or the field of a type, repectively).
 The script must respond with a single line out putput matching "/absolute/file/path:1:2" where "1" is the line number in the file and "2" is the character on that line that the definition starts with. If it fails
 to match this pattern (or the script fails to execute for some reason) the GraphQL schema will be opened as a fallback.
+
+This option requires >15.0.0 of the Relay compiler to function.
 
 ## Features
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relay",
   "displayName": "Relay GraphQL",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Relay-powered IDE experience",
   "repository": {
     "type": "git",
@@ -67,6 +67,15 @@
             "debug"
           ],
           "description": "Controls what is logged to the Output Channel for the Relay language server."
+        },
+        "relay.pathToExtraDataProviderScript": {
+          "scope": "workspace",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to an optional script to look up the actual definition for a GraphQL entity for implementation-first GraphQL schemas."
         },
         "relay.pathToRelay": {
           "scope": "workspace",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -68,7 +68,7 @@
           ],
           "description": "Controls what is logged to the Output Channel for the Relay language server."
         },
-        "relay.pathToExtraDataProviderScript": {
+        "relay.pathToLocateCommand": {
           "scope": "workspace",
           "default": null,
           "type": [

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -11,6 +11,7 @@ export type Config = {
   rootDirectory: string | null;
   pathToRelay: string | null;
   pathToConfig: string | null;
+  pathToExtraDataProviderScript: string | null;
   lspOutputLevel: string;
   compilerOutpuLevel: string;
   autoStartCompiler: boolean;
@@ -22,6 +23,7 @@ export function getConfig(scope?: ConfigurationScope): Config {
   return {
     pathToRelay: configuration.get('pathToRelay') ?? null,
     pathToConfig: configuration.get('pathToConfig') ?? null,
+    pathToExtraDataProviderScript: configuration.get('pathToExtraDataProviderScript') ?? null,
     lspOutputLevel: configuration.get('lspOutputLevel') ?? 'quiet-with-errros',
     compilerOutpuLevel: configuration.get('compilerOutputLevel') ?? 'info',
     rootDirectory: configuration.get('rootDirectory') ?? null,

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -11,7 +11,7 @@ export type Config = {
   rootDirectory: string | null;
   pathToRelay: string | null;
   pathToConfig: string | null;
-  pathToExtraDataProviderScript: string | null;
+  pathToLocateCommand: string | null;
   lspOutputLevel: string;
   compilerOutpuLevel: string;
   autoStartCompiler: boolean;
@@ -23,7 +23,7 @@ export function getConfig(scope?: ConfigurationScope): Config {
   return {
     pathToRelay: configuration.get('pathToRelay') ?? null,
     pathToConfig: configuration.get('pathToConfig') ?? null,
-    pathToExtraDataProviderScript: configuration.get('pathToExtraDataProviderScript') ?? null,
+    pathToLocateCommand: configuration.get('pathToLocateCommand') ?? null,
     lspOutputLevel: configuration.get('lspOutputLevel') ?? 'quiet-with-errros',
     compilerOutpuLevel: configuration.get('compilerOutputLevel') ?? 'info',
     rootDirectory: configuration.get('rootDirectory') ?? null,

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -30,8 +30,8 @@ export function createAndStartLanguageClient(context: RelayExtensionContext) {
     args.push(config.pathToConfig);
   }
 
-  if (config.pathToExtraDataProviderScript) {
-    args.push(`--extraDataProviderScript=${config.pathToExtraDataProviderScript}`);
+  if (config.pathToLocateCommand) {
+    args.push(`--locateCommand=${config.pathToLocateCommand}`);
   }
 
   const serverOptions: ServerOptions = {

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -30,6 +30,10 @@ export function createAndStartLanguageClient(context: RelayExtensionContext) {
     args.push(config.pathToConfig);
   }
 
+  if (config.pathToExtraDataProviderScript) {
+    args.push(`--extraDataProviderScript=${config.pathToExtraDataProviderScript}`);
+  }
+
   const serverOptions: ServerOptions = {
     options: {
       cwd: context.relayBinaryExecutionOptions.rootPath,


### PR DESCRIPTION
I basically just took @captbaritone 's POC and made it configurable based on our conversation [on Threads](https://www.threads.net/@janjonzen/post/CwwfXJ7LlL_)

This should be reasonably generalized to support different use-cases, but I'm open to rewriting all of this.

Test plan:

```
cd compiler
cargo build --release --bin relay
cd ../vscode-extension
yarn build-local
```

In a private project, I configured the new option and overrode the relay binary location:

```diff
+ "relay.pathToExtraDataProviderScript": "../scripts/graphql_lookup.sh",
+ "relay.pathToRelay": ".../relay/compiler/target/release/relay"
```

I manually installed the `relay-2.1.0.vsix` file in my VSCode and reloaded

I opened a file with a Relay GraphQL query in it and ctrl-clicked (goto def on my machine) and it went to the correct file!