### PR TITLE
fix(docs): `readInlineData` function

### DIFF
--- a/website/docs/glossary/glossary.md
+++ b/website/docs/glossary/glossary.md
@@ -393,7 +393,7 @@ A directive that applies to fragments which enables developers to pass masked da
 Normally, data is read out using `useFragment`. However, this function can only be called during the render phase. If store data is needed in a outside of the render phase, a developer has several options:
 
 * read that data during the render phase, and pass it to the function/have the function close over that data. (See also [#relay])
-* pass a reference to an `@inline` fragment, which can then be accessed (outside of the render phase) using the `readInlineData` directive.
+* pass a reference to an `@inline` fragment, which can then be accessed (outside of the render phase) using the `readInlineData` function.
 
 This directive causes them to be read out when the parent fragment is read out, and unmasked by the call to `readInlineData`.
 


### PR DESCRIPTION
> * pass a reference to an `@inline` fragment, which can then be accessed (outside of the render phase) using the `readInlineData` function.


`readInlineData` is a function, not a directive.