### PR TITLE
Add link to graphql mutations guide into sidebars

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -50,11 +50,11 @@ const GuidesRescuedFromOldTutorial = [
   'guided-tour/updating-data/graphql-subscriptions',
   {
     'Updating Data': [
+      'guided-tour/updating-data/graphql-mutations',
       'guided-tour/list-data/updating-connections',
       'guided-tour/updating-data/imperatively-modifying-store-data',
       'guided-tour/updating-data/imperatively-modifying-linked-fields',
       'guided-tour/updating-data/typesafe-updaters-faq',
-      'guided-tour/updating-data/graphql-mutations',
       'guided-tour/updating-data/local-data-updates',
       'guided-tour/updating-data/client-only-data',
     ],

--- a/website/versioned_sidebars/version-v15.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-v15.0.0-sidebars.json
@@ -55,6 +55,7 @@
           "guided-tour/updating-data/graphql-subscriptions",
           {
             "Updating Data": [
+              "guided-tour/updating-data/graphql-mutations",
               "guided-tour/updating-data/imperatively-modifying-store-data-unsafe",
               "guided-tour/updating-data/local-data-updates",
               "guided-tour/updating-data/client-only-data"

--- a/website/versioned_sidebars/version-v16.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-v16.0.0-sidebars.json
@@ -55,6 +55,7 @@
           "guided-tour/updating-data/graphql-subscriptions",
           {
             "Updating Data": [
+              "guided-tour/updating-data/graphql-mutations",
               "guided-tour/updating-data/imperatively-modifying-store-data",
               "guided-tour/updating-data/imperatively-modifying-linked-fields",
               "guided-tour/updating-data/typesafe-updaters-faq",


### PR DESCRIPTION
The sidebar in DOCs currently doesn't include https://relay.dev/docs/next/guided-tour/updating-data/graphql-mutations/ which is quite valuable and is probably missing.