### PR TITLE
[vscode] Make the Relay Compiler Terminal Transient

### DIFF
--- a/vscode-extension/src/compiler.ts
+++ b/vscode-extension/src/compiler.ts
@@ -25,6 +25,7 @@ export function createAndStartCompiler(context: RelayExtensionContext) {
   const terminal = window.createTerminal({
     name: 'Relay Compiler',
     cwd: context.relayBinaryExecutionOptions.rootPath,
+    isTransient: true,
   });
 
   terminal.sendText(


### PR DESCRIPTION
If you enable `relay.autoStartCompiler`, the extension will open a compiler in a new Terminal on every VS Code reload (e.g. Developer: Reload Window). This can easily lead to many copies of the compiler running.

Instead, we can mark the terminal with `isTransient`, and it won't survive reloads. While this means reloads must restart the compiler, it is very fast and this avoid many "Relay Compiler" terminals.

Test Plan:

- Debug on a project with `"relay.autoStartCompiler": true`
- Reload the window
- Note there is only one "Relay Compiler" terminal