### PR TITLE
Make all compiler fixture tests async

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "relay-transforms",
  "rustc-hash",
  "schema",
+ "tokio",
 ]
 
 [[package]]
@@ -469,6 +470,7 @@ dependencies = [
  "intern",
  "serde",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -530,6 +532,7 @@ dependencies = [
  "docblock-syntax",
  "fixture-tests",
  "graphql-syntax",
+ "tokio",
 ]
 
 [[package]]
@@ -551,6 +554,7 @@ dependencies = [
  "lazy_static",
  "parking_lot",
  "signedsource",
+ "tokio",
 ]
 
 [[package]]
@@ -750,6 +754,7 @@ dependencies = [
  "schema",
  "serde",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -769,6 +774,7 @@ dependencies = [
  "relay-test-schema",
  "schema",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -782,6 +788,7 @@ dependencies = [
  "logos",
  "serde",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -810,6 +817,7 @@ dependencies = [
  "relay-test-schema",
  "relay-transforms",
  "schema",
+ "tokio",
 ]
 
 [[package]]
@@ -1637,6 +1645,7 @@ dependencies = [
  "relay-test-schema",
  "relay-transforms",
  "schema",
+ "tokio",
 ]
 
 [[package]]
@@ -1756,6 +1765,7 @@ dependencies = [
  "relay-test-schema",
  "schema",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1845,6 +1855,7 @@ dependencies = [
  "rustc-hash",
  "schema",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1868,6 +1879,7 @@ dependencies = [
  "relay-test-schema",
  "relay-transforms",
  "schema",
+ "tokio",
 ]
 
 [[package]]
@@ -1970,6 +1982,7 @@ dependencies = [
  "schema-flatbuffer",
  "strsim",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2009,6 +2022,7 @@ dependencies = [
  "intern",
  "itertools",
  "schema",
+ "tokio",
 ]
 
 [[package]]
@@ -2026,6 +2040,7 @@ dependencies = [
  "schema",
  "schema-print",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/compiler/crates/dependency-analyzer/Cargo.toml
+++ b/compiler/crates/dependency-analyzer/Cargo.toml
@@ -26,3 +26,4 @@ common = { path = "../common" }
 fixture-tests = { path = "../fixture-tests" }
 intern = { path = "../intern" }
 relay-test-schema = { path = "../relay-test-schema" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/dependency-analyzer/tests/ast/mod.rs
+++ b/compiler/crates/dependency-analyzer/tests/ast/mod.rs
@@ -12,7 +12,7 @@ use fixture_tests::Fixture;
 use graphql_syntax::*;
 use intern::Lookup;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<&str> = fixture.content.split("%definitions%").collect();
 
     let source_location = SourceLocationKey::standalone(fixture.file_name);

--- a/compiler/crates/dependency-analyzer/tests/ast_test.rs
+++ b/compiler/crates/dependency-analyzer/tests/ast_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3ecc95204640f547290f1ab25b144c25>>
+ * @generated SignedSource<<136a8e87899ea84cea0d34b4c2dd6080>>
  */
 
 mod ast;
@@ -12,30 +12,30 @@ mod ast;
 use ast::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn base_definitions() {
+#[tokio::test]
+async fn base_definitions() {
     let input = include_str!("ast/fixtures/base-definitions.graphql");
     let expected = include_str!("ast/fixtures/base-definitions.expected");
-    test_fixture(transform_fixture, "base-definitions.graphql", "ast/fixtures/base-definitions.expected", input, expected);
+    test_fixture(transform_fixture, "base-definitions.graphql", "ast/fixtures/base-definitions.expected", input, expected).await;
 }
 
-#[test]
-fn definitions_only() {
+#[tokio::test]
+async fn definitions_only() {
     let input = include_str!("ast/fixtures/definitions-only.graphql");
     let expected = include_str!("ast/fixtures/definitions-only.expected");
-    test_fixture(transform_fixture, "definitions-only.graphql", "ast/fixtures/definitions-only.expected", input, expected);
+    test_fixture(transform_fixture, "definitions-only.graphql", "ast/fixtures/definitions-only.expected", input, expected).await;
 }
 
-#[test]
-fn missing_fragments() {
+#[tokio::test]
+async fn missing_fragments() {
     let input = include_str!("ast/fixtures/missing-fragments.graphql");
     let expected = include_str!("ast/fixtures/missing-fragments.expected");
-    test_fixture(transform_fixture, "missing-fragments.graphql", "ast/fixtures/missing-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "missing-fragments.graphql", "ast/fixtures/missing-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_base_definitions() {
+#[tokio::test]
+async fn multiple_base_definitions() {
     let input = include_str!("ast/fixtures/multiple-base-definitions.graphql");
     let expected = include_str!("ast/fixtures/multiple-base-definitions.expected");
-    test_fixture(transform_fixture, "multiple-base-definitions.graphql", "ast/fixtures/multiple-base-definitions.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-base-definitions.graphql", "ast/fixtures/multiple-base-definitions.expected", input, expected).await;
 }

--- a/compiler/crates/dependency-analyzer/tests/ir/mod.rs
+++ b/compiler/crates/dependency-analyzer/tests/ir/mod.rs
@@ -27,7 +27,7 @@ fn format_definition(def: ExecutableDefinition) -> String {
 }
 
 // TODO: Test without using snapshot tests
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts = fixture.content.split("%extensions%").collect::<Vec<_>>();
 
     let (content, schema): (&str, Arc<SDLSchema>) = match parts.as_slice() {

--- a/compiler/crates/dependency-analyzer/tests/ir_test.rs
+++ b/compiler/crates/dependency-analyzer/tests/ir_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1370ea763208b340fd15717d45729c87>>
+ * @generated SignedSource<<4d5d37a14a41f5a7598f6291fddd1af5>>
  */
 
 mod ir;
@@ -12,93 +12,93 @@ mod ir;
 use ir::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn base_definitions_change_fragment() {
+#[tokio::test]
+async fn base_definitions_change_fragment() {
     let input = include_str!("ir/fixtures/base-definitions-change-fragment.graphql");
     let expected = include_str!("ir/fixtures/base-definitions-change-fragment.expected");
-    test_fixture(transform_fixture, "base-definitions-change-fragment.graphql", "ir/fixtures/base-definitions-change-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "base-definitions-change-fragment.graphql", "ir/fixtures/base-definitions-change-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn base_definitions_change_fragment2() {
+#[tokio::test]
+async fn base_definitions_change_fragment2() {
     let input = include_str!("ir/fixtures/base-definitions-change-fragment2.graphql");
     let expected = include_str!("ir/fixtures/base-definitions-change-fragment2.expected");
-    test_fixture(transform_fixture, "base-definitions-change-fragment2.graphql", "ir/fixtures/base-definitions-change-fragment2.expected", input, expected);
+    test_fixture(transform_fixture, "base-definitions-change-fragment2.graphql", "ir/fixtures/base-definitions-change-fragment2.expected", input, expected).await;
 }
 
-#[test]
-fn base_definitions_change_query() {
+#[tokio::test]
+async fn base_definitions_change_query() {
     let input = include_str!("ir/fixtures/base-definitions-change-query.graphql");
     let expected = include_str!("ir/fixtures/base-definitions-change-query.expected");
-    test_fixture(transform_fixture, "base-definitions-change-query.graphql", "ir/fixtures/base-definitions-change-query.expected", input, expected);
+    test_fixture(transform_fixture, "base-definitions-change-query.graphql", "ir/fixtures/base-definitions-change-query.expected", input, expected).await;
 }
 
-#[test]
-fn definitions_only_change_fragment() {
+#[tokio::test]
+async fn definitions_only_change_fragment() {
     let input = include_str!("ir/fixtures/definitions-only-change-fragment.graphql");
     let expected = include_str!("ir/fixtures/definitions-only-change-fragment.expected");
-    test_fixture(transform_fixture, "definitions-only-change-fragment.graphql", "ir/fixtures/definitions-only-change-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "definitions-only-change-fragment.graphql", "ir/fixtures/definitions-only-change-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn definitions_only_change_query() {
+#[tokio::test]
+async fn definitions_only_change_query() {
     let input = include_str!("ir/fixtures/definitions-only-change-query.graphql");
     let expected = include_str!("ir/fixtures/definitions-only-change-query.expected");
-    test_fixture(transform_fixture, "definitions-only-change-query.graphql", "ir/fixtures/definitions-only-change-query.expected", input, expected);
+    test_fixture(transform_fixture, "definitions-only-change-query.graphql", "ir/fixtures/definitions-only-change-query.expected", input, expected).await;
 }
 
-#[test]
-fn definitions_only_no_change() {
+#[tokio::test]
+async fn definitions_only_no_change() {
     let input = include_str!("ir/fixtures/definitions-only-no-change.graphql");
     let expected = include_str!("ir/fixtures/definitions-only-no-change.expected");
-    test_fixture(transform_fixture, "definitions-only-no-change.graphql", "ir/fixtures/definitions-only-no-change.expected", input, expected);
+    test_fixture(transform_fixture, "definitions-only-no-change.graphql", "ir/fixtures/definitions-only-no-change.expected", input, expected).await;
 }
 
-#[test]
-fn implicit_dependencies_parent_child() {
+#[tokio::test]
+async fn implicit_dependencies_parent_child() {
     let input = include_str!("ir/fixtures/implicit-dependencies-parent-child.graphql");
     let expected = include_str!("ir/fixtures/implicit-dependencies-parent-child.expected");
-    test_fixture(transform_fixture, "implicit-dependencies-parent-child.graphql", "ir/fixtures/implicit-dependencies-parent-child.expected", input, expected);
+    test_fixture(transform_fixture, "implicit-dependencies-parent-child.graphql", "ir/fixtures/implicit-dependencies-parent-child.expected", input, expected).await;
 }
 
-#[test]
-fn new_resolver_field() {
+#[tokio::test]
+async fn new_resolver_field() {
     let input = include_str!("ir/fixtures/new-resolver-field.graphql");
     let expected = include_str!("ir/fixtures/new-resolver-field.expected");
-    test_fixture(transform_fixture, "new-resolver-field.graphql", "ir/fixtures/new-resolver-field.expected", input, expected);
+    test_fixture(transform_fixture, "new-resolver-field.graphql", "ir/fixtures/new-resolver-field.expected", input, expected).await;
 }
 
-#[test]
-fn new_resolver_model_field() {
+#[tokio::test]
+async fn new_resolver_model_field() {
     let input = include_str!("ir/fixtures/new-resolver-model-field.graphql");
     let expected = include_str!("ir/fixtures/new-resolver-model-field.expected");
-    test_fixture(transform_fixture, "new-resolver-model-field.graphql", "ir/fixtures/new-resolver-model-field.expected", input, expected);
+    test_fixture(transform_fixture, "new-resolver-model-field.graphql", "ir/fixtures/new-resolver-model-field.expected", input, expected).await;
 }
 
-#[test]
-fn new_resolver_model_field_with_custom_fragment() {
+#[tokio::test]
+async fn new_resolver_model_field_with_custom_fragment() {
     let input = include_str!("ir/fixtures/new-resolver-model-field-with-custom-fragment.graphql");
     let expected = include_str!("ir/fixtures/new-resolver-model-field-with-custom-fragment.expected");
-    test_fixture(transform_fixture, "new-resolver-model-field-with-custom-fragment.graphql", "ir/fixtures/new-resolver-model-field-with-custom-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "new-resolver-model-field-with-custom-fragment.graphql", "ir/fixtures/new-resolver-model-field-with-custom-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn query_then_fragment() {
+#[tokio::test]
+async fn query_then_fragment() {
     let input = include_str!("ir/fixtures/query-then-fragment.graphql");
     let expected = include_str!("ir/fixtures/query-then-fragment.expected");
-    test_fixture(transform_fixture, "query-then-fragment.graphql", "ir/fixtures/query-then-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "query-then-fragment.graphql", "ir/fixtures/query-then-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn recursive_fragments() {
+#[tokio::test]
+async fn recursive_fragments() {
     let input = include_str!("ir/fixtures/recursive-fragments.graphql");
     let expected = include_str!("ir/fixtures/recursive-fragments.expected");
-    test_fixture(transform_fixture, "recursive-fragments.graphql", "ir/fixtures/recursive-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "recursive-fragments.graphql", "ir/fixtures/recursive-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn transitive_implicit_dependency() {
+#[tokio::test]
+async fn transitive_implicit_dependency() {
     let input = include_str!("ir/fixtures/transitive-implicit-dependency.graphql");
     let expected = include_str!("ir/fixtures/transitive-implicit-dependency.expected");
-    test_fixture(transform_fixture, "transitive-implicit-dependency.graphql", "ir/fixtures/transitive-implicit-dependency.expected", input, expected);
+    test_fixture(transform_fixture, "transitive-implicit-dependency.graphql", "ir/fixtures/transitive-implicit-dependency.expected", input, expected).await;
 }

--- a/compiler/crates/docblock-syntax/Cargo.toml
+++ b/compiler/crates/docblock-syntax/Cargo.toml
@@ -20,3 +20,4 @@ thiserror = "1.0.43"
 [dev-dependencies]
 fixture-tests = { path = "../fixture-tests" }
 graphql-test-helpers = { path = "../graphql-test-helpers" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/docblock-syntax/tests/parse/mod.rs
+++ b/compiler/crates/docblock-syntax/tests/parse/mod.rs
@@ -10,7 +10,7 @@ use docblock_syntax::parse_docblock;
 use fixture_tests::Fixture;
 use graphql_test_helpers::diagnostics_to_sorted_string;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let mut content = fixture.content;
     if !content.starts_with("/*") {
         panic!("Expected fixture to start with \"/*\".")

--- a/compiler/crates/docblock-syntax/tests/parse_test.rs
+++ b/compiler/crates/docblock-syntax/tests/parse_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cfbc1b0c55b29bb5b8a94089f5dfc16f>>
+ * @generated SignedSource<<b058c9546782fd87c03424968df50741>>
  */
 
 mod parse;
@@ -12,65 +12,65 @@ mod parse;
 use parse::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn docblock_ends_mid_line() {
+#[tokio::test]
+async fn docblock_ends_mid_line() {
     let input = include_str!("parse/fixtures/docblock-ends-mid-line.ecmascript");
     let expected = include_str!("parse/fixtures/docblock-ends-mid-line.expected");
-    test_fixture(transform_fixture, "docblock-ends-mid-line.ecmascript", "parse/fixtures/docblock-ends-mid-line.expected", input, expected);
+    test_fixture(transform_fixture, "docblock-ends-mid-line.ecmascript", "parse/fixtures/docblock-ends-mid-line.expected", input, expected).await;
 }
 
-#[test]
-fn empty_block() {
+#[tokio::test]
+async fn empty_block() {
     let input = include_str!("parse/fixtures/empty-block.ecmascript");
     let expected = include_str!("parse/fixtures/empty-block.expected");
-    test_fixture(transform_fixture, "empty-block.ecmascript", "parse/fixtures/empty-block.expected", input, expected);
+    test_fixture(transform_fixture, "empty-block.ecmascript", "parse/fixtures/empty-block.expected", input, expected).await;
 }
 
-#[test]
-fn field_followed_by_free_text() {
+#[tokio::test]
+async fn field_followed_by_free_text() {
     let input = include_str!("parse/fixtures/field-followed-by-free-text.ecmascript");
     let expected = include_str!("parse/fixtures/field-followed-by-free-text.expected");
-    test_fixture(transform_fixture, "field-followed-by-free-text.ecmascript", "parse/fixtures/field-followed-by-free-text.expected", input, expected);
+    test_fixture(transform_fixture, "field-followed-by-free-text.ecmascript", "parse/fixtures/field-followed-by-free-text.expected", input, expected).await;
 }
 
-#[test]
-fn free_text_starting_with_star() {
+#[tokio::test]
+async fn free_text_starting_with_star() {
     let input = include_str!("parse/fixtures/free-text-starting-with-star.ecmascript");
     let expected = include_str!("parse/fixtures/free-text-starting-with-star.expected");
-    test_fixture(transform_fixture, "free-text-starting-with-star.ecmascript", "parse/fixtures/free-text-starting-with-star.expected", input, expected);
+    test_fixture(transform_fixture, "free-text-starting-with-star.ecmascript", "parse/fixtures/free-text-starting-with-star.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_docblock_invalid() {
+#[tokio::test]
+async fn invalid_docblock_invalid() {
     let input = include_str!("parse/fixtures/invalid_docblock.invalid.ecmascript");
     let expected = include_str!("parse/fixtures/invalid_docblock.invalid.expected");
-    test_fixture(transform_fixture, "invalid_docblock.invalid.ecmascript", "parse/fixtures/invalid_docblock.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "invalid_docblock.invalid.ecmascript", "parse/fixtures/invalid_docblock.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_field_name_invalid() {
+#[tokio::test]
+async fn invalid_field_name_invalid() {
     let input = include_str!("parse/fixtures/invalid_field_name.invalid.ecmascript");
     let expected = include_str!("parse/fixtures/invalid_field_name.invalid.expected");
-    test_fixture(transform_fixture, "invalid_field_name.invalid.ecmascript", "parse/fixtures/invalid_field_name.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "invalid_field_name.invalid.ecmascript", "parse/fixtures/invalid_field_name.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn missing_star_invalid() {
+#[tokio::test]
+async fn missing_star_invalid() {
     let input = include_str!("parse/fixtures/missing_star.invalid.ecmascript");
     let expected = include_str!("parse/fixtures/missing_star.invalid.expected");
-    test_fixture(transform_fixture, "missing_star.invalid.ecmascript", "parse/fixtures/missing_star.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing_star.invalid.ecmascript", "parse/fixtures/missing_star.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_fields() {
+#[tokio::test]
+async fn multiple_fields() {
     let input = include_str!("parse/fixtures/multiple-fields.ecmascript");
     let expected = include_str!("parse/fixtures/multiple-fields.expected");
-    test_fixture(transform_fixture, "multiple-fields.ecmascript", "parse/fixtures/multiple-fields.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-fields.ecmascript", "parse/fixtures/multiple-fields.expected", input, expected).await;
 }
 
-#[test]
-fn simple_docblock() {
+#[tokio::test]
+async fn simple_docblock() {
     let input = include_str!("parse/fixtures/simple_docblock.ecmascript");
     let expected = include_str!("parse/fixtures/simple_docblock.expected");
-    test_fixture(transform_fixture, "simple_docblock.ecmascript", "parse/fixtures/simple_docblock.expected", input, expected);
+    test_fixture(transform_fixture, "simple_docblock.ecmascript", "parse/fixtures/simple_docblock.expected", input, expected).await;
 }

--- a/compiler/crates/extract-graphql/Cargo.toml
+++ b/compiler/crates/extract-graphql/Cargo.toml
@@ -17,3 +17,4 @@ graphql-syntax = { path = "../graphql-syntax" }
 
 [dev-dependencies]
 fixture-tests = { path = "../fixture-tests" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/extract-graphql/tests/extract/mod.rs
+++ b/compiler/crates/extract-graphql/tests/extract/mod.rs
@@ -9,7 +9,7 @@ use extract_graphql::extract;
 use extract_graphql::JavaScriptSourceFeature;
 use fixture_tests::Fixture;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let features = extract(fixture.content);
     Ok(features
         .into_iter()

--- a/compiler/crates/extract-graphql/tests/extract_test.rs
+++ b/compiler/crates/extract-graphql/tests/extract_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7414a7d21db69b967b49c36af99ace12>>
+ * @generated SignedSource<<1e082a5e3a4d018986991c9e179b9dd7>>
  */
 
 mod extract;
@@ -12,79 +12,79 @@ mod extract;
 use extract::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn comments() {
+#[tokio::test]
+async fn comments() {
     let input = include_str!("extract/fixtures/comments.js");
     let expected = include_str!("extract/fixtures/comments.expected");
-    test_fixture(transform_fixture, "comments.js", "extract/fixtures/comments.expected", input, expected);
+    test_fixture(transform_fixture, "comments.js", "extract/fixtures/comments.expected", input, expected).await;
 }
 
-#[test]
-fn inline() {
+#[tokio::test]
+async fn inline() {
     let input = include_str!("extract/fixtures/inline.js");
     let expected = include_str!("extract/fixtures/inline.expected");
-    test_fixture(transform_fixture, "inline.js", "extract/fixtures/inline.expected", input, expected);
+    test_fixture(transform_fixture, "inline.js", "extract/fixtures/inline.expected", input, expected).await;
 }
 
-#[test]
-fn nested_template_literals() {
+#[tokio::test]
+async fn nested_template_literals() {
     let input = include_str!("extract/fixtures/nested_template_literals.js");
     let expected = include_str!("extract/fixtures/nested_template_literals.expected");
-    test_fixture(transform_fixture, "nested_template_literals.js", "extract/fixtures/nested_template_literals.expected", input, expected);
+    test_fixture(transform_fixture, "nested_template_literals.js", "extract/fixtures/nested_template_literals.expected", input, expected).await;
 }
 
-#[test]
-fn no_graphql() {
+#[tokio::test]
+async fn no_graphql() {
     let input = include_str!("extract/fixtures/no_graphql.js");
     let expected = include_str!("extract/fixtures/no_graphql.expected");
-    test_fixture(transform_fixture, "no_graphql.js", "extract/fixtures/no_graphql.expected", input, expected);
+    test_fixture(transform_fixture, "no_graphql.js", "extract/fixtures/no_graphql.expected", input, expected).await;
 }
 
-#[test]
-fn quote_in_jsx() {
+#[tokio::test]
+async fn quote_in_jsx() {
     let input = include_str!("extract/fixtures/quote_in_jsx.js");
     let expected = include_str!("extract/fixtures/quote_in_jsx.expected");
-    test_fixture(transform_fixture, "quote_in_jsx.js", "extract/fixtures/quote_in_jsx.expected", input, expected);
+    test_fixture(transform_fixture, "quote_in_jsx.js", "extract/fixtures/quote_in_jsx.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver() {
+#[tokio::test]
+async fn relay_resolver() {
     let input = include_str!("extract/fixtures/relay_resolver.js");
     let expected = include_str!("extract/fixtures/relay_resolver.expected");
-    test_fixture(transform_fixture, "relay_resolver.js", "extract/fixtures/relay_resolver.expected", input, expected);
+    test_fixture(transform_fixture, "relay_resolver.js", "extract/fixtures/relay_resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_and_graphql() {
+#[tokio::test]
+async fn relay_resolver_and_graphql() {
     let input = include_str!("extract/fixtures/relay_resolver_and_graphql.js");
     let expected = include_str!("extract/fixtures/relay_resolver_and_graphql.expected");
-    test_fixture(transform_fixture, "relay_resolver_and_graphql.js", "extract/fixtures/relay_resolver_and_graphql.expected", input, expected);
+    test_fixture(transform_fixture, "relay_resolver_and_graphql.js", "extract/fixtures/relay_resolver_and_graphql.expected", input, expected).await;
 }
 
-#[test]
-fn simple() {
+#[tokio::test]
+async fn simple() {
     let input = include_str!("extract/fixtures/simple.flow");
     let expected = include_str!("extract/fixtures/simple.expected");
-    test_fixture(transform_fixture, "simple.flow", "extract/fixtures/simple.expected", input, expected);
+    test_fixture(transform_fixture, "simple.flow", "extract/fixtures/simple.expected", input, expected).await;
 }
 
-#[test]
-fn tabbed() {
+#[tokio::test]
+async fn tabbed() {
     let input = include_str!("extract/fixtures/tabbed.js");
     let expected = include_str!("extract/fixtures/tabbed.expected");
-    test_fixture(transform_fixture, "tabbed.js", "extract/fixtures/tabbed.expected", input, expected);
+    test_fixture(transform_fixture, "tabbed.js", "extract/fixtures/tabbed.expected", input, expected).await;
 }
 
-#[test]
-fn template_literal() {
+#[tokio::test]
+async fn template_literal() {
     let input = include_str!("extract/fixtures/template_literal.js");
     let expected = include_str!("extract/fixtures/template_literal.expected");
-    test_fixture(transform_fixture, "template_literal.js", "extract/fixtures/template_literal.expected", input, expected);
+    test_fixture(transform_fixture, "template_literal.js", "extract/fixtures/template_literal.expected", input, expected).await;
 }
 
-#[test]
-fn with_space() {
+#[tokio::test]
+async fn with_space() {
     let input = include_str!("extract/fixtures/with_space.js");
     let expected = include_str!("extract/fixtures/with_space.expected");
-    test_fixture(transform_fixture, "with_space.js", "extract/fixtures/with_space.expected", input, expected);
+    test_fixture(transform_fixture, "with_space.js", "extract/fixtures/with_space.expected", input, expected).await;
 }

--- a/compiler/crates/fixture-tests/Cargo.toml
+++ b/compiler/crates/fixture-tests/Cargo.toml
@@ -21,3 +21,6 @@ diff = "0.1"
 lazy_static = "1.4"
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 signedsource = { path = "../signedsource" }
+
+[dev-dependencies]
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/fixture-tests/src/lib.rs
+++ b/compiler/crates/fixture-tests/src/lib.rs
@@ -32,7 +32,7 @@
 //! `tests/first_transform/mod.rs` exports the transform to test, for example:
 //!
 //! ```ignore
-//! pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+//! pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
 //!   Ok(fixture.to_uppercase())
 //! }
 //! ```
@@ -54,6 +54,7 @@ mod print_diff;
 
 use std::env;
 use std::fs::File;
+use std::future::Future;
 use std::io::prelude::*;
 use std::sync::Arc;
 
@@ -72,16 +73,26 @@ pub struct Fixture<'a> {
     pub content: &'a str,
 }
 
+// https://stackoverflow.com/a/70511636
+pub trait AsyncFn<T>: Fn(T) -> <Self as AsyncFn<T>>::Fut {
+    type Fut: Future<Output = <Self as AsyncFn<T>>::Output>;
+    type Output;
+}
+impl<T, F, Fut> AsyncFn<T> for F where F: Fn(T) -> Fut, Fut: Future {
+    type Fut = Fut;
+    type Output = Fut::Output;
+}
+
 /// This is an internal function and is typically called from generated code
 /// containing one test per fixture.
-pub fn test_fixture<T, U, V>(
+pub async fn test_fixture<T, U, V>(
     transform: T,
     input_file_name: &str,
     expected_file_name: &str,
     input: &str,
     expected: &str,
 ) where
-    T: FnOnce(&Fixture<'_>) -> Result<U, V>,
+    T: for<'b> AsyncFn<&'b Fixture<'b>, Output = Result<U,V>>,
     U: std::fmt::Display,
     V: std::fmt::Display,
 {
@@ -94,7 +105,7 @@ pub fn test_fixture<T, U, V>(
     {
         let _guard = LOCK.lock();
         colored::control::set_override(false);
-        actual_result = transform(&fixture);
+        actual_result = transform(&fixture).await;
         colored::control::unset_override();
     }
 

--- a/compiler/crates/fixture-tests/src/main.rs
+++ b/compiler/crates/fixture-tests/src/main.rs
@@ -93,11 +93,11 @@ fn main() {
             .map(|(_, test_case)| {
                 let test_case_name = &test_case.name;
                 format!(
-                    r#"#[test]
-fn {0}() {{
+                    r#"#[tokio::test]
+async fn {0}() {{
     let input = include_str!("{1}/fixtures/{2}");
     let expected = include_str!("{1}/fixtures/{3}");
-    test_fixture(transform_fixture, "{2}", "{1}/fixtures/{3}", input, expected);
+    test_fixture(transform_fixture, "{2}", "{1}/fixtures/{3}", input, expected).await;
 }}"#,
                     test_case.name,
                     &test_name,

--- a/compiler/crates/fixture-tests/tests/uppercase_test.rs
+++ b/compiler/crates/fixture-tests/tests/uppercase_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<759fa81dcfd359632faaf5a2bd8f9555>>
+ * @generated SignedSource<<243baf95062016610d80387505b888e9>>
  */
 
 mod uppercase;
@@ -12,16 +12,16 @@ mod uppercase;
 use uppercase::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn hello() {
+#[tokio::test]
+async fn hello() {
     let input = include_str!("uppercase/fixtures/hello.txt");
     let expected = include_str!("uppercase/fixtures/hello.expected");
-    test_fixture(transform_fixture, "hello.txt", "uppercase/fixtures/hello.expected", input, expected);
+    test_fixture(transform_fixture, "hello.txt", "uppercase/fixtures/hello.expected", input, expected).await;
 }
 
-#[test]
-fn world() {
+#[tokio::test]
+async fn world() {
     let input = include_str!("uppercase/fixtures/world.txt");
     let expected = include_str!("uppercase/fixtures/world.expected");
-    test_fixture(transform_fixture, "world.txt", "uppercase/fixtures/world.expected", input, expected);
+    test_fixture(transform_fixture, "world.txt", "uppercase/fixtures/world.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-ir-validations/Cargo.toml
+++ b/compiler/crates/graphql-ir-validations/Cargo.toml
@@ -26,3 +26,4 @@ graphql-cli = { path = "../graphql-cli" }
 graphql-syntax = { path = "../graphql-syntax" }
 graphql-test-helpers = { path = "../graphql-test-helpers" }
 relay-test-schema = { path = "../relay-test-schema" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/graphql-ir-validations/tests/validate_selection_conflict/mod.rs
+++ b/compiler/crates/graphql-ir-validations/tests/validate_selection_conflict/mod.rs
@@ -31,7 +31,7 @@ impl LocationAgnosticBehavior for LocationAgnosticBehaviorForTestOnly {
     }
 }
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/graphql-ir-validations/tests/validate_selection_conflict_test.rs
+++ b/compiler/crates/graphql-ir-validations/tests/validate_selection_conflict_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<82816cf559b0847f27b559ede51c9022>>
+ * @generated SignedSource<<d62d403bf49a1ef9e1be13e30060b979>>
  */
 
 mod validate_selection_conflict;
@@ -12,51 +12,51 @@ mod validate_selection_conflict;
 use validate_selection_conflict::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn same_alias_list_non_list() {
+#[tokio::test]
+async fn same_alias_list_non_list() {
     let input = include_str!("validate_selection_conflict/fixtures/same-alias-list-non-list.graphql");
     let expected = include_str!("validate_selection_conflict/fixtures/same-alias-list-non-list.expected");
-    test_fixture(transform_fixture, "same-alias-list-non-list.graphql", "validate_selection_conflict/fixtures/same-alias-list-non-list.expected", input, expected);
+    test_fixture(transform_fixture, "same-alias-list-non-list.graphql", "validate_selection_conflict/fixtures/same-alias-list-non-list.expected", input, expected).await;
 }
 
-#[test]
-fn same_alias_nested() {
+#[tokio::test]
+async fn same_alias_nested() {
     let input = include_str!("validate_selection_conflict/fixtures/same-alias-nested.graphql");
     let expected = include_str!("validate_selection_conflict/fixtures/same-alias-nested.expected");
-    test_fixture(transform_fixture, "same-alias-nested.graphql", "validate_selection_conflict/fixtures/same-alias-nested.expected", input, expected);
+    test_fixture(transform_fixture, "same-alias-nested.graphql", "validate_selection_conflict/fixtures/same-alias-nested.expected", input, expected).await;
 }
 
-#[test]
-fn same_alias_nested_mutually_exclusive() {
+#[tokio::test]
+async fn same_alias_nested_mutually_exclusive() {
     let input = include_str!("validate_selection_conflict/fixtures/same-alias-nested-mutually-exclusive.graphql");
     let expected = include_str!("validate_selection_conflict/fixtures/same-alias-nested-mutually-exclusive.expected");
-    test_fixture(transform_fixture, "same-alias-nested-mutually-exclusive.graphql", "validate_selection_conflict/fixtures/same-alias-nested-mutually-exclusive.expected", input, expected);
+    test_fixture(transform_fixture, "same-alias-nested-mutually-exclusive.graphql", "validate_selection_conflict/fixtures/same-alias-nested-mutually-exclusive.expected", input, expected).await;
 }
 
-#[test]
-fn same_alias_on_different_types() {
+#[tokio::test]
+async fn same_alias_on_different_types() {
     let input = include_str!("validate_selection_conflict/fixtures/same-alias-on-different-types.graphql");
     let expected = include_str!("validate_selection_conflict/fixtures/same-alias-on-different-types.expected");
-    test_fixture(transform_fixture, "same-alias-on-different-types.graphql", "validate_selection_conflict/fixtures/same-alias-on-different-types.expected", input, expected);
+    test_fixture(transform_fixture, "same-alias-on-different-types.graphql", "validate_selection_conflict/fixtures/same-alias-on-different-types.expected", input, expected).await;
 }
 
-#[test]
-fn same_alias_on_different_types_inline_fragments() {
+#[tokio::test]
+async fn same_alias_on_different_types_inline_fragments() {
     let input = include_str!("validate_selection_conflict/fixtures/same-alias-on-different-types-inline-fragments.graphql");
     let expected = include_str!("validate_selection_conflict/fixtures/same-alias-on-different-types-inline-fragments.expected");
-    test_fixture(transform_fixture, "same-alias-on-different-types-inline-fragments.graphql", "validate_selection_conflict/fixtures/same-alias-on-different-types-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "same-alias-on-different-types-inline-fragments.graphql", "validate_selection_conflict/fixtures/same-alias-on-different-types-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn same_alias_under_different_inline_fragments() {
+#[tokio::test]
+async fn same_alias_under_different_inline_fragments() {
     let input = include_str!("validate_selection_conflict/fixtures/same-alias-under-different-inline-fragments.graphql");
     let expected = include_str!("validate_selection_conflict/fixtures/same-alias-under-different-inline-fragments.expected");
-    test_fixture(transform_fixture, "same-alias-under-different-inline-fragments.graphql", "validate_selection_conflict/fixtures/same-alias-under-different-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "same-alias-under-different-inline-fragments.graphql", "validate_selection_conflict/fixtures/same-alias-under-different-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn same_alias_under_duplicated_linked_field() {
+#[tokio::test]
+async fn same_alias_under_duplicated_linked_field() {
     let input = include_str!("validate_selection_conflict/fixtures/same-alias-under-duplicated-linked-field.graphql");
     let expected = include_str!("validate_selection_conflict/fixtures/same-alias-under-duplicated-linked-field.expected");
-    test_fixture(transform_fixture, "same-alias-under-duplicated-linked-field.graphql", "validate_selection_conflict/fixtures/same-alias-under-duplicated-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "same-alias-under-duplicated-linked-field.graphql", "validate_selection_conflict/fixtures/same-alias-under-duplicated-linked-field.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-ir/Cargo.toml
+++ b/compiler/crates/graphql-ir/Cargo.toml
@@ -35,3 +35,4 @@ thiserror = "1.0.43"
 fixture-tests = { path = "../fixture-tests" }
 graphql-cli = { path = "../graphql-cli" }
 relay-test-schema = { path = "../relay-test-schema" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/graphql-ir/tests/parse/mod.rs
+++ b/compiler/crates/graphql-ir/tests/parse/mod.rs
@@ -16,7 +16,7 @@ use graphql_syntax::FragmentArgumentSyntaxKind;
 use graphql_syntax::ParserFeatures;
 use relay_test_schema::TEST_SCHEMA;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let features = ParserFeatures {
         fragment_argument_capability:

--- a/compiler/crates/graphql-ir/tests/parse_test.rs
+++ b/compiler/crates/graphql-ir/tests/parse_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9dade3d0ff881e265617477148740319>>
+ * @generated SignedSource<<cae03fccd5b86d0bc871c94d655304f1>>
  */
 
 mod parse;
@@ -12,618 +12,618 @@ mod parse;
 use parse::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn argument_complex_object_invalid() {
+#[tokio::test]
+async fn argument_complex_object_invalid() {
     let input = include_str!("parse/fixtures/argument-complex-object.invalid.graphql");
     let expected = include_str!("parse/fixtures/argument-complex-object.invalid.expected");
-    test_fixture(transform_fixture, "argument-complex-object.invalid.graphql", "parse/fixtures/argument-complex-object.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "argument-complex-object.invalid.graphql", "parse/fixtures/argument-complex-object.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn argument_definitions() {
+#[tokio::test]
+async fn argument_definitions() {
     let input = include_str!("parse/fixtures/argument_definitions.graphql");
     let expected = include_str!("parse/fixtures/argument_definitions.expected");
-    test_fixture(transform_fixture, "argument_definitions.graphql", "parse/fixtures/argument_definitions.expected", input, expected);
+    test_fixture(transform_fixture, "argument_definitions.graphql", "parse/fixtures/argument_definitions.expected", input, expected).await;
 }
 
-#[test]
-fn argument_definitions_directives_invalid_directive_arg_invalid() {
+#[tokio::test]
+async fn argument_definitions_directives_invalid_directive_arg_invalid() {
     let input = include_str!("parse/fixtures/argument_definitions_directives_invalid_directive_arg.invalid.graphql");
     let expected = include_str!("parse/fixtures/argument_definitions_directives_invalid_directive_arg.invalid.expected");
-    test_fixture(transform_fixture, "argument_definitions_directives_invalid_directive_arg.invalid.graphql", "parse/fixtures/argument_definitions_directives_invalid_directive_arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "argument_definitions_directives_invalid_directive_arg.invalid.graphql", "parse/fixtures/argument_definitions_directives_invalid_directive_arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn argument_definitions_directives_invalid_locations_invalid() {
+#[tokio::test]
+async fn argument_definitions_directives_invalid_locations_invalid() {
     let input = include_str!("parse/fixtures/argument_definitions_directives_invalid_locations.invalid.graphql");
     let expected = include_str!("parse/fixtures/argument_definitions_directives_invalid_locations.invalid.expected");
-    test_fixture(transform_fixture, "argument_definitions_directives_invalid_locations.invalid.graphql", "parse/fixtures/argument_definitions_directives_invalid_locations.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "argument_definitions_directives_invalid_locations.invalid.graphql", "parse/fixtures/argument_definitions_directives_invalid_locations.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn argument_definitions_directives_invalid_syntax_invalid() {
+#[tokio::test]
+async fn argument_definitions_directives_invalid_syntax_invalid() {
     let input = include_str!("parse/fixtures/argument_definitions_directives_invalid_syntax.invalid.graphql");
     let expected = include_str!("parse/fixtures/argument_definitions_directives_invalid_syntax.invalid.expected");
-    test_fixture(transform_fixture, "argument_definitions_directives_invalid_syntax.invalid.graphql", "parse/fixtures/argument_definitions_directives_invalid_syntax.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "argument_definitions_directives_invalid_syntax.invalid.graphql", "parse/fixtures/argument_definitions_directives_invalid_syntax.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn argument_definitions_directives_invalid_type_invalid() {
+#[tokio::test]
+async fn argument_definitions_directives_invalid_type_invalid() {
     let input = include_str!("parse/fixtures/argument_definitions_directives_invalid_type.invalid.graphql");
     let expected = include_str!("parse/fixtures/argument_definitions_directives_invalid_type.invalid.expected");
-    test_fixture(transform_fixture, "argument_definitions_directives_invalid_type.invalid.graphql", "parse/fixtures/argument_definitions_directives_invalid_type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "argument_definitions_directives_invalid_type.invalid.graphql", "parse/fixtures/argument_definitions_directives_invalid_type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn argument_definitions_typo_invalid() {
+#[tokio::test]
+async fn argument_definitions_typo_invalid() {
     let input = include_str!("parse/fixtures/argument_definitions_typo.invalid.graphql");
     let expected = include_str!("parse/fixtures/argument_definitions_typo.invalid.expected");
-    test_fixture(transform_fixture, "argument_definitions_typo.invalid.graphql", "parse/fixtures/argument_definitions_typo.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "argument_definitions_typo.invalid.graphql", "parse/fixtures/argument_definitions_typo.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn complex_object_with_invalid_constant_fields_invalid() {
+#[tokio::test]
+async fn complex_object_with_invalid_constant_fields_invalid() {
     let input = include_str!("parse/fixtures/complex-object-with-invalid-constant-fields.invalid.graphql");
     let expected = include_str!("parse/fixtures/complex-object-with-invalid-constant-fields.invalid.expected");
-    test_fixture(transform_fixture, "complex-object-with-invalid-constant-fields.invalid.graphql", "parse/fixtures/complex-object-with-invalid-constant-fields.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "complex-object-with-invalid-constant-fields.invalid.graphql", "parse/fixtures/complex-object-with-invalid-constant-fields.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn complex_object_with_invalid_fields_invalid() {
+#[tokio::test]
+async fn complex_object_with_invalid_fields_invalid() {
     let input = include_str!("parse/fixtures/complex-object-with-invalid-fields.invalid.graphql");
     let expected = include_str!("parse/fixtures/complex-object-with-invalid-fields.invalid.expected");
-    test_fixture(transform_fixture, "complex-object-with-invalid-fields.invalid.graphql", "parse/fixtures/complex-object-with-invalid-fields.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "complex-object-with-invalid-fields.invalid.graphql", "parse/fixtures/complex-object-with-invalid-fields.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn complex_object_with_missing_fields_invalid() {
+#[tokio::test]
+async fn complex_object_with_missing_fields_invalid() {
     let input = include_str!("parse/fixtures/complex-object-with-missing-fields.invalid.graphql");
     let expected = include_str!("parse/fixtures/complex-object-with-missing-fields.invalid.expected");
-    test_fixture(transform_fixture, "complex-object-with-missing-fields.invalid.graphql", "parse/fixtures/complex-object-with-missing-fields.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "complex-object-with-missing-fields.invalid.graphql", "parse/fixtures/complex-object-with-missing-fields.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_generic() {
+#[tokio::test]
+async fn directive_generic() {
     let input = include_str!("parse/fixtures/directive-generic.graphql");
     let expected = include_str!("parse/fixtures/directive-generic.expected");
-    test_fixture(transform_fixture, "directive-generic.graphql", "parse/fixtures/directive-generic.expected", input, expected);
+    test_fixture(transform_fixture, "directive-generic.graphql", "parse/fixtures/directive-generic.expected", input, expected).await;
 }
 
-#[test]
-fn directive_include() {
+#[tokio::test]
+async fn directive_include() {
     let input = include_str!("parse/fixtures/directive-include.graphql");
     let expected = include_str!("parse/fixtures/directive-include.expected");
-    test_fixture(transform_fixture, "directive-include.graphql", "parse/fixtures/directive-include.expected", input, expected);
+    test_fixture(transform_fixture, "directive-include.graphql", "parse/fixtures/directive-include.expected", input, expected).await;
 }
 
-#[test]
-fn directive_match_on_fragment_invalid() {
+#[tokio::test]
+async fn directive_match_on_fragment_invalid() {
     let input = include_str!("parse/fixtures/directive-match-on-fragment.invalid.graphql");
     let expected = include_str!("parse/fixtures/directive-match-on-fragment.invalid.expected");
-    test_fixture(transform_fixture, "directive-match-on-fragment.invalid.graphql", "parse/fixtures/directive-match-on-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive-match-on-fragment.invalid.graphql", "parse/fixtures/directive-match-on-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_missing_required_argument_invalid() {
+#[tokio::test]
+async fn directive_missing_required_argument_invalid() {
     let input = include_str!("parse/fixtures/directive_missing_required_argument.invalid.graphql");
     let expected = include_str!("parse/fixtures/directive_missing_required_argument.invalid.expected");
-    test_fixture(transform_fixture, "directive_missing_required_argument.invalid.graphql", "parse/fixtures/directive_missing_required_argument.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive_missing_required_argument.invalid.graphql", "parse/fixtures/directive_missing_required_argument.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_module_match_on_query_invalid() {
+#[tokio::test]
+async fn directive_module_match_on_query_invalid() {
     let input = include_str!("parse/fixtures/directive-module-match-on-query.invalid.graphql");
     let expected = include_str!("parse/fixtures/directive-module-match-on-query.invalid.expected");
-    test_fixture(transform_fixture, "directive-module-match-on-query.invalid.graphql", "parse/fixtures/directive-module-match-on-query.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive-module-match-on-query.invalid.graphql", "parse/fixtures/directive-module-match-on-query.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_module_on_field_invalid() {
+#[tokio::test]
+async fn directive_module_on_field_invalid() {
     let input = include_str!("parse/fixtures/directive-module-on-field.invalid.graphql");
     let expected = include_str!("parse/fixtures/directive-module-on-field.invalid.expected");
-    test_fixture(transform_fixture, "directive-module-on-field.invalid.graphql", "parse/fixtures/directive-module-on-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive-module-on-field.invalid.graphql", "parse/fixtures/directive-module-on-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_unknown_argument_invalid() {
+#[tokio::test]
+async fn directive_unknown_argument_invalid() {
     let input = include_str!("parse/fixtures/directive-unknown-argument.invalid.graphql");
     let expected = include_str!("parse/fixtures/directive-unknown-argument.invalid.expected");
-    test_fixture(transform_fixture, "directive-unknown-argument.invalid.graphql", "parse/fixtures/directive-unknown-argument.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive-unknown-argument.invalid.graphql", "parse/fixtures/directive-unknown-argument.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_wrong_argument_type_invalid() {
+#[tokio::test]
+async fn directive_wrong_argument_type_invalid() {
     let input = include_str!("parse/fixtures/directive_wrong_argument_type.invalid.graphql");
     let expected = include_str!("parse/fixtures/directive_wrong_argument_type.invalid.expected");
-    test_fixture(transform_fixture, "directive_wrong_argument_type.invalid.graphql", "parse/fixtures/directive_wrong_argument_type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive_wrong_argument_type.invalid.graphql", "parse/fixtures/directive_wrong_argument_type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_arguments_invalid() {
+#[tokio::test]
+async fn duplicate_arguments_invalid() {
     let input = include_str!("parse/fixtures/duplicate_arguments.invalid.graphql");
     let expected = include_str!("parse/fixtures/duplicate_arguments.invalid.expected");
-    test_fixture(transform_fixture, "duplicate_arguments.invalid.graphql", "parse/fixtures/duplicate_arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate_arguments.invalid.graphql", "parse/fixtures/duplicate_arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_variables_invalid() {
+#[tokio::test]
+async fn duplicate_variables_invalid() {
     let input = include_str!("parse/fixtures/duplicate_variables_invalid.graphql");
     let expected = include_str!("parse/fixtures/duplicate_variables_invalid.expected");
-    test_fixture(transform_fixture, "duplicate_variables_invalid.graphql", "parse/fixtures/duplicate_variables_invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate_variables_invalid.graphql", "parse/fixtures/duplicate_variables_invalid.expected", input, expected).await;
 }
 
-#[test]
-fn enum_values() {
+#[tokio::test]
+async fn enum_values() {
     let input = include_str!("parse/fixtures/enum-values.graphql");
     let expected = include_str!("parse/fixtures/enum-values.expected");
-    test_fixture(transform_fixture, "enum-values.graphql", "parse/fixtures/enum-values.expected", input, expected);
+    test_fixture(transform_fixture, "enum-values.graphql", "parse/fixtures/enum-values.expected", input, expected).await;
 }
 
-#[test]
-fn enum_values_invalid() {
+#[tokio::test]
+async fn enum_values_invalid() {
     let input = include_str!("parse/fixtures/enum-values.invalid.graphql");
     let expected = include_str!("parse/fixtures/enum-values.invalid.expected");
-    test_fixture(transform_fixture, "enum-values.invalid.graphql", "parse/fixtures/enum-values.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "enum-values.invalid.graphql", "parse/fixtures/enum-values.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fetch_token_with_arguments_invalid() {
+#[tokio::test]
+async fn fetch_token_with_arguments_invalid() {
     let input = include_str!("parse/fixtures/fetch_token_with_arguments.invalid.graphql");
     let expected = include_str!("parse/fixtures/fetch_token_with_arguments.invalid.expected");
-    test_fixture(transform_fixture, "fetch_token_with_arguments.invalid.graphql", "parse/fixtures/fetch_token_with_arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fetch_token_with_arguments.invalid.graphql", "parse/fixtures/fetch_token_with_arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn field_argument_missing_required_invalid() {
+#[tokio::test]
+async fn field_argument_missing_required_invalid() {
     let input = include_str!("parse/fixtures/field_argument_missing_required.invalid.graphql");
     let expected = include_str!("parse/fixtures/field_argument_missing_required.invalid.expected");
-    test_fixture(transform_fixture, "field_argument_missing_required.invalid.graphql", "parse/fixtures/field_argument_missing_required.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "field_argument_missing_required.invalid.graphql", "parse/fixtures/field_argument_missing_required.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn field_argument_unknown_invalid() {
+#[tokio::test]
+async fn field_argument_unknown_invalid() {
     let input = include_str!("parse/fixtures/field_argument_unknown.invalid.graphql");
     let expected = include_str!("parse/fixtures/field_argument_unknown.invalid.expected");
-    test_fixture(transform_fixture, "field_argument_unknown.invalid.graphql", "parse/fixtures/field_argument_unknown.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "field_argument_unknown.invalid.graphql", "parse/fixtures/field_argument_unknown.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn field_argument_wrong_type_invalid() {
+#[tokio::test]
+async fn field_argument_wrong_type_invalid() {
     let input = include_str!("parse/fixtures/field_argument_wrong_type.invalid.graphql");
     let expected = include_str!("parse/fixtures/field_argument_wrong_type.invalid.expected");
-    test_fixture(transform_fixture, "field_argument_wrong_type.invalid.graphql", "parse/fixtures/field_argument_wrong_type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "field_argument_wrong_type.invalid.graphql", "parse/fixtures/field_argument_wrong_type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn field_arguments() {
+#[tokio::test]
+async fn field_arguments() {
     let input = include_str!("parse/fixtures/field-arguments.graphql");
     let expected = include_str!("parse/fixtures/field-arguments.expected");
-    test_fixture(transform_fixture, "field-arguments.graphql", "parse/fixtures/field-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "field-arguments.graphql", "parse/fixtures/field-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn fixme_fat_interface_on_union() {
+#[tokio::test]
+async fn fixme_fat_interface_on_union() {
     let input = include_str!("parse/fixtures/fixme_fat_interface_on_union.graphql");
     let expected = include_str!("parse/fixtures/fixme_fat_interface_on_union.expected");
-    test_fixture(transform_fixture, "fixme_fat_interface_on_union.graphql", "parse/fixtures/fixme_fat_interface_on_union.expected", input, expected);
+    test_fixture(transform_fixture, "fixme_fat_interface_on_union.graphql", "parse/fixtures/fixme_fat_interface_on_union.expected", input, expected).await;
 }
 
-#[test]
-fn fixme_fat_interface_on_union_invalid() {
+#[tokio::test]
+async fn fixme_fat_interface_on_union_invalid() {
     let input = include_str!("parse/fixtures/fixme_fat_interface_on_union.invalid.graphql");
     let expected = include_str!("parse/fixtures/fixme_fat_interface_on_union.invalid.expected");
-    test_fixture(transform_fixture, "fixme_fat_interface_on_union.invalid.graphql", "parse/fixtures/fixme_fat_interface_on_union.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fixme_fat_interface_on_union.invalid.graphql", "parse/fixtures/fixme_fat_interface_on_union.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread_on_wrong_type_invalid() {
+#[tokio::test]
+async fn fragment_spread_on_wrong_type_invalid() {
     let input = include_str!("parse/fixtures/fragment-spread-on-wrong-type.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-spread-on-wrong-type.invalid.expected");
-    test_fixture(transform_fixture, "fragment-spread-on-wrong-type.invalid.graphql", "parse/fixtures/fragment-spread-on-wrong-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-spread-on-wrong-type.invalid.graphql", "parse/fixtures/fragment-spread-on-wrong-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread_within_wrong_parent_type_invalid() {
+#[tokio::test]
+async fn fragment_spread_within_wrong_parent_type_invalid() {
     let input = include_str!("parse/fixtures/fragment-spread-within-wrong-parent-type.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-spread-within-wrong-parent-type.invalid.expected");
-    test_fixture(transform_fixture, "fragment-spread-within-wrong-parent-type.invalid.graphql", "parse/fixtures/fragment-spread-within-wrong-parent-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-spread-within-wrong-parent-type.invalid.graphql", "parse/fixtures/fragment-spread-within-wrong-parent-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_argument_type_invalid() {
+#[tokio::test]
+async fn fragment_with_argument_type_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-argument-type.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-argument-type.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-argument-type.invalid.graphql", "parse/fixtures/fragment-with-argument-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-argument-type.invalid.graphql", "parse/fixtures/fragment-with-argument-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_argument_type_syntax_error_invalid() {
+#[tokio::test]
+async fn fragment_with_argument_type_syntax_error_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-argument-type-syntax-error.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-argument-type-syntax-error.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-argument-type-syntax-error.invalid.graphql", "parse/fixtures/fragment-with-argument-type-syntax-error.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-argument-type-syntax-error.invalid.graphql", "parse/fixtures/fragment-with-argument-type-syntax-error.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_arguments() {
+#[tokio::test]
+async fn fragment_with_arguments() {
     let input = include_str!("parse/fixtures/fragment-with-arguments.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-arguments.expected");
-    test_fixture(transform_fixture, "fragment-with-arguments.graphql", "parse/fixtures/fragment-with-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-arguments.graphql", "parse/fixtures/fragment-with-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_arguments_defaulting() {
+#[tokio::test]
+async fn fragment_with_arguments_defaulting() {
     let input = include_str!("parse/fixtures/fragment_with_arguments_defaulting.graphql");
     let expected = include_str!("parse/fixtures/fragment_with_arguments_defaulting.expected");
-    test_fixture(transform_fixture, "fragment_with_arguments_defaulting.graphql", "parse/fixtures/fragment_with_arguments_defaulting.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_with_arguments_defaulting.graphql", "parse/fixtures/fragment_with_arguments_defaulting.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_arguments_duplicate_invalid() {
+#[tokio::test]
+async fn fragment_with_arguments_duplicate_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-arguments-duplicate.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-arguments-duplicate.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-arguments-duplicate.invalid.graphql", "parse/fixtures/fragment-with-arguments-duplicate.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-arguments-duplicate.invalid.graphql", "parse/fixtures/fragment-with-arguments-duplicate.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_arguments_incorrect_nullability_invalid() {
+#[tokio::test]
+async fn fragment_with_arguments_incorrect_nullability_invalid() {
     let input = include_str!("parse/fixtures/fragment_with_arguments_incorrect_nullability.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment_with_arguments_incorrect_nullability.invalid.expected");
-    test_fixture(transform_fixture, "fragment_with_arguments_incorrect_nullability.invalid.graphql", "parse/fixtures/fragment_with_arguments_incorrect_nullability.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_with_arguments_incorrect_nullability.invalid.graphql", "parse/fixtures/fragment_with_arguments_incorrect_nullability.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_arguments_invalid_type_invalid() {
+#[tokio::test]
+async fn fragment_with_arguments_invalid_type_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-arguments-invalid-type.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-arguments-invalid-type.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-arguments-invalid-type.invalid.graphql", "parse/fixtures/fragment-with-arguments-invalid-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-arguments-invalid-type.invalid.graphql", "parse/fixtures/fragment-with-arguments-invalid-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_arguments_syntax() {
+#[tokio::test]
+async fn fragment_with_arguments_syntax() {
     let input = include_str!("parse/fixtures/fragment-with-arguments-syntax.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-arguments-syntax.expected");
-    test_fixture(transform_fixture, "fragment-with-arguments-syntax.graphql", "parse/fixtures/fragment-with-arguments-syntax.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-arguments-syntax.graphql", "parse/fixtures/fragment-with-arguments-syntax.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_both_arguments_and_directive_invalid() {
+#[tokio::test]
+async fn fragment_with_both_arguments_and_directive_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-both-arguments-and-directive.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-both-arguments-and-directive.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-both-arguments-and-directive.invalid.graphql", "parse/fixtures/fragment-with-both-arguments-and-directive.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-both-arguments-and-directive.invalid.graphql", "parse/fixtures/fragment-with-both-arguments-and-directive.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_both_variable_definition_and_directive_invalid() {
+#[tokio::test]
+async fn fragment_with_both_variable_definition_and_directive_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-both-variable-definition-and-directive.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-both-variable-definition-and-directive.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-both-variable-definition-and-directive.invalid.graphql", "parse/fixtures/fragment-with-both-variable-definition-and-directive.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-both-variable-definition-and-directive.invalid.graphql", "parse/fixtures/fragment-with-both-variable-definition-and-directive.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_literal_arguments() {
+#[tokio::test]
+async fn fragment_with_literal_arguments() {
     let input = include_str!("parse/fixtures/fragment-with-literal-arguments.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-literal-arguments.expected");
-    test_fixture(transform_fixture, "fragment-with-literal-arguments.graphql", "parse/fixtures/fragment-with-literal-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-literal-arguments.graphql", "parse/fixtures/fragment-with-literal-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_literal_enum_arguments() {
+#[tokio::test]
+async fn fragment_with_literal_enum_arguments() {
     let input = include_str!("parse/fixtures/fragment-with-literal-enum-arguments.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-literal-enum-arguments.expected");
-    test_fixture(transform_fixture, "fragment-with-literal-enum-arguments.graphql", "parse/fixtures/fragment-with-literal-enum-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-literal-enum-arguments.graphql", "parse/fixtures/fragment-with-literal-enum-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_literal_enum_arguments_into_enum_list() {
+#[tokio::test]
+async fn fragment_with_literal_enum_arguments_into_enum_list() {
     let input = include_str!("parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list.expected");
-    test_fixture(transform_fixture, "fragment-with-literal-enum-arguments-into-enum-list.graphql", "parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-literal-enum-arguments-into-enum-list.graphql", "parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_literal_enum_arguments_into_enum_list_indirect_invalid() {
+#[tokio::test]
+async fn fragment_with_literal_enum_arguments_into_enum_list_indirect_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list-indirect.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list-indirect.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-literal-enum-arguments-into-enum-list-indirect.invalid.graphql", "parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list-indirect.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-literal-enum-arguments-into-enum-list-indirect.invalid.graphql", "parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list-indirect.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_literal_enum_list_arguments() {
+#[tokio::test]
+async fn fragment_with_literal_enum_list_arguments() {
     let input = include_str!("parse/fixtures/fragment-with-literal-enum-list-arguments.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-literal-enum-list-arguments.expected");
-    test_fixture(transform_fixture, "fragment-with-literal-enum-list-arguments.graphql", "parse/fixtures/fragment-with-literal-enum-list-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-literal-enum-list-arguments.graphql", "parse/fixtures/fragment-with-literal-enum-list-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_literal_object_arguments() {
+#[tokio::test]
+async fn fragment_with_literal_object_arguments() {
     let input = include_str!("parse/fixtures/fragment-with-literal-object-arguments.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-literal-object-arguments.expected");
-    test_fixture(transform_fixture, "fragment-with-literal-object-arguments.graphql", "parse/fixtures/fragment-with-literal-object-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-literal-object-arguments.graphql", "parse/fixtures/fragment-with-literal-object-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_literal_object_list_arguments() {
+#[tokio::test]
+async fn fragment_with_literal_object_list_arguments() {
     let input = include_str!("parse/fixtures/fragment-with-literal-object-list-arguments.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-literal-object-list-arguments.expected");
-    test_fixture(transform_fixture, "fragment-with-literal-object-list-arguments.graphql", "parse/fixtures/fragment-with-literal-object-list-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-literal-object-list-arguments.graphql", "parse/fixtures/fragment-with-literal-object-list-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_undefined_literal_arguments_invalid() {
+#[tokio::test]
+async fn fragment_with_undefined_literal_arguments_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-undefined-literal-arguments.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-undefined-literal-arguments.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-undefined-literal-arguments.invalid.graphql", "parse/fixtures/fragment-with-undefined-literal-arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-undefined-literal-arguments.invalid.graphql", "parse/fixtures/fragment-with-undefined-literal-arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_undefined_variable_arguments_invalid() {
+#[tokio::test]
+async fn fragment_with_undefined_variable_arguments_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-undefined-variable-arguments.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-undefined-variable-arguments.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-undefined-variable-arguments.invalid.graphql", "parse/fixtures/fragment-with-undefined-variable-arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-undefined-variable-arguments.invalid.graphql", "parse/fixtures/fragment-with-undefined-variable-arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_unnecessary_unchecked_arguments_invalid() {
+#[tokio::test]
+async fn fragment_with_unnecessary_unchecked_arguments_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-unnecessary-unchecked-arguments.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-unnecessary-unchecked-arguments.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-unnecessary-unchecked-arguments.invalid.graphql", "parse/fixtures/fragment-with-unnecessary-unchecked-arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-unnecessary-unchecked-arguments.invalid.graphql", "parse/fixtures/fragment-with-unnecessary-unchecked-arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_variable_definitions_syntax() {
+#[tokio::test]
+async fn fragment_with_variable_definitions_syntax() {
     let input = include_str!("parse/fixtures/fragment-with-variable-definitions-syntax.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-variable-definitions-syntax.expected");
-    test_fixture(transform_fixture, "fragment-with-variable-definitions-syntax.graphql", "parse/fixtures/fragment-with-variable-definitions-syntax.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-variable-definitions-syntax.graphql", "parse/fixtures/fragment-with-variable-definitions-syntax.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_variable_definitions_syntax_and_argdefs_invalid() {
+#[tokio::test]
+async fn fragment_with_variable_definitions_syntax_and_argdefs_invalid() {
     let input = include_str!("parse/fixtures/fragment-with-variable-definitions-syntax-and-argdefs.invalid.graphql");
     let expected = include_str!("parse/fixtures/fragment-with-variable-definitions-syntax-and-argdefs.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-variable-definitions-syntax-and-argdefs.invalid.graphql", "parse/fixtures/fragment-with-variable-definitions-syntax-and-argdefs.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-variable-definitions-syntax-and-argdefs.invalid.graphql", "parse/fixtures/fragment-with-variable-definitions-syntax-and-argdefs.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_wrong_type_invalid() {
+#[tokio::test]
+async fn inline_fragment_on_wrong_type_invalid() {
     let input = include_str!("parse/fixtures/inline-fragment-on-wrong-type.invalid.graphql");
     let expected = include_str!("parse/fixtures/inline-fragment-on-wrong-type.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-on-wrong-type.invalid.graphql", "parse/fixtures/inline-fragment-on-wrong-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-on-wrong-type.invalid.graphql", "parse/fixtures/inline-fragment-on-wrong-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_with_invalid_type() {
+#[tokio::test]
+async fn inline_fragment_with_invalid_type() {
     let input = include_str!("parse/fixtures/inline-fragment-with-invalid-type.graphql");
     let expected = include_str!("parse/fixtures/inline-fragment-with-invalid-type.expected");
-    test_fixture(transform_fixture, "inline-fragment-with-invalid-type.graphql", "parse/fixtures/inline-fragment-with-invalid-type.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-with-invalid-type.graphql", "parse/fixtures/inline-fragment-with-invalid-type.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_within_invalid_inline_fragment_grandparent_invalid() {
+#[tokio::test]
+async fn inline_fragment_within_invalid_inline_fragment_grandparent_invalid() {
     let input = include_str!("parse/fixtures/inline-fragment-within-invalid-inline-fragment-grandparent.invalid.graphql");
     let expected = include_str!("parse/fixtures/inline-fragment-within-invalid-inline-fragment-grandparent.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-within-invalid-inline-fragment-grandparent.invalid.graphql", "parse/fixtures/inline-fragment-within-invalid-inline-fragment-grandparent.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-within-invalid-inline-fragment-grandparent.invalid.graphql", "parse/fixtures/inline-fragment-within-invalid-inline-fragment-grandparent.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_within_linked_field_and_wrong_inline_fragment_invalid() {
+#[tokio::test]
+async fn inline_fragment_within_linked_field_and_wrong_inline_fragment_invalid() {
     let input = include_str!("parse/fixtures/inline-fragment-within-linked-field-and-wrong-inline-fragment.invalid.graphql");
     let expected = include_str!("parse/fixtures/inline-fragment-within-linked-field-and-wrong-inline-fragment.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-within-linked-field-and-wrong-inline-fragment.invalid.graphql", "parse/fixtures/inline-fragment-within-linked-field-and-wrong-inline-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-within-linked-field-and-wrong-inline-fragment.invalid.graphql", "parse/fixtures/inline-fragment-within-linked-field-and-wrong-inline-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_within_wrong_parent_type_invalid() {
+#[tokio::test]
+async fn inline_fragment_within_wrong_parent_type_invalid() {
     let input = include_str!("parse/fixtures/inline-fragment-within-wrong-parent-type.invalid.graphql");
     let expected = include_str!("parse/fixtures/inline-fragment-within-wrong-parent-type.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-within-wrong-parent-type.invalid.graphql", "parse/fixtures/inline-fragment-within-wrong-parent-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-within-wrong-parent-type.invalid.graphql", "parse/fixtures/inline-fragment-within-wrong-parent-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_untyped_fragment() {
+#[tokio::test]
+async fn inline_untyped_fragment() {
     let input = include_str!("parse/fixtures/inline-untyped-fragment.graphql");
     let expected = include_str!("parse/fixtures/inline-untyped-fragment.expected");
-    test_fixture(transform_fixture, "inline-untyped-fragment.graphql", "parse/fixtures/inline-untyped-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "inline-untyped-fragment.graphql", "parse/fixtures/inline-untyped-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_argument_type_invalid() {
+#[tokio::test]
+async fn invalid_argument_type_invalid() {
     let input = include_str!("parse/fixtures/invalid-argument-type.invalid.graphql");
     let expected = include_str!("parse/fixtures/invalid-argument-type.invalid.expected");
-    test_fixture(transform_fixture, "invalid-argument-type.invalid.graphql", "parse/fixtures/invalid-argument-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-argument-type.invalid.graphql", "parse/fixtures/invalid-argument-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn linked_field_with_no_selection_invalid() {
+#[tokio::test]
+async fn linked_field_with_no_selection_invalid() {
     let input = include_str!("parse/fixtures/linked-field-with-no-selection.invalid.graphql");
     let expected = include_str!("parse/fixtures/linked-field-with-no-selection.invalid.expected");
-    test_fixture(transform_fixture, "linked-field-with-no-selection.invalid.graphql", "parse/fixtures/linked-field-with-no-selection.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "linked-field-with-no-selection.invalid.graphql", "parse/fixtures/linked-field-with-no-selection.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn linked_handle_field() {
+#[tokio::test]
+async fn linked_handle_field() {
     let input = include_str!("parse/fixtures/linked-handle-field.graphql");
     let expected = include_str!("parse/fixtures/linked-handle-field.expected");
-    test_fixture(transform_fixture, "linked-handle-field.graphql", "parse/fixtures/linked-handle-field.expected", input, expected);
+    test_fixture(transform_fixture, "linked-handle-field.graphql", "parse/fixtures/linked-handle-field.expected", input, expected).await;
 }
 
-#[test]
-fn linked_handle_field_with_filters() {
+#[tokio::test]
+async fn linked_handle_field_with_filters() {
     let input = include_str!("parse/fixtures/linked-handle-field-with-filters.graphql");
     let expected = include_str!("parse/fixtures/linked-handle-field-with-filters.expected");
-    test_fixture(transform_fixture, "linked-handle-field-with-filters.graphql", "parse/fixtures/linked-handle-field-with-filters.expected", input, expected);
+    test_fixture(transform_fixture, "linked-handle-field-with-filters.graphql", "parse/fixtures/linked-handle-field-with-filters.expected", input, expected).await;
 }
 
-#[test]
-fn linked_handle_field_with_key() {
+#[tokio::test]
+async fn linked_handle_field_with_key() {
     let input = include_str!("parse/fixtures/linked-handle-field-with-key.graphql");
     let expected = include_str!("parse/fixtures/linked-handle-field-with-key.expected");
-    test_fixture(transform_fixture, "linked-handle-field-with-key.graphql", "parse/fixtures/linked-handle-field-with-key.expected", input, expected);
+    test_fixture(transform_fixture, "linked-handle-field-with-key.graphql", "parse/fixtures/linked-handle-field-with-key.expected", input, expected).await;
 }
 
-#[test]
-fn linked_handle_filter() {
+#[tokio::test]
+async fn linked_handle_filter() {
     let input = include_str!("parse/fixtures/linked-handle-filter.graphql");
     let expected = include_str!("parse/fixtures/linked-handle-filter.expected");
-    test_fixture(transform_fixture, "linked-handle-filter.graphql", "parse/fixtures/linked-handle-filter.expected", input, expected);
+    test_fixture(transform_fixture, "linked-handle-filter.graphql", "parse/fixtures/linked-handle-filter.expected", input, expected).await;
 }
 
-#[test]
-fn list_argument() {
+#[tokio::test]
+async fn list_argument() {
     let input = include_str!("parse/fixtures/list-argument.graphql");
     let expected = include_str!("parse/fixtures/list-argument.expected");
-    test_fixture(transform_fixture, "list-argument.graphql", "parse/fixtures/list-argument.expected", input, expected);
+    test_fixture(transform_fixture, "list-argument.graphql", "parse/fixtures/list-argument.expected", input, expected).await;
 }
 
-#[test]
-fn list_argument_complex_object() {
+#[tokio::test]
+async fn list_argument_complex_object() {
     let input = include_str!("parse/fixtures/list-argument-complex-object.graphql");
     let expected = include_str!("parse/fixtures/list-argument-complex-object.expected");
-    test_fixture(transform_fixture, "list-argument-complex-object.graphql", "parse/fixtures/list-argument-complex-object.expected", input, expected);
+    test_fixture(transform_fixture, "list-argument-complex-object.graphql", "parse/fixtures/list-argument-complex-object.expected", input, expected).await;
 }
 
-#[test]
-fn list_of_enums() {
+#[tokio::test]
+async fn list_of_enums() {
     let input = include_str!("parse/fixtures/list-of-enums.graphql");
     let expected = include_str!("parse/fixtures/list-of-enums.expected");
-    test_fixture(transform_fixture, "list-of-enums.graphql", "parse/fixtures/list-of-enums.expected", input, expected);
+    test_fixture(transform_fixture, "list-of-enums.graphql", "parse/fixtures/list-of-enums.expected", input, expected).await;
 }
 
-#[test]
-fn literal_list_argument() {
+#[tokio::test]
+async fn literal_list_argument() {
     let input = include_str!("parse/fixtures/literal-list-argument.graphql");
     let expected = include_str!("parse/fixtures/literal-list-argument.expected");
-    test_fixture(transform_fixture, "literal-list-argument.graphql", "parse/fixtures/literal-list-argument.expected", input, expected);
+    test_fixture(transform_fixture, "literal-list-argument.graphql", "parse/fixtures/literal-list-argument.expected", input, expected).await;
 }
 
-#[test]
-fn literal_list_argument_invalid() {
+#[tokio::test]
+async fn literal_list_argument_invalid() {
     let input = include_str!("parse/fixtures/literal-list-argument.invalid.graphql");
     let expected = include_str!("parse/fixtures/literal-list-argument.invalid.expected");
-    test_fixture(transform_fixture, "literal-list-argument.invalid.graphql", "parse/fixtures/literal-list-argument.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "literal-list-argument.invalid.graphql", "parse/fixtures/literal-list-argument.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn literal_object_argument() {
+#[tokio::test]
+async fn literal_object_argument() {
     let input = include_str!("parse/fixtures/literal-object-argument.graphql");
     let expected = include_str!("parse/fixtures/literal-object-argument.expected");
-    test_fixture(transform_fixture, "literal-object-argument.graphql", "parse/fixtures/literal-object-argument.expected", input, expected);
+    test_fixture(transform_fixture, "literal-object-argument.graphql", "parse/fixtures/literal-object-argument.expected", input, expected).await;
 }
 
-#[test]
-fn literal_object_argument_invalid() {
+#[tokio::test]
+async fn literal_object_argument_invalid() {
     let input = include_str!("parse/fixtures/literal-object-argument.invalid.graphql");
     let expected = include_str!("parse/fixtures/literal-object-argument.invalid.expected");
-    test_fixture(transform_fixture, "literal-object-argument.invalid.graphql", "parse/fixtures/literal-object-argument.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "literal-object-argument.invalid.graphql", "parse/fixtures/literal-object-argument.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn null_values() {
+#[tokio::test]
+async fn null_values() {
     let input = include_str!("parse/fixtures/null-values.graphql");
     let expected = include_str!("parse/fixtures/null-values.expected");
-    test_fixture(transform_fixture, "null-values.graphql", "parse/fixtures/null-values.expected", input, expected);
+    test_fixture(transform_fixture, "null-values.graphql", "parse/fixtures/null-values.expected", input, expected).await;
 }
 
-#[test]
-fn null_values_invalid() {
+#[tokio::test]
+async fn null_values_invalid() {
     let input = include_str!("parse/fixtures/null-values.invalid.graphql");
     let expected = include_str!("parse/fixtures/null-values.invalid.expected");
-    test_fixture(transform_fixture, "null-values.invalid.graphql", "parse/fixtures/null-values.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "null-values.invalid.graphql", "parse/fixtures/null-values.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn object_argument() {
+#[tokio::test]
+async fn object_argument() {
     let input = include_str!("parse/fixtures/object-argument.graphql");
     let expected = include_str!("parse/fixtures/object-argument.expected");
-    test_fixture(transform_fixture, "object-argument.graphql", "parse/fixtures/object-argument.expected", input, expected);
+    test_fixture(transform_fixture, "object-argument.graphql", "parse/fixtures/object-argument.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_argument_invalid() {
+#[tokio::test]
+async fn query_with_argument_invalid() {
     let input = include_str!("parse/fixtures/query-with-argument.invalid.graphql");
     let expected = include_str!("parse/fixtures/query-with-argument.invalid.expected");
-    test_fixture(transform_fixture, "query-with-argument.invalid.graphql", "parse/fixtures/query-with-argument.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-argument.invalid.graphql", "parse/fixtures/query-with-argument.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_field_with_selection() {
+#[tokio::test]
+async fn scalar_field_with_selection() {
     let input = include_str!("parse/fixtures/scalar-field-with-selection.graphql");
     let expected = include_str!("parse/fixtures/scalar-field-with-selection.expected");
-    test_fixture(transform_fixture, "scalar-field-with-selection.graphql", "parse/fixtures/scalar-field-with-selection.expected", input, expected);
+    test_fixture(transform_fixture, "scalar-field-with-selection.graphql", "parse/fixtures/scalar-field-with-selection.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_handle_field() {
+#[tokio::test]
+async fn scalar_handle_field() {
     let input = include_str!("parse/fixtures/scalar-handle-field.graphql");
     let expected = include_str!("parse/fixtures/scalar-handle-field.expected");
-    test_fixture(transform_fixture, "scalar-handle-field.graphql", "parse/fixtures/scalar-handle-field.expected", input, expected);
+    test_fixture(transform_fixture, "scalar-handle-field.graphql", "parse/fixtures/scalar-handle-field.expected", input, expected).await;
 }
 
-#[test]
-fn simple_fragment() {
+#[tokio::test]
+async fn simple_fragment() {
     let input = include_str!("parse/fixtures/simple-fragment.graphql");
     let expected = include_str!("parse/fixtures/simple-fragment.expected");
-    test_fixture(transform_fixture, "simple-fragment.graphql", "parse/fixtures/simple-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "simple-fragment.graphql", "parse/fixtures/simple-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn simple_query() {
+#[tokio::test]
+async fn simple_query() {
     let input = include_str!("parse/fixtures/simple-query.graphql");
     let expected = include_str!("parse/fixtures/simple-query.expected");
-    test_fixture(transform_fixture, "simple-query.graphql", "parse/fixtures/simple-query.expected", input, expected);
+    test_fixture(transform_fixture, "simple-query.graphql", "parse/fixtures/simple-query.expected", input, expected).await;
 }
 
-#[test]
-fn subscription_with_multiple_selections_invalid() {
+#[tokio::test]
+async fn subscription_with_multiple_selections_invalid() {
     let input = include_str!("parse/fixtures/subscription-with-multiple-selections.invalid.graphql");
     let expected = include_str!("parse/fixtures/subscription-with-multiple-selections.invalid.expected");
-    test_fixture(transform_fixture, "subscription-with-multiple-selections.invalid.graphql", "parse/fixtures/subscription-with-multiple-selections.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "subscription-with-multiple-selections.invalid.graphql", "parse/fixtures/subscription-with-multiple-selections.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn typename_with_arguments_invalid() {
+#[tokio::test]
+async fn typename_with_arguments_invalid() {
     let input = include_str!("parse/fixtures/typename_with_arguments.invalid.graphql");
     let expected = include_str!("parse/fixtures/typename_with_arguments.invalid.expected");
-    test_fixture(transform_fixture, "typename_with_arguments.invalid.graphql", "parse/fixtures/typename_with_arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "typename_with_arguments.invalid.graphql", "parse/fixtures/typename_with_arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn undefined_fragment_but_close_invalid() {
+#[tokio::test]
+async fn undefined_fragment_but_close_invalid() {
     let input = include_str!("parse/fixtures/undefined-fragment-but-close.invalid.graphql");
     let expected = include_str!("parse/fixtures/undefined-fragment-but-close.invalid.expected");
-    test_fixture(transform_fixture, "undefined-fragment-but-close.invalid.graphql", "parse/fixtures/undefined-fragment-but-close.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "undefined-fragment-but-close.invalid.graphql", "parse/fixtures/undefined-fragment-but-close.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn undefined_fragment_invalid() {
+#[tokio::test]
+async fn undefined_fragment_invalid() {
     let input = include_str!("parse/fixtures/undefined-fragment.invalid.graphql");
     let expected = include_str!("parse/fixtures/undefined-fragment.invalid.expected");
-    test_fixture(transform_fixture, "undefined-fragment.invalid.graphql", "parse/fixtures/undefined-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "undefined-fragment.invalid.graphql", "parse/fixtures/undefined-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn undefined_type_invalid() {
+#[tokio::test]
+async fn undefined_type_invalid() {
     let input = include_str!("parse/fixtures/undefined-type.invalid.graphql");
     let expected = include_str!("parse/fixtures/undefined-type.invalid.expected");
-    test_fixture(transform_fixture, "undefined-type.invalid.graphql", "parse/fixtures/undefined-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "undefined-type.invalid.graphql", "parse/fixtures/undefined-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unknown_field_invalid() {
+#[tokio::test]
+async fn unknown_field_invalid() {
     let input = include_str!("parse/fixtures/unknown_field.invalid.graphql");
     let expected = include_str!("parse/fixtures/unknown_field.invalid.expected");
-    test_fixture(transform_fixture, "unknown_field.invalid.graphql", "parse/fixtures/unknown_field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unknown_field.invalid.graphql", "parse/fixtures/unknown_field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unknown_fragment_type_invalid() {
+#[tokio::test]
+async fn unknown_fragment_type_invalid() {
     let input = include_str!("parse/fixtures/unknown-fragment-type.invalid.graphql");
     let expected = include_str!("parse/fixtures/unknown-fragment-type.invalid.expected");
-    test_fixture(transform_fixture, "unknown-fragment-type.invalid.graphql", "parse/fixtures/unknown-fragment-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unknown-fragment-type.invalid.graphql", "parse/fixtures/unknown-fragment-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unknown_fragment_type_suggestions_invalid() {
+#[tokio::test]
+async fn unknown_fragment_type_suggestions_invalid() {
     let input = include_str!("parse/fixtures/unknown-fragment-type-suggestions.invalid.graphql");
     let expected = include_str!("parse/fixtures/unknown-fragment-type-suggestions.invalid.expected");
-    test_fixture(transform_fixture, "unknown-fragment-type-suggestions.invalid.graphql", "parse/fixtures/unknown-fragment-type-suggestions.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unknown-fragment-type-suggestions.invalid.graphql", "parse/fixtures/unknown-fragment-type-suggestions.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions/mod.rs
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions/mod.rs
@@ -14,7 +14,7 @@ use graphql_ir::build;
 use graphql_syntax::parse_executable;
 use relay_test_schema::get_test_schema_with_extensions;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let mut sources = FnvHashMap::default();
     sources.insert(
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions_test.rs
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e573b168de2e50d455bd24bed56b02c6>>
+ * @generated SignedSource<<52d5e6416c694968846ac5ec0fb6f8a4>>
  */
 
 mod parse_with_extensions;
@@ -12,16 +12,16 @@ mod parse_with_extensions;
 use parse_with_extensions::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn client_fields() {
+#[tokio::test]
+async fn client_fields() {
     let input = include_str!("parse_with_extensions/fixtures/client-fields.graphql");
     let expected = include_str!("parse_with_extensions/fixtures/client-fields.expected");
-    test_fixture(transform_fixture, "client-fields.graphql", "parse_with_extensions/fixtures/client-fields.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields.graphql", "parse_with_extensions/fixtures/client-fields.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_invalid() {
+#[tokio::test]
+async fn client_fields_invalid() {
     let input = include_str!("parse_with_extensions/fixtures/client-fields.invalid.graphql");
     let expected = include_str!("parse_with_extensions/fixtures/client-fields.invalid.expected");
-    test_fixture(transform_fixture, "client-fields.invalid.graphql", "parse_with_extensions/fixtures/client-fields.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields.invalid.graphql", "parse_with_extensions/fixtures/client-fields.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-ir/tests/parse_with_provider/mod.rs
+++ b/compiler/crates/graphql-ir/tests/parse_with_provider/mod.rs
@@ -19,7 +19,7 @@ use graphql_syntax::FragmentArgumentSyntaxKind;
 use graphql_syntax::ParserFeatures;
 use relay_test_schema::TEST_SCHEMA;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let features = ParserFeatures {
         fragment_argument_capability:

--- a/compiler/crates/graphql-ir/tests/parse_with_provider_test.rs
+++ b/compiler/crates/graphql-ir/tests/parse_with_provider_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1670bffb19ef1ac0b170241dddc11e88>>
+ * @generated SignedSource<<b92dbb5e2f930d15607b78f6fba95604>>
  */
 
 mod parse_with_provider;
@@ -12,30 +12,30 @@ mod parse_with_provider;
 use parse_with_provider::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_with_invalid_defaultvalue_provider() {
+#[tokio::test]
+async fn fragment_with_invalid_defaultvalue_provider() {
     let input = include_str!("parse_with_provider/fixtures/fragment_with_invalid_defaultvalue_provider.graphql");
     let expected = include_str!("parse_with_provider/fixtures/fragment_with_invalid_defaultvalue_provider.expected");
-    test_fixture(transform_fixture, "fragment_with_invalid_defaultvalue_provider.graphql", "parse_with_provider/fixtures/fragment_with_invalid_defaultvalue_provider.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_with_invalid_defaultvalue_provider.graphql", "parse_with_provider/fixtures/fragment_with_invalid_defaultvalue_provider.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_invalid_type_provider() {
+#[tokio::test]
+async fn fragment_with_invalid_type_provider() {
     let input = include_str!("parse_with_provider/fixtures/fragment_with_invalid_type_provider.graphql");
     let expected = include_str!("parse_with_provider/fixtures/fragment_with_invalid_type_provider.expected");
-    test_fixture(transform_fixture, "fragment_with_invalid_type_provider.graphql", "parse_with_provider/fixtures/fragment_with_invalid_type_provider.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_with_invalid_type_provider.graphql", "parse_with_provider/fixtures/fragment_with_invalid_type_provider.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_valid_provider() {
+#[tokio::test]
+async fn fragment_with_valid_provider() {
     let input = include_str!("parse_with_provider/fixtures/fragment_with_valid_provider.graphql");
     let expected = include_str!("parse_with_provider/fixtures/fragment_with_valid_provider.expected");
-    test_fixture(transform_fixture, "fragment_with_valid_provider.graphql", "parse_with_provider/fixtures/fragment_with_valid_provider.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_with_valid_provider.graphql", "parse_with_provider/fixtures/fragment_with_valid_provider.expected", input, expected).await;
 }
 
-#[test]
-fn use_fragment_spread_with_provider() {
+#[tokio::test]
+async fn use_fragment_spread_with_provider() {
     let input = include_str!("parse_with_provider/fixtures/use_fragment_spread_with_provider.graphql");
     let expected = include_str!("parse_with_provider/fixtures/use_fragment_spread_with_provider.expected");
-    test_fixture(transform_fixture, "use_fragment_spread_with_provider.graphql", "parse_with_provider/fixtures/use_fragment_spread_with_provider.expected", input, expected);
+    test_fixture(transform_fixture, "use_fragment_spread_with_provider.graphql", "parse_with_provider/fixtures/use_fragment_spread_with_provider.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-syntax/Cargo.toml
+++ b/compiler/crates/graphql-syntax/Cargo.toml
@@ -20,3 +20,4 @@ thiserror = "1.0.43"
 [dev-dependencies]
 fixture-tests = { path = "../fixture-tests" }
 graphql-cli = { path = "../graphql-cli" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/graphql-syntax/tests/parse_document/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_document/mod.rs
@@ -12,7 +12,7 @@ use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
 use graphql_syntax::parse_document;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_document(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/graphql-syntax/tests/parse_document_test.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_document_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<abc8378151c6180b46a82e4d45bd0129>>
+ * @generated SignedSource<<c3c58e78e47eaed1e921ea0b8a91ef2f>>
  */
 
 mod parse_document;
@@ -12,16 +12,16 @@ mod parse_document;
 use parse_document::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn invalid_definition_invalid() {
+#[tokio::test]
+async fn invalid_definition_invalid() {
     let input = include_str!("parse_document/fixtures/invalid_definition.invalid.graphql");
     let expected = include_str!("parse_document/fixtures/invalid_definition.invalid.expected");
-    test_fixture(transform_fixture, "invalid_definition.invalid.graphql", "parse_document/fixtures/invalid_definition.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "invalid_definition.invalid.graphql", "parse_document/fixtures/invalid_definition.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn mixed() {
+#[tokio::test]
+async fn mixed() {
     let input = include_str!("parse_document/fixtures/mixed.graphql");
     let expected = include_str!("parse_document/fixtures/mixed.expected");
-    test_fixture(transform_fixture, "mixed.graphql", "parse_document/fixtures/mixed.expected", input, expected);
+    test_fixture(transform_fixture, "mixed.graphql", "parse_document/fixtures/mixed.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-syntax/tests/parse_document_with_features/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_document_with_features/mod.rs
@@ -14,7 +14,7 @@ use graphql_syntax::parse_document_with_features;
 use graphql_syntax::FragmentArgumentSyntaxKind;
 use graphql_syntax::ParserFeatures;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_document_with_features(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/graphql-syntax/tests/parse_document_with_features_test.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_document_with_features_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<467adf22a47715eb35bf37efa6f69f7f>>
+ * @generated SignedSource<<33bcece13cd67363832cda0aca24da2b>>
  */
 
 mod parse_document_with_features;
@@ -12,30 +12,30 @@ mod parse_document_with_features;
 use parse_document_with_features::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_with_empty_vardefs_invalid() {
+#[tokio::test]
+async fn fragment_with_empty_vardefs_invalid() {
     let input = include_str!("parse_document_with_features/fixtures/fragment_with_empty_vardefs.invalid.graphql");
     let expected = include_str!("parse_document_with_features/fixtures/fragment_with_empty_vardefs.invalid.expected");
-    test_fixture(transform_fixture, "fragment_with_empty_vardefs.invalid.graphql", "parse_document_with_features/fixtures/fragment_with_empty_vardefs.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_with_empty_vardefs.invalid.graphql", "parse_document_with_features/fixtures/fragment_with_empty_vardefs.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_variable_defs() {
+#[tokio::test]
+async fn fragment_with_variable_defs() {
     let input = include_str!("parse_document_with_features/fixtures/fragment_with_variable_defs.graphql");
     let expected = include_str!("parse_document_with_features/fixtures/fragment_with_variable_defs.expected");
-    test_fixture(transform_fixture, "fragment_with_variable_defs.graphql", "parse_document_with_features/fixtures/fragment_with_variable_defs.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_with_variable_defs.graphql", "parse_document_with_features/fixtures/fragment_with_variable_defs.expected", input, expected).await;
 }
 
-#[test]
-fn spread_with_arguments() {
+#[tokio::test]
+async fn spread_with_arguments() {
     let input = include_str!("parse_document_with_features/fixtures/spread_with_arguments.graphql");
     let expected = include_str!("parse_document_with_features/fixtures/spread_with_arguments.expected");
-    test_fixture(transform_fixture, "spread_with_arguments.graphql", "parse_document_with_features/fixtures/spread_with_arguments.expected", input, expected);
+    test_fixture(transform_fixture, "spread_with_arguments.graphql", "parse_document_with_features/fixtures/spread_with_arguments.expected", input, expected).await;
 }
 
-#[test]
-fn spread_with_empty_arguments_invalid() {
+#[tokio::test]
+async fn spread_with_empty_arguments_invalid() {
     let input = include_str!("parse_document_with_features/fixtures/spread_with_empty_arguments.invalid.graphql");
     let expected = include_str!("parse_document_with_features/fixtures/spread_with_empty_arguments.invalid.expected");
-    test_fixture(transform_fixture, "spread_with_empty_arguments.invalid.graphql", "parse_document_with_features/fixtures/spread_with_empty_arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "spread_with_empty_arguments.invalid.graphql", "parse_document_with_features/fixtures/spread_with_empty_arguments.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-syntax/tests/parse_executable_document/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_executable_document/mod.rs
@@ -12,7 +12,7 @@ use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
 use graphql_syntax::parse_executable;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_executable(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/graphql-syntax/tests/parse_executable_document_test.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_executable_document_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<dd4791b79658f50a23574eb6f4548bf9>>
+ * @generated SignedSource<<b0a2958309c0f951547c9fcf5a6d0fe3>>
  */
 
 mod parse_executable_document;
@@ -12,93 +12,93 @@ mod parse_executable_document;
 use parse_executable_document::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn block_string() {
+#[tokio::test]
+async fn block_string() {
     let input = include_str!("parse_executable_document/fixtures/block_string.graphql");
     let expected = include_str!("parse_executable_document/fixtures/block_string.expected");
-    test_fixture(transform_fixture, "block_string.graphql", "parse_executable_document/fixtures/block_string.expected", input, expected);
+    test_fixture(transform_fixture, "block_string.graphql", "parse_executable_document/fixtures/block_string.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_variable_defs_invalid() {
+#[tokio::test]
+async fn fragment_with_variable_defs_invalid() {
     let input = include_str!("parse_executable_document/fixtures/fragment_with_variable_defs.invalid.graphql");
     let expected = include_str!("parse_executable_document/fixtures/fragment_with_variable_defs.invalid.expected");
-    test_fixture(transform_fixture, "fragment_with_variable_defs.invalid.graphql", "parse_executable_document/fixtures/fragment_with_variable_defs.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_with_variable_defs.invalid.graphql", "parse_executable_document/fixtures/fragment_with_variable_defs.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn incomplete_field_alias() {
+#[tokio::test]
+async fn incomplete_field_alias() {
     let input = include_str!("parse_executable_document/fixtures/incomplete_field_alias.graphql");
     let expected = include_str!("parse_executable_document/fixtures/incomplete_field_alias.expected");
-    test_fixture(transform_fixture, "incomplete_field_alias.graphql", "parse_executable_document/fixtures/incomplete_field_alias.expected", input, expected);
+    test_fixture(transform_fixture, "incomplete_field_alias.graphql", "parse_executable_document/fixtures/incomplete_field_alias.expected", input, expected).await;
 }
 
-#[test]
-fn incorrect_variable_name_invalid() {
+#[tokio::test]
+async fn incorrect_variable_name_invalid() {
     let input = include_str!("parse_executable_document/fixtures/incorrect_variable_name.invalid.graphql");
     let expected = include_str!("parse_executable_document/fixtures/incorrect_variable_name.invalid.expected");
-    test_fixture(transform_fixture, "incorrect_variable_name.invalid.graphql", "parse_executable_document/fixtures/incorrect_variable_name.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "incorrect_variable_name.invalid.graphql", "parse_executable_document/fixtures/incorrect_variable_name.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_number() {
+#[tokio::test]
+async fn invalid_number() {
     let input = include_str!("parse_executable_document/fixtures/invalid_number.graphql");
     let expected = include_str!("parse_executable_document/fixtures/invalid_number.expected");
-    test_fixture(transform_fixture, "invalid_number.graphql", "parse_executable_document/fixtures/invalid_number.expected", input, expected);
+    test_fixture(transform_fixture, "invalid_number.graphql", "parse_executable_document/fixtures/invalid_number.expected", input, expected).await;
 }
 
-#[test]
-fn keyword_as_name() {
+#[tokio::test]
+async fn keyword_as_name() {
     let input = include_str!("parse_executable_document/fixtures/keyword_as_name.graphql");
     let expected = include_str!("parse_executable_document/fixtures/keyword_as_name.expected");
-    test_fixture(transform_fixture, "keyword_as_name.graphql", "parse_executable_document/fixtures/keyword_as_name.expected", input, expected);
+    test_fixture(transform_fixture, "keyword_as_name.graphql", "parse_executable_document/fixtures/keyword_as_name.expected", input, expected).await;
 }
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("parse_executable_document/fixtures/kitchen-sink.graphql");
     let expected = include_str!("parse_executable_document/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "parse_executable_document/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "parse_executable_document/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn list_of_enum() {
+#[tokio::test]
+async fn list_of_enum() {
     let input = include_str!("parse_executable_document/fixtures/list_of_enum.graphql");
     let expected = include_str!("parse_executable_document/fixtures/list_of_enum.expected");
-    test_fixture(transform_fixture, "list_of_enum.graphql", "parse_executable_document/fixtures/list_of_enum.expected", input, expected);
+    test_fixture(transform_fixture, "list_of_enum.graphql", "parse_executable_document/fixtures/list_of_enum.expected", input, expected).await;
 }
 
-#[test]
-fn missing_zero_on_float_invalid() {
+#[tokio::test]
+async fn missing_zero_on_float_invalid() {
     let input = include_str!("parse_executable_document/fixtures/missing_zero_on_float.invalid.graphql");
     let expected = include_str!("parse_executable_document/fixtures/missing_zero_on_float.invalid.expected");
-    test_fixture(transform_fixture, "missing_zero_on_float.invalid.graphql", "parse_executable_document/fixtures/missing_zero_on_float.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing_zero_on_float.invalid.graphql", "parse_executable_document/fixtures/missing_zero_on_float.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_parse_errors_invalid() {
+#[tokio::test]
+async fn multiple_parse_errors_invalid() {
     let input = include_str!("parse_executable_document/fixtures/multiple_parse_errors.invalid.graphql");
     let expected = include_str!("parse_executable_document/fixtures/multiple_parse_errors.invalid.expected");
-    test_fixture(transform_fixture, "multiple_parse_errors.invalid.graphql", "parse_executable_document/fixtures/multiple_parse_errors.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "multiple_parse_errors.invalid.graphql", "parse_executable_document/fixtures/multiple_parse_errors.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn space_in_variable() {
+#[tokio::test]
+async fn space_in_variable() {
     let input = include_str!("parse_executable_document/fixtures/space_in_variable.graphql");
     let expected = include_str!("parse_executable_document/fixtures/space_in_variable.expected");
-    test_fixture(transform_fixture, "space_in_variable.graphql", "parse_executable_document/fixtures/space_in_variable.expected", input, expected);
+    test_fixture(transform_fixture, "space_in_variable.graphql", "parse_executable_document/fixtures/space_in_variable.expected", input, expected).await;
 }
 
-#[test]
-fn spread_with_arguments_invalid() {
+#[tokio::test]
+async fn spread_with_arguments_invalid() {
     let input = include_str!("parse_executable_document/fixtures/spread_with_arguments.invalid.graphql");
     let expected = include_str!("parse_executable_document/fixtures/spread_with_arguments.invalid.expected");
-    test_fixture(transform_fixture, "spread_with_arguments.invalid.graphql", "parse_executable_document/fixtures/spread_with_arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "spread_with_arguments.invalid.graphql", "parse_executable_document/fixtures/spread_with_arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unterminated_string_invalid() {
+#[tokio::test]
+async fn unterminated_string_invalid() {
     let input = include_str!("parse_executable_document/fixtures/unterminated_string.invalid.graphql");
     let expected = include_str!("parse_executable_document/fixtures/unterminated_string.invalid.expected");
-    test_fixture(transform_fixture, "unterminated_string.invalid.graphql", "parse_executable_document/fixtures/unterminated_string.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unterminated_string.invalid.graphql", "parse_executable_document/fixtures/unterminated_string.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-syntax/tests/parse_executable_document_with_error_recovery/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_executable_document_with_error_recovery/mod.rs
@@ -12,7 +12,7 @@ use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
 use graphql_syntax::parse_executable_with_error_recovery;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let result = parse_executable_with_error_recovery(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/graphql-syntax/tests/parse_executable_document_with_error_recovery_test.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_executable_document_with_error_recovery_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<74f4b149daa4ad7e9564404219116b8d>>
+ * @generated SignedSource<<3496b19a9f5a3e7052fcab60d5e39303>>
  */
 
 mod parse_executable_document_with_error_recovery;
@@ -12,114 +12,114 @@ mod parse_executable_document_with_error_recovery;
 use parse_executable_document_with_error_recovery::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn argument_missing_identifier() {
+#[tokio::test]
+async fn argument_missing_identifier() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-missing-identifier.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-missing-identifier.expected");
-    test_fixture(transform_fixture, "argument-missing-identifier.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-missing-identifier.expected", input, expected);
+    test_fixture(transform_fixture, "argument-missing-identifier.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-missing-identifier.expected", input, expected).await;
 }
 
-#[test]
-fn argument_missing_identifier_2() {
+#[tokio::test]
+async fn argument_missing_identifier_2() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-missing-identifier-2.grahql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-missing-identifier-2.expected");
-    test_fixture(transform_fixture, "argument-missing-identifier-2.grahql", "parse_executable_document_with_error_recovery/fixtures/argument-missing-identifier-2.expected", input, expected);
+    test_fixture(transform_fixture, "argument-missing-identifier-2.grahql", "parse_executable_document_with_error_recovery/fixtures/argument-missing-identifier-2.expected", input, expected).await;
 }
 
-#[test]
-fn argument_missing_value() {
+#[tokio::test]
+async fn argument_missing_value() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-missing-value.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-missing-value.expected");
-    test_fixture(transform_fixture, "argument-missing-value.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-missing-value.expected", input, expected);
+    test_fixture(transform_fixture, "argument-missing-value.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-missing-value.expected", input, expected).await;
 }
 
-#[test]
-fn argument_missing_value_2() {
+#[tokio::test]
+async fn argument_missing_value_2() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-missing-value-2.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-missing-value-2.expected");
-    test_fixture(transform_fixture, "argument-missing-value-2.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-missing-value-2.expected", input, expected);
+    test_fixture(transform_fixture, "argument-missing-value-2.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-missing-value-2.expected", input, expected).await;
 }
 
-#[test]
-fn argument_name_only() {
+#[tokio::test]
+async fn argument_name_only() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-name-only.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-name-only.expected");
-    test_fixture(transform_fixture, "argument-name-only.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-name-only.expected", input, expected);
+    test_fixture(transform_fixture, "argument-name-only.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-name-only.expected", input, expected).await;
 }
 
-#[test]
-fn argument_name_only_2() {
+#[tokio::test]
+async fn argument_name_only_2() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-name-only-2.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-name-only-2.expected");
-    test_fixture(transform_fixture, "argument-name-only-2.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-name-only-2.expected", input, expected);
+    test_fixture(transform_fixture, "argument-name-only-2.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-name-only-2.expected", input, expected).await;
 }
 
-#[test]
-fn argument_value_only() {
+#[tokio::test]
+async fn argument_value_only() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-value-only.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-value-only.expected");
-    test_fixture(transform_fixture, "argument-value-only.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-value-only.expected", input, expected);
+    test_fixture(transform_fixture, "argument-value-only.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-value-only.expected", input, expected).await;
 }
 
-#[test]
-fn argument_value_only_2() {
+#[tokio::test]
+async fn argument_value_only_2() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-value-only-2.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-value-only-2.expected");
-    test_fixture(transform_fixture, "argument-value-only-2.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-value-only-2.expected", input, expected);
+    test_fixture(transform_fixture, "argument-value-only-2.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-value-only-2.expected", input, expected).await;
 }
 
-#[test]
-fn argument_value_only_3() {
+#[tokio::test]
+async fn argument_value_only_3() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-value-only-3.grahql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-value-only-3.expected");
-    test_fixture(transform_fixture, "argument-value-only-3.grahql", "parse_executable_document_with_error_recovery/fixtures/argument-value-only-3.expected", input, expected);
+    test_fixture(transform_fixture, "argument-value-only-3.grahql", "parse_executable_document_with_error_recovery/fixtures/argument-value-only-3.expected", input, expected).await;
 }
 
-#[test]
-fn argument_without_closing_paren() {
+#[tokio::test]
+async fn argument_without_closing_paren() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-without-closing-paren.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/argument-without-closing-paren.expected");
-    test_fixture(transform_fixture, "argument-without-closing-paren.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-without-closing-paren.expected", input, expected);
+    test_fixture(transform_fixture, "argument-without-closing-paren.graphql", "parse_executable_document_with_error_recovery/fixtures/argument-without-closing-paren.expected", input, expected).await;
 }
 
-#[test]
-fn directive_without_name() {
+#[tokio::test]
+async fn directive_without_name() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/directive-without-name.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/directive-without-name.expected");
-    test_fixture(transform_fixture, "directive-without-name.graphql", "parse_executable_document_with_error_recovery/fixtures/directive-without-name.expected", input, expected);
+    test_fixture(transform_fixture, "directive-without-name.graphql", "parse_executable_document_with_error_recovery/fixtures/directive-without-name.expected", input, expected).await;
 }
 
-#[test]
-fn empty_argument_list() {
+#[tokio::test]
+async fn empty_argument_list() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/empty-argument-list.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/empty-argument-list.expected");
-    test_fixture(transform_fixture, "empty-argument-list.graphql", "parse_executable_document_with_error_recovery/fixtures/empty-argument-list.expected", input, expected);
+    test_fixture(transform_fixture, "empty-argument-list.graphql", "parse_executable_document_with_error_recovery/fixtures/empty-argument-list.expected", input, expected).await;
 }
 
-#[test]
-fn empty_linked_field() {
+#[tokio::test]
+async fn empty_linked_field() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/empty-linked-field.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/empty-linked-field.expected");
-    test_fixture(transform_fixture, "empty-linked-field.graphql", "parse_executable_document_with_error_recovery/fixtures/empty-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "empty-linked-field.graphql", "parse_executable_document_with_error_recovery/fixtures/empty-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_without_selection() {
+#[tokio::test]
+async fn inline_fragment_without_selection() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/inline-fragment-without-selection.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/inline-fragment-without-selection.expected");
-    test_fixture(transform_fixture, "inline-fragment-without-selection.graphql", "parse_executable_document_with_error_recovery/fixtures/inline-fragment-without-selection.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-without-selection.graphql", "parse_executable_document_with_error_recovery/fixtures/inline-fragment-without-selection.expected", input, expected).await;
 }
 
-#[test]
-fn type_in_argument_value() {
+#[tokio::test]
+async fn type_in_argument_value() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/type-in-argument-value.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/type-in-argument-value.expected");
-    test_fixture(transform_fixture, "type-in-argument-value.graphql", "parse_executable_document_with_error_recovery/fixtures/type-in-argument-value.expected", input, expected);
+    test_fixture(transform_fixture, "type-in-argument-value.graphql", "parse_executable_document_with_error_recovery/fixtures/type-in-argument-value.expected", input, expected).await;
 }
 
-#[test]
-fn variable_definition_with_directive() {
+#[tokio::test]
+async fn variable_definition_with_directive() {
     let input = include_str!("parse_executable_document_with_error_recovery/fixtures/variable-definition-with-directive.graphql");
     let expected = include_str!("parse_executable_document_with_error_recovery/fixtures/variable-definition-with-directive.expected");
-    test_fixture(transform_fixture, "variable-definition-with-directive.graphql", "parse_executable_document_with_error_recovery/fixtures/variable-definition-with-directive.expected", input, expected);
+    test_fixture(transform_fixture, "variable-definition-with-directive.graphql", "parse_executable_document_with_error_recovery/fixtures/variable-definition-with-directive.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-syntax/tests/parse_schema_document/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_schema_document/mod.rs
@@ -12,7 +12,7 @@ use fixture_tests::Fixture;
 use graphql_cli::DiagnosticPrinter;
 use graphql_syntax::parse_schema_document;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     parse_schema_document(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/graphql-syntax/tests/parse_schema_document_test.rs
+++ b/compiler/crates/graphql-syntax/tests/parse_schema_document_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5807697a03122f4474b041010ef2dc34>>
+ * @generated SignedSource<<527acf1d121ec4ea5e12f1d27955b12b>>
  */
 
 mod parse_schema_document;
@@ -12,37 +12,37 @@ mod parse_schema_document;
 use parse_schema_document::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn directive_description() {
+#[tokio::test]
+async fn directive_description() {
     let input = include_str!("parse_schema_document/fixtures/directive_description.graphql");
     let expected = include_str!("parse_schema_document/fixtures/directive_description.expected");
-    test_fixture(transform_fixture, "directive_description.graphql", "parse_schema_document/fixtures/directive_description.expected", input, expected);
+    test_fixture(transform_fixture, "directive_description.graphql", "parse_schema_document/fixtures/directive_description.expected", input, expected).await;
 }
 
-#[test]
-fn field_description() {
+#[tokio::test]
+async fn field_description() {
     let input = include_str!("parse_schema_document/fixtures/field_description.graphql");
     let expected = include_str!("parse_schema_document/fixtures/field_description.expected");
-    test_fixture(transform_fixture, "field_description.graphql", "parse_schema_document/fixtures/field_description.expected", input, expected);
+    test_fixture(transform_fixture, "field_description.graphql", "parse_schema_document/fixtures/field_description.expected", input, expected).await;
 }
 
-#[test]
-fn schema_kitchen_sink() {
+#[tokio::test]
+async fn schema_kitchen_sink() {
     let input = include_str!("parse_schema_document/fixtures/schema_kitchen_sink.graphql");
     let expected = include_str!("parse_schema_document/fixtures/schema_kitchen_sink.expected");
-    test_fixture(transform_fixture, "schema_kitchen_sink.graphql", "parse_schema_document/fixtures/schema_kitchen_sink.expected", input, expected);
+    test_fixture(transform_fixture, "schema_kitchen_sink.graphql", "parse_schema_document/fixtures/schema_kitchen_sink.expected", input, expected).await;
 }
 
-#[test]
-fn schema_with_leading_comment() {
+#[tokio::test]
+async fn schema_with_leading_comment() {
     let input = include_str!("parse_schema_document/fixtures/schema_with_leading_comment.graphql");
     let expected = include_str!("parse_schema_document/fixtures/schema_with_leading_comment.expected");
-    test_fixture(transform_fixture, "schema_with_leading_comment.graphql", "parse_schema_document/fixtures/schema_with_leading_comment.expected", input, expected);
+    test_fixture(transform_fixture, "schema_with_leading_comment.graphql", "parse_schema_document/fixtures/schema_with_leading_comment.expected", input, expected).await;
 }
 
-#[test]
-fn type_definition() {
+#[tokio::test]
+async fn type_definition() {
     let input = include_str!("parse_schema_document/fixtures/type_definition.graphql");
     let expected = include_str!("parse_schema_document/fixtures/type_definition.expected");
-    test_fixture(transform_fixture, "type_definition.graphql", "parse_schema_document/fixtures/type_definition.expected", input, expected);
+    test_fixture(transform_fixture, "type_definition.graphql", "parse_schema_document/fixtures/type_definition.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-syntax/tests/print/mod.rs
+++ b/compiler/crates/graphql-syntax/tests/print/mod.rs
@@ -9,7 +9,7 @@ use common::SourceLocationKey;
 use fixture_tests::Fixture;
 use graphql_syntax::parse_schema_document;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let type_system_definitions =
         parse_schema_document(fixture.content, SourceLocationKey::generated())
             .expect("Failed to parse definitions")

--- a/compiler/crates/graphql-syntax/tests/print_test.rs
+++ b/compiler/crates/graphql-syntax/tests/print_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e754c9b986474e80e9bc346aa6c77fcd>>
+ * @generated SignedSource<<6ee0c0b1903ff9915b858c3c4a9cf6a5>>
  */
 
 mod print;
@@ -12,9 +12,9 @@ mod print;
 use print::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn schema() {
+#[tokio::test]
+async fn schema() {
     let input = include_str!("print/fixtures/schema.graphql");
     let expected = include_str!("print/fixtures/schema.expected");
-    test_fixture(transform_fixture, "schema.graphql", "print/fixtures/schema.expected", input, expected);
+    test_fixture(transform_fixture, "schema.graphql", "print/fixtures/schema.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-text-printer/Cargo.toml
+++ b/compiler/crates/graphql-text-printer/Cargo.toml
@@ -30,3 +30,4 @@ schema = { path = "../schema" }
 fixture-tests = { path = "../fixture-tests" }
 relay-test-schema = { path = "../relay-test-schema" }
 relay-transforms = { path = "../relay-transforms" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/graphql-text-printer/tests/compact/mod.rs
+++ b/compiler/crates/graphql-text-printer/tests/compact/mod.rs
@@ -19,7 +19,7 @@ use graphql_text_printer::PrinterOptions;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::RelayLocationAgnosticBehavior;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let initial_ast = parse_executable(fixture.content, source_location).unwrap();
     let initial_ir = build(&TEST_SCHEMA, &initial_ast.definitions).unwrap();

--- a/compiler/crates/graphql-text-printer/tests/compact_test.rs
+++ b/compiler/crates/graphql-text-printer/tests/compact_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6d1db34f88e5cb87dff2002fd51965c4>>
+ * @generated SignedSource<<95fee5a83dc7780f12f9c01eeb53489d>>
  */
 
 mod compact;
@@ -12,51 +12,51 @@ mod compact;
 use compact::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn basic_directives() {
+#[tokio::test]
+async fn basic_directives() {
     let input = include_str!("compact/fixtures/basic_directives.graphql");
     let expected = include_str!("compact/fixtures/basic_directives.expected");
-    test_fixture(transform_fixture, "basic_directives.graphql", "compact/fixtures/basic_directives.expected", input, expected);
+    test_fixture(transform_fixture, "basic_directives.graphql", "compact/fixtures/basic_directives.expected", input, expected).await;
 }
 
-#[test]
-fn basic_query() {
+#[tokio::test]
+async fn basic_query() {
     let input = include_str!("compact/fixtures/basic_query.graphql");
     let expected = include_str!("compact/fixtures/basic_query.expected");
-    test_fixture(transform_fixture, "basic_query.graphql", "compact/fixtures/basic_query.expected", input, expected);
+    test_fixture(transform_fixture, "basic_query.graphql", "compact/fixtures/basic_query.expected", input, expected).await;
 }
 
-#[test]
-fn basic_var_defs() {
+#[tokio::test]
+async fn basic_var_defs() {
     let input = include_str!("compact/fixtures/basic_var_defs.graphql");
     let expected = include_str!("compact/fixtures/basic_var_defs.expected");
-    test_fixture(transform_fixture, "basic_var_defs.graphql", "compact/fixtures/basic_var_defs.expected", input, expected);
+    test_fixture(transform_fixture, "basic_var_defs.graphql", "compact/fixtures/basic_var_defs.expected", input, expected).await;
 }
 
-#[test]
-fn compact_test() {
+#[tokio::test]
+async fn compact_test() {
     let input = include_str!("compact/fixtures/compact_test.graphql");
     let expected = include_str!("compact/fixtures/compact_test.expected");
-    test_fixture(transform_fixture, "compact_test.graphql", "compact/fixtures/compact_test.expected", input, expected);
+    test_fixture(transform_fixture, "compact_test.graphql", "compact/fixtures/compact_test.expected", input, expected).await;
 }
 
-#[test]
-fn empty_args() {
+#[tokio::test]
+async fn empty_args() {
     let input = include_str!("compact/fixtures/empty_args.graphql");
     let expected = include_str!("compact/fixtures/empty_args.expected");
-    test_fixture(transform_fixture, "empty_args.graphql", "compact/fixtures/empty_args.expected", input, expected);
+    test_fixture(transform_fixture, "empty_args.graphql", "compact/fixtures/empty_args.expected", input, expected).await;
 }
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("compact/fixtures/kitchen-sink.graphql");
     let expected = include_str!("compact/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "compact/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "compact/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn single_value_array_of_objects() {
+#[tokio::test]
+async fn single_value_array_of_objects() {
     let input = include_str!("compact/fixtures/single-value-array-of-objects.graphql");
     let expected = include_str!("compact/fixtures/single-value-array-of-objects.expected");
-    test_fixture(transform_fixture, "single-value-array-of-objects.graphql", "compact/fixtures/single-value-array-of-objects.expected", input, expected);
+    test_fixture(transform_fixture, "single-value-array-of-objects.graphql", "compact/fixtures/single-value-array-of-objects.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-text-printer/tests/operation_printer/mod.rs
+++ b/compiler/crates/graphql-text-printer/tests/operation_printer/mod.rs
@@ -16,7 +16,7 @@ use graphql_syntax::parse_executable;
 use graphql_text_printer::print_full_operation;
 use relay_test_schema::TEST_SCHEMA;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let ast = parse_executable(fixture.content, source_location).unwrap();
     let ir = build(&TEST_SCHEMA, &ast.definitions).unwrap();

--- a/compiler/crates/graphql-text-printer/tests/operation_printer_test.rs
+++ b/compiler/crates/graphql-text-printer/tests/operation_printer_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7cba6c2fe0d54fa5abd9ec9b9a70bb05>>
+ * @generated SignedSource<<779d1ff1d7269d4933db4447d79a5551>>
  */
 
 mod operation_printer;
@@ -12,37 +12,37 @@ mod operation_printer;
 use operation_printer::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn field_arguments() {
+#[tokio::test]
+async fn field_arguments() {
     let input = include_str!("operation_printer/fixtures/field-arguments.graphql");
     let expected = include_str!("operation_printer/fixtures/field-arguments.expected");
-    test_fixture(transform_fixture, "field-arguments.graphql", "operation_printer/fixtures/field-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "field-arguments.graphql", "operation_printer/fixtures/field-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_queries_with_same_fragment() {
+#[tokio::test]
+async fn multiple_queries_with_same_fragment() {
     let input = include_str!("operation_printer/fixtures/multiple-queries-with-same-fragment.graphql");
     let expected = include_str!("operation_printer/fixtures/multiple-queries-with-same-fragment.expected");
-    test_fixture(transform_fixture, "multiple-queries-with-same-fragment.graphql", "operation_printer/fixtures/multiple-queries-with-same-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-queries-with-same-fragment.graphql", "operation_printer/fixtures/multiple-queries-with-same-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn query_variables() {
+#[tokio::test]
+async fn query_variables() {
     let input = include_str!("operation_printer/fixtures/query-variables.graphql");
     let expected = include_str!("operation_printer/fixtures/query-variables.expected");
-    test_fixture(transform_fixture, "query-variables.graphql", "operation_printer/fixtures/query-variables.expected", input, expected);
+    test_fixture(transform_fixture, "query-variables.graphql", "operation_printer/fixtures/query-variables.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_fragment_spreads() {
+#[tokio::test]
+async fn query_with_fragment_spreads() {
     let input = include_str!("operation_printer/fixtures/query-with-fragment-spreads.graphql");
     let expected = include_str!("operation_printer/fixtures/query-with-fragment-spreads.expected");
-    test_fixture(transform_fixture, "query-with-fragment-spreads.graphql", "operation_printer/fixtures/query-with-fragment-spreads.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-fragment-spreads.graphql", "operation_printer/fixtures/query-with-fragment-spreads.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_nested_fragment_srpeads() {
+#[tokio::test]
+async fn query_with_nested_fragment_srpeads() {
     let input = include_str!("operation_printer/fixtures/query-with-nested-fragment-srpeads.graphql");
     let expected = include_str!("operation_printer/fixtures/query-with-nested-fragment-srpeads.expected");
-    test_fixture(transform_fixture, "query-with-nested-fragment-srpeads.graphql", "operation_printer/fixtures/query-with-nested-fragment-srpeads.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-nested-fragment-srpeads.graphql", "operation_printer/fixtures/query-with-nested-fragment-srpeads.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-text-printer/tests/print/mod.rs
+++ b/compiler/crates/graphql-text-printer/tests/print/mod.rs
@@ -14,7 +14,7 @@ use graphql_syntax::ParserFeatures;
 use graphql_text_printer::print_ir;
 use relay_test_schema::TEST_SCHEMA;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let ast = parse_executable_with_features(
         fixture.content,

--- a/compiler/crates/graphql-text-printer/tests/print_ast/mod.rs
+++ b/compiler/crates/graphql-text-printer/tests/print_ast/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use graphql_syntax::parse_executable;
 use graphql_text_printer::print_executable_definition_ast;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let ast = parse_executable(fixture.content, source_location).unwrap();
 

--- a/compiler/crates/graphql-text-printer/tests/print_ast_test.rs
+++ b/compiler/crates/graphql-text-printer/tests/print_ast_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ac613948ae97fa3d5385399cf284e3fe>>
+ * @generated SignedSource<<2e58248072e7d07bc3acb5c5da29e449>>
  */
 
 mod print_ast;
@@ -12,142 +12,142 @@ mod print_ast;
 use print_ast::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn basic_arg_defs() {
+#[tokio::test]
+async fn basic_arg_defs() {
     let input = include_str!("print_ast/fixtures/basic_arg_defs.graphql");
     let expected = include_str!("print_ast/fixtures/basic_arg_defs.expected");
-    test_fixture(transform_fixture, "basic_arg_defs.graphql", "print_ast/fixtures/basic_arg_defs.expected", input, expected);
+    test_fixture(transform_fixture, "basic_arg_defs.graphql", "print_ast/fixtures/basic_arg_defs.expected", input, expected).await;
 }
 
-#[test]
-fn basic_arg_defs_type() {
+#[tokio::test]
+async fn basic_arg_defs_type() {
     let input = include_str!("print_ast/fixtures/basic_arg_defs_type.graphql");
     let expected = include_str!("print_ast/fixtures/basic_arg_defs_type.expected");
-    test_fixture(transform_fixture, "basic_arg_defs_type.graphql", "print_ast/fixtures/basic_arg_defs_type.expected", input, expected);
+    test_fixture(transform_fixture, "basic_arg_defs_type.graphql", "print_ast/fixtures/basic_arg_defs_type.expected", input, expected).await;
 }
 
-#[test]
-fn basic_directives() {
+#[tokio::test]
+async fn basic_directives() {
     let input = include_str!("print_ast/fixtures/basic_directives.graphql");
     let expected = include_str!("print_ast/fixtures/basic_directives.expected");
-    test_fixture(transform_fixture, "basic_directives.graphql", "print_ast/fixtures/basic_directives.expected", input, expected);
+    test_fixture(transform_fixture, "basic_directives.graphql", "print_ast/fixtures/basic_directives.expected", input, expected).await;
 }
 
-#[test]
-fn basic_fragment() {
+#[tokio::test]
+async fn basic_fragment() {
     let input = include_str!("print_ast/fixtures/basic_fragment.graphql");
     let expected = include_str!("print_ast/fixtures/basic_fragment.expected");
-    test_fixture(transform_fixture, "basic_fragment.graphql", "print_ast/fixtures/basic_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "basic_fragment.graphql", "print_ast/fixtures/basic_fragment.expected", input, expected).await;
 }
 
-#[test]
-fn basic_inline_fragments() {
+#[tokio::test]
+async fn basic_inline_fragments() {
     let input = include_str!("print_ast/fixtures/basic_inline_fragments.graphql");
     let expected = include_str!("print_ast/fixtures/basic_inline_fragments.expected");
-    test_fixture(transform_fixture, "basic_inline_fragments.graphql", "print_ast/fixtures/basic_inline_fragments.expected", input, expected);
+    test_fixture(transform_fixture, "basic_inline_fragments.graphql", "print_ast/fixtures/basic_inline_fragments.expected", input, expected).await;
 }
 
-#[test]
-fn basic_list_object_values() {
+#[tokio::test]
+async fn basic_list_object_values() {
     let input = include_str!("print_ast/fixtures/basic_list_object_values.graphql");
     let expected = include_str!("print_ast/fixtures/basic_list_object_values.expected");
-    test_fixture(transform_fixture, "basic_list_object_values.graphql", "print_ast/fixtures/basic_list_object_values.expected", input, expected);
+    test_fixture(transform_fixture, "basic_list_object_values.graphql", "print_ast/fixtures/basic_list_object_values.expected", input, expected).await;
 }
 
-#[test]
-fn basic_query() {
+#[tokio::test]
+async fn basic_query() {
     let input = include_str!("print_ast/fixtures/basic_query.graphql");
     let expected = include_str!("print_ast/fixtures/basic_query.expected");
-    test_fixture(transform_fixture, "basic_query.graphql", "print_ast/fixtures/basic_query.expected", input, expected);
+    test_fixture(transform_fixture, "basic_query.graphql", "print_ast/fixtures/basic_query.expected", input, expected).await;
 }
 
-#[test]
-fn basic_query_with_float() {
+#[tokio::test]
+async fn basic_query_with_float() {
     let input = include_str!("print_ast/fixtures/basic_query_with_float.graphql");
     let expected = include_str!("print_ast/fixtures/basic_query_with_float.expected");
-    test_fixture(transform_fixture, "basic_query_with_float.graphql", "print_ast/fixtures/basic_query_with_float.expected", input, expected);
+    test_fixture(transform_fixture, "basic_query_with_float.graphql", "print_ast/fixtures/basic_query_with_float.expected", input, expected).await;
 }
 
-#[test]
-fn basic_var_defs() {
+#[tokio::test]
+async fn basic_var_defs() {
     let input = include_str!("print_ast/fixtures/basic_var_defs.graphql");
     let expected = include_str!("print_ast/fixtures/basic_var_defs.expected");
-    test_fixture(transform_fixture, "basic_var_defs.graphql", "print_ast/fixtures/basic_var_defs.expected", input, expected);
+    test_fixture(transform_fixture, "basic_var_defs.graphql", "print_ast/fixtures/basic_var_defs.expected", input, expected).await;
 }
 
-#[test]
-fn basic_var_defs_with_directives() {
+#[tokio::test]
+async fn basic_var_defs_with_directives() {
     let input = include_str!("print_ast/fixtures/basic_var_defs_with_directives.graphql");
     let expected = include_str!("print_ast/fixtures/basic_var_defs_with_directives.expected");
-    test_fixture(transform_fixture, "basic_var_defs_with_directives.graphql", "print_ast/fixtures/basic_var_defs_with_directives.expected", input, expected);
+    test_fixture(transform_fixture, "basic_var_defs_with_directives.graphql", "print_ast/fixtures/basic_var_defs_with_directives.expected", input, expected).await;
 }
 
-#[test]
-fn conditions() {
+#[tokio::test]
+async fn conditions() {
     let input = include_str!("print_ast/fixtures/conditions.graphql");
     let expected = include_str!("print_ast/fixtures/conditions.expected");
-    test_fixture(transform_fixture, "conditions.graphql", "print_ast/fixtures/conditions.expected", input, expected);
+    test_fixture(transform_fixture, "conditions.graphql", "print_ast/fixtures/conditions.expected", input, expected).await;
 }
 
-#[test]
-fn empty_args() {
+#[tokio::test]
+async fn empty_args() {
     let input = include_str!("print_ast/fixtures/empty_args.graphql");
     let expected = include_str!("print_ast/fixtures/empty_args.expected");
-    test_fixture(transform_fixture, "empty_args.graphql", "print_ast/fixtures/empty_args.expected", input, expected);
+    test_fixture(transform_fixture, "empty_args.graphql", "print_ast/fixtures/empty_args.expected", input, expected).await;
 }
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("print_ast/fixtures/kitchen-sink.graphql");
     let expected = include_str!("print_ast/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "print_ast/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "print_ast/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn lowercase_enum_fragment_arg() {
+#[tokio::test]
+async fn lowercase_enum_fragment_arg() {
     let input = include_str!("print_ast/fixtures/lowercase-enum-fragment-arg.graphql");
     let expected = include_str!("print_ast/fixtures/lowercase-enum-fragment-arg.expected");
-    test_fixture(transform_fixture, "lowercase-enum-fragment-arg.graphql", "print_ast/fixtures/lowercase-enum-fragment-arg.expected", input, expected);
+    test_fixture(transform_fixture, "lowercase-enum-fragment-arg.graphql", "print_ast/fixtures/lowercase-enum-fragment-arg.expected", input, expected).await;
 }
 
-#[test]
-fn nested_conditions() {
+#[tokio::test]
+async fn nested_conditions() {
     let input = include_str!("print_ast/fixtures/nested_conditions.graphql");
     let expected = include_str!("print_ast/fixtures/nested_conditions.expected");
-    test_fixture(transform_fixture, "nested_conditions.graphql", "print_ast/fixtures/nested_conditions.expected", input, expected);
+    test_fixture(transform_fixture, "nested_conditions.graphql", "print_ast/fixtures/nested_conditions.expected", input, expected).await;
 }
 
-#[test]
-fn single_value_array_of_objects() {
+#[tokio::test]
+async fn single_value_array_of_objects() {
     let input = include_str!("print_ast/fixtures/single-value-array-of-objects.graphql");
     let expected = include_str!("print_ast/fixtures/single-value-array-of-objects.expected");
-    test_fixture(transform_fixture, "single-value-array-of-objects.graphql", "print_ast/fixtures/single-value-array-of-objects.expected", input, expected);
+    test_fixture(transform_fixture, "single-value-array-of-objects.graphql", "print_ast/fixtures/single-value-array-of-objects.expected", input, expected).await;
 }
 
-#[test]
-fn string_enum_arg_invalid() {
+#[tokio::test]
+async fn string_enum_arg_invalid() {
     let input = include_str!("print_ast/fixtures/string-enum-arg.invalid.graphql");
     let expected = include_str!("print_ast/fixtures/string-enum-arg.invalid.expected");
-    test_fixture(transform_fixture, "string-enum-arg.invalid.graphql", "print_ast/fixtures/string-enum-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "string-enum-arg.invalid.graphql", "print_ast/fixtures/string-enum-arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn string_enum_fragment_arg() {
+#[tokio::test]
+async fn string_enum_fragment_arg() {
     let input = include_str!("print_ast/fixtures/string-enum-fragment-arg.graphql");
     let expected = include_str!("print_ast/fixtures/string-enum-fragment-arg.expected");
-    test_fixture(transform_fixture, "string-enum-fragment-arg.graphql", "print_ast/fixtures/string-enum-fragment-arg.expected", input, expected);
+    test_fixture(transform_fixture, "string-enum-fragment-arg.graphql", "print_ast/fixtures/string-enum-fragment-arg.expected", input, expected).await;
 }
 
-#[test]
-fn string_enum_fragment_arg_with_complex_input() {
+#[tokio::test]
+async fn string_enum_fragment_arg_with_complex_input() {
     let input = include_str!("print_ast/fixtures/string-enum-fragment-arg-with-complex-input.graphql");
     let expected = include_str!("print_ast/fixtures/string-enum-fragment-arg-with-complex-input.expected");
-    test_fixture(transform_fixture, "string-enum-fragment-arg-with-complex-input.graphql", "print_ast/fixtures/string-enum-fragment-arg-with-complex-input.expected", input, expected);
+    test_fixture(transform_fixture, "string-enum-fragment-arg-with-complex-input.graphql", "print_ast/fixtures/string-enum-fragment-arg-with-complex-input.expected", input, expected).await;
 }
 
-#[test]
-fn unknown_enum_arg_invalid() {
+#[tokio::test]
+async fn unknown_enum_arg_invalid() {
     let input = include_str!("print_ast/fixtures/unknown-enum-arg.invalid.graphql");
     let expected = include_str!("print_ast/fixtures/unknown-enum-arg.invalid.expected");
-    test_fixture(transform_fixture, "unknown-enum-arg.invalid.graphql", "print_ast/fixtures/unknown-enum-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unknown-enum-arg.invalid.graphql", "print_ast/fixtures/unknown-enum-arg.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/graphql-text-printer/tests/print_test.rs
+++ b/compiler/crates/graphql-text-printer/tests/print_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d33bba31770d0dda6327e188acc496a6>>
+ * @generated SignedSource<<0c4c23f1eb192cea64b28801e30c2d21>>
  */
 
 mod print;
@@ -12,121 +12,121 @@ mod print;
 use print::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn basic_arg_defs() {
+#[tokio::test]
+async fn basic_arg_defs() {
     let input = include_str!("print/fixtures/basic_arg_defs.graphql");
     let expected = include_str!("print/fixtures/basic_arg_defs.expected");
-    test_fixture(transform_fixture, "basic_arg_defs.graphql", "print/fixtures/basic_arg_defs.expected", input, expected);
+    test_fixture(transform_fixture, "basic_arg_defs.graphql", "print/fixtures/basic_arg_defs.expected", input, expected).await;
 }
 
-#[test]
-fn basic_directives() {
+#[tokio::test]
+async fn basic_directives() {
     let input = include_str!("print/fixtures/basic_directives.graphql");
     let expected = include_str!("print/fixtures/basic_directives.expected");
-    test_fixture(transform_fixture, "basic_directives.graphql", "print/fixtures/basic_directives.expected", input, expected);
+    test_fixture(transform_fixture, "basic_directives.graphql", "print/fixtures/basic_directives.expected", input, expected).await;
 }
 
-#[test]
-fn basic_fragment() {
+#[tokio::test]
+async fn basic_fragment() {
     let input = include_str!("print/fixtures/basic_fragment.graphql");
     let expected = include_str!("print/fixtures/basic_fragment.expected");
-    test_fixture(transform_fixture, "basic_fragment.graphql", "print/fixtures/basic_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "basic_fragment.graphql", "print/fixtures/basic_fragment.expected", input, expected).await;
 }
 
-#[test]
-fn basic_inline_fragments() {
+#[tokio::test]
+async fn basic_inline_fragments() {
     let input = include_str!("print/fixtures/basic_inline_fragments.graphql");
     let expected = include_str!("print/fixtures/basic_inline_fragments.expected");
-    test_fixture(transform_fixture, "basic_inline_fragments.graphql", "print/fixtures/basic_inline_fragments.expected", input, expected);
+    test_fixture(transform_fixture, "basic_inline_fragments.graphql", "print/fixtures/basic_inline_fragments.expected", input, expected).await;
 }
 
-#[test]
-fn basic_list_object_values() {
+#[tokio::test]
+async fn basic_list_object_values() {
     let input = include_str!("print/fixtures/basic_list_object_values.graphql");
     let expected = include_str!("print/fixtures/basic_list_object_values.expected");
-    test_fixture(transform_fixture, "basic_list_object_values.graphql", "print/fixtures/basic_list_object_values.expected", input, expected);
+    test_fixture(transform_fixture, "basic_list_object_values.graphql", "print/fixtures/basic_list_object_values.expected", input, expected).await;
 }
 
-#[test]
-fn basic_query() {
+#[tokio::test]
+async fn basic_query() {
     let input = include_str!("print/fixtures/basic_query.graphql");
     let expected = include_str!("print/fixtures/basic_query.expected");
-    test_fixture(transform_fixture, "basic_query.graphql", "print/fixtures/basic_query.expected", input, expected);
+    test_fixture(transform_fixture, "basic_query.graphql", "print/fixtures/basic_query.expected", input, expected).await;
 }
 
-#[test]
-fn basic_var_defs() {
+#[tokio::test]
+async fn basic_var_defs() {
     let input = include_str!("print/fixtures/basic_var_defs.graphql");
     let expected = include_str!("print/fixtures/basic_var_defs.expected");
-    test_fixture(transform_fixture, "basic_var_defs.graphql", "print/fixtures/basic_var_defs.expected", input, expected);
+    test_fixture(transform_fixture, "basic_var_defs.graphql", "print/fixtures/basic_var_defs.expected", input, expected).await;
 }
 
-#[test]
-fn conditions() {
+#[tokio::test]
+async fn conditions() {
     let input = include_str!("print/fixtures/conditions.graphql");
     let expected = include_str!("print/fixtures/conditions.expected");
-    test_fixture(transform_fixture, "conditions.graphql", "print/fixtures/conditions.expected", input, expected);
+    test_fixture(transform_fixture, "conditions.graphql", "print/fixtures/conditions.expected", input, expected).await;
 }
 
-#[test]
-fn empty_args() {
+#[tokio::test]
+async fn empty_args() {
     let input = include_str!("print/fixtures/empty_args.graphql");
     let expected = include_str!("print/fixtures/empty_args.expected");
-    test_fixture(transform_fixture, "empty_args.graphql", "print/fixtures/empty_args.expected", input, expected);
+    test_fixture(transform_fixture, "empty_args.graphql", "print/fixtures/empty_args.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_variables() {
+#[tokio::test]
+async fn fragment_variables() {
     let input = include_str!("print/fixtures/fragment_variables.graphql");
     let expected = include_str!("print/fixtures/fragment_variables.expected");
-    test_fixture(transform_fixture, "fragment_variables.graphql", "print/fixtures/fragment_variables.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_variables.graphql", "print/fixtures/fragment_variables.expected", input, expected).await;
 }
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("print/fixtures/kitchen-sink.graphql");
     let expected = include_str!("print/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "print/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "print/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn nested_conditions() {
+#[tokio::test]
+async fn nested_conditions() {
     let input = include_str!("print/fixtures/nested_conditions.graphql");
     let expected = include_str!("print/fixtures/nested_conditions.expected");
-    test_fixture(transform_fixture, "nested_conditions.graphql", "print/fixtures/nested_conditions.expected", input, expected);
+    test_fixture(transform_fixture, "nested_conditions.graphql", "print/fixtures/nested_conditions.expected", input, expected).await;
 }
 
-#[test]
-fn single_value_array_of_objects() {
+#[tokio::test]
+async fn single_value_array_of_objects() {
     let input = include_str!("print/fixtures/single-value-array-of-objects.graphql");
     let expected = include_str!("print/fixtures/single-value-array-of-objects.expected");
-    test_fixture(transform_fixture, "single-value-array-of-objects.graphql", "print/fixtures/single-value-array-of-objects.expected", input, expected);
+    test_fixture(transform_fixture, "single-value-array-of-objects.graphql", "print/fixtures/single-value-array-of-objects.expected", input, expected).await;
 }
 
-#[test]
-fn string_enum_arg_invalid() {
+#[tokio::test]
+async fn string_enum_arg_invalid() {
     let input = include_str!("print/fixtures/string-enum-arg.invalid.graphql");
     let expected = include_str!("print/fixtures/string-enum-arg.invalid.expected");
-    test_fixture(transform_fixture, "string-enum-arg.invalid.graphql", "print/fixtures/string-enum-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "string-enum-arg.invalid.graphql", "print/fixtures/string-enum-arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn string_enum_fragment_arg() {
+#[tokio::test]
+async fn string_enum_fragment_arg() {
     let input = include_str!("print/fixtures/string-enum-fragment-arg.graphql");
     let expected = include_str!("print/fixtures/string-enum-fragment-arg.expected");
-    test_fixture(transform_fixture, "string-enum-fragment-arg.graphql", "print/fixtures/string-enum-fragment-arg.expected", input, expected);
+    test_fixture(transform_fixture, "string-enum-fragment-arg.graphql", "print/fixtures/string-enum-fragment-arg.expected", input, expected).await;
 }
 
-#[test]
-fn string_enum_fragment_arg_with_complex_input() {
+#[tokio::test]
+async fn string_enum_fragment_arg_with_complex_input() {
     let input = include_str!("print/fixtures/string-enum-fragment-arg-with-complex-input.graphql");
     let expected = include_str!("print/fixtures/string-enum-fragment-arg-with-complex-input.expected");
-    test_fixture(transform_fixture, "string-enum-fragment-arg-with-complex-input.graphql", "print/fixtures/string-enum-fragment-arg-with-complex-input.expected", input, expected);
+    test_fixture(transform_fixture, "string-enum-fragment-arg-with-complex-input.graphql", "print/fixtures/string-enum-fragment-arg-with-complex-input.expected", input, expected).await;
 }
 
-#[test]
-fn unknown_enum_arg_invalid() {
+#[tokio::test]
+async fn unknown_enum_arg_invalid() {
     let input = include_str!("print/fixtures/unknown-enum-arg.invalid.graphql");
     let expected = include_str!("print/fixtures/unknown-enum-arg.invalid.expected");
-    test_fixture(transform_fixture, "unknown-enum-arg.invalid.graphql", "print/fixtures/unknown-enum-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unknown-enum-arg.invalid.graphql", "print/fixtures/unknown-enum-arg.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/Cargo.toml
+++ b/compiler/crates/relay-codegen/Cargo.toml
@@ -52,3 +52,4 @@ schema = { path = "../schema" }
 fixture-tests = { path = "../fixture-tests" }
 graphql-test-helpers = { path = "../graphql-test-helpers" }
 relay-test-schema = { path = "../relay-test-schema" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/relay-codegen/tests/aliased_fragments/mod.rs
+++ b/compiler/crates/relay-codegen/tests/aliased_fragments/mod.rs
@@ -21,7 +21,7 @@ use relay_config::ProjectConfig;
 use relay_test_schema::get_test_schema;
 use relay_transforms::fragment_alias_directive;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let base = fixture.content;
     let schema = get_test_schema();
 

--- a/compiler/crates/relay-codegen/tests/aliased_fragments_test.rs
+++ b/compiler/crates/relay-codegen/tests/aliased_fragments_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<82605c02b8c64d2e0d4b47e0e3b61579>>
+ * @generated SignedSource<<ef4dc6cec444448350b14fb2f6e7d3e4>>
  */
 
 mod aliased_fragments;
@@ -12,23 +12,23 @@ mod aliased_fragments;
 use aliased_fragments::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn aliased_fragment_on_abstract_type() {
+#[tokio::test]
+async fn aliased_fragment_on_abstract_type() {
     let input = include_str!("aliased_fragments/fixtures/aliased_fragment_on_abstract_type.graphql");
     let expected = include_str!("aliased_fragments/fixtures/aliased_fragment_on_abstract_type.expected");
-    test_fixture(transform_fixture, "aliased_fragment_on_abstract_type.graphql", "aliased_fragments/fixtures/aliased_fragment_on_abstract_type.expected", input, expected);
+    test_fixture(transform_fixture, "aliased_fragment_on_abstract_type.graphql", "aliased_fragments/fixtures/aliased_fragment_on_abstract_type.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_fragment_spread() {
+#[tokio::test]
+async fn aliased_fragment_spread() {
     let input = include_str!("aliased_fragments/fixtures/aliased_fragment_spread.graphql");
     let expected = include_str!("aliased_fragments/fixtures/aliased_fragment_spread.expected");
-    test_fixture(transform_fixture, "aliased_fragment_spread.graphql", "aliased_fragments/fixtures/aliased_fragment_spread.expected", input, expected);
+    test_fixture(transform_fixture, "aliased_fragment_spread.graphql", "aliased_fragments/fixtures/aliased_fragment_spread.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_spread() {
+#[tokio::test]
+async fn aliased_inline_fragment_spread() {
     let input = include_str!("aliased_fragments/fixtures/aliased_inline_fragment_spread.graphql");
     let expected = include_str!("aliased_fragments/fixtures/aliased_inline_fragment_spread.expected");
-    test_fixture(transform_fixture, "aliased_inline_fragment_spread.graphql", "aliased_fragments/fixtures/aliased_inline_fragment_spread.expected", input, expected);
+    test_fixture(transform_fixture, "aliased_inline_fragment_spread.graphql", "aliased_fragments/fixtures/aliased_inline_fragment_spread.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/client_edges/mod.rs
+++ b/compiler/crates/relay-codegen/tests/client_edges/mod.rs
@@ -24,7 +24,7 @@ use relay_transforms::client_edges;
 use relay_transforms::relay_resolvers;
 use relay_transforms::sort_selections;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     if let [base, extensions] = parts.as_slice() {
         let ast = parse_executable(base, SourceLocationKey::standalone(fixture.file_name)).unwrap();

--- a/compiler/crates/relay-codegen/tests/client_edges_test.rs
+++ b/compiler/crates/relay-codegen/tests/client_edges_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<dd56e861b0bff2823f35d73903e01dc6>>
+ * @generated SignedSource<<59e0ffd32b5ef091295aa6a0a83d0b5f>>
  */
 
 mod client_edges;
@@ -12,30 +12,30 @@ mod client_edges;
 use client_edges::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn client_edge_backed_by_resolver() {
+#[tokio::test]
+async fn client_edge_backed_by_resolver() {
     let input = include_str!("client_edges/fixtures/client-edge-backed-by-resolver.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-backed-by-resolver.expected");
-    test_fixture(transform_fixture, "client-edge-backed-by-resolver.graphql", "client_edges/fixtures/client-edge-backed-by-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-backed-by-resolver.graphql", "client_edges/fixtures/client-edge-backed-by-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_to_client_object() {
+#[tokio::test]
+async fn client_edge_to_client_object() {
     let input = include_str!("client_edges/fixtures/client-edge-to-client-object.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-to-client-object.expected");
-    test_fixture(transform_fixture, "client-edge-to-client-object.graphql", "client_edges/fixtures/client-edge-to-client-object.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-to-client-object.graphql", "client_edges/fixtures/client-edge-to-client-object.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_to_plural_client_object() {
+#[tokio::test]
+async fn client_edge_to_plural_client_object() {
     let input = include_str!("client_edges/fixtures/client-edge-to-plural-client-object.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-to-plural-client-object.expected");
-    test_fixture(transform_fixture, "client-edge-to-plural-client-object.graphql", "client_edges/fixtures/client-edge-to-plural-client-object.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-to-plural-client-object.graphql", "client_edges/fixtures/client-edge-to-plural-client-object.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_field_and_fragment_args() {
+#[tokio::test]
+async fn relay_resolver_field_and_fragment_args() {
     let input = include_str!("client_edges/fixtures/relay-resolver-field-and-fragment-args.graphql");
     let expected = include_str!("client_edges/fixtures/relay-resolver-field-and-fragment-args.expected");
-    test_fixture(transform_fixture, "relay-resolver-field-and-fragment-args.graphql", "client_edges/fixtures/relay-resolver-field-and-fragment-args.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-field-and-fragment-args.graphql", "client_edges/fixtures/relay-resolver-field-and-fragment-args.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/client_extensions/mod.rs
+++ b/compiler/crates/relay-codegen/tests/client_extensions/mod.rs
@@ -20,7 +20,7 @@ use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::client_extensions;
 use relay_transforms::sort_selections;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     if let [base, extensions] = parts.as_slice() {
         let ast = parse_executable(base, SourceLocationKey::standalone(fixture.file_name)).unwrap();

--- a/compiler/crates/relay-codegen/tests/client_extensions_abstract_types/mod.rs
+++ b/compiler/crates/relay-codegen/tests/client_extensions_abstract_types/mod.rs
@@ -20,7 +20,7 @@ use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::client_extensions_abstract_types;
 use relay_transforms::sort_selections;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     if let [base, extensions] = parts.as_slice() {
         let ast = parse_executable(base, SourceLocationKey::standalone(fixture.file_name)).unwrap();

--- a/compiler/crates/relay-codegen/tests/client_extensions_abstract_types_test.rs
+++ b/compiler/crates/relay-codegen/tests/client_extensions_abstract_types_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e5c24b5453bde4b099eb2517e15d853f>>
+ * @generated SignedSource<<63af903d78866a0666372e89b633a412>>
  */
 
 mod client_extensions_abstract_types;
@@ -12,30 +12,30 @@ mod client_extensions_abstract_types;
 use client_extensions_abstract_types::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_spread_on_client_interface() {
+#[tokio::test]
+async fn fragment_spread_on_client_interface() {
     let input = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface.graphql");
     let expected = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface.expected");
-    test_fixture(transform_fixture, "fragment_spread_on_client_interface.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_spread_on_client_interface.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread_on_client_interface_transitively() {
+#[tokio::test]
+async fn fragment_spread_on_client_interface_transitively() {
     let input = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface_transitively.graphql");
     let expected = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface_transitively.expected");
-    test_fixture(transform_fixture, "fragment_spread_on_client_interface_transitively.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface_transitively.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_spread_on_client_interface_transitively.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface_transitively.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread_on_client_union() {
+#[tokio::test]
+async fn fragment_spread_on_client_union() {
     let input = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_union.graphql");
     let expected = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_union.expected");
-    test_fixture(transform_fixture, "fragment_spread_on_client_union.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_union.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_spread_on_client_union.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_union.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_client_interface() {
+#[tokio::test]
+async fn inline_fragment_on_client_interface() {
     let input = include_str!("client_extensions_abstract_types/fixtures/inline_fragment_on_client_interface.graphql");
     let expected = include_str!("client_extensions_abstract_types/fixtures/inline_fragment_on_client_interface.expected");
-    test_fixture(transform_fixture, "inline_fragment_on_client_interface.graphql", "client_extensions_abstract_types/fixtures/inline_fragment_on_client_interface.expected", input, expected);
+    test_fixture(transform_fixture, "inline_fragment_on_client_interface.graphql", "client_extensions_abstract_types/fixtures/inline_fragment_on_client_interface.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/client_extensions_test.rs
+++ b/compiler/crates/relay-codegen/tests/client_extensions_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9a35afd125f7a2bbdee5bdb73d9c90f2>>
+ * @generated SignedSource<<043978d7302a827dee13fb1b46b27584>>
  */
 
 mod client_extensions;
@@ -12,30 +12,30 @@ mod client_extensions;
 use client_extensions::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn client_conditions() {
+#[tokio::test]
+async fn client_conditions() {
     let input = include_str!("client_extensions/fixtures/client-conditions.graphql");
     let expected = include_str!("client_extensions/fixtures/client-conditions.expected");
-    test_fixture(transform_fixture, "client-conditions.graphql", "client_extensions/fixtures/client-conditions.expected", input, expected);
+    test_fixture(transform_fixture, "client-conditions.graphql", "client_extensions/fixtures/client-conditions.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_in_inline_fragments() {
+#[tokio::test]
+async fn client_fields_in_inline_fragments() {
     let input = include_str!("client_extensions/fixtures/client-fields-in-inline-fragments.graphql");
     let expected = include_str!("client_extensions/fixtures/client-fields-in-inline-fragments.expected");
-    test_fixture(transform_fixture, "client-fields-in-inline-fragments.graphql", "client_extensions/fixtures/client-fields-in-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-in-inline-fragments.graphql", "client_extensions/fixtures/client-fields-in-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_on_roots() {
+#[tokio::test]
+async fn client_fields_on_roots() {
     let input = include_str!("client_extensions/fixtures/client-fields-on-roots.graphql");
     let expected = include_str!("client_extensions/fixtures/client-fields-on-roots.expected");
-    test_fixture(transform_fixture, "client-fields-on-roots.graphql", "client_extensions/fixtures/client-fields-on-roots.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-on-roots.graphql", "client_extensions/fixtures/client-fields-on-roots.expected", input, expected).await;
 }
 
-#[test]
-fn sibling_client_selections() {
+#[tokio::test]
+async fn sibling_client_selections() {
     let input = include_str!("client_extensions/fixtures/sibling-client-selections.graphql");
     let expected = include_str!("client_extensions/fixtures/sibling-client-selections.expected");
-    test_fixture(transform_fixture, "sibling-client-selections.graphql", "client_extensions/fixtures/sibling-client-selections.expected", input, expected);
+    test_fixture(transform_fixture, "sibling-client-selections.graphql", "client_extensions/fixtures/sibling-client-selections.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/connections/mod.rs
+++ b/compiler/crates/relay-codegen/tests/connections/mod.rs
@@ -24,7 +24,7 @@ use relay_transforms::transform_connections;
 use relay_transforms::validate_connections;
 use relay_transforms::ConnectionInterface;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let project_config = ProjectConfig {
         js_module_format: JsModuleFormat::Haste,
         ..Default::default()

--- a/compiler/crates/relay-codegen/tests/connections_test.rs
+++ b/compiler/crates/relay-codegen/tests/connections_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<44a8c537a98a80a74d430701a2fb3bd8>>
+ * @generated SignedSource<<0d71cf64a4e19d3710a2db4104edd4eb>>
  */
 
 mod connections;
@@ -12,65 +12,65 @@ mod connections;
 use connections::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn connection() {
+#[tokio::test]
+async fn connection() {
     let input = include_str!("connections/fixtures/connection.graphql");
     let expected = include_str!("connections/fixtures/connection.expected");
-    test_fixture(transform_fixture, "connection.graphql", "connections/fixtures/connection.expected", input, expected);
+    test_fixture(transform_fixture, "connection.graphql", "connections/fixtures/connection.expected", input, expected).await;
 }
 
-#[test]
-fn connection_directions() {
+#[tokio::test]
+async fn connection_directions() {
     let input = include_str!("connections/fixtures/connection-directions.graphql");
     let expected = include_str!("connections/fixtures/connection-directions.expected");
-    test_fixture(transform_fixture, "connection-directions.graphql", "connections/fixtures/connection-directions.expected", input, expected);
+    test_fixture(transform_fixture, "connection-directions.graphql", "connections/fixtures/connection-directions.expected", input, expected).await;
 }
 
-#[test]
-fn connection_empty_filters() {
+#[tokio::test]
+async fn connection_empty_filters() {
     let input = include_str!("connections/fixtures/connection-empty-filters.graphql");
     let expected = include_str!("connections/fixtures/connection-empty-filters.expected");
-    test_fixture(transform_fixture, "connection-empty-filters.graphql", "connections/fixtures/connection-empty-filters.expected", input, expected);
+    test_fixture(transform_fixture, "connection-empty-filters.graphql", "connections/fixtures/connection-empty-filters.expected", input, expected).await;
 }
 
-#[test]
-fn connection_filters() {
+#[tokio::test]
+async fn connection_filters() {
     let input = include_str!("connections/fixtures/connection-filters.graphql");
     let expected = include_str!("connections/fixtures/connection-filters.expected");
-    test_fixture(transform_fixture, "connection-filters.graphql", "connections/fixtures/connection-filters.expected", input, expected);
+    test_fixture(transform_fixture, "connection-filters.graphql", "connections/fixtures/connection-filters.expected", input, expected).await;
 }
 
-#[test]
-fn connection_generate_filters() {
+#[tokio::test]
+async fn connection_generate_filters() {
     let input = include_str!("connections/fixtures/connection-generate-filters.graphql");
     let expected = include_str!("connections/fixtures/connection-generate-filters.expected");
-    test_fixture(transform_fixture, "connection-generate-filters.graphql", "connections/fixtures/connection-generate-filters.expected", input, expected);
+    test_fixture(transform_fixture, "connection-generate-filters.graphql", "connections/fixtures/connection-generate-filters.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_aliased_edges_page_info() {
+#[tokio::test]
+async fn connection_with_aliased_edges_page_info() {
     let input = include_str!("connections/fixtures/connection-with-aliased-edges-page-info.graphql");
     let expected = include_str!("connections/fixtures/connection-with-aliased-edges-page-info.expected");
-    test_fixture(transform_fixture, "connection-with-aliased-edges-page-info.graphql", "connections/fixtures/connection-with-aliased-edges-page-info.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-aliased-edges-page-info.graphql", "connections/fixtures/connection-with-aliased-edges-page-info.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_custom_handler() {
+#[tokio::test]
+async fn connection_with_custom_handler() {
     let input = include_str!("connections/fixtures/connection-with-custom-handler.graphql");
     let expected = include_str!("connections/fixtures/connection-with-custom-handler.expected");
-    test_fixture(transform_fixture, "connection-with-custom-handler.graphql", "connections/fixtures/connection-with-custom-handler.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-custom-handler.graphql", "connections/fixtures/connection-with-custom-handler.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_page_info() {
+#[tokio::test]
+async fn connection_with_page_info() {
     let input = include_str!("connections/fixtures/connection-with-page-info.graphql");
     let expected = include_str!("connections/fixtures/connection-with-page-info.expected");
-    test_fixture(transform_fixture, "connection-with-page-info.graphql", "connections/fixtures/connection-with-page-info.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-page-info.graphql", "connections/fixtures/connection-with-page-info.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_variables() {
+#[tokio::test]
+async fn connection_with_variables() {
     let input = include_str!("connections/fixtures/connection-with-variables.graphql");
     let expected = include_str!("connections/fixtures/connection-with-variables.expected");
-    test_fixture(transform_fixture, "connection-with-variables.graphql", "connections/fixtures/connection-with-variables.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-variables.graphql", "connections/fixtures/connection-with-variables.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/deduped_json_codegen/mod.rs
+++ b/compiler/crates/relay-codegen/tests/deduped_json_codegen/mod.rs
@@ -14,7 +14,7 @@ use relay_codegen::Printer;
 use relay_config::ProjectConfig;
 use relay_test_schema::TEST_SCHEMA;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let project_config = ProjectConfig {
         js_module_format: JsModuleFormat::Haste,
         ..Default::default()

--- a/compiler/crates/relay-codegen/tests/deduped_json_codegen_test.rs
+++ b/compiler/crates/relay-codegen/tests/deduped_json_codegen_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8c1491751a56c21d043d0a431f86d2cb>>
+ * @generated SignedSource<<5396bb129a2ed677dcb74745c7b414e5>>
  */
 
 mod deduped_json_codegen;
@@ -12,23 +12,23 @@ mod deduped_json_codegen;
 use deduped_json_codegen::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("deduped_json_codegen/fixtures/kitchen-sink.graphql");
     let expected = include_str!("deduped_json_codegen/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "deduped_json_codegen/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "deduped_json_codegen/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn stable_literals() {
+#[tokio::test]
+async fn stable_literals() {
     let input = include_str!("deduped_json_codegen/fixtures/stable-literals.graphql");
     let expected = include_str!("deduped_json_codegen/fixtures/stable-literals.expected");
-    test_fixture(transform_fixture, "stable-literals.graphql", "deduped_json_codegen/fixtures/stable-literals.expected", input, expected);
+    test_fixture(transform_fixture, "stable-literals.graphql", "deduped_json_codegen/fixtures/stable-literals.expected", input, expected).await;
 }
 
-#[test]
-fn stable_literals_duplicates() {
+#[tokio::test]
+async fn stable_literals_duplicates() {
     let input = include_str!("deduped_json_codegen/fixtures/stable-literals-duplicates.graphql");
     let expected = include_str!("deduped_json_codegen/fixtures/stable-literals-duplicates.expected");
-    test_fixture(transform_fixture, "stable-literals-duplicates.graphql", "deduped_json_codegen/fixtures/stable-literals-duplicates.expected", input, expected);
+    test_fixture(transform_fixture, "stable-literals-duplicates.graphql", "deduped_json_codegen/fixtures/stable-literals-duplicates.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/defer_stream/mod.rs
+++ b/compiler/crates/relay-codegen/tests/defer_stream/mod.rs
@@ -20,7 +20,7 @@ use relay_test_schema::get_test_schema;
 use relay_transforms::sort_selections;
 use relay_transforms::transform_defer_stream;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let ast = parse_executable(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/relay-codegen/tests/defer_stream_test.rs
+++ b/compiler/crates/relay-codegen/tests/defer_stream_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fdc5d4fcae9d2796db625c70fdb644eb>>
+ * @generated SignedSource<<42234d6da86bc8752f2d982c8dfd13d3>>
  */
 
 mod defer_stream;
@@ -12,16 +12,16 @@ mod defer_stream;
 use defer_stream::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_with_defer_default_label() {
+#[tokio::test]
+async fn fragment_with_defer_default_label() {
     let input = include_str!("defer_stream/fixtures/fragment-with-defer-default-label.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-defer-default-label.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-default-label.graphql", "defer_stream/fixtures/fragment-with-defer-default-label.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-default-label.graphql", "defer_stream/fixtures/fragment-with-defer-default-label.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_default_label() {
+#[tokio::test]
+async fn fragment_with_stream_default_label() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-default-label.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-default-label.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-default-label.graphql", "defer_stream/fixtures/fragment-with-stream-default-label.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-default-label.graphql", "defer_stream/fixtures/fragment-with-stream-default-label.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/json_codegen/mod.rs
+++ b/compiler/crates/relay-codegen/tests/json_codegen/mod.rs
@@ -16,7 +16,7 @@ use relay_codegen::JsModuleFormat;
 use relay_config::ProjectConfig;
 use relay_test_schema::TEST_SCHEMA;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let ast = parse_executable(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/relay-codegen/tests/json_codegen_test.rs
+++ b/compiler/crates/relay-codegen/tests/json_codegen_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c76fde417081b2595591a1ffa8f5fa64>>
+ * @generated SignedSource<<2be2d03ad0abd59a3759d6b5cbf7e6e5>>
  */
 
 mod json_codegen;
@@ -12,16 +12,16 @@ mod json_codegen;
 use json_codegen::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("json_codegen/fixtures/kitchen-sink.graphql");
     let expected = include_str!("json_codegen/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "json_codegen/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "json_codegen/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn stable_literals() {
+#[tokio::test]
+async fn stable_literals() {
     let input = include_str!("json_codegen/fixtures/stable-literals.graphql");
     let expected = include_str!("json_codegen/fixtures/stable-literals.expected");
-    test_fixture(transform_fixture, "stable-literals.graphql", "json_codegen/fixtures/stable-literals.expected", input, expected);
+    test_fixture(transform_fixture, "stable-literals.graphql", "json_codegen/fixtures/stable-literals.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/relay_actor_change/mod.rs
+++ b/compiler/crates/relay-codegen/tests/relay_actor_change/mod.rs
@@ -21,7 +21,7 @@ use relay_config::ProjectConfig;
 use relay_test_schema::get_test_schema;
 use relay_transforms::relay_actor_change_transform;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let ast = parse_executable(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/relay-codegen/tests/relay_actor_change_test.rs
+++ b/compiler/crates/relay-codegen/tests/relay_actor_change_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<346e464f90b119168d614671e5aa003e>>
+ * @generated SignedSource<<0c6036c8c21574a8526657883ea1d95d>>
  */
 
 mod relay_actor_change;
@@ -12,9 +12,9 @@ mod relay_actor_change;
 use relay_actor_change::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn relay_actor_change_simple_query() {
+#[tokio::test]
+async fn relay_actor_change_simple_query() {
     let input = include_str!("relay_actor_change/fixtures/relay_actor_change-simple-query.graphql");
     let expected = include_str!("relay_actor_change/fixtures/relay_actor_change-simple-query.expected");
-    test_fixture(transform_fixture, "relay_actor_change-simple-query.graphql", "relay_actor_change/fixtures/relay_actor_change-simple-query.expected", input, expected);
+    test_fixture(transform_fixture, "relay_actor_change-simple-query.graphql", "relay_actor_change/fixtures/relay_actor_change-simple-query.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/request_metadata/mod.rs
+++ b/compiler/crates/relay-codegen/tests/request_metadata/mod.rs
@@ -28,7 +28,7 @@ use relay_codegen::JsModuleFormat;
 use relay_config::ProjectConfig;
 use relay_test_schema::TEST_SCHEMA;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let ast = parse_executable(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/relay-codegen/tests/request_metadata_test.rs
+++ b/compiler/crates/relay-codegen/tests/request_metadata_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<876b7ae96c21e9c336b8c69eab102066>>
+ * @generated SignedSource<<1636a306a81073fb1fbe0383dff25209>>
  */
 
 mod request_metadata;
@@ -12,9 +12,9 @@ mod request_metadata;
 use request_metadata::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn valid_documents() {
+#[tokio::test]
+async fn valid_documents() {
     let input = include_str!("request_metadata/fixtures/valid-documents.graphql");
     let expected = include_str!("request_metadata/fixtures/valid-documents.expected");
-    test_fixture(transform_fixture, "valid-documents.graphql", "request_metadata/fixtures/valid-documents.expected", input, expected);
+    test_fixture(transform_fixture, "valid-documents.graphql", "request_metadata/fixtures/valid-documents.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/required_directive_codegen/mod.rs
+++ b/compiler/crates/relay-codegen/tests/required_directive_codegen/mod.rs
@@ -21,7 +21,7 @@ use relay_test_schema::get_test_schema;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::required_directive;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     let (base, schema) = match parts.as_slice() {
         [base, extensions] => (base, get_test_schema_with_extensions(extensions)),

--- a/compiler/crates/relay-codegen/tests/required_directive_codegen_test.rs
+++ b/compiler/crates/relay-codegen/tests/required_directive_codegen_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d7f6b07657a47f42fd7e757781d23210>>
+ * @generated SignedSource<<b92e818e9a3cf703711f64b459b67c1a>>
  */
 
 mod required_directive_codegen;
@@ -12,16 +12,16 @@ mod required_directive_codegen;
 use required_directive_codegen::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn required_directive() {
+#[tokio::test]
+async fn required_directive() {
     let input = include_str!("required_directive_codegen/fixtures/required_directive.graphql");
     let expected = include_str!("required_directive_codegen/fixtures/required_directive.expected");
-    test_fixture(transform_fixture, "required_directive.graphql", "required_directive_codegen/fixtures/required_directive.expected", input, expected);
+    test_fixture(transform_fixture, "required_directive.graphql", "required_directive_codegen/fixtures/required_directive.expected", input, expected).await;
 }
 
-#[test]
-fn required_linked_field() {
+#[tokio::test]
+async fn required_linked_field() {
     let input = include_str!("required_directive_codegen/fixtures/required_linked_field.graphql");
     let expected = include_str!("required_directive_codegen/fixtures/required_linked_field.expected");
-    test_fixture(transform_fixture, "required_linked_field.graphql", "required_directive_codegen/fixtures/required_linked_field.expected", input, expected);
+    test_fixture(transform_fixture, "required_linked_field.graphql", "required_directive_codegen/fixtures/required_linked_field.expected", input, expected).await;
 }

--- a/compiler/crates/relay-codegen/tests/skip_printing_nulls/mod.rs
+++ b/compiler/crates/relay-codegen/tests/skip_printing_nulls/mod.rs
@@ -19,7 +19,7 @@ use relay_codegen::print_operation;
 use relay_config::ProjectConfig;
 use relay_test_schema::TEST_SCHEMA;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let ast = parse_executable(
         fixture.content,
         SourceLocationKey::standalone(fixture.file_name),

--- a/compiler/crates/relay-codegen/tests/skip_printing_nulls_test.rs
+++ b/compiler/crates/relay-codegen/tests/skip_printing_nulls_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<664b28507e153b2bcb16860b7d2119c3>>
+ * @generated SignedSource<<b33bb86ad6bae7fd661e19cab59650cf>>
  */
 
 mod skip_printing_nulls;
@@ -12,9 +12,9 @@ mod skip_printing_nulls;
 use skip_printing_nulls::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("skip_printing_nulls/fixtures/kitchen-sink.graphql");
     let expected = include_str!("skip_printing_nulls/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "skip_printing_nulls/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "skip_printing_nulls/fixtures/kitchen-sink.expected", input, expected).await;
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/mod.rs
@@ -44,7 +44,7 @@ use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::apply_transforms;
 use relay_transforms::DIRECTIVE_SPLIT_OPERATION;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     if fixture.content.contains("%TODO%") {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<11f5c357cbf50e7a7e17cbcced1fca1a>>
+ * @generated SignedSource<<3500dcb867d80cd51e9dc7cad71006c2>>
  */
 
 mod compile_relay_artifacts;
@@ -12,1766 +12,1766 @@ mod compile_relay_artifacts;
 use compile_relay_artifacts::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn abstract_type_refinement() {
+#[tokio::test]
+async fn abstract_type_refinement() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_flatten_type_discriminator_fragment_spread() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_flatten_type_discriminator_fragment_spread() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_flatten_type_discriminator_fragment_spread_conditional() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_flatten_type_discriminator_fragment_spread_conditional() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_flatten_type_discriminator_inline_fragment() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_flatten_type_discriminator_inline_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_flatten_type_discriminator_inline_fragment_conditional() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_flatten_type_discriminator_inline_fragment_conditional() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment-conditional.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment-conditional.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment-conditional.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment-conditional.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment-conditional.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-inline-fragment-conditional.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_flatten_type_discriminator_nested_fragment_spread() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_flatten_type_discriminator_nested_fragment_spread() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_flatten_type_discriminator_nested_fragment_spread_within_inline_fragment() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_flatten_type_discriminator_nested_fragment_spread_within_inline_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_flatten_type_discriminator_nested_fragment_spread_within_inline_fragment_different_fields() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_flatten_type_discriminator_nested_fragment_spread_within_inline_fragment_different_fields() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment-different-fields.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment-different-fields.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment-different-fields.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment-different-fields.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment-different-fields.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-fragment-spread-within-inline-fragment-different-fields.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_flatten_type_discriminator_nested_inline_fragment() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_flatten_type_discriminator_nested_inline_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-inline-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-inline-fragment.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-nested-inline-fragment.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-flatten-type-discriminator-nested-inline-fragment.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-nested-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_skip_type_discriminator_fragment_spread() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_skip_type_discriminator_fragment_spread() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_skip_type_discriminator_inline_fragment() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_skip_type_discriminator_inline_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_dont_skip_type_discriminator_when_identical_selections() {
+#[tokio::test]
+async fn abstract_type_refinement_dont_skip_type_discriminator_when_identical_selections() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-when-identical-selections.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-when-identical-selections.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-dont-skip-type-discriminator-when-identical-selections.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-when-identical-selections.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-dont-skip-type-discriminator-when-identical-selections.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-when-identical-selections.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_type_refinement_no_unnecessary_type_discriminator_under_condition_incorrect() {
+#[tokio::test]
+async fn abstract_type_refinement_no_unnecessary_type_discriminator_under_condition_incorrect() {
     let input = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-no-unnecessary-type-discriminator-under-condition_incorrect.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/abstract-type-refinement-no-unnecessary-type-discriminator-under-condition_incorrect.expected");
-    test_fixture(transform_fixture, "abstract-type-refinement-no-unnecessary-type-discriminator-under-condition_incorrect.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-no-unnecessary-type-discriminator-under-condition_incorrect.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-type-refinement-no-unnecessary-type-discriminator-under-condition_incorrect.graphql", "compile_relay_artifacts/fixtures/abstract-type-refinement-no-unnecessary-type-discriminator-under-condition_incorrect.expected", input, expected).await;
 }
 
-#[test]
-fn actor_change_simple_query() {
+#[tokio::test]
+async fn actor_change_simple_query() {
     let input = include_str!("compile_relay_artifacts/fixtures/actor-change-simple-query.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/actor-change-simple-query.expected");
-    test_fixture(transform_fixture, "actor-change-simple-query.graphql", "compile_relay_artifacts/fixtures/actor-change-simple-query.expected", input, expected);
+    test_fixture(transform_fixture, "actor-change-simple-query.graphql", "compile_relay_artifacts/fixtures/actor-change-simple-query.expected", input, expected).await;
 }
 
-#[test]
-fn alias_same_as_name() {
+#[tokio::test]
+async fn alias_same_as_name() {
     let input = include_str!("compile_relay_artifacts/fixtures/alias-same-as-name.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/alias-same-as-name.expected");
-    test_fixture(transform_fixture, "alias-same-as-name.graphql", "compile_relay_artifacts/fixtures/alias-same-as-name.expected", input, expected);
+    test_fixture(transform_fixture, "alias-same-as-name.graphql", "compile_relay_artifacts/fixtures/alias-same-as-name.expected", input, expected).await;
 }
 
-#[test]
-fn append_edge() {
+#[tokio::test]
+async fn append_edge() {
     let input = include_str!("compile_relay_artifacts/fixtures/append-edge.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/append-edge.expected");
-    test_fixture(transform_fixture, "append-edge.graphql", "compile_relay_artifacts/fixtures/append-edge.expected", input, expected);
+    test_fixture(transform_fixture, "append-edge.graphql", "compile_relay_artifacts/fixtures/append-edge.expected", input, expected).await;
 }
 
-#[test]
-fn append_edge_on_interface() {
+#[tokio::test]
+async fn append_edge_on_interface() {
     let input = include_str!("compile_relay_artifacts/fixtures/append-edge-on-interface.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/append-edge-on-interface.expected");
-    test_fixture(transform_fixture, "append-edge-on-interface.graphql", "compile_relay_artifacts/fixtures/append-edge-on-interface.expected", input, expected);
+    test_fixture(transform_fixture, "append-edge-on-interface.graphql", "compile_relay_artifacts/fixtures/append-edge-on-interface.expected", input, expected).await;
 }
 
-#[test]
-fn append_node() {
+#[tokio::test]
+async fn append_node() {
     let input = include_str!("compile_relay_artifacts/fixtures/append-node.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/append-node.expected");
-    test_fixture(transform_fixture, "append-node.graphql", "compile_relay_artifacts/fixtures/append-node.expected", input, expected);
+    test_fixture(transform_fixture, "append-node.graphql", "compile_relay_artifacts/fixtures/append-node.expected", input, expected).await;
 }
 
-#[test]
-fn append_node_literal_edge_type_name() {
+#[tokio::test]
+async fn append_node_literal_edge_type_name() {
     let input = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.expected");
-    test_fixture(transform_fixture, "append-node-literal-edge-type-name.graphql", "compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.expected", input, expected);
+    test_fixture(transform_fixture, "append-node-literal-edge-type-name.graphql", "compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.expected", input, expected).await;
 }
 
-#[test]
-fn auto_filled_argument_on_defer() {
+#[tokio::test]
+async fn auto_filled_argument_on_defer() {
     let input = include_str!("compile_relay_artifacts/fixtures/auto-filled-argument-on-defer.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/auto-filled-argument-on-defer.expected");
-    test_fixture(transform_fixture, "auto-filled-argument-on-defer.graphql", "compile_relay_artifacts/fixtures/auto-filled-argument-on-defer.expected", input, expected);
+    test_fixture(transform_fixture, "auto-filled-argument-on-defer.graphql", "compile_relay_artifacts/fixtures/auto-filled-argument-on-defer.expected", input, expected).await;
 }
 
-#[test]
-fn auto_filled_argument_on_match() {
+#[tokio::test]
+async fn auto_filled_argument_on_match() {
     let input = include_str!("compile_relay_artifacts/fixtures/auto-filled-argument-on-match.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/auto-filled-argument-on-match.expected");
-    test_fixture(transform_fixture, "auto-filled-argument-on-match.graphql", "compile_relay_artifacts/fixtures/auto-filled-argument-on-match.expected", input, expected);
+    test_fixture(transform_fixture, "auto-filled-argument-on-match.graphql", "compile_relay_artifacts/fixtures/auto-filled-argument-on-match.expected", input, expected).await;
 }
 
-#[test]
-fn circular_inline_fragment_invalid() {
+#[tokio::test]
+async fn circular_inline_fragment_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/circular-inline-fragment.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/circular-inline-fragment.invalid.expected");
-    test_fixture(transform_fixture, "circular-inline-fragment.invalid.graphql", "compile_relay_artifacts/fixtures/circular-inline-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "circular-inline-fragment.invalid.graphql", "compile_relay_artifacts/fixtures/circular-inline-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn circular_no_inline_fragment() {
+#[tokio::test]
+async fn circular_no_inline_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/circular-no-inline-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/circular-no-inline-fragment.expected");
-    test_fixture(transform_fixture, "circular-no-inline-fragment.graphql", "compile_relay_artifacts/fixtures/circular-no-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "circular-no-inline-fragment.graphql", "compile_relay_artifacts/fixtures/circular-no-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn client_conditions() {
+#[tokio::test]
+async fn client_conditions() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-conditions.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-conditions.expected");
-    test_fixture(transform_fixture, "client-conditions.graphql", "compile_relay_artifacts/fixtures/client-conditions.expected", input, expected);
+    test_fixture(transform_fixture, "client-conditions.graphql", "compile_relay_artifacts/fixtures/client-conditions.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_from_client_type_to_client_type() {
+#[tokio::test]
+async fn client_edge_from_client_type_to_client_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/client_edge_from_client_type_to_client_type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client_edge_from_client_type_to_client_type.expected");
-    test_fixture(transform_fixture, "client_edge_from_client_type_to_client_type.graphql", "compile_relay_artifacts/fixtures/client_edge_from_client_type_to_client_type.expected", input, expected);
+    test_fixture(transform_fixture, "client_edge_from_client_type_to_client_type.graphql", "compile_relay_artifacts/fixtures/client_edge_from_client_type_to_client_type.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_from_server_type_to_client_type() {
+#[tokio::test]
+async fn client_edge_from_server_type_to_client_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/client_edge_from_server_type_to_client_type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client_edge_from_server_type_to_client_type.expected");
-    test_fixture(transform_fixture, "client_edge_from_server_type_to_client_type.graphql", "compile_relay_artifacts/fixtures/client_edge_from_server_type_to_client_type.expected", input, expected);
+    test_fixture(transform_fixture, "client_edge_from_server_type_to_client_type.graphql", "compile_relay_artifacts/fixtures/client_edge_from_server_type_to_client_type.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_from_server_type_to_client_type_fragment_reads_client_field() {
+#[tokio::test]
+async fn client_edge_from_server_type_to_client_type_fragment_reads_client_field() {
     let input = include_str!("compile_relay_artifacts/fixtures/client_edge_from_server_type_to_client_type_fragment_reads_client_field.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client_edge_from_server_type_to_client_type_fragment_reads_client_field.expected");
-    test_fixture(transform_fixture, "client_edge_from_server_type_to_client_type_fragment_reads_client_field.graphql", "compile_relay_artifacts/fixtures/client_edge_from_server_type_to_client_type_fragment_reads_client_field.expected", input, expected);
+    test_fixture(transform_fixture, "client_edge_from_server_type_to_client_type_fragment_reads_client_field.graphql", "compile_relay_artifacts/fixtures/client_edge_from_server_type_to_client_type_fragment_reads_client_field.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_in_inline_fragments() {
+#[tokio::test]
+async fn client_fields_in_inline_fragments() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-fields-in-inline-fragments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-fields-in-inline-fragments.expected");
-    test_fixture(transform_fixture, "client-fields-in-inline-fragments.graphql", "compile_relay_artifacts/fixtures/client-fields-in-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-in-inline-fragments.graphql", "compile_relay_artifacts/fixtures/client-fields-in-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_of_client_type() {
+#[tokio::test]
+async fn client_fields_of_client_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-fields-of-client-type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-fields-of-client-type.expected");
-    test_fixture(transform_fixture, "client-fields-of-client-type.graphql", "compile_relay_artifacts/fixtures/client-fields-of-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-of-client-type.graphql", "compile_relay_artifacts/fixtures/client-fields-of-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_on_roots() {
+#[tokio::test]
+async fn client_fields_on_roots() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-fields-on-roots.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-fields-on-roots.expected");
-    test_fixture(transform_fixture, "client-fields-on-roots.graphql", "compile_relay_artifacts/fixtures/client-fields-on-roots.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-on-roots.graphql", "compile_relay_artifacts/fixtures/client-fields-on-roots.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_only_invalid() {
+#[tokio::test]
+async fn client_fields_only_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/client_fields_only_invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client_fields_only_invalid.expected");
-    test_fixture(transform_fixture, "client_fields_only_invalid.graphql", "compile_relay_artifacts/fixtures/client_fields_only_invalid.expected", input, expected);
+    test_fixture(transform_fixture, "client_fields_only_invalid.graphql", "compile_relay_artifacts/fixtures/client_fields_only_invalid.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_only_no_fragment_invalid() {
+#[tokio::test]
+async fn client_fields_only_no_fragment_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/client_fields_only_no_fragment_invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client_fields_only_no_fragment_invalid.expected");
-    test_fixture(transform_fixture, "client_fields_only_no_fragment_invalid.graphql", "compile_relay_artifacts/fixtures/client_fields_only_no_fragment_invalid.expected", input, expected);
+    test_fixture(transform_fixture, "client_fields_only_no_fragment_invalid.graphql", "compile_relay_artifacts/fixtures/client_fields_only_no_fragment_invalid.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_overlapping_error_invalid() {
+#[tokio::test]
+async fn client_fields_overlapping_error_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-fields-overlapping-error.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-fields-overlapping-error.invalid.expected");
-    test_fixture(transform_fixture, "client-fields-overlapping-error.invalid.graphql", "compile_relay_artifacts/fixtures/client-fields-overlapping-error.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-overlapping-error.invalid.graphql", "compile_relay_artifacts/fixtures/client-fields-overlapping-error.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_overlapping_with_nulls() {
+#[tokio::test]
+async fn client_fields_overlapping_with_nulls() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-fields-overlapping-with-nulls.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-fields-overlapping-with-nulls.expected");
-    test_fixture(transform_fixture, "client-fields-overlapping-with-nulls.graphql", "compile_relay_artifacts/fixtures/client-fields-overlapping-with-nulls.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-overlapping-with-nulls.graphql", "compile_relay_artifacts/fixtures/client-fields-overlapping-with-nulls.expected", input, expected).await;
 }
 
-#[test]
-fn client_fragment_spreads() {
+#[tokio::test]
+async fn client_fragment_spreads() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-fragment-spreads.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-fragment-spreads.expected");
-    test_fixture(transform_fixture, "client-fragment-spreads.graphql", "compile_relay_artifacts/fixtures/client-fragment-spreads.expected", input, expected);
+    test_fixture(transform_fixture, "client-fragment-spreads.graphql", "compile_relay_artifacts/fixtures/client-fragment-spreads.expected", input, expected).await;
 }
 
-#[test]
-fn client_fragment_spreads_in_query() {
+#[tokio::test]
+async fn client_fragment_spreads_in_query() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.expected");
-    test_fixture(transform_fixture, "client-fragment-spreads-in-query.graphql", "compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.expected", input, expected);
+    test_fixture(transform_fixture, "client-fragment-spreads-in-query.graphql", "compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.expected", input, expected).await;
 }
 
-#[test]
-fn client_inline_fragments() {
+#[tokio::test]
+async fn client_inline_fragments() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-inline-fragments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-inline-fragments.expected");
-    test_fixture(transform_fixture, "client-inline-fragments.graphql", "compile_relay_artifacts/fixtures/client-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "client-inline-fragments.graphql", "compile_relay_artifacts/fixtures/client-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn client_inline_fragments_in_query() {
+#[tokio::test]
+async fn client_inline_fragments_in_query() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-inline-fragments-in-query.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-inline-fragments-in-query.expected");
-    test_fixture(transform_fixture, "client-inline-fragments-in-query.graphql", "compile_relay_artifacts/fixtures/client-inline-fragments-in-query.expected", input, expected);
+    test_fixture(transform_fixture, "client-inline-fragments-in-query.graphql", "compile_relay_artifacts/fixtures/client-inline-fragments-in-query.expected", input, expected).await;
 }
 
-#[test]
-fn client_linked_fields() {
+#[tokio::test]
+async fn client_linked_fields() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-linked-fields.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-linked-fields.expected");
-    test_fixture(transform_fixture, "client-linked-fields.graphql", "compile_relay_artifacts/fixtures/client-linked-fields.expected", input, expected);
+    test_fixture(transform_fixture, "client-linked-fields.graphql", "compile_relay_artifacts/fixtures/client-linked-fields.expected", input, expected).await;
 }
 
-#[test]
-fn client_only_query() {
+#[tokio::test]
+async fn client_only_query() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-only-query.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-only-query.expected");
-    test_fixture(transform_fixture, "client-only-query.graphql", "compile_relay_artifacts/fixtures/client-only-query.expected", input, expected);
+    test_fixture(transform_fixture, "client-only-query.graphql", "compile_relay_artifacts/fixtures/client-only-query.expected", input, expected).await;
 }
 
-#[test]
-fn client_only_query_with_scalar_extension() {
+#[tokio::test]
+async fn client_only_query_with_scalar_extension() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-only-query-with-scalar-extension.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-only-query-with-scalar-extension.expected");
-    test_fixture(transform_fixture, "client-only-query-with-scalar-extension.graphql", "compile_relay_artifacts/fixtures/client-only-query-with-scalar-extension.expected", input, expected);
+    test_fixture(transform_fixture, "client-only-query-with-scalar-extension.graphql", "compile_relay_artifacts/fixtures/client-only-query-with-scalar-extension.expected", input, expected).await;
 }
 
-#[test]
-fn client_scalar_fields() {
+#[tokio::test]
+async fn client_scalar_fields() {
     let input = include_str!("compile_relay_artifacts/fixtures/client-scalar-fields.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/client-scalar-fields.expected");
-    test_fixture(transform_fixture, "client-scalar-fields.graphql", "compile_relay_artifacts/fixtures/client-scalar-fields.expected", input, expected);
+    test_fixture(transform_fixture, "client-scalar-fields.graphql", "compile_relay_artifacts/fixtures/client-scalar-fields.expected", input, expected).await;
 }
 
-#[test]
-fn complex_arguments() {
+#[tokio::test]
+async fn complex_arguments() {
     let input = include_str!("compile_relay_artifacts/fixtures/complex-arguments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/complex-arguments.expected");
-    test_fixture(transform_fixture, "complex-arguments.graphql", "compile_relay_artifacts/fixtures/complex-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "complex-arguments.graphql", "compile_relay_artifacts/fixtures/complex-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn complex_arguments_in_list() {
+#[tokio::test]
+async fn complex_arguments_in_list() {
     let input = include_str!("compile_relay_artifacts/fixtures/complex-arguments-in-list.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/complex-arguments-in-list.expected");
-    test_fixture(transform_fixture, "complex-arguments-in-list.graphql", "compile_relay_artifacts/fixtures/complex-arguments-in-list.expected", input, expected);
+    test_fixture(transform_fixture, "complex-arguments-in-list.graphql", "compile_relay_artifacts/fixtures/complex-arguments-in-list.expected", input, expected).await;
 }
 
-#[test]
-fn complex_arguments_with_mutliple_variables() {
+#[tokio::test]
+async fn complex_arguments_with_mutliple_variables() {
     let input = include_str!("compile_relay_artifacts/fixtures/complex-arguments-with-mutliple-variables.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/complex-arguments-with-mutliple-variables.expected");
-    test_fixture(transform_fixture, "complex-arguments-with-mutliple-variables.graphql", "compile_relay_artifacts/fixtures/complex-arguments-with-mutliple-variables.expected", input, expected);
+    test_fixture(transform_fixture, "complex-arguments-with-mutliple-variables.graphql", "compile_relay_artifacts/fixtures/complex-arguments-with-mutliple-variables.expected", input, expected).await;
 }
 
-#[test]
-fn conflicting_selections_with_actor_change_invalid() {
+#[tokio::test]
+async fn conflicting_selections_with_actor_change_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/conflicting-selections-with-actor-change.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/conflicting-selections-with-actor-change.invalid.expected");
-    test_fixture(transform_fixture, "conflicting-selections-with-actor-change.invalid.graphql", "compile_relay_artifacts/fixtures/conflicting-selections-with-actor-change.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "conflicting-selections-with-actor-change.invalid.graphql", "compile_relay_artifacts/fixtures/conflicting-selections-with-actor-change.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn conflicting_selections_with_defer_invalid() {
+#[tokio::test]
+async fn conflicting_selections_with_defer_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/conflicting-selections-with-defer.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/conflicting-selections-with-defer.invalid.expected");
-    test_fixture(transform_fixture, "conflicting-selections-with-defer.invalid.graphql", "compile_relay_artifacts/fixtures/conflicting-selections-with-defer.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "conflicting-selections-with-defer.invalid.graphql", "compile_relay_artifacts/fixtures/conflicting-selections-with-defer.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn conflicting_selections_with_no_inline_invalid() {
+#[tokio::test]
+async fn conflicting_selections_with_no_inline_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/conflicting-selections-with-no-inline.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/conflicting-selections-with-no-inline.invalid.expected");
-    test_fixture(transform_fixture, "conflicting-selections-with-no-inline.invalid.graphql", "compile_relay_artifacts/fixtures/conflicting-selections-with-no-inline.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "conflicting-selections-with-no-inline.invalid.graphql", "compile_relay_artifacts/fixtures/conflicting-selections-with-no-inline.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection() {
+#[tokio::test]
+async fn connection() {
     let input = include_str!("compile_relay_artifacts/fixtures/connection.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/connection.expected");
-    test_fixture(transform_fixture, "connection.graphql", "compile_relay_artifacts/fixtures/connection.expected", input, expected);
+    test_fixture(transform_fixture, "connection.graphql", "compile_relay_artifacts/fixtures/connection.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_aliased_edges_page_info() {
+#[tokio::test]
+async fn connection_with_aliased_edges_page_info() {
     let input = include_str!("compile_relay_artifacts/fixtures/connection-with-aliased-edges-page_info.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/connection-with-aliased-edges-page_info.expected");
-    test_fixture(transform_fixture, "connection-with-aliased-edges-page_info.graphql", "compile_relay_artifacts/fixtures/connection-with-aliased-edges-page_info.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-aliased-edges-page_info.graphql", "compile_relay_artifacts/fixtures/connection-with-aliased-edges-page_info.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_dynamic_key() {
+#[tokio::test]
+async fn connection_with_dynamic_key() {
     let input = include_str!("compile_relay_artifacts/fixtures/connection-with-dynamic-key.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/connection-with-dynamic-key.expected");
-    test_fixture(transform_fixture, "connection-with-dynamic-key.graphql", "compile_relay_artifacts/fixtures/connection-with-dynamic-key.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-dynamic-key.graphql", "compile_relay_artifacts/fixtures/connection-with-dynamic-key.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_dynamic_key_missing_variable_definition_invalid() {
+#[tokio::test]
+async fn connection_with_dynamic_key_missing_variable_definition_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/connection-with-dynamic-key-missing-variable-definition.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/connection-with-dynamic-key-missing-variable-definition.invalid.expected");
-    test_fixture(transform_fixture, "connection-with-dynamic-key-missing-variable-definition.invalid.graphql", "compile_relay_artifacts/fixtures/connection-with-dynamic-key-missing-variable-definition.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-dynamic-key-missing-variable-definition.invalid.graphql", "compile_relay_artifacts/fixtures/connection-with-dynamic-key-missing-variable-definition.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn constant_variable_matches_constant_value() {
+#[tokio::test]
+async fn constant_variable_matches_constant_value() {
     let input = include_str!("compile_relay_artifacts/fixtures/constant_variable_matches_constant_value.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/constant_variable_matches_constant_value.expected");
-    test_fixture(transform_fixture, "constant_variable_matches_constant_value.graphql", "compile_relay_artifacts/fixtures/constant_variable_matches_constant_value.expected", input, expected);
+    test_fixture(transform_fixture, "constant_variable_matches_constant_value.graphql", "compile_relay_artifacts/fixtures/constant_variable_matches_constant_value.expected", input, expected).await;
 }
 
-#[test]
-fn defer_if_arguments() {
+#[tokio::test]
+async fn defer_if_arguments() {
     let input = include_str!("compile_relay_artifacts/fixtures/defer_if_arguments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/defer_if_arguments.expected");
-    test_fixture(transform_fixture, "defer_if_arguments.graphql", "compile_relay_artifacts/fixtures/defer_if_arguments.expected", input, expected);
+    test_fixture(transform_fixture, "defer_if_arguments.graphql", "compile_relay_artifacts/fixtures/defer_if_arguments.expected", input, expected).await;
 }
 
-#[test]
-fn defer_multiple_fragments_same_parent() {
+#[tokio::test]
+async fn defer_multiple_fragments_same_parent() {
     let input = include_str!("compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.expected");
-    test_fixture(transform_fixture, "defer-multiple-fragments-same-parent.graphql", "compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.expected", input, expected);
+    test_fixture(transform_fixture, "defer-multiple-fragments-same-parent.graphql", "compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.expected", input, expected).await;
 }
 
-#[test]
-fn delete_edge() {
+#[tokio::test]
+async fn delete_edge() {
     let input = include_str!("compile_relay_artifacts/fixtures/delete-edge.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/delete-edge.expected");
-    test_fixture(transform_fixture, "delete-edge.graphql", "compile_relay_artifacts/fixtures/delete-edge.expected", input, expected);
+    test_fixture(transform_fixture, "delete-edge.graphql", "compile_relay_artifacts/fixtures/delete-edge.expected", input, expected).await;
 }
 
-#[test]
-fn delete_edge_plural() {
+#[tokio::test]
+async fn delete_edge_plural() {
     let input = include_str!("compile_relay_artifacts/fixtures/delete-edge-plural.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/delete-edge-plural.expected");
-    test_fixture(transform_fixture, "delete-edge-plural.graphql", "compile_relay_artifacts/fixtures/delete-edge-plural.expected", input, expected);
+    test_fixture(transform_fixture, "delete-edge-plural.graphql", "compile_relay_artifacts/fixtures/delete-edge-plural.expected", input, expected).await;
 }
 
-#[test]
-fn directive_with_conditions() {
+#[tokio::test]
+async fn directive_with_conditions() {
     let input = include_str!("compile_relay_artifacts/fixtures/directive_with_conditions.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/directive_with_conditions.expected");
-    test_fixture(transform_fixture, "directive_with_conditions.graphql", "compile_relay_artifacts/fixtures/directive_with_conditions.expected", input, expected);
+    test_fixture(transform_fixture, "directive_with_conditions.graphql", "compile_relay_artifacts/fixtures/directive_with_conditions.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_directive_invalid() {
+#[tokio::test]
+async fn duplicate_directive_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/duplicate-directive.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/duplicate-directive.invalid.expected");
-    test_fixture(transform_fixture, "duplicate-directive.invalid.graphql", "compile_relay_artifacts/fixtures/duplicate-directive.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate-directive.invalid.graphql", "compile_relay_artifacts/fixtures/duplicate-directive.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_fragment_name() {
+#[tokio::test]
+async fn duplicate_fragment_name() {
     let input = include_str!("compile_relay_artifacts/fixtures/duplicate_fragment_name.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/duplicate_fragment_name.expected");
-    test_fixture(transform_fixture, "duplicate_fragment_name.graphql", "compile_relay_artifacts/fixtures/duplicate_fragment_name.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate_fragment_name.graphql", "compile_relay_artifacts/fixtures/duplicate_fragment_name.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_query_name() {
+#[tokio::test]
+async fn duplicate_query_name() {
     let input = include_str!("compile_relay_artifacts/fixtures/duplicate_query_name.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/duplicate_query_name.expected");
-    test_fixture(transform_fixture, "duplicate_query_name.graphql", "compile_relay_artifacts/fixtures/duplicate_query_name.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate_query_name.graphql", "compile_relay_artifacts/fixtures/duplicate_query_name.expected", input, expected).await;
 }
 
-#[test]
-fn explicit_null_argument() {
+#[tokio::test]
+async fn explicit_null_argument() {
     let input = include_str!("compile_relay_artifacts/fixtures/explicit-null-argument.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/explicit-null-argument.expected");
-    test_fixture(transform_fixture, "explicit-null-argument.graphql", "compile_relay_artifacts/fixtures/explicit-null-argument.expected", input, expected);
+    test_fixture(transform_fixture, "explicit-null-argument.graphql", "compile_relay_artifacts/fixtures/explicit-null-argument.expected", input, expected).await;
 }
 
-#[test]
-fn explicit_null_default_value() {
+#[tokio::test]
+async fn explicit_null_default_value() {
     let input = include_str!("compile_relay_artifacts/fixtures/explicit-null-default-value.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/explicit-null-default-value.expected");
-    test_fixture(transform_fixture, "explicit-null-default-value.graphql", "compile_relay_artifacts/fixtures/explicit-null-default-value.expected", input, expected);
+    test_fixture(transform_fixture, "explicit-null-default-value.graphql", "compile_relay_artifacts/fixtures/explicit-null-default-value.expected", input, expected).await;
 }
 
-#[test]
-fn false_positive_circular_fragment_reference_regression() {
+#[tokio::test]
+async fn false_positive_circular_fragment_reference_regression() {
     let input = include_str!("compile_relay_artifacts/fixtures/false-positive-circular-fragment-reference-regression.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/false-positive-circular-fragment-reference-regression.expected");
-    test_fixture(transform_fixture, "false-positive-circular-fragment-reference-regression.graphql", "compile_relay_artifacts/fixtures/false-positive-circular-fragment-reference-regression.expected", input, expected);
+    test_fixture(transform_fixture, "false-positive-circular-fragment-reference-regression.graphql", "compile_relay_artifacts/fixtures/false-positive-circular-fragment-reference-regression.expected", input, expected).await;
 }
 
-#[test]
-fn fields_with_null_argument_values() {
+#[tokio::test]
+async fn fields_with_null_argument_values() {
     let input = include_str!("compile_relay_artifacts/fixtures/fields-with-null-argument-values.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fields-with-null-argument-values.expected");
-    test_fixture(transform_fixture, "fields-with-null-argument-values.graphql", "compile_relay_artifacts/fixtures/fields-with-null-argument-values.expected", input, expected);
+    test_fixture(transform_fixture, "fields-with-null-argument-values.graphql", "compile_relay_artifacts/fixtures/fields-with-null-argument-values.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_alias() {
+#[tokio::test]
+async fn fragment_alias() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-alias.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-alias.expected");
-    test_fixture(transform_fixture, "fragment-alias.graphql", "compile_relay_artifacts/fixtures/fragment-alias.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-alias.graphql", "compile_relay_artifacts/fixtures/fragment-alias.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_alias_on_inline_fragment_does_not_get_flattened() {
+#[tokio::test]
+async fn fragment_alias_on_inline_fragment_does_not_get_flattened() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-alias-on-inline-fragment-does-not-get-flattened.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-alias-on-inline-fragment-does-not-get-flattened.expected");
-    test_fixture(transform_fixture, "fragment-alias-on-inline-fragment-does-not-get-flattened.graphql", "compile_relay_artifacts/fixtures/fragment-alias-on-inline-fragment-does-not-get-flattened.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-alias-on-inline-fragment-does-not-get-flattened.graphql", "compile_relay_artifacts/fixtures/fragment-alias-on-inline-fragment-does-not-get-flattened.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_node_interface() {
+#[tokio::test]
+async fn fragment_on_node_interface() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-on-node-interface.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-on-node-interface.expected");
-    test_fixture(transform_fixture, "fragment-on-node-interface.graphql", "compile_relay_artifacts/fixtures/fragment-on-node-interface.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-node-interface.graphql", "compile_relay_artifacts/fixtures/fragment-on-node-interface.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_non_node_fetchable_type() {
+#[tokio::test]
+async fn fragment_on_non_node_fetchable_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.expected");
-    test_fixture(transform_fixture, "fragment-on-non-node-fetchable-type.graphql", "compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-non-node-fetchable-type.graphql", "compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_object_implementing_node_interface() {
+#[tokio::test]
+async fn fragment_on_object_implementing_node_interface() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-on-object-implementing-node-interface.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-on-object-implementing-node-interface.expected");
-    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface.graphql", "compile_relay_artifacts/fixtures/fragment-on-object-implementing-node-interface.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface.graphql", "compile_relay_artifacts/fixtures/fragment-on-object-implementing-node-interface.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_query() {
+#[tokio::test]
+async fn fragment_on_query() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-on-query.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-on-query.expected");
-    test_fixture(transform_fixture, "fragment-on-query.graphql", "compile_relay_artifacts/fixtures/fragment-on-query.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-query.graphql", "compile_relay_artifacts/fixtures/fragment-on-query.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_query_with_cycle_invalid() {
+#[tokio::test]
+async fn fragment_on_query_with_cycle_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-on-query-with-cycle.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-on-query-with-cycle.invalid.expected");
-    test_fixture(transform_fixture, "fragment-on-query-with-cycle.invalid.graphql", "compile_relay_artifacts/fixtures/fragment-on-query-with-cycle.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-query-with-cycle.invalid.graphql", "compile_relay_artifacts/fixtures/fragment-on-query-with-cycle.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_viewer() {
+#[tokio::test]
+async fn fragment_on_viewer() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-on-viewer.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-on-viewer.expected");
-    test_fixture(transform_fixture, "fragment-on-viewer.graphql", "compile_relay_artifacts/fixtures/fragment-on-viewer.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-viewer.graphql", "compile_relay_artifacts/fixtures/fragment-on-viewer.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_arguments() {
+#[tokio::test]
+async fn fragment_with_defer_arguments() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-with-defer-arguments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-with-defer-arguments.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-arguments.graphql", "compile_relay_artifacts/fixtures/fragment-with-defer-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-arguments.graphql", "compile_relay_artifacts/fixtures/fragment-with-defer-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_arguments_without_label() {
+#[tokio::test]
+async fn fragment_with_defer_arguments_without_label() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-with-defer-arguments-without-label.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-with-defer-arguments-without-label.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-arguments-without-label.graphql", "compile_relay_artifacts/fixtures/fragment-with-defer-arguments-without-label.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-arguments-without-label.graphql", "compile_relay_artifacts/fixtures/fragment-with-defer-arguments-without-label.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_in_stream() {
+#[tokio::test]
+async fn fragment_with_defer_in_stream() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-in-stream.graphql", "compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-in-stream.graphql", "compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_on_abstract_type() {
+#[tokio::test]
+async fn fragment_with_defer_on_abstract_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-with-defer-on-abstract-type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-with-defer-on-abstract-type.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-on-abstract-type.graphql", "compile_relay_artifacts/fixtures/fragment-with-defer-on-abstract-type.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-on-abstract-type.graphql", "compile_relay_artifacts/fixtures/fragment-with-defer-on-abstract-type.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_match_directive() {
+#[tokio::test]
+async fn fragment_with_match_directive() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-with-match-directive.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-with-match-directive.expected");
-    test_fixture(transform_fixture, "fragment-with-match-directive.graphql", "compile_relay_artifacts/fixtures/fragment-with-match-directive.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-match-directive.graphql", "compile_relay_artifacts/fixtures/fragment-with-match-directive.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream() {
+#[tokio::test]
+async fn fragment_with_stream() {
     let input = include_str!("compile_relay_artifacts/fixtures/fragment-with-stream.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/fragment-with-stream.expected");
-    test_fixture(transform_fixture, "fragment-with-stream.graphql", "compile_relay_artifacts/fixtures/fragment-with-stream.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream.graphql", "compile_relay_artifacts/fixtures/fragment-with-stream.expected", input, expected).await;
 }
 
-#[test]
-fn id_as_alias_invalid() {
+#[tokio::test]
+async fn id_as_alias_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/id-as-alias.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/id-as-alias.invalid.expected");
-    test_fixture(transform_fixture, "id-as-alias.invalid.graphql", "compile_relay_artifacts/fixtures/id-as-alias.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "id-as-alias.invalid.graphql", "compile_relay_artifacts/fixtures/id-as-alias.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn incompatible_variable_usage_across_documents() {
+#[tokio::test]
+async fn incompatible_variable_usage_across_documents() {
     let input = include_str!("compile_relay_artifacts/fixtures/incompatible-variable-usage-across-documents.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/incompatible-variable-usage-across-documents.expected");
-    test_fixture(transform_fixture, "incompatible-variable-usage-across-documents.graphql", "compile_relay_artifacts/fixtures/incompatible-variable-usage-across-documents.expected", input, expected);
+    test_fixture(transform_fixture, "incompatible-variable-usage-across-documents.graphql", "compile_relay_artifacts/fixtures/incompatible-variable-usage-across-documents.expected", input, expected).await;
 }
 
-#[test]
-fn inline_and_mask_are_incompatible_invalid() {
+#[tokio::test]
+async fn inline_and_mask_are_incompatible_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/inline-and-mask-are-incompatible.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/inline-and-mask-are-incompatible.invalid.expected");
-    test_fixture(transform_fixture, "inline-and-mask-are-incompatible.invalid.graphql", "compile_relay_artifacts/fixtures/inline-and-mask-are-incompatible.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-and-mask-are-incompatible.invalid.graphql", "compile_relay_artifacts/fixtures/inline-and-mask-are-incompatible.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_data_fragment() {
+#[tokio::test]
+async fn inline_data_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/inline-data-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/inline-data-fragment.expected");
-    test_fixture(transform_fixture, "inline-data-fragment.graphql", "compile_relay_artifacts/fixtures/inline-data-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "inline-data-fragment.graphql", "compile_relay_artifacts/fixtures/inline-data-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn inline_data_fragment_global_vars() {
+#[tokio::test]
+async fn inline_data_fragment_global_vars() {
     let input = include_str!("compile_relay_artifacts/fixtures/inline-data-fragment-global-vars.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/inline-data-fragment-global-vars.expected");
-    test_fixture(transform_fixture, "inline-data-fragment-global-vars.graphql", "compile_relay_artifacts/fixtures/inline-data-fragment-global-vars.expected", input, expected);
+    test_fixture(transform_fixture, "inline-data-fragment-global-vars.graphql", "compile_relay_artifacts/fixtures/inline-data-fragment-global-vars.expected", input, expected).await;
 }
 
-#[test]
-fn inline_data_fragment_local_args() {
+#[tokio::test]
+async fn inline_data_fragment_local_args() {
     let input = include_str!("compile_relay_artifacts/fixtures/inline-data-fragment-local-args.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/inline-data-fragment-local-args.expected");
-    test_fixture(transform_fixture, "inline-data-fragment-local-args.graphql", "compile_relay_artifacts/fixtures/inline-data-fragment-local-args.expected", input, expected);
+    test_fixture(transform_fixture, "inline-data-fragment-local-args.graphql", "compile_relay_artifacts/fixtures/inline-data-fragment-local-args.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_abstract_client_type_nested_in_resolver_client_edge() {
+#[tokio::test]
+async fn inline_fragment_on_abstract_client_type_nested_in_resolver_client_edge() {
     let input = include_str!("compile_relay_artifacts/fixtures/inline-fragment-on-abstract-client-type-nested-in-resolver-client-edge.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/inline-fragment-on-abstract-client-type-nested-in-resolver-client-edge.expected");
-    test_fixture(transform_fixture, "inline-fragment-on-abstract-client-type-nested-in-resolver-client-edge.graphql", "compile_relay_artifacts/fixtures/inline-fragment-on-abstract-client-type-nested-in-resolver-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-on-abstract-client-type-nested-in-resolver-client-edge.graphql", "compile_relay_artifacts/fixtures/inline-fragment-on-abstract-client-type-nested-in-resolver-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("compile_relay_artifacts/fixtures/kitchen-sink.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "compile_relay_artifacts/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "compile_relay_artifacts/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn linked_handle_field() {
+#[tokio::test]
+async fn linked_handle_field() {
     let input = include_str!("compile_relay_artifacts/fixtures/linked-handle-field.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/linked-handle-field.expected");
-    test_fixture(transform_fixture, "linked-handle-field.graphql", "compile_relay_artifacts/fixtures/linked-handle-field.expected", input, expected);
+    test_fixture(transform_fixture, "linked-handle-field.graphql", "compile_relay_artifacts/fixtures/linked-handle-field.expected", input, expected).await;
 }
 
-#[test]
-fn match_field_overlap_across_documents() {
+#[tokio::test]
+async fn match_field_overlap_across_documents() {
     let input = include_str!("compile_relay_artifacts/fixtures/match-field-overlap-across-documents.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/match-field-overlap-across-documents.expected");
-    test_fixture(transform_fixture, "match-field-overlap-across-documents.graphql", "compile_relay_artifacts/fixtures/match-field-overlap-across-documents.expected", input, expected);
+    test_fixture(transform_fixture, "match-field-overlap-across-documents.graphql", "compile_relay_artifacts/fixtures/match-field-overlap-across-documents.expected", input, expected).await;
 }
 
-#[test]
-fn match_on_child_of_plural() {
+#[tokio::test]
+async fn match_on_child_of_plural() {
     let input = include_str!("compile_relay_artifacts/fixtures/match-on-child-of-plural.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/match-on-child-of-plural.expected");
-    test_fixture(transform_fixture, "match-on-child-of-plural.graphql", "compile_relay_artifacts/fixtures/match-on-child-of-plural.expected", input, expected);
+    test_fixture(transform_fixture, "match-on-child-of-plural.graphql", "compile_relay_artifacts/fixtures/match-on-child-of-plural.expected", input, expected).await;
 }
 
-#[test]
-fn match_with_invalid_key_invalid() {
+#[tokio::test]
+async fn match_with_invalid_key_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/match-with-invalid-key.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/match-with-invalid-key.invalid.expected");
-    test_fixture(transform_fixture, "match-with-invalid-key.invalid.graphql", "compile_relay_artifacts/fixtures/match-with-invalid-key.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "match-with-invalid-key.invalid.graphql", "compile_relay_artifacts/fixtures/match-with-invalid-key.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn missing_argument_on_field_invalid() {
+#[tokio::test]
+async fn missing_argument_on_field_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/missing-argument-on-field.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/missing-argument-on-field.invalid.expected");
-    test_fixture(transform_fixture, "missing-argument-on-field.invalid.graphql", "compile_relay_artifacts/fixtures/missing-argument-on-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing-argument-on-field.invalid.graphql", "compile_relay_artifacts/fixtures/missing-argument-on-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn module_deduping() {
+#[tokio::test]
+async fn module_deduping() {
     let input = include_str!("compile_relay_artifacts/fixtures/module-deduping.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/module-deduping.expected");
-    test_fixture(transform_fixture, "module-deduping.graphql", "compile_relay_artifacts/fixtures/module-deduping.expected", input, expected);
+    test_fixture(transform_fixture, "module-deduping.graphql", "compile_relay_artifacts/fixtures/module-deduping.expected", input, expected).await;
 }
 
-#[test]
-fn module_in_inline_fragment() {
+#[tokio::test]
+async fn module_in_inline_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/module-in-inline-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/module-in-inline-fragment.expected");
-    test_fixture(transform_fixture, "module-in-inline-fragment.graphql", "compile_relay_artifacts/fixtures/module-in-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "module-in-inline-fragment.graphql", "compile_relay_artifacts/fixtures/module-in-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn module_overlap_across_documents() {
+#[tokio::test]
+async fn module_overlap_across_documents() {
     let input = include_str!("compile_relay_artifacts/fixtures/module-overlap-across-documents.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/module-overlap-across-documents.expected");
-    test_fixture(transform_fixture, "module-overlap-across-documents.graphql", "compile_relay_artifacts/fixtures/module-overlap-across-documents.expected", input, expected);
+    test_fixture(transform_fixture, "module-overlap-across-documents.graphql", "compile_relay_artifacts/fixtures/module-overlap-across-documents.expected", input, expected).await;
 }
 
-#[test]
-fn module_overlap_within_document_invalid() {
+#[tokio::test]
+async fn module_overlap_within_document_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/module-overlap-within-document.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/module-overlap-within-document.invalid.expected");
-    test_fixture(transform_fixture, "module-overlap-within-document.invalid.graphql", "compile_relay_artifacts/fixtures/module-overlap-within-document.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "module-overlap-within-document.invalid.graphql", "compile_relay_artifacts/fixtures/module-overlap-within-document.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn module_with_defer() {
+#[tokio::test]
+async fn module_with_defer() {
     let input = include_str!("compile_relay_artifacts/fixtures/module-with-defer.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/module-with-defer.expected");
-    test_fixture(transform_fixture, "module-with-defer.graphql", "compile_relay_artifacts/fixtures/module-with-defer.expected", input, expected);
+    test_fixture(transform_fixture, "module-with-defer.graphql", "compile_relay_artifacts/fixtures/module-with-defer.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_client_edges() {
+#[tokio::test]
+async fn multiple_client_edges() {
     let input = include_str!("compile_relay_artifacts/fixtures/multiple-client-edges.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/multiple-client-edges.expected");
-    test_fixture(transform_fixture, "multiple-client-edges.graphql", "compile_relay_artifacts/fixtures/multiple-client-edges.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-client-edges.graphql", "compile_relay_artifacts/fixtures/multiple-client-edges.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_conditions() {
+#[tokio::test]
+async fn multiple_conditions() {
     let input = include_str!("compile_relay_artifacts/fixtures/multiple_conditions.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/multiple_conditions.expected");
-    test_fixture(transform_fixture, "multiple_conditions.graphql", "compile_relay_artifacts/fixtures/multiple_conditions.expected", input, expected);
+    test_fixture(transform_fixture, "multiple_conditions.graphql", "compile_relay_artifacts/fixtures/multiple_conditions.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_modules_different_component_invalid() {
+#[tokio::test]
+async fn multiple_modules_different_component_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/multiple-modules-different-component.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/multiple-modules-different-component.invalid.expected");
-    test_fixture(transform_fixture, "multiple-modules-different-component.invalid.graphql", "compile_relay_artifacts/fixtures/multiple-modules-different-component.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-modules-different-component.invalid.graphql", "compile_relay_artifacts/fixtures/multiple-modules-different-component.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_modules_different_fragment_invalid() {
+#[tokio::test]
+async fn multiple_modules_different_fragment_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/multiple-modules-different-fragment.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/multiple-modules-different-fragment.invalid.expected");
-    test_fixture(transform_fixture, "multiple-modules-different-fragment.invalid.graphql", "compile_relay_artifacts/fixtures/multiple-modules-different-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-modules-different-fragment.invalid.graphql", "compile_relay_artifacts/fixtures/multiple-modules-different-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_modules_same_selections() {
+#[tokio::test]
+async fn multiple_modules_same_selections() {
     let input = include_str!("compile_relay_artifacts/fixtures/multiple-modules-same-selections.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/multiple-modules-same-selections.expected");
-    test_fixture(transform_fixture, "multiple-modules-same-selections.graphql", "compile_relay_artifacts/fixtures/multiple-modules-same-selections.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-modules-same-selections.graphql", "compile_relay_artifacts/fixtures/multiple-modules-same-selections.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_modules_with_key() {
+#[tokio::test]
+async fn multiple_modules_with_key() {
     let input = include_str!("compile_relay_artifacts/fixtures/multiple-modules-with-key.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/multiple-modules-with-key.expected");
-    test_fixture(transform_fixture, "multiple-modules-with-key.graphql", "compile_relay_artifacts/fixtures/multiple-modules-with-key.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-modules-with-key.graphql", "compile_relay_artifacts/fixtures/multiple-modules-with-key.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_modules_without_key_invalid() {
+#[tokio::test]
+async fn multiple_modules_without_key_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/multiple-modules-without-key.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/multiple-modules-without-key.invalid.expected");
-    test_fixture(transform_fixture, "multiple-modules-without-key.invalid.graphql", "compile_relay_artifacts/fixtures/multiple-modules-without-key.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-modules-without-key.invalid.graphql", "compile_relay_artifacts/fixtures/multiple-modules-without-key.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn nested_conditions() {
+#[tokio::test]
+async fn nested_conditions() {
     let input = include_str!("compile_relay_artifacts/fixtures/nested_conditions.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/nested_conditions.expected");
-    test_fixture(transform_fixture, "nested_conditions.graphql", "compile_relay_artifacts/fixtures/nested_conditions.expected", input, expected);
+    test_fixture(transform_fixture, "nested_conditions.graphql", "compile_relay_artifacts/fixtures/nested_conditions.expected", input, expected).await;
 }
 
-#[test]
-fn nested_conditions_2() {
+#[tokio::test]
+async fn nested_conditions_2() {
     let input = include_str!("compile_relay_artifacts/fixtures/nested-conditions-2.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/nested-conditions-2.expected");
-    test_fixture(transform_fixture, "nested-conditions-2.graphql", "compile_relay_artifacts/fixtures/nested-conditions-2.expected", input, expected);
+    test_fixture(transform_fixture, "nested-conditions-2.graphql", "compile_relay_artifacts/fixtures/nested-conditions-2.expected", input, expected).await;
 }
 
-#[test]
-fn no_inline_abstract_fragment() {
+#[tokio::test]
+async fn no_inline_abstract_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/no-inline-abstract-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/no-inline-abstract-fragment.expected");
-    test_fixture(transform_fixture, "no-inline-abstract-fragment.graphql", "compile_relay_artifacts/fixtures/no-inline-abstract-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "no-inline-abstract-fragment.graphql", "compile_relay_artifacts/fixtures/no-inline-abstract-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn no_inline_fragment() {
+#[tokio::test]
+async fn no_inline_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/no-inline-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/no-inline-fragment.expected");
-    test_fixture(transform_fixture, "no-inline-fragment.graphql", "compile_relay_artifacts/fixtures/no-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "no-inline-fragment.graphql", "compile_relay_artifacts/fixtures/no-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn no_inline_fragment_and_module() {
+#[tokio::test]
+async fn no_inline_fragment_and_module() {
     let input = include_str!("compile_relay_artifacts/fixtures/no-inline-fragment-and-module.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/no-inline-fragment-and-module.expected");
-    test_fixture(transform_fixture, "no-inline-fragment-and-module.graphql", "compile_relay_artifacts/fixtures/no-inline-fragment-and-module.expected", input, expected);
+    test_fixture(transform_fixture, "no-inline-fragment-and-module.graphql", "compile_relay_artifacts/fixtures/no-inline-fragment-and-module.expected", input, expected).await;
 }
 
-#[test]
-fn no_inline_fragment_in_raw_response_query() {
+#[tokio::test]
+async fn no_inline_fragment_in_raw_response_query() {
     let input = include_str!("compile_relay_artifacts/fixtures/no-inline-fragment-in-raw-response-query.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/no-inline-fragment-in-raw-response-query.expected");
-    test_fixture(transform_fixture, "no-inline-fragment-in-raw-response-query.graphql", "compile_relay_artifacts/fixtures/no-inline-fragment-in-raw-response-query.expected", input, expected);
+    test_fixture(transform_fixture, "no-inline-fragment-in-raw-response-query.graphql", "compile_relay_artifacts/fixtures/no-inline-fragment-in-raw-response-query.expected", input, expected).await;
 }
 
-#[test]
-fn original_client_fields_test() {
+#[tokio::test]
+async fn original_client_fields_test() {
     let input = include_str!("compile_relay_artifacts/fixtures/original-client-fields-test.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/original-client-fields-test.expected");
-    test_fixture(transform_fixture, "original-client-fields-test.graphql", "compile_relay_artifacts/fixtures/original-client-fields-test.expected", input, expected);
+    test_fixture(transform_fixture, "original-client-fields-test.graphql", "compile_relay_artifacts/fixtures/original-client-fields-test.expected", input, expected).await;
 }
 
-#[test]
-fn plural_fragment() {
+#[tokio::test]
+async fn plural_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/plural-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/plural-fragment.expected");
-    test_fixture(transform_fixture, "plural-fragment.graphql", "compile_relay_artifacts/fixtures/plural-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "plural-fragment.graphql", "compile_relay_artifacts/fixtures/plural-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn prepend_node() {
+#[tokio::test]
+async fn prepend_node() {
     let input = include_str!("compile_relay_artifacts/fixtures/prepend-node.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/prepend-node.expected");
-    test_fixture(transform_fixture, "prepend-node.graphql", "compile_relay_artifacts/fixtures/prepend-node.expected", input, expected);
+    test_fixture(transform_fixture, "prepend-node.graphql", "compile_relay_artifacts/fixtures/prepend-node.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_directive() {
+#[tokio::test]
+async fn provided_variable_directive() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-directive.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-directive.expected");
-    test_fixture(transform_fixture, "provided-variable-directive.graphql", "compile_relay_artifacts/fixtures/provided-variable-directive.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-directive.graphql", "compile_relay_artifacts/fixtures/provided-variable-directive.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_in_fragment() {
+#[tokio::test]
+async fn provided_variable_in_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-in-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-in-fragment.expected");
-    test_fixture(transform_fixture, "provided-variable-in-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-in-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-in-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-in-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_multiple_queries() {
+#[tokio::test]
+async fn provided_variable_multiple_queries() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-multiple-queries.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-multiple-queries.expected");
-    test_fixture(transform_fixture, "provided-variable-multiple-queries.graphql", "compile_relay_artifacts/fixtures/provided-variable-multiple-queries.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-multiple-queries.graphql", "compile_relay_artifacts/fixtures/provided-variable-multiple-queries.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_nested_split_operation() {
+#[tokio::test]
+async fn provided_variable_nested_split_operation() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-nested-split-operation.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-nested-split-operation.expected");
-    test_fixture(transform_fixture, "provided-variable-nested-split-operation.graphql", "compile_relay_artifacts/fixtures/provided-variable-nested-split-operation.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-nested-split-operation.graphql", "compile_relay_artifacts/fixtures/provided-variable-nested-split-operation.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_no_inline_fragment() {
+#[tokio::test]
+async fn provided_variable_no_inline_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-no-inline-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-no-inline-fragment.expected");
-    test_fixture(transform_fixture, "provided-variable-no-inline-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-no-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-no-inline-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-no-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_passed_in_argument_invalid() {
+#[tokio::test]
+async fn provided_variable_passed_in_argument_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-passed-in-argument-invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-passed-in-argument-invalid.expected");
-    test_fixture(transform_fixture, "provided-variable-passed-in-argument-invalid.graphql", "compile_relay_artifacts/fixtures/provided-variable-passed-in-argument-invalid.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-passed-in-argument-invalid.graphql", "compile_relay_artifacts/fixtures/provided-variable-passed-in-argument-invalid.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_passed_in_argument_refetchable_fragment_invalid() {
+#[tokio::test]
+async fn provided_variable_passed_in_argument_refetchable_fragment_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-passed-in-argument-refetchable-fragment-invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-passed-in-argument-refetchable-fragment-invalid.expected");
-    test_fixture(transform_fixture, "provided-variable-passed-in-argument-refetchable-fragment-invalid.graphql", "compile_relay_artifacts/fixtures/provided-variable-passed-in-argument-refetchable-fragment-invalid.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-passed-in-argument-refetchable-fragment-invalid.graphql", "compile_relay_artifacts/fixtures/provided-variable-passed-in-argument-refetchable-fragment-invalid.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_refetchable_fragment() {
+#[tokio::test]
+async fn provided_variable_refetchable_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment.expected");
-    test_fixture(transform_fixture, "provided-variable-refetchable-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-refetchable-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_refetchable_fragment_combination() {
+#[tokio::test]
+async fn provided_variable_refetchable_fragment_combination() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment-combination.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment-combination.expected");
-    test_fixture(transform_fixture, "provided-variable-refetchable-fragment-combination.graphql", "compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment-combination.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-refetchable-fragment-combination.graphql", "compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment-combination.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_reused_nested_fragment() {
+#[tokio::test]
+async fn provided_variable_reused_nested_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.expected");
-    test_fixture(transform_fixture, "provided-variable-reused-nested-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-reused-nested-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_reused_nested_linked_fragment() {
+#[tokio::test]
+async fn provided_variable_reused_nested_linked_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.expected");
-    test_fixture(transform_fixture, "provided-variable-reused-nested-linked-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-reused-nested-linked-fragment.graphql", "compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn provided_variable_split_operation() {
+#[tokio::test]
+async fn provided_variable_split_operation() {
     let input = include_str!("compile_relay_artifacts/fixtures/provided-variable-split-operation.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/provided-variable-split-operation.expected");
-    test_fixture(transform_fixture, "provided-variable-split-operation.graphql", "compile_relay_artifacts/fixtures/provided-variable-split-operation.expected", input, expected);
+    test_fixture(transform_fixture, "provided-variable-split-operation.graphql", "compile_relay_artifacts/fixtures/provided-variable-split-operation.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_and_without_module_directive() {
+#[tokio::test]
+async fn query_with_and_without_module_directive() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-and-without-module-directive.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-and-without-module-directive.expected");
-    test_fixture(transform_fixture, "query-with-and-without-module-directive.graphql", "compile_relay_artifacts/fixtures/query-with-and-without-module-directive.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-and-without-module-directive.graphql", "compile_relay_artifacts/fixtures/query-with-and-without-module-directive.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_conditional_module() {
+#[tokio::test]
+async fn query_with_conditional_module() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-conditional-module.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-conditional-module.expected");
-    test_fixture(transform_fixture, "query-with-conditional-module.graphql", "compile_relay_artifacts/fixtures/query-with-conditional-module.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-conditional-module.graphql", "compile_relay_artifacts/fixtures/query-with-conditional-module.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_fragment_variables() {
+#[tokio::test]
+async fn query_with_fragment_variables() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-fragment-variables.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-fragment-variables.expected");
-    test_fixture(transform_fixture, "query-with-fragment-variables.graphql", "compile_relay_artifacts/fixtures/query-with-fragment-variables.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-fragment-variables.graphql", "compile_relay_artifacts/fixtures/query-with-fragment-variables.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_match_directive() {
+#[tokio::test]
+async fn query_with_match_directive() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive.expected");
-    test_fixture(transform_fixture, "query-with-match-directive.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-match-directive.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_match_directive_no_inline_experimental() {
+#[tokio::test]
+async fn query_with_match_directive_no_inline_experimental() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.expected");
-    test_fixture(transform_fixture, "query-with-match-directive-no-inline-experimental.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-match-directive-no-inline-experimental.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_match_directive_no_modules_invalid() {
+#[tokio::test]
+async fn query_with_match_directive_no_modules_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive-no-modules.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive-no-modules.invalid.expected");
-    test_fixture(transform_fixture, "query-with-match-directive-no-modules.invalid.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive-no-modules.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-match-directive-no-modules.invalid.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive-no-modules.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_match_directive_with_extra_argument() {
+#[tokio::test]
+async fn query_with_match_directive_with_extra_argument() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.expected");
-    test_fixture(transform_fixture, "query-with-match-directive-with-extra-argument.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-match-directive-with-extra-argument.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_match_directive_with_typename() {
+#[tokio::test]
+async fn query_with_match_directive_with_typename() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.expected");
-    test_fixture(transform_fixture, "query-with-match-directive-with-typename.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-match-directive-with-typename.graphql", "compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_module_directive() {
+#[tokio::test]
+async fn query_with_module_directive() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-module-directive.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-module-directive.expected");
-    test_fixture(transform_fixture, "query-with-module-directive.graphql", "compile_relay_artifacts/fixtures/query-with-module-directive.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-module-directive.graphql", "compile_relay_artifacts/fixtures/query-with-module-directive.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_module_directive_and_arguments() {
+#[tokio::test]
+async fn query_with_module_directive_and_arguments() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.expected");
-    test_fixture(transform_fixture, "query-with-module-directive-and-arguments.graphql", "compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-module-directive-and-arguments.graphql", "compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_module_directive_custom_import() {
+#[tokio::test]
+async fn query_with_module_directive_custom_import() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.expected");
-    test_fixture(transform_fixture, "query-with-module-directive-custom-import.graphql", "compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-module-directive-custom-import.graphql", "compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_module_directive_jsresource_import() {
+#[tokio::test]
+async fn query_with_module_directive_jsresource_import() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.expected");
-    test_fixture(transform_fixture, "query-with-module-directive-jsresource-import.graphql", "compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-module-directive-jsresource-import.graphql", "compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_raw_response_type_directive() {
+#[tokio::test]
+async fn query_with_raw_response_type_directive() {
     let input = include_str!("compile_relay_artifacts/fixtures/query-with-raw-response-type-directive.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/query-with-raw-response-type-directive.expected");
-    test_fixture(transform_fixture, "query-with-raw-response-type-directive.graphql", "compile_relay_artifacts/fixtures/query-with-raw-response-type-directive.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-raw-response-type-directive.graphql", "compile_relay_artifacts/fixtures/query-with-raw-response-type-directive.expected", input, expected).await;
 }
 
-#[test]
-fn redundant_selection_in_inline_fragments() {
+#[tokio::test]
+async fn redundant_selection_in_inline_fragments() {
     let input = include_str!("compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.expected");
-    test_fixture(transform_fixture, "redundant-selection-in-inline-fragments.graphql", "compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "redundant-selection-in-inline-fragments.graphql", "compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_conflict_with_operation_invalid() {
+#[tokio::test]
+async fn refetchable_conflict_with_operation_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable_conflict_with_operation.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable_conflict_with_operation.invalid.expected");
-    test_fixture(transform_fixture, "refetchable_conflict_with_operation.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable_conflict_with_operation.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable_conflict_with_operation.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable_conflict_with_operation.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_conflict_with_refetchable_invalid() {
+#[tokio::test]
+async fn refetchable_conflict_with_refetchable_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable_conflict_with_refetchable.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable_conflict_with_refetchable.invalid.expected");
-    test_fixture(transform_fixture, "refetchable_conflict_with_refetchable.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable_conflict_with_refetchable.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable_conflict_with_refetchable.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable_conflict_with_refetchable.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_connection() {
+#[tokio::test]
+async fn refetchable_connection() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable-connection.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable-connection.expected");
-    test_fixture(transform_fixture, "refetchable-connection.graphql", "compile_relay_artifacts/fixtures/refetchable-connection.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-connection.graphql", "compile_relay_artifacts/fixtures/refetchable-connection.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_connection_custom_handler() {
+#[tokio::test]
+async fn refetchable_connection_custom_handler() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable-connection-custom-handler.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable-connection-custom-handler.expected");
-    test_fixture(transform_fixture, "refetchable-connection-custom-handler.graphql", "compile_relay_artifacts/fixtures/refetchable-connection-custom-handler.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-connection-custom-handler.graphql", "compile_relay_artifacts/fixtures/refetchable-connection-custom-handler.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_directives_invalid() {
+#[tokio::test]
+async fn refetchable_fragment_directives_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable_fragment_directives.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable_fragment_directives.invalid.expected");
-    test_fixture(transform_fixture, "refetchable_fragment_directives.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable_fragment_directives.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable_fragment_directives.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable_fragment_directives.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_on_node_with_missing_id() {
+#[tokio::test]
+async fn refetchable_fragment_on_node_with_missing_id() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-on-node-with-missing-id.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-on-node-with-missing-id.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-with-connection.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-with-connection.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-with-connection.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-with-connection.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection_bidirectional() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection_bidirectional() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-bidirectional.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-bidirectional.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection-bidirectional.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-bidirectional.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection-bidirectional.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-bidirectional.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection_es_modules() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection_es_modules() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-es-modules.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-es-modules.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection-es-modules.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-es-modules.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection-es-modules.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-es-modules.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection_with_stream() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection_with_stream() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection-with-stream.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection-with-stream.graphql", "compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_with_arguments_conflicting_invalid() {
+#[tokio::test]
+async fn refetchable_with_arguments_conflicting_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable-with-arguments-conflicting.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable-with-arguments-conflicting.invalid.expected");
-    test_fixture(transform_fixture, "refetchable-with-arguments-conflicting.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable-with-arguments-conflicting.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-with-arguments-conflicting.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable-with-arguments-conflicting.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_with_arguments_invalid() {
+#[tokio::test]
+async fn refetchable_with_arguments_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/refetchable-with-arguments.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/refetchable-with-arguments.invalid.expected");
-    test_fixture(transform_fixture, "refetchable-with-arguments.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable-with-arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-with-arguments.invalid.graphql", "compile_relay_artifacts/fixtures/refetchable-with-arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_client_id_field() {
+#[tokio::test]
+async fn relay_client_id_field() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-client-id-field.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-client-id-field.expected");
-    test_fixture(transform_fixture, "relay-client-id-field.graphql", "compile_relay_artifacts/fixtures/relay-client-id-field.expected", input, expected);
+    test_fixture(transform_fixture, "relay-client-id-field.graphql", "compile_relay_artifacts/fixtures/relay-client-id-field.expected", input, expected).await;
 }
 
-#[test]
-fn relay_live_resolver() {
+#[tokio::test]
+async fn relay_live_resolver() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-live-resolver.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-live-resolver.expected");
-    test_fixture(transform_fixture, "relay-live-resolver.graphql", "compile_relay_artifacts/fixtures/relay-live-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "relay-live-resolver.graphql", "compile_relay_artifacts/fixtures/relay-live-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_live_resolver_without_fragment() {
+#[tokio::test]
+async fn relay_live_resolver_without_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-live-resolver-without-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-live-resolver-without-fragment.expected");
-    test_fixture(transform_fixture, "relay-live-resolver-without-fragment.graphql", "compile_relay_artifacts/fixtures/relay-live-resolver-without-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "relay-live-resolver-without-fragment.graphql", "compile_relay_artifacts/fixtures/relay-live-resolver-without-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn relay_model_resolver() {
+#[tokio::test]
+async fn relay_model_resolver() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-model-resolver.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-model-resolver.expected");
-    test_fixture(transform_fixture, "relay-model-resolver.graphql", "compile_relay_artifacts/fixtures/relay-model-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "relay-model-resolver.graphql", "compile_relay_artifacts/fixtures/relay-model-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver() {
+#[tokio::test]
+async fn relay_resolver() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver.expected");
-    test_fixture(transform_fixture, "relay-resolver.graphql", "compile_relay_artifacts/fixtures/relay-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver.graphql", "compile_relay_artifacts/fixtures/relay-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_alias() {
+#[tokio::test]
+async fn relay_resolver_alias() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-alias.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-alias.expected");
-    test_fixture(transform_fixture, "relay-resolver-alias.graphql", "compile_relay_artifacts/fixtures/relay-resolver-alias.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-alias.graphql", "compile_relay_artifacts/fixtures/relay-resolver-alias.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_backing_client_edge() {
+#[tokio::test]
+async fn relay_resolver_backing_client_edge() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-backing-client-edge.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-backing-client-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-backing-client-edge.graphql", "compile_relay_artifacts/fixtures/relay-resolver-backing-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-backing-client-edge.graphql", "compile_relay_artifacts/fixtures/relay-resolver-backing-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_edge_to_interface_with_child_interface_and_no_implementors() {
+#[tokio::test]
+async fn relay_resolver_edge_to_interface_with_child_interface_and_no_implementors() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-edge-to-interface-with-child-interface-and-no-implementors.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-edge-to-interface-with-child-interface-and-no-implementors.expected");
-    test_fixture(transform_fixture, "relay-resolver-edge-to-interface-with-child-interface-and-no-implementors.graphql", "compile_relay_artifacts/fixtures/relay-resolver-edge-to-interface-with-child-interface-and-no-implementors.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-edge-to-interface-with-child-interface-and-no-implementors.graphql", "compile_relay_artifacts/fixtures/relay-resolver-edge-to-interface-with-child-interface-and-no-implementors.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_edge_to_interface_with_no_implementors() {
+#[tokio::test]
+async fn relay_resolver_edge_to_interface_with_no_implementors() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-edge-to-interface-with-no-implementors.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-edge-to-interface-with-no-implementors.expected");
-    test_fixture(transform_fixture, "relay-resolver-edge-to-interface-with-no-implementors.graphql", "compile_relay_artifacts/fixtures/relay-resolver-edge-to-interface-with-no-implementors.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-edge-to-interface-with-no-implementors.graphql", "compile_relay_artifacts/fixtures/relay-resolver-edge-to-interface-with-no-implementors.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_es_modules() {
+#[tokio::test]
+async fn relay_resolver_es_modules() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-es-modules.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-es-modules.expected");
-    test_fixture(transform_fixture, "relay-resolver-es-modules.graphql", "compile_relay_artifacts/fixtures/relay-resolver-es-modules.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-es-modules.graphql", "compile_relay_artifacts/fixtures/relay-resolver-es-modules.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_live_weak_object() {
+#[tokio::test]
+async fn relay_resolver_live_weak_object() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-live-weak-object.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-live-weak-object.expected");
-    test_fixture(transform_fixture, "relay-resolver-live-weak-object.graphql", "compile_relay_artifacts/fixtures/relay-resolver-live-weak-object.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-live-weak-object.graphql", "compile_relay_artifacts/fixtures/relay-resolver-live-weak-object.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_named_import() {
+#[tokio::test]
+async fn relay_resolver_named_import() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-named-import.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-named-import.expected");
-    test_fixture(transform_fixture, "relay-resolver-named-import.graphql", "compile_relay_artifacts/fixtures/relay-resolver-named-import.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-named-import.graphql", "compile_relay_artifacts/fixtures/relay-resolver-named-import.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_abstract_client_type() {
+#[tokio::test]
+async fn relay_resolver_on_abstract_client_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-on-abstract-client-type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-on-abstract-client-type.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-abstract-client-type.graphql", "compile_relay_artifacts/fixtures/relay-resolver-on-abstract-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-abstract-client-type.graphql", "compile_relay_artifacts/fixtures/relay-resolver-on-abstract-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_required() {
+#[tokio::test]
+async fn relay_resolver_required() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-required.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-required.expected");
-    test_fixture(transform_fixture, "relay-resolver-required.graphql", "compile_relay_artifacts/fixtures/relay-resolver-required.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-required.graphql", "compile_relay_artifacts/fixtures/relay-resolver-required.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_weak_object() {
+#[tokio::test]
+async fn relay_resolver_weak_object() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-weak-object.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-weak-object.expected");
-    test_fixture(transform_fixture, "relay-resolver-weak-object.graphql", "compile_relay_artifacts/fixtures/relay-resolver-weak-object.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-weak-object.graphql", "compile_relay_artifacts/fixtures/relay-resolver-weak-object.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_weak_object_normalization_ast() {
+#[tokio::test]
+async fn relay_resolver_weak_object_normalization_ast() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-weak-object-normalization-ast.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-weak-object-normalization-ast.expected");
-    test_fixture(transform_fixture, "relay-resolver-weak-object-normalization-ast.graphql", "compile_relay_artifacts/fixtures/relay-resolver-weak-object-normalization-ast.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-weak-object-normalization-ast.graphql", "compile_relay_artifacts/fixtures/relay-resolver-weak-object-normalization-ast.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_weak_object_plural() {
+#[tokio::test]
+async fn relay_resolver_weak_object_plural() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-weak-object-plural.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-weak-object-plural.expected");
-    test_fixture(transform_fixture, "relay-resolver-weak-object-plural.graphql", "compile_relay_artifacts/fixtures/relay-resolver-weak-object-plural.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-weak-object-plural.graphql", "compile_relay_artifacts/fixtures/relay-resolver-weak-object-plural.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_args() {
+#[tokio::test]
+async fn relay_resolver_with_args() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-args.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-args.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-args.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-args.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-args.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-args.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_args_and_alias() {
+#[tokio::test]
+async fn relay_resolver_with_args_and_alias() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-args-and-alias.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-args-and-alias.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-args-and-alias.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-args-and-alias.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-args-and-alias.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-args-and-alias.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_args_and_alias_no_fragment() {
+#[tokio::test]
+async fn relay_resolver_with_args_and_alias_no_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-args-and-alias-no-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-args-and-alias-no-fragment.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-args-and-alias-no-fragment.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-args-and-alias-no-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-args-and-alias-no-fragment.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-args-and-alias-no-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_fragment_on_client_type() {
+#[tokio::test]
+async fn relay_resolver_with_fragment_on_client_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-fragment-on-client-type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-fragment-on-client-type.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-fragment-on-client-type.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-fragment-on-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-fragment-on-client-type.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-fragment-on-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_client_object() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_client_object() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-output-type-client-object.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-output-type-client-object.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-object.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-output-type-client-object.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-object.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-output-type-client-object.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_scalar() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_scalar() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-output-type-scalar.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-output-type-scalar.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-scalar.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-output-type-scalar.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-scalar.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-output-type-scalar.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_required_client_edge() {
+#[tokio::test]
+async fn relay_resolver_with_required_client_edge() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-required-client-edge.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-required-client-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-required-client-edge.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-required-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-required-client-edge.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-required-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_spread_invalid() {
+#[tokio::test]
+async fn relay_resolver_with_spread_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-spread.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-with-spread.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-spread.invalid.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-spread.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-spread.invalid.graphql", "compile_relay_artifacts/fixtures/relay-resolver-with-spread.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_without_fragment_on_client_type() {
+#[tokio::test]
+async fn relay_resolver_without_fragment_on_client_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolver-without-fragment-on-client-type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolver-without-fragment-on-client-type.expected");
-    test_fixture(transform_fixture, "relay-resolver-without-fragment-on-client-type.graphql", "compile_relay_artifacts/fixtures/relay-resolver-without-fragment-on-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-without-fragment-on-client-type.graphql", "compile_relay_artifacts/fixtures/relay-resolver-without-fragment-on-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolvers_with_different_field_args_are_not_merged() {
+#[tokio::test]
+async fn relay_resolvers_with_different_field_args_are_not_merged() {
     let input = include_str!("compile_relay_artifacts/fixtures/relay-resolvers-with-different-field-args-are-not-merged.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/relay-resolvers-with-different-field-args-are-not-merged.expected");
-    test_fixture(transform_fixture, "relay-resolvers-with-different-field-args-are-not-merged.graphql", "compile_relay_artifacts/fixtures/relay-resolvers-with-different-field-args-are-not-merged.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolvers-with-different-field-args-are-not-merged.graphql", "compile_relay_artifacts/fixtures/relay-resolvers-with-different-field-args-are-not-merged.expected", input, expected).await;
 }
 
-#[test]
-fn required_argument_not_passed_default_value() {
+#[tokio::test]
+async fn required_argument_not_passed_default_value() {
     let input = include_str!("compile_relay_artifacts/fixtures/required_argument_not_passed_default_value.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/required_argument_not_passed_default_value.expected");
-    test_fixture(transform_fixture, "required_argument_not_passed_default_value.graphql", "compile_relay_artifacts/fixtures/required_argument_not_passed_default_value.expected", input, expected);
+    test_fixture(transform_fixture, "required_argument_not_passed_default_value.graphql", "compile_relay_artifacts/fixtures/required_argument_not_passed_default_value.expected", input, expected).await;
 }
 
-#[test]
-fn required_argument_not_passed_no_args_invalid() {
+#[tokio::test]
+async fn required_argument_not_passed_no_args_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/required_argument_not_passed_no_args.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/required_argument_not_passed_no_args.invalid.expected");
-    test_fixture(transform_fixture, "required_argument_not_passed_no_args.invalid.graphql", "compile_relay_artifacts/fixtures/required_argument_not_passed_no_args.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "required_argument_not_passed_no_args.invalid.graphql", "compile_relay_artifacts/fixtures/required_argument_not_passed_no_args.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn required_argument_not_passed_other_args_invalid() {
+#[tokio::test]
+async fn required_argument_not_passed_other_args_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/required_argument_not_passed_other_args.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/required_argument_not_passed_other_args.invalid.expected");
-    test_fixture(transform_fixture, "required_argument_not_passed_other_args.invalid.graphql", "compile_relay_artifacts/fixtures/required_argument_not_passed_other_args.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "required_argument_not_passed_other_args.invalid.graphql", "compile_relay_artifacts/fixtures/required_argument_not_passed_other_args.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_client_edge() {
+#[tokio::test]
+async fn required_bubbles_to_client_edge() {
     let input = include_str!("compile_relay_artifacts/fixtures/required-bubbles-to-client-edge.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/required-bubbles-to-client-edge.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-client-edge.graphql", "compile_relay_artifacts/fixtures/required-bubbles-to-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-client-edge.graphql", "compile_relay_artifacts/fixtures/required-bubbles-to-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn required_directive() {
+#[tokio::test]
+async fn required_directive() {
     let input = include_str!("compile_relay_artifacts/fixtures/required-directive.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/required-directive.expected");
-    test_fixture(transform_fixture, "required-directive.graphql", "compile_relay_artifacts/fixtures/required-directive.expected", input, expected);
+    test_fixture(transform_fixture, "required-directive.graphql", "compile_relay_artifacts/fixtures/required-directive.expected", input, expected).await;
 }
 
-#[test]
-fn resolver_with_root_fragment_on_model_type() {
+#[tokio::test]
+async fn resolver_with_root_fragment_on_model_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/resolver-with-root-fragment-on-model-type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/resolver-with-root-fragment-on-model-type.expected");
-    test_fixture(transform_fixture, "resolver-with-root-fragment-on-model-type.graphql", "compile_relay_artifacts/fixtures/resolver-with-root-fragment-on-model-type.expected", input, expected);
+    test_fixture(transform_fixture, "resolver-with-root-fragment-on-model-type.graphql", "compile_relay_artifacts/fixtures/resolver-with-root-fragment-on-model-type.expected", input, expected).await;
 }
 
-#[test]
-fn same_fields_with_different_args_invalid() {
+#[tokio::test]
+async fn same_fields_with_different_args_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/same-fields-with-different-args.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/same-fields-with-different-args.invalid.expected");
-    test_fixture(transform_fixture, "same-fields-with-different-args.invalid.graphql", "compile_relay_artifacts/fixtures/same-fields-with-different-args.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "same-fields-with-different-args.invalid.graphql", "compile_relay_artifacts/fixtures/same-fields-with-different-args.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn same_fields_with_different_args_variables_invalid() {
+#[tokio::test]
+async fn same_fields_with_different_args_variables_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/same_fields_with_different_args_variables.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/same_fields_with_different_args_variables.invalid.expected");
-    test_fixture(transform_fixture, "same_fields_with_different_args_variables.invalid.graphql", "compile_relay_artifacts/fixtures/same_fields_with_different_args_variables.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "same_fields_with_different_args_variables.invalid.graphql", "compile_relay_artifacts/fixtures/same_fields_with_different_args_variables.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_handle_field() {
+#[tokio::test]
+async fn scalar_handle_field() {
     let input = include_str!("compile_relay_artifacts/fixtures/scalar-handle-field.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/scalar-handle-field.expected");
-    test_fixture(transform_fixture, "scalar-handle-field.graphql", "compile_relay_artifacts/fixtures/scalar-handle-field.expected", input, expected);
+    test_fixture(transform_fixture, "scalar-handle-field.graphql", "compile_relay_artifacts/fixtures/scalar-handle-field.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_added_argument() {
+#[tokio::test]
+async fn selection_set_conflict_added_argument() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_added_argument.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_added_argument.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_added_argument.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_added_argument.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_added_argument.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_added_argument.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_alias_covering_name() {
+#[tokio::test]
+async fn selection_set_conflict_alias_covering_name() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_alias_covering_name.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_alias_covering_name.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_alias_covering_name.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_alias_covering_name.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_alias_covering_name.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_alias_covering_name.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_composite_vs_noncomposite() {
+#[tokio::test]
+async fn selection_set_conflict_composite_vs_noncomposite() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_composite_vs_noncomposite.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_composite_vs_noncomposite.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_composite_vs_noncomposite.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_composite_vs_noncomposite.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_composite_vs_noncomposite.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_composite_vs_noncomposite.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_conflicting_list_and_non_list_types() {
+#[tokio::test]
+async fn selection_set_conflict_conflicting_list_and_non_list_types() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_list_and_non_list_types.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_list_and_non_list_types.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_conflicting_list_and_non_list_types.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_list_and_non_list_types.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_conflicting_list_and_non_list_types.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_list_and_non_list_types.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_conflicting_list_and_non_list_types_opposite_order() {
+#[tokio::test]
+async fn selection_set_conflict_conflicting_list_and_non_list_types_opposite_order() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_list_and_non_list_types_opposite_order.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_list_and_non_list_types_opposite_order.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_conflicting_list_and_non_list_types_opposite_order.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_list_and_non_list_types_opposite_order.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_conflicting_list_and_non_list_types_opposite_order.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_list_and_non_list_types_opposite_order.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_conflicting_nullable_and_non_nullable_types() {
+#[tokio::test]
+async fn selection_set_conflict_conflicting_nullable_and_non_nullable_types() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_nullable_and_non_nullable_types.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_nullable_and_non_nullable_types.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_conflicting_nullable_and_non_nullable_types.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_nullable_and_non_nullable_types.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_conflicting_nullable_and_non_nullable_types.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_nullable_and_non_nullable_types.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_conflicting_selection_sets_inside_list_type() {
+#[tokio::test]
+async fn selection_set_conflict_conflicting_selection_sets_inside_list_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_selection_sets_inside_list_type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_selection_sets_inside_list_type.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_conflicting_selection_sets_inside_list_type.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_selection_sets_inside_list_type.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_conflicting_selection_sets_inside_list_type.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_selection_sets_inside_list_type.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_conflicting_selection_sets_inside_list_type_multiple_conflicts() {
+#[tokio::test]
+async fn selection_set_conflict_conflicting_selection_sets_inside_list_type_multiple_conflicts() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_selection_sets_inside_list_type_multiple_conflicts.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_selection_sets_inside_list_type_multiple_conflicts.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_conflicting_selection_sets_inside_list_type_multiple_conflicts.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_selection_sets_inside_list_type_multiple_conflicts.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_conflicting_selection_sets_inside_list_type_multiple_conflicts.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_conflicting_selection_sets_inside_list_type_multiple_conflicts.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_aliases() {
+#[tokio::test]
+async fn selection_set_conflict_different_aliases() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_aliases.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_aliases.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_aliases.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_aliases.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_aliases.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_aliases.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_arguments() {
+#[tokio::test]
+async fn selection_set_conflict_different_arguments() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_arguments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_arguments.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_arguments.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_arguments.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_arguments.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_arguments.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_arguments_with_list() {
+#[tokio::test]
+async fn selection_set_conflict_different_arguments_with_list() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_arguments_with_list.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_arguments_with_list.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_arguments_with_list.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_arguments_with_list.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_arguments_with_list.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_arguments_with_list.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_name() {
+#[tokio::test]
+async fn selection_set_conflict_different_name() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_name.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_name.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_name.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_name.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_name.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_name.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_return_types_for_field_but_same_shape() {
+#[tokio::test]
+async fn selection_set_conflict_different_return_types_for_field_but_same_shape() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_return_types_for_field_but_same_shape.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_return_types_for_field_but_same_shape.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_return_types_for_field_but_same_shape.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_return_types_for_field_but_same_shape.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_return_types_for_field_but_same_shape.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_return_types_for_field_but_same_shape.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_types_with_conflict() {
+#[tokio::test]
+async fn selection_set_conflict_different_types_with_conflict() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_types_with_conflict.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_types_with_conflict.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_types_with_conflict_different_shape() {
+#[tokio::test]
+async fn selection_set_conflict_different_types_with_conflict_different_shape() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict_different_shape.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict_different_shape.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_types_with_conflict_different_shape.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict_different_shape.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_types_with_conflict_different_shape.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict_different_shape.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_types_with_conflict_in_typeless_inline_fragments() {
+#[tokio::test]
+async fn selection_set_conflict_different_types_with_conflict_in_typeless_inline_fragments() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict_in_typeless_inline_fragments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict_in_typeless_inline_fragments.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_types_with_conflict_in_typeless_inline_fragments.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict_in_typeless_inline_fragments.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_types_with_conflict_in_typeless_inline_fragments.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_with_conflict_in_typeless_inline_fragments.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_types_without_conflict() {
+#[tokio::test]
+async fn selection_set_conflict_different_types_without_conflict() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_types_without_conflict.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_types_without_conflict.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_types_without_conflict_1() {
+#[tokio::test]
+async fn selection_set_conflict_different_types_without_conflict_1() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict_1.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict_1.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_types_without_conflict_1.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict_1.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_types_without_conflict_1.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict_1.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_different_types_without_conflict_in_typeless_inline_fragments() {
+#[tokio::test]
+async fn selection_set_conflict_different_types_without_conflict_in_typeless_inline_fragments() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict_in_typeless_inline_fragments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict_in_typeless_inline_fragments.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_different_types_without_conflict_in_typeless_inline_fragments.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict_in_typeless_inline_fragments.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_different_types_without_conflict_in_typeless_inline_fragments.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_different_types_without_conflict_in_typeless_inline_fragments.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_inconsistent_stream_usage_1() {
+#[tokio::test]
+async fn selection_set_conflict_inconsistent_stream_usage_1() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_inconsistent_stream_usage_1.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_inconsistent_stream_usage_1.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_inconsistent_stream_usage_2() {
+#[tokio::test]
+async fn selection_set_conflict_inconsistent_stream_usage_2() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_inconsistent_stream_usage_2.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_inconsistent_stream_usage_2.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_invalid_same_fragments_in_different_contexts() {
+#[tokio::test]
+async fn selection_set_conflict_invalid_same_fragments_in_different_contexts() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_invalid_same_fragments_in_different_contexts.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_invalid_same_fragments_in_different_contexts.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_invalid_same_fragments_in_different_contexts.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_invalid_same_fragments_in_different_contexts.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_invalid_same_fragments_in_different_contexts.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_invalid_same_fragments_in_different_contexts.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_missing_argument() {
+#[tokio::test]
+async fn selection_set_conflict_missing_argument() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_missing_argument.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_missing_argument.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_missing_argument.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_missing_argument.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_missing_argument.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_missing_argument.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_multiple_conflicts() {
+#[tokio::test]
+async fn selection_set_conflict_multiple_conflicts() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_multiple_conflicts.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_multiple_conflicts.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_multiple_conflicts.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_multiple_conflicts.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_multiple_conflicts.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_multiple_conflicts.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_multiple_conflicts_with_different_args() {
+#[tokio::test]
+async fn selection_set_conflict_multiple_conflicts_with_different_args() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_multiple_conflicts_with_different_args.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_multiple_conflicts_with_different_args.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_multiple_conflicts_with_different_args.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_multiple_conflicts_with_different_args.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_multiple_conflicts_with_different_args.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_multiple_conflicts_with_different_args.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_nested_conflict() {
+#[tokio::test]
+async fn selection_set_conflict_nested_conflict() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_nested_conflict.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_nested_conflict.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_nested_conflict.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_nested_conflict.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_nested_conflict.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_nested_conflict.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_stream_on_nodes_or_edges() {
+#[tokio::test]
+async fn selection_set_conflict_stream_on_nodes_or_edges() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_stream_on_nodes_or_edges.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_stream_on_nodes_or_edges.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info() {
+#[tokio::test]
+async fn selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias() {
+#[tokio::test]
+async fn selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_valid() {
+#[tokio::test]
+async fn selection_set_conflict_valid() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_valid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_valid.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_valid.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_valid.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_valid.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_valid.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_valid_stream() {
+#[tokio::test]
+async fn selection_set_conflict_valid_stream() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_valid_stream.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_valid_stream.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_with_fragment() {
+#[tokio::test]
+async fn selection_set_conflict_with_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_with_fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_with_fragment.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_with_fragment.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_with_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_with_fragment.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_with_fragment.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_with_inline_fragment() {
+#[tokio::test]
+async fn selection_set_conflict_with_inline_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_with_inline_fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_with_inline_fragment.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_with_inline_fragment.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_with_inline_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_with_inline_fragment.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_with_inline_fragment.expected", input, expected).await;
 }
 
-#[test]
-fn selection_set_conflict_with_nested_fragments() {
+#[tokio::test]
+async fn selection_set_conflict_with_nested_fragments() {
     let input = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_with_nested_fragments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selection_set_conflict_with_nested_fragments.expected");
-    test_fixture(transform_fixture, "selection_set_conflict_with_nested_fragments.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_with_nested_fragments.expected", input, expected);
+    test_fixture(transform_fixture, "selection_set_conflict_with_nested_fragments.graphql", "compile_relay_artifacts/fixtures/selection_set_conflict_with_nested_fragments.expected", input, expected).await;
 }
 
-#[test]
-fn selections_on_interface() {
+#[tokio::test]
+async fn selections_on_interface() {
     let input = include_str!("compile_relay_artifacts/fixtures/selections-on-interface.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/selections-on-interface.expected");
-    test_fixture(transform_fixture, "selections-on-interface.graphql", "compile_relay_artifacts/fixtures/selections-on-interface.expected", input, expected);
+    test_fixture(transform_fixture, "selections-on-interface.graphql", "compile_relay_artifacts/fixtures/selections-on-interface.expected", input, expected).await;
 }
 
-#[test]
-fn sibling_client_selections() {
+#[tokio::test]
+async fn sibling_client_selections() {
     let input = include_str!("compile_relay_artifacts/fixtures/sibling-client-selections.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/sibling-client-selections.expected");
-    test_fixture(transform_fixture, "sibling-client-selections.graphql", "compile_relay_artifacts/fixtures/sibling-client-selections.expected", input, expected);
+    test_fixture(transform_fixture, "sibling-client-selections.graphql", "compile_relay_artifacts/fixtures/sibling-client-selections.expected", input, expected).await;
 }
 
-#[test]
-fn spread_of_assignable_fragment() {
+#[tokio::test]
+async fn spread_of_assignable_fragment() {
     let input = include_str!("compile_relay_artifacts/fixtures/spread-of-assignable-fragment.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/spread-of-assignable-fragment.expected");
-    test_fixture(transform_fixture, "spread-of-assignable-fragment.graphql", "compile_relay_artifacts/fixtures/spread-of-assignable-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "spread-of-assignable-fragment.graphql", "compile_relay_artifacts/fixtures/spread-of-assignable-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn stable_literals() {
+#[tokio::test]
+async fn stable_literals() {
     let input = include_str!("compile_relay_artifacts/fixtures/stable-literals.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/stable-literals.expected");
-    test_fixture(transform_fixture, "stable-literals.graphql", "compile_relay_artifacts/fixtures/stable-literals.expected", input, expected);
+    test_fixture(transform_fixture, "stable-literals.graphql", "compile_relay_artifacts/fixtures/stable-literals.expected", input, expected).await;
 }
 
-#[test]
-fn stream_and_handle() {
+#[tokio::test]
+async fn stream_and_handle() {
     let input = include_str!("compile_relay_artifacts/fixtures/stream-and-handle.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/stream-and-handle.expected");
-    test_fixture(transform_fixture, "stream-and-handle.graphql", "compile_relay_artifacts/fixtures/stream-and-handle.expected", input, expected);
+    test_fixture(transform_fixture, "stream-and-handle.graphql", "compile_relay_artifacts/fixtures/stream-and-handle.expected", input, expected).await;
 }
 
-#[test]
-fn stream_connection() {
+#[tokio::test]
+async fn stream_connection() {
     let input = include_str!("compile_relay_artifacts/fixtures/stream-connection.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/stream-connection.expected");
-    test_fixture(transform_fixture, "stream-connection.graphql", "compile_relay_artifacts/fixtures/stream-connection.expected", input, expected);
+    test_fixture(transform_fixture, "stream-connection.graphql", "compile_relay_artifacts/fixtures/stream-connection.expected", input, expected).await;
 }
 
-#[test]
-fn stream_connection_conditional() {
+#[tokio::test]
+async fn stream_connection_conditional() {
     let input = include_str!("compile_relay_artifacts/fixtures/stream-connection-conditional.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/stream-connection-conditional.expected");
-    test_fixture(transform_fixture, "stream-connection-conditional.graphql", "compile_relay_artifacts/fixtures/stream-connection-conditional.expected", input, expected);
+    test_fixture(transform_fixture, "stream-connection-conditional.graphql", "compile_relay_artifacts/fixtures/stream-connection-conditional.expected", input, expected).await;
 }
 
-#[test]
-fn stream_if_arguments() {
+#[tokio::test]
+async fn stream_if_arguments() {
     let input = include_str!("compile_relay_artifacts/fixtures/stream_if_arguments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/stream_if_arguments.expected");
-    test_fixture(transform_fixture, "stream_if_arguments.graphql", "compile_relay_artifacts/fixtures/stream_if_arguments.expected", input, expected);
+    test_fixture(transform_fixture, "stream_if_arguments.graphql", "compile_relay_artifacts/fixtures/stream_if_arguments.expected", input, expected).await;
 }
 
-#[test]
-fn supported_arg() {
+#[tokio::test]
+async fn supported_arg() {
     let input = include_str!("compile_relay_artifacts/fixtures/supported_arg.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/supported_arg.expected");
-    test_fixture(transform_fixture, "supported_arg.graphql", "compile_relay_artifacts/fixtures/supported_arg.expected", input, expected);
+    test_fixture(transform_fixture, "supported_arg.graphql", "compile_relay_artifacts/fixtures/supported_arg.expected", input, expected).await;
 }
 
-#[test]
-fn supported_arg_non_static_invalid() {
+#[tokio::test]
+async fn supported_arg_non_static_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/supported_arg_non_static.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/supported_arg_non_static.invalid.expected");
-    test_fixture(transform_fixture, "supported_arg_non_static.invalid.graphql", "compile_relay_artifacts/fixtures/supported_arg_non_static.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "supported_arg_non_static.invalid.graphql", "compile_relay_artifacts/fixtures/supported_arg_non_static.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unions() {
+#[tokio::test]
+async fn unions() {
     let input = include_str!("compile_relay_artifacts/fixtures/unions.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unions.expected");
-    test_fixture(transform_fixture, "unions.graphql", "compile_relay_artifacts/fixtures/unions.expected", input, expected);
+    test_fixture(transform_fixture, "unions.graphql", "compile_relay_artifacts/fixtures/unions.expected", input, expected).await;
 }
 
-#[test]
-fn unknown_root_variable_in_fragment_invalid() {
+#[tokio::test]
+async fn unknown_root_variable_in_fragment_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/unknown-root-variable-in-fragment.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unknown-root-variable-in-fragment.invalid.expected");
-    test_fixture(transform_fixture, "unknown-root-variable-in-fragment.invalid.graphql", "compile_relay_artifacts/fixtures/unknown-root-variable-in-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unknown-root-variable-in-fragment.invalid.graphql", "compile_relay_artifacts/fixtures/unknown-root-variable-in-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_fragment_spreads_dup_arguments() {
+#[tokio::test]
+async fn unmasked_fragment_spreads_dup_arguments() {
     let input = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-dup-arguments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-dup-arguments.expected");
-    test_fixture(transform_fixture, "unmasked-fragment-spreads-dup-arguments.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-dup-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-fragment-spreads-dup-arguments.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-dup-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_fragment_spreads_global_arguments() {
+#[tokio::test]
+async fn unmasked_fragment_spreads_global_arguments() {
     let input = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-global-arguments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-global-arguments.expected");
-    test_fixture(transform_fixture, "unmasked-fragment-spreads-global-arguments.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-global-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-fragment-spreads-global-arguments.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-global-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_fragment_spreads_local_arguments_invalid() {
+#[tokio::test]
+async fn unmasked_fragment_spreads_local_arguments_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-local-arguments.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-local-arguments.invalid.expected");
-    test_fixture(transform_fixture, "unmasked-fragment-spreads-local-arguments.invalid.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-local-arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-fragment-spreads-local-arguments.invalid.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-local-arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_fragment_spreads_on_query() {
+#[tokio::test]
+async fn unmasked_fragment_spreads_on_query() {
     let input = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-on-query.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-on-query.expected");
-    test_fixture(transform_fixture, "unmasked-fragment-spreads-on-query.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-on-query.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-fragment-spreads-on-query.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-on-query.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_fragment_spreads_recursive() {
+#[tokio::test]
+async fn unmasked_fragment_spreads_recursive() {
     let input = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-recursive.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unmasked-fragment-spreads-recursive.expected");
-    test_fixture(transform_fixture, "unmasked-fragment-spreads-recursive.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-recursive.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-fragment-spreads-recursive.graphql", "compile_relay_artifacts/fixtures/unmasked-fragment-spreads-recursive.expected", input, expected).await;
 }
 
-#[test]
-fn unused_fragment_arg_invalid() {
+#[tokio::test]
+async fn unused_fragment_arg_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/unused_fragment_arg.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unused_fragment_arg.invalid.expected");
-    test_fixture(transform_fixture, "unused_fragment_arg.invalid.graphql", "compile_relay_artifacts/fixtures/unused_fragment_arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unused_fragment_arg.invalid.graphql", "compile_relay_artifacts/fixtures/unused_fragment_arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unused_fragment_arg_unchecked() {
+#[tokio::test]
+async fn unused_fragment_arg_unchecked() {
     let input = include_str!("compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.expected");
-    test_fixture(transform_fixture, "unused_fragment_arg_unchecked.graphql", "compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.expected", input, expected);
+    test_fixture(transform_fixture, "unused_fragment_arg_unchecked.graphql", "compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.expected", input, expected).await;
 }
 
-#[test]
-fn unused_fragment_argdef_invalid() {
+#[tokio::test]
+async fn unused_fragment_argdef_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/unused_fragment_argdef.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unused_fragment_argdef.invalid.expected");
-    test_fixture(transform_fixture, "unused_fragment_argdef.invalid.graphql", "compile_relay_artifacts/fixtures/unused_fragment_argdef.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unused_fragment_argdef.invalid.graphql", "compile_relay_artifacts/fixtures/unused_fragment_argdef.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unused_fragment_argdef_invalid_suppression_arg_invalid() {
+#[tokio::test]
+async fn unused_fragment_argdef_invalid_suppression_arg_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/unused_fragment_argdef_invalid_suppression_arg.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unused_fragment_argdef_invalid_suppression_arg.invalid.expected");
-    test_fixture(transform_fixture, "unused_fragment_argdef_invalid_suppression_arg.invalid.graphql", "compile_relay_artifacts/fixtures/unused_fragment_argdef_invalid_suppression_arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unused_fragment_argdef_invalid_suppression_arg.invalid.graphql", "compile_relay_artifacts/fixtures/unused_fragment_argdef_invalid_suppression_arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unused_variables_removed_from_print_not_codegen() {
+#[tokio::test]
+async fn unused_variables_removed_from_print_not_codegen() {
     let input = include_str!("compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.expected");
-    test_fixture(transform_fixture, "unused-variables-removed-from-print-not-codegen.graphql", "compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.expected", input, expected);
+    test_fixture(transform_fixture, "unused-variables-removed-from-print-not-codegen.graphql", "compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread() {
+#[tokio::test]
+async fn updatable_fragment_spread() {
     let input = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread.expected");
-    test_fixture(transform_fixture, "updatable-fragment-spread.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment-spread.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_with_defer_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_with_defer_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-defer.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-defer.invalid.expected");
-    test_fixture(transform_fixture, "updatable-fragment-spread-with-defer.invalid.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-defer.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment-spread-with-defer.invalid.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-defer.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_with_include_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_with_include_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-include.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-include.invalid.expected");
-    test_fixture(transform_fixture, "updatable-fragment-spread-with-include.invalid.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-include.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment-spread-with-include.invalid.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-include.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_with_typename_sibling() {
+#[tokio::test]
+async fn updatable_fragment_spread_with_typename_sibling() {
     let input = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-typename-sibling.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-typename-sibling.expected");
-    test_fixture(transform_fixture, "updatable-fragment-spread-with-typename-sibling.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-typename-sibling.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment-spread-with-typename-sibling.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-typename-sibling.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_with_unused_variables() {
+#[tokio::test]
+async fn updatable_fragment_spread_with_unused_variables() {
     let input = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-unused-variables.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-unused-variables.expected");
-    test_fixture(transform_fixture, "updatable-fragment-spread-with-unused-variables.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-unused-variables.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment-spread-with-unused-variables.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-unused-variables.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_with_variables() {
+#[tokio::test]
+async fn updatable_fragment_spread_with_variables() {
     let input = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-variables.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/updatable-fragment-spread-with-variables.expected");
-    test_fixture(transform_fixture, "updatable-fragment-spread-with-variables.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-variables.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment-spread-with-variables.graphql", "compile_relay_artifacts/fixtures/updatable-fragment-spread-with-variables.expected", input, expected).await;
 }
 
-#[test]
-fn validate_global_variables_invalid() {
+#[tokio::test]
+async fn validate_global_variables_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/validate-global-variables.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/validate-global-variables.invalid.expected");
-    test_fixture(transform_fixture, "validate-global-variables.invalid.graphql", "compile_relay_artifacts/fixtures/validate-global-variables.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "validate-global-variables.invalid.graphql", "compile_relay_artifacts/fixtures/validate-global-variables.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn validate_global_variables_shared_fragment_invalid() {
+#[tokio::test]
+async fn validate_global_variables_shared_fragment_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/validate-global-variables-shared-fragment.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/validate-global-variables-shared-fragment.invalid.expected");
-    test_fixture(transform_fixture, "validate-global-variables-shared-fragment.invalid.graphql", "compile_relay_artifacts/fixtures/validate-global-variables-shared-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "validate-global-variables-shared-fragment.invalid.graphql", "compile_relay_artifacts/fixtures/validate-global-variables-shared-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn viewer_query() {
+#[tokio::test]
+async fn viewer_query() {
     let input = include_str!("compile_relay_artifacts/fixtures/viewer-query.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/viewer-query.expected");
-    test_fixture(transform_fixture, "viewer-query.graphql", "compile_relay_artifacts/fixtures/viewer-query.expected", input, expected);
+    test_fixture(transform_fixture, "viewer-query.graphql", "compile_relay_artifacts/fixtures/viewer-query.expected", input, expected).await;
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id/mod.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id/mod.rs
@@ -40,7 +40,7 @@ use relay_test_schema::get_test_schema_with_custom_id_with_extensions;
 use relay_transforms::apply_transforms;
 use relay_transforms::DIRECTIVE_SPLIT_OPERATION;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     if fixture.content.contains("%TODO%") {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id_test.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1e99c40a98b34b55c49b7b2a2bfddae2>>
+ * @generated SignedSource<<2f3663ff1e048e3545e5cb7b479734e7>>
  */
 
 mod compile_relay_artifacts_with_custom_id;
@@ -12,135 +12,135 @@ mod compile_relay_artifacts_with_custom_id;
 use compile_relay_artifacts_with_custom_id::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_on_node_interface() {
+#[tokio::test]
+async fn fragment_on_node_interface() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-node-interface.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-node-interface.expected");
-    test_fixture(transform_fixture, "fragment-on-node-interface.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-node-interface.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-node-interface.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-node-interface.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_node_interface_with_custom_variable_name() {
+#[tokio::test]
+async fn fragment_on_node_interface_with_custom_variable_name() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-node-interface-with-custom-variable-name.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-node-interface-with-custom-variable-name.expected");
-    test_fixture(transform_fixture, "fragment-on-node-interface-with-custom-variable-name.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-node-interface-with-custom-variable-name.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-node-interface-with-custom-variable-name.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-node-interface-with-custom-variable-name.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_object_implementing_node_interface() {
+#[tokio::test]
+async fn fragment_on_object_implementing_node_interface() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-object-implementing-node-interface.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-object-implementing-node-interface.expected");
-    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-object-implementing-node-interface.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-object-implementing-node-interface.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_object_implementing_node_interface_with_custom_variable_name() {
+#[tokio::test]
+async fn fragment_on_object_implementing_node_interface_with_custom_variable_name() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-object-implementing-node-interface-with-custom-variable-name.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-object-implementing-node-interface-with-custom-variable-name.expected");
-    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface-with-custom-variable-name.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-object-implementing-node-interface-with-custom-variable-name.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface-with-custom-variable-name.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-object-implementing-node-interface-with-custom-variable-name.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_query() {
+#[tokio::test]
+async fn fragment_on_query() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-query.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-query.expected");
-    test_fixture(transform_fixture, "fragment-on-query.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-query.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-query.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-query.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_query_with_cycle_invalid() {
+#[tokio::test]
+async fn fragment_on_query_with_cycle_invalid() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-query-with-cycle.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-query-with-cycle.invalid.expected");
-    test_fixture(transform_fixture, "fragment-on-query-with-cycle.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-query-with-cycle.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-query-with-cycle.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-query-with-cycle.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_viewer() {
+#[tokio::test]
+async fn fragment_on_viewer() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-viewer.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/fragment-on-viewer.expected");
-    test_fixture(transform_fixture, "fragment-on-viewer.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-viewer.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-viewer.graphql", "compile_relay_artifacts_with_custom_id/fixtures/fragment-on-viewer.expected", input, expected).await;
 }
 
-#[test]
-fn id_as_alias_invalid() {
+#[tokio::test]
+async fn id_as_alias_invalid() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/id-as-alias.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/id-as-alias.invalid.expected");
-    test_fixture(transform_fixture, "id-as-alias.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/id-as-alias.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "id-as-alias.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/id-as-alias.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/kitchen-sink.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "compile_relay_artifacts_with_custom_id/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "compile_relay_artifacts_with_custom_id/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_conflict_with_operation_invalid() {
+#[tokio::test]
+async fn refetchable_conflict_with_operation_invalid() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable_conflict_with_operation.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable_conflict_with_operation.invalid.expected");
-    test_fixture(transform_fixture, "refetchable_conflict_with_operation.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable_conflict_with_operation.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable_conflict_with_operation.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable_conflict_with_operation.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_conflict_with_refetchable_invalid() {
+#[tokio::test]
+async fn refetchable_conflict_with_refetchable_invalid() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable_conflict_with_refetchable.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable_conflict_with_refetchable.invalid.expected");
-    test_fixture(transform_fixture, "refetchable_conflict_with_refetchable.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable_conflict_with_refetchable.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable_conflict_with_refetchable.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable_conflict_with_refetchable.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_connection() {
+#[tokio::test]
+async fn refetchable_connection() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-connection.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-connection.expected");
-    test_fixture(transform_fixture, "refetchable-connection.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-connection.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-connection.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-connection.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_connection_with_custom_variable_name() {
+#[tokio::test]
+async fn refetchable_connection_with_custom_variable_name() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-connection-with-custom-variable-name.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-connection-with-custom-variable-name.expected");
-    test_fixture(transform_fixture, "refetchable-connection-with-custom-variable-name.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-connection-with-custom-variable-name.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-connection-with-custom-variable-name.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-connection-with-custom-variable-name.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_on_node_with_missing_id() {
+#[tokio::test]
+async fn refetchable_fragment_on_node_with_missing_id() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-fragment-on-node-with-missing-id.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-fragment-on-node-with-missing-id.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-on-node-with-missing-id.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-fragment-on-node-with-missing-id.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-on-node-with-missing-id.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-fragment-on-node-with-missing-id.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_with_arguments_conflicting_invalid() {
+#[tokio::test]
+async fn refetchable_with_arguments_conflicting_invalid() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-with-arguments-conflicting.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-with-arguments-conflicting.invalid.expected");
-    test_fixture(transform_fixture, "refetchable-with-arguments-conflicting.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-with-arguments-conflicting.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-with-arguments-conflicting.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-with-arguments-conflicting.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_with_arguments_invalid() {
+#[tokio::test]
+async fn refetchable_with_arguments_invalid() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-with-arguments.invalid.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/refetchable-with-arguments.invalid.expected");
-    test_fixture(transform_fixture, "refetchable-with-arguments.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-with-arguments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-with-arguments.invalid.graphql", "compile_relay_artifacts_with_custom_id/fixtures/refetchable-with-arguments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_client_id_field() {
+#[tokio::test]
+async fn relay_client_id_field() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/relay-client-id-field.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/relay-client-id-field.expected");
-    test_fixture(transform_fixture, "relay-client-id-field.graphql", "compile_relay_artifacts_with_custom_id/fixtures/relay-client-id-field.expected", input, expected);
+    test_fixture(transform_fixture, "relay-client-id-field.graphql", "compile_relay_artifacts_with_custom_id/fixtures/relay-client-id-field.expected", input, expected).await;
 }
 
-#[test]
-fn unions() {
+#[tokio::test]
+async fn unions() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/unions.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/unions.expected");
-    test_fixture(transform_fixture, "unions.graphql", "compile_relay_artifacts_with_custom_id/fixtures/unions.expected", input, expected);
+    test_fixture(transform_fixture, "unions.graphql", "compile_relay_artifacts_with_custom_id/fixtures/unions.expected", input, expected).await;
 }
 
-#[test]
-fn viewer_query() {
+#[tokio::test]
+async fn viewer_query() {
     let input = include_str!("compile_relay_artifacts_with_custom_id/fixtures/viewer-query.graphql");
     let expected = include_str!("compile_relay_artifacts_with_custom_id/fixtures/viewer-query.expected");
-    test_fixture(transform_fixture, "viewer-query.graphql", "compile_relay_artifacts_with_custom_id/fixtures/viewer-query.expected", input, expected);
+    test_fixture(transform_fixture, "viewer-query.graphql", "compile_relay_artifacts_with_custom_id/fixtures/viewer-query.expected", input, expected).await;
 }

--- a/compiler/crates/relay-docblock/Cargo.toml
+++ b/compiler/crates/relay-docblock/Cargo.toml
@@ -33,3 +33,4 @@ fixture-tests = { path = "../fixture-tests" }
 graphql-cli = { path = "../graphql-cli" }
 graphql-test-helpers = { path = "../graphql-test-helpers" }
 relay-test-schema = { path = "../relay-test-schema" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/relay-docblock/tests/parse/mod.rs
+++ b/compiler/crates/relay-docblock/tests/parse/mod.rs
@@ -19,7 +19,7 @@ use relay_config::ProjectName;
 use relay_docblock::parse_docblock_ast;
 use relay_docblock::ParseOptions;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let js_features = extract_graphql::extract(fixture.content);
     let executable_documents = js_features
         .iter()

--- a/compiler/crates/relay-docblock/tests/parse_test.rs
+++ b/compiler/crates/relay-docblock/tests/parse_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5d997f008adc06523bb95fb0fe4781a6>>
+ * @generated SignedSource<<922ebcc07d4b777e361186abd5fec252>>
  */
 
 mod parse;
@@ -12,289 +12,289 @@ mod parse;
 use parse::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn edge_to_non_null_invalid() {
+#[tokio::test]
+async fn edge_to_non_null_invalid() {
     let input = include_str!("parse/fixtures/edge-to-non-null.invalid.js");
     let expected = include_str!("parse/fixtures/edge-to-non-null.invalid.expected");
-    test_fixture(transform_fixture, "edge-to-non-null.invalid.js", "parse/fixtures/edge-to-non-null.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "edge-to-non-null.invalid.js", "parse/fixtures/edge-to-non-null.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn edge_to_non_null_plural_item_invalid() {
+#[tokio::test]
+async fn edge_to_non_null_plural_item_invalid() {
     let input = include_str!("parse/fixtures/edge-to-non-null-plural-item.invalid.js");
     let expected = include_str!("parse/fixtures/edge-to-non-null-plural-item.invalid.expected");
-    test_fixture(transform_fixture, "edge-to-non-null-plural-item.invalid.js", "parse/fixtures/edge-to-non-null-plural-item.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "edge-to-non-null-plural-item.invalid.js", "parse/fixtures/edge-to-non-null-plural-item.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn edge_to_not_identifier_invalid() {
+#[tokio::test]
+async fn edge_to_not_identifier_invalid() {
     let input = include_str!("parse/fixtures/edge-to-not-identifier.invalid.js");
     let expected = include_str!("parse/fixtures/edge-to-not-identifier.invalid.expected");
-    test_fixture(transform_fixture, "edge-to-not-identifier.invalid.js", "parse/fixtures/edge-to-not-identifier.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "edge-to-not-identifier.invalid.js", "parse/fixtures/edge-to-not-identifier.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_edge_to_invalid() {
+#[tokio::test]
+async fn output_type_edge_to_invalid() {
     let input = include_str!("parse/fixtures/output-type-edge-to-invalid.js");
     let expected = include_str!("parse/fixtures/output-type-edge-to-invalid.expected");
-    test_fixture(transform_fixture, "output-type-edge-to-invalid.js", "parse/fixtures/output-type-edge-to-invalid.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-edge-to-invalid.js", "parse/fixtures/output-type-edge-to-invalid.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_invalid_type() {
+#[tokio::test]
+async fn output_type_invalid_type() {
     let input = include_str!("parse/fixtures/output-type-invalid-type.js");
     let expected = include_str!("parse/fixtures/output-type-invalid-type.expected");
-    test_fixture(transform_fixture, "output-type-invalid-type.js", "parse/fixtures/output-type-invalid-type.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-invalid-type.js", "parse/fixtures/output-type-invalid-type.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver() {
+#[tokio::test]
+async fn relay_resolver() {
     let input = include_str!("parse/fixtures/relay-resolver.js");
     let expected = include_str!("parse/fixtures/relay-resolver.expected");
-    test_fixture(transform_fixture, "relay-resolver.js", "parse/fixtures/relay-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver.js", "parse/fixtures/relay-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_deprecated() {
+#[tokio::test]
+async fn relay_resolver_deprecated() {
     let input = include_str!("parse/fixtures/relay-resolver-deprecated.js");
     let expected = include_str!("parse/fixtures/relay-resolver-deprecated.expected");
-    test_fixture(transform_fixture, "relay-resolver-deprecated.js", "parse/fixtures/relay-resolver-deprecated.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-deprecated.js", "parse/fixtures/relay-resolver-deprecated.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_deprecated_no_description() {
+#[tokio::test]
+async fn relay_resolver_deprecated_no_description() {
     let input = include_str!("parse/fixtures/relay-resolver-deprecated-no-description.js");
     let expected = include_str!("parse/fixtures/relay-resolver-deprecated-no-description.expected");
-    test_fixture(transform_fixture, "relay-resolver-deprecated-no-description.js", "parse/fixtures/relay-resolver-deprecated-no-description.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-deprecated-no-description.js", "parse/fixtures/relay-resolver-deprecated-no-description.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_invalid_field_invalid() {
+#[tokio::test]
+async fn relay_resolver_invalid_field_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-invalid-field.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-invalid-field.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-invalid-field.invalid.js", "parse/fixtures/relay-resolver-invalid-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-invalid-field.invalid.js", "parse/fixtures/relay-resolver-invalid-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_live() {
+#[tokio::test]
+async fn relay_resolver_live() {
     let input = include_str!("parse/fixtures/relay-resolver-live.js");
     let expected = include_str!("parse/fixtures/relay-resolver-live.expected");
-    test_fixture(transform_fixture, "relay-resolver-live.js", "parse/fixtures/relay-resolver-live.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-live.js", "parse/fixtures/relay-resolver-live.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_live_with_text_invalid() {
+#[tokio::test]
+async fn relay_resolver_live_with_text_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-live-with-text.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-live-with-text.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-live-with-text.invalid.js", "parse/fixtures/relay-resolver-live-with-text.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-live-with-text.invalid.js", "parse/fixtures/relay-resolver-live-with-text.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_missing_field_invalid() {
+#[tokio::test]
+async fn relay_resolver_missing_field_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-missing-field.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-missing-field.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-missing-field.invalid.js", "parse/fixtures/relay-resolver-missing-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-missing-field.invalid.js", "parse/fixtures/relay-resolver-missing-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_missing_multiple_fields_invalid() {
+#[tokio::test]
+async fn relay_resolver_missing_multiple_fields_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-missing-multiple-fields.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-missing-multiple-fields.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-missing-multiple-fields.invalid.js", "parse/fixtures/relay-resolver-missing-multiple-fields.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-missing-multiple-fields.invalid.js", "parse/fixtures/relay-resolver-missing-multiple-fields.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_named_export() {
+#[tokio::test]
+async fn relay_resolver_named_export() {
     let input = include_str!("parse/fixtures/relay-resolver-named-export.js");
     let expected = include_str!("parse/fixtures/relay-resolver-named-export.expected");
-    test_fixture(transform_fixture, "relay-resolver-named-export.js", "parse/fixtures/relay-resolver-named-export.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-named-export.js", "parse/fixtures/relay-resolver-named-export.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_interface_mismatch_invalid() {
+#[tokio::test]
+async fn relay_resolver_on_interface_mismatch_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-on-interface-mismatch.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-on-interface-mismatch.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-interface-mismatch.invalid.js", "parse/fixtures/relay-resolver-on-interface-mismatch.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-interface-mismatch.invalid.js", "parse/fixtures/relay-resolver-on-interface-mismatch.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_interface_no_value_invalid() {
+#[tokio::test]
+async fn relay_resolver_on_interface_no_value_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-on-interface-no-value.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-on-interface-no-value.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-interface-no-value.invalid.js", "parse/fixtures/relay-resolver-on-interface-no-value.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-interface-no-value.invalid.js", "parse/fixtures/relay-resolver-on-interface-no-value.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_type_and_on_interface_invalid() {
+#[tokio::test]
+async fn relay_resolver_on_type_and_on_interface_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-on-type-and-on-interface.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-on-type-and-on-interface.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-type-and-on-interface.invalid.js", "parse/fixtures/relay-resolver-on-type-and-on-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-type-and-on-interface.invalid.js", "parse/fixtures/relay-resolver-on-type-and-on-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_type_mismatch_invalid() {
+#[tokio::test]
+async fn relay_resolver_on_type_mismatch_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-on-type-mismatch.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-on-type-mismatch.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-type-mismatch.invalid.js", "parse/fixtures/relay-resolver-on-type-mismatch.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-type-mismatch.invalid.js", "parse/fixtures/relay-resolver-on-type-mismatch.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_type_no_value_invalid() {
+#[tokio::test]
+async fn relay_resolver_on_type_no_value_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-on-type-no-value.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-on-type-no-value.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-type-no-value.invalid.js", "parse/fixtures/relay-resolver-on-type-no-value.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-type-no-value.invalid.js", "parse/fixtures/relay-resolver-on-type-no-value.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object() {
+#[tokio::test]
+async fn relay_resolver_strong_object() {
     let input = include_str!("parse/fixtures/relay-resolver-strong-object.js");
     let expected = include_str!("parse/fixtures/relay-resolver-strong-object.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object.js", "parse/fixtures/relay-resolver-strong-object.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object.js", "parse/fixtures/relay-resolver-strong-object.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object_with_gibberish_invalid() {
+#[tokio::test]
+async fn relay_resolver_strong_object_with_gibberish_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-strong-object-with-gibberish.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-strong-object-with-gibberish.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object-with-gibberish.invalid.js", "parse/fixtures/relay-resolver-strong-object-with-gibberish.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object-with-gibberish.invalid.js", "parse/fixtures/relay-resolver-strong-object-with-gibberish.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object_with_implements() {
+#[tokio::test]
+async fn relay_resolver_strong_object_with_implements() {
     let input = include_str!("parse/fixtures/relay-resolver-strong-object-with-implements.js");
     let expected = include_str!("parse/fixtures/relay-resolver-strong-object-with-implements.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements.js", "parse/fixtures/relay-resolver-strong-object-with-implements.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements.js", "parse/fixtures/relay-resolver-strong-object-with-implements.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_terse_invalid_type_name() {
+#[tokio::test]
+async fn relay_resolver_terse_invalid_type_name() {
     let input = include_str!("parse/fixtures/relay-resolver-terse-invalid-type-name.js");
     let expected = include_str!("parse/fixtures/relay-resolver-terse-invalid-type-name.expected");
-    test_fixture(transform_fixture, "relay-resolver-terse-invalid-type-name.js", "parse/fixtures/relay-resolver-terse-invalid-type-name.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-terse-invalid-type-name.js", "parse/fixtures/relay-resolver-terse-invalid-type-name.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_weak_object_with_gibberish_invalid() {
+#[tokio::test]
+async fn relay_resolver_weak_object_with_gibberish_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-weak-object-with-gibberish.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-weak-object-with-gibberish.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-weak-object-with-gibberish.invalid.js", "parse/fixtures/relay-resolver-weak-object-with-gibberish.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-weak-object-with-gibberish.invalid.js", "parse/fixtures/relay-resolver-weak-object-with-gibberish.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_args() {
+#[tokio::test]
+async fn relay_resolver_with_args() {
     let input = include_str!("parse/fixtures/relay-resolver-with-args.js");
     let expected = include_str!("parse/fixtures/relay-resolver-with-args.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-args.js", "parse/fixtures/relay-resolver-with-args.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-args.js", "parse/fixtures/relay-resolver-with-args.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_args_default_value_invalid() {
+#[tokio::test]
+async fn relay_resolver_with_args_default_value_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-with-args-default-value.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-with-args-default-value.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-args-default-value.invalid.js", "parse/fixtures/relay-resolver-with-args-default-value.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-args-default-value.invalid.js", "parse/fixtures/relay-resolver-with-args-default-value.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_args_syntax_error_invalid() {
+#[tokio::test]
+async fn relay_resolver_with_args_syntax_error_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-with-args-syntax-error.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-with-args-syntax-error.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-args-syntax-error.invalid.js", "parse/fixtures/relay-resolver-with-args-syntax-error.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-args-syntax-error.invalid.js", "parse/fixtures/relay-resolver-with-args-syntax-error.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_conflicting_args_invalid() {
+#[tokio::test]
+async fn relay_resolver_with_conflicting_args_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-with-conflicting-args.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-with-conflicting-args.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-conflicting-args.invalid.js", "parse/fixtures/relay-resolver-with-conflicting-args.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-conflicting-args.invalid.js", "parse/fixtures/relay-resolver-with-conflicting-args.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_field_and_fragment_args() {
+#[tokio::test]
+async fn relay_resolver_with_field_and_fragment_args() {
     let input = include_str!("parse/fixtures/relay-resolver-with-field-and-fragment-args.js");
     let expected = include_str!("parse/fixtures/relay-resolver-with-field-and-fragment-args.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-field-and-fragment-args.js", "parse/fixtures/relay-resolver-with-field-and-fragment-args.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-field-and-fragment-args.js", "parse/fixtures/relay-resolver-with-field-and-fragment-args.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_field_args() {
+#[tokio::test]
+async fn relay_resolver_with_field_args() {
     let input = include_str!("parse/fixtures/relay-resolver-with-field-args.js");
     let expected = include_str!("parse/fixtures/relay-resolver-with-field-args.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-field-args.js", "parse/fixtures/relay-resolver-with-field-args.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-field-args.js", "parse/fixtures/relay-resolver-with-field-args.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_fragment() {
+#[tokio::test]
+async fn relay_resolver_with_fragment() {
     let input = include_str!("parse/fixtures/relay-resolver-with-fragment.js");
     let expected = include_str!("parse/fixtures/relay-resolver-with-fragment.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-fragment.js", "parse/fixtures/relay-resolver-with-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-fragment.js", "parse/fixtures/relay-resolver-with-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_fragment_invalid() {
+#[tokio::test]
+async fn relay_resolver_with_fragment_invalid() {
     let input = include_str!("parse/fixtures/relay-resolver-with-fragment.invalid.js");
     let expected = include_str!("parse/fixtures/relay-resolver-with-fragment.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-fragment.invalid.js", "parse/fixtures/relay-resolver-with-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-fragment.invalid.js", "parse/fixtures/relay-resolver-with-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type() {
+#[tokio::test]
+async fn relay_resolver_with_output_type() {
     let input = include_str!("parse/fixtures/relay-resolver-with-output-type.js");
     let expected = include_str!("parse/fixtures/relay-resolver-with-output-type.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type.js", "parse/fixtures/relay-resolver-with-output-type.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type.js", "parse/fixtures/relay-resolver-with-output-type.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver() {
+#[tokio::test]
+async fn terse_relay_resolver() {
     let input = include_str!("parse/fixtures/terse-relay-resolver.js");
     let expected = include_str!("parse/fixtures/terse-relay-resolver.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver.js", "parse/fixtures/terse-relay-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver.js", "parse/fixtures/terse-relay-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_forbidden_fields_invalid() {
+#[tokio::test]
+async fn terse_relay_resolver_forbidden_fields_invalid() {
     let input = include_str!("parse/fixtures/terse-relay-resolver-forbidden-fields.invalid.js");
     let expected = include_str!("parse/fixtures/terse-relay-resolver-forbidden-fields.invalid.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-forbidden-fields.invalid.js", "parse/fixtures/terse-relay-resolver-forbidden-fields.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-forbidden-fields.invalid.js", "parse/fixtures/terse-relay-resolver-forbidden-fields.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_fragment_type_does_not_match_parent_invalid() {
+#[tokio::test]
+async fn terse_relay_resolver_fragment_type_does_not_match_parent_invalid() {
     let input = include_str!("parse/fixtures/terse-relay-resolver-fragment-type-does-not-match-parent.invalid.js");
     let expected = include_str!("parse/fixtures/terse-relay-resolver-fragment-type-does-not-match-parent.invalid.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-fragment-type-does-not-match-parent.invalid.js", "parse/fixtures/terse-relay-resolver-fragment-type-does-not-match-parent.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-fragment-type-does-not-match-parent.invalid.js", "parse/fixtures/terse-relay-resolver-fragment-type-does-not-match-parent.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_no_dot_2_invalid() {
+#[tokio::test]
+async fn terse_relay_resolver_no_dot_2_invalid() {
     let input = include_str!("parse/fixtures/terse-relay-resolver-no-dot-2.invalid.js");
     let expected = include_str!("parse/fixtures/terse-relay-resolver-no-dot-2.invalid.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-no-dot-2.invalid.js", "parse/fixtures/terse-relay-resolver-no-dot-2.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-no-dot-2.invalid.js", "parse/fixtures/terse-relay-resolver-no-dot-2.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_no_dot_invalid() {
+#[tokio::test]
+async fn terse_relay_resolver_no_dot_invalid() {
     let input = include_str!("parse/fixtures/terse-relay-resolver-no-dot.invalid.js");
     let expected = include_str!("parse/fixtures/terse-relay-resolver-no-dot.invalid.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-no-dot.invalid.js", "parse/fixtures/terse-relay-resolver-no-dot.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-no-dot.invalid.js", "parse/fixtures/terse-relay-resolver-no-dot.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_non_nullable() {
+#[tokio::test]
+async fn terse_relay_resolver_non_nullable() {
     let input = include_str!("parse/fixtures/terse-relay-resolver-non-nullable.js");
     let expected = include_str!("parse/fixtures/terse-relay-resolver-non-nullable.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-non-nullable.js", "parse/fixtures/terse-relay-resolver-non-nullable.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-non-nullable.js", "parse/fixtures/terse-relay-resolver-non-nullable.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_non_nullable_list() {
+#[tokio::test]
+async fn terse_relay_resolver_non_nullable_list() {
     let input = include_str!("parse/fixtures/terse-relay-resolver-non-nullable-list.js");
     let expected = include_str!("parse/fixtures/terse-relay-resolver-non-nullable-list.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-non-nullable-list.js", "parse/fixtures/terse-relay-resolver-non-nullable-list.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-non-nullable-list.js", "parse/fixtures/terse-relay-resolver-non-nullable-list.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_non_nullable_list_item() {
+#[tokio::test]
+async fn terse_relay_resolver_non_nullable_list_item() {
     let input = include_str!("parse/fixtures/terse-relay-resolver-non-nullable-list-item.js");
     let expected = include_str!("parse/fixtures/terse-relay-resolver-non-nullable-list-item.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-non-nullable-list-item.js", "parse/fixtures/terse-relay-resolver-non-nullable-list-item.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-non-nullable-list-item.js", "parse/fixtures/terse-relay-resolver-non-nullable-list-item.expected", input, expected).await;
 }

--- a/compiler/crates/relay-docblock/tests/to_schema/mod.rs
+++ b/compiler/crates/relay-docblock/tests/to_schema/mod.rs
@@ -25,7 +25,7 @@ use relay_docblock::ParseOptions;
 use relay_test_schema::get_test_schema_with_extensions;
 use schema::SDLSchema;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     let (base, mut schema) = match parts.as_slice() {
         [base, extensions] => (base, extract_schema_from_js(extensions)),

--- a/compiler/crates/relay-docblock/tests/to_schema_test.rs
+++ b/compiler/crates/relay-docblock/tests/to_schema_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b0c707529f8b045554b20820c2e3e271>>
+ * @generated SignedSource<<27fd1dc9ac6f6e9544d7163eedd5134b>>
  */
 
 mod to_schema;
@@ -12,261 +12,261 @@ mod to_schema;
 use to_schema::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn client_edge_relay_resolver() {
+#[tokio::test]
+async fn client_edge_relay_resolver() {
     let input = include_str!("to_schema/fixtures/client-edge-relay-resolver.js");
     let expected = include_str!("to_schema/fixtures/client-edge-relay-resolver.expected");
-    test_fixture(transform_fixture, "client-edge-relay-resolver.js", "to_schema/fixtures/client-edge-relay-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-relay-resolver.js", "to_schema/fixtures/client-edge-relay-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_to_non_null_plural_server_object_relay_resolver_invalid() {
+#[tokio::test]
+async fn client_edge_to_non_null_plural_server_object_relay_resolver_invalid() {
     let input = include_str!("to_schema/fixtures/client-edge-to-non-null-plural-server-object-relay-resolver.invalid.js");
     let expected = include_str!("to_schema/fixtures/client-edge-to-non-null-plural-server-object-relay-resolver.invalid.expected");
-    test_fixture(transform_fixture, "client-edge-to-non-null-plural-server-object-relay-resolver.invalid.js", "to_schema/fixtures/client-edge-to-non-null-plural-server-object-relay-resolver.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-to-non-null-plural-server-object-relay-resolver.invalid.js", "to_schema/fixtures/client-edge-to-non-null-plural-server-object-relay-resolver.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_to_plural_server_object_relay_resolver_invalid() {
+#[tokio::test]
+async fn client_edge_to_plural_server_object_relay_resolver_invalid() {
     let input = include_str!("to_schema/fixtures/client-edge-to-plural-server-object-relay-resolver.invalid.js");
     let expected = include_str!("to_schema/fixtures/client-edge-to-plural-server-object-relay-resolver.invalid.expected");
-    test_fixture(transform_fixture, "client-edge-to-plural-server-object-relay-resolver.invalid.js", "to_schema/fixtures/client-edge-to-plural-server-object-relay-resolver.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-to-plural-server-object-relay-resolver.invalid.js", "to_schema/fixtures/client-edge-to-plural-server-object-relay-resolver.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn legacy_relay_resolver_with_root_fragment_on_model() {
+#[tokio::test]
+async fn legacy_relay_resolver_with_root_fragment_on_model() {
     let input = include_str!("to_schema/fixtures/legacy-relay-resolver-with-root-fragment-on-model.js");
     let expected = include_str!("to_schema/fixtures/legacy-relay-resolver-with-root-fragment-on-model.expected");
-    test_fixture(transform_fixture, "legacy-relay-resolver-with-root-fragment-on-model.js", "to_schema/fixtures/legacy-relay-resolver-with-root-fragment-on-model.expected", input, expected);
+    test_fixture(transform_fixture, "legacy-relay-resolver-with-root-fragment-on-model.js", "to_schema/fixtures/legacy-relay-resolver-with-root-fragment-on-model.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver() {
+#[tokio::test]
+async fn relay_resolver() {
     let input = include_str!("to_schema/fixtures/relay-resolver.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver.expected");
-    test_fixture(transform_fixture, "relay-resolver.js", "to_schema/fixtures/relay-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver.js", "to_schema/fixtures/relay-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_deprecated() {
+#[tokio::test]
+async fn relay_resolver_deprecated() {
     let input = include_str!("to_schema/fixtures/relay-resolver-deprecated.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-deprecated.expected");
-    test_fixture(transform_fixture, "relay-resolver-deprecated.js", "to_schema/fixtures/relay-resolver-deprecated.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-deprecated.js", "to_schema/fixtures/relay-resolver-deprecated.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_deprecated_no_description() {
+#[tokio::test]
+async fn relay_resolver_deprecated_no_description() {
     let input = include_str!("to_schema/fixtures/relay-resolver-deprecated-no-description.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-deprecated-no-description.expected");
-    test_fixture(transform_fixture, "relay-resolver-deprecated-no-description.js", "to_schema/fixtures/relay-resolver-deprecated-no-description.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-deprecated-no-description.js", "to_schema/fixtures/relay-resolver-deprecated-no-description.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_id_invalid() {
+#[tokio::test]
+async fn relay_resolver_id_invalid() {
     let input = include_str!("to_schema/fixtures/relay-resolver-id.invalid.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-id.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-id.invalid.js", "to_schema/fixtures/relay-resolver-id.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-id.invalid.js", "to_schema/fixtures/relay-resolver-id.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_implementing_a_field_defined_by_grandparent_interface() {
+#[tokio::test]
+async fn relay_resolver_implementing_a_field_defined_by_grandparent_interface() {
     let input = include_str!("to_schema/fixtures/relay-resolver-implementing-a-field-defined-by-grandparent-interface.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-implementing-a-field-defined-by-grandparent-interface.expected");
-    test_fixture(transform_fixture, "relay-resolver-implementing-a-field-defined-by-grandparent-interface.js", "to_schema/fixtures/relay-resolver-implementing-a-field-defined-by-grandparent-interface.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-implementing-a-field-defined-by-grandparent-interface.js", "to_schema/fixtures/relay-resolver-implementing-a-field-defined-by-grandparent-interface.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_implementing_a_field_defined_by_parent_interface() {
+#[tokio::test]
+async fn relay_resolver_implementing_a_field_defined_by_parent_interface() {
     let input = include_str!("to_schema/fixtures/relay-resolver-implementing-a-field-defined-by-parent-interface.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-implementing-a-field-defined-by-parent-interface.expected");
-    test_fixture(transform_fixture, "relay-resolver-implementing-a-field-defined-by-parent-interface.js", "to_schema/fixtures/relay-resolver-implementing-a-field-defined-by-parent-interface.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-implementing-a-field-defined-by-parent-interface.js", "to_schema/fixtures/relay-resolver-implementing-a-field-defined-by-parent-interface.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_named_export() {
+#[tokio::test]
+async fn relay_resolver_named_export() {
     let input = include_str!("to_schema/fixtures/relay-resolver-named-export.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-named-export.expected");
-    test_fixture(transform_fixture, "relay-resolver-named-export.js", "to_schema/fixtures/relay-resolver-named-export.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-named-export.js", "to_schema/fixtures/relay-resolver-named-export.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_interface() {
+#[tokio::test]
+async fn relay_resolver_on_interface() {
     let input = include_str!("to_schema/fixtures/relay-resolver-on-interface.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-on-interface.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-interface.js", "to_schema/fixtures/relay-resolver-on-interface.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-interface.js", "to_schema/fixtures/relay-resolver-on-interface.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_interface_implementing_a_field_defined_by_parent_interface() {
+#[tokio::test]
+async fn relay_resolver_on_interface_implementing_a_field_defined_by_parent_interface() {
     let input = include_str!("to_schema/fixtures/relay-resolver-on-interface-implementing-a-field-defined-by-parent-interface.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-on-interface-implementing-a-field-defined-by-parent-interface.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-interface-implementing-a-field-defined-by-parent-interface.js", "to_schema/fixtures/relay-resolver-on-interface-implementing-a-field-defined-by-parent-interface.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-interface-implementing-a-field-defined-by-parent-interface.js", "to_schema/fixtures/relay-resolver-on-interface-implementing-a-field-defined-by-parent-interface.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_interface_with_type_invalid() {
+#[tokio::test]
+async fn relay_resolver_on_interface_with_type_invalid() {
     let input = include_str!("to_schema/fixtures/relay-resolver-on-interface-with-type.invalid.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-on-interface-with-type.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-interface-with-type.invalid.js", "to_schema/fixtures/relay-resolver-on-interface-with-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-interface-with-type.invalid.js", "to_schema/fixtures/relay-resolver-on-interface-with-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_invalid_interface_invalid() {
+#[tokio::test]
+async fn relay_resolver_on_invalid_interface_invalid() {
     let input = include_str!("to_schema/fixtures/relay-resolver-on-invalid-interface.invalid.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-on-invalid-interface.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-invalid-interface.invalid.js", "to_schema/fixtures/relay-resolver-on-invalid-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-invalid-interface.invalid.js", "to_schema/fixtures/relay-resolver-on-invalid-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_invalid_type_invalid() {
+#[tokio::test]
+async fn relay_resolver_on_invalid_type_invalid() {
     let input = include_str!("to_schema/fixtures/relay-resolver-on-invalid-type.invalid.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-on-invalid-type.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-invalid-type.invalid.js", "to_schema/fixtures/relay-resolver-on-invalid-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-invalid-type.invalid.js", "to_schema/fixtures/relay-resolver-on-invalid-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_on_type_with_interface_invalid() {
+#[tokio::test]
+async fn relay_resolver_on_type_with_interface_invalid() {
     let input = include_str!("to_schema/fixtures/relay-resolver-on-type-with-interface.invalid.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-on-type-with-interface.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-on-type-with-interface.invalid.js", "to_schema/fixtures/relay-resolver-on-type-with-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-on-type-with-interface.invalid.js", "to_schema/fixtures/relay-resolver-on-type-with-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object() {
+#[tokio::test]
+async fn relay_resolver_strong_object() {
     let input = include_str!("to_schema/fixtures/relay-resolver-strong-object.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-strong-object.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object.js", "to_schema/fixtures/relay-resolver-strong-object.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object.js", "to_schema/fixtures/relay-resolver-strong-object.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object_with_implements() {
+#[tokio::test]
+async fn relay_resolver_strong_object_with_implements() {
     let input = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object_with_implements_interface_bad_id_invalid() {
+#[tokio::test]
+async fn relay_resolver_strong_object_with_implements_interface_bad_id_invalid() {
     let input = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-bad-id.invalid.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-bad-id.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-interface-bad-id.invalid.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-bad-id.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-interface-bad-id.invalid.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-bad-id.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object_with_implements_interface_no_id_invalid() {
+#[tokio::test]
+async fn relay_resolver_strong_object_with_implements_interface_no_id_invalid() {
     let input = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-no-id.invalid.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-no-id.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-interface-no-id.invalid.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-no-id.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-interface-no-id.invalid.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-no-id.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object_with_implements_interface_non_interface() {
+#[tokio::test]
+async fn relay_resolver_strong_object_with_implements_interface_non_interface() {
     let input = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-non-interface.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-non-interface.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-interface-non-interface.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-non-interface.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-interface-non-interface.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-interface-non-interface.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object_with_implements_non_existing_type() {
+#[tokio::test]
+async fn relay_resolver_strong_object_with_implements_non_existing_type() {
     let input = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-non-existing-type.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-non-existing-type.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-non-existing-type.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-non-existing-type.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-non-existing-type.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-non-existing-type.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object_with_implements_server_interface_invalid() {
+#[tokio::test]
+async fn relay_resolver_strong_object_with_implements_server_interface_invalid() {
     let input = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-server-interface.invalid.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-implements-server-interface.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-server-interface.invalid.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-server-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object-with-implements-server-interface.invalid.js", "to_schema/fixtures/relay-resolver-strong-object-with-implements-server-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_strong_object_with_multiple_implements() {
+#[tokio::test]
+async fn relay_resolver_strong_object_with_multiple_implements() {
     let input = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-multiple-implements.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-strong-object-with-multiple-implements.expected");
-    test_fixture(transform_fixture, "relay-resolver-strong-object-with-multiple-implements.js", "to_schema/fixtures/relay-resolver-strong-object-with-multiple-implements.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-strong-object-with-multiple-implements.js", "to_schema/fixtures/relay-resolver-strong-object-with-multiple-implements.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_args() {
+#[tokio::test]
+async fn relay_resolver_with_args() {
     let input = include_str!("to_schema/fixtures/relay-resolver-with-args.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-with-args.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-args.js", "to_schema/fixtures/relay-resolver-with-args.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-args.js", "to_schema/fixtures/relay-resolver-with-args.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_field_and_fragment_args() {
+#[tokio::test]
+async fn relay_resolver_with_field_and_fragment_args() {
     let input = include_str!("to_schema/fixtures/relay-resolver-with-field-and-fragment-args.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-with-field-and-fragment-args.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-field-and-fragment-args.js", "to_schema/fixtures/relay-resolver-with-field-and-fragment-args.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-field-and-fragment-args.js", "to_schema/fixtures/relay-resolver-with-field-and-fragment-args.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_field_args() {
+#[tokio::test]
+async fn relay_resolver_with_field_args() {
     let input = include_str!("to_schema/fixtures/relay-resolver-with-field-args.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-with-field-args.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-field-args.js", "to_schema/fixtures/relay-resolver-with-field-args.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-field-args.js", "to_schema/fixtures/relay-resolver-with-field-args.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type() {
+#[tokio::test]
+async fn relay_resolver_with_output_type() {
     let input = include_str!("to_schema/fixtures/relay-resolver-with-output-type.js");
     let expected = include_str!("to_schema/fixtures/relay-resolver-with-output-type.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type.js", "to_schema/fixtures/relay-resolver-with-output-type.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type.js", "to_schema/fixtures/relay-resolver-with-output-type.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver() {
+#[tokio::test]
+async fn terse_relay_resolver() {
     let input = include_str!("to_schema/fixtures/terse-relay-resolver.js");
     let expected = include_str!("to_schema/fixtures/terse-relay-resolver.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver.js", "to_schema/fixtures/terse-relay-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver.js", "to_schema/fixtures/terse-relay-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_id_invalid() {
+#[tokio::test]
+async fn terse_relay_resolver_id_invalid() {
     let input = include_str!("to_schema/fixtures/terse-relay-resolver-id.invalid.js");
     let expected = include_str!("to_schema/fixtures/terse-relay-resolver-id.invalid.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-id.invalid.js", "to_schema/fixtures/terse-relay-resolver-id.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-id.invalid.js", "to_schema/fixtures/terse-relay-resolver-id.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_interface() {
+#[tokio::test]
+async fn terse_relay_resolver_interface() {
     let input = include_str!("to_schema/fixtures/terse-relay-resolver-interface.js");
     let expected = include_str!("to_schema/fixtures/terse-relay-resolver-interface.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-interface.js", "to_schema/fixtures/terse-relay-resolver-interface.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-interface.js", "to_schema/fixtures/terse-relay-resolver-interface.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_non_existent_type_invalid() {
+#[tokio::test]
+async fn terse_relay_resolver_non_existent_type_invalid() {
     let input = include_str!("to_schema/fixtures/terse-relay-resolver-non-existent-type.invalid.js");
     let expected = include_str!("to_schema/fixtures/terse-relay-resolver-non-existent-type.invalid.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-non-existent-type.invalid.js", "to_schema/fixtures/terse-relay-resolver-non-existent-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-non-existent-type.invalid.js", "to_schema/fixtures/terse-relay-resolver-non-existent-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_with_output_type() {
+#[tokio::test]
+async fn terse_relay_resolver_with_output_type() {
     let input = include_str!("to_schema/fixtures/terse-relay-resolver-with-output-type.js");
     let expected = include_str!("to_schema/fixtures/terse-relay-resolver-with-output-type.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-with-output-type.js", "to_schema/fixtures/terse-relay-resolver-with-output-type.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-with-output-type.js", "to_schema/fixtures/terse-relay-resolver-with-output-type.expected", input, expected).await;
 }
 
-#[test]
-fn terse_relay_resolver_with_root_fragment_on_model() {
+#[tokio::test]
+async fn terse_relay_resolver_with_root_fragment_on_model() {
     let input = include_str!("to_schema/fixtures/terse-relay-resolver-with-root-fragment-on-model.js");
     let expected = include_str!("to_schema/fixtures/terse-relay-resolver-with-root-fragment-on-model.expected");
-    test_fixture(transform_fixture, "terse-relay-resolver-with-root-fragment-on-model.js", "to_schema/fixtures/terse-relay-resolver-with-root-fragment-on-model.expected", input, expected);
+    test_fixture(transform_fixture, "terse-relay-resolver-with-root-fragment-on-model.js", "to_schema/fixtures/terse-relay-resolver-with-root-fragment-on-model.expected", input, expected).await;
 }
 
-#[test]
-fn terse_resolver_duplicated_invalid() {
+#[tokio::test]
+async fn terse_resolver_duplicated_invalid() {
     let input = include_str!("to_schema/fixtures/terse-resolver-duplicated.invalid.js");
     let expected = include_str!("to_schema/fixtures/terse-resolver-duplicated.invalid.expected");
-    test_fixture(transform_fixture, "terse-resolver-duplicated.invalid.js", "to_schema/fixtures/terse-resolver-duplicated.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "terse-resolver-duplicated.invalid.js", "to_schema/fixtures/terse-resolver-duplicated.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn weak_type() {
+#[tokio::test]
+async fn weak_type() {
     let input = include_str!("to_schema/fixtures/weak-type.js");
     let expected = include_str!("to_schema/fixtures/weak-type.expected");
-    test_fixture(transform_fixture, "weak-type.js", "to_schema/fixtures/weak-type.expected", input, expected);
+    test_fixture(transform_fixture, "weak-type.js", "to_schema/fixtures/weak-type.expected", input, expected).await;
 }

--- a/compiler/crates/relay-lsp/tests/find_field_usages/mod.rs
+++ b/compiler/crates/relay-lsp/tests/find_field_usages/mod.rs
@@ -14,7 +14,7 @@ use graphql_syntax::parse_executable;
 use relay_lsp::find_field_usages;
 use relay_test_schema::get_test_schema;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%arguments%").collect();
     if let [document, arguments] = parts.as_slice() {
         if let [type_name, field_name] = arguments

--- a/compiler/crates/relay-lsp/tests/find_field_usages_test.rs
+++ b/compiler/crates/relay-lsp/tests/find_field_usages_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1ca9d7eb11468f905882356aaeae390b>>
+ * @generated SignedSource<<dd163bfabf9f3e28d732c3205ca07807>>
  */
 
 mod find_field_usages;
@@ -12,72 +12,72 @@ mod find_field_usages;
 use find_field_usages::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn find_subtype() {
+#[tokio::test]
+async fn find_subtype() {
     let input = include_str!("find_field_usages/fixtures/find_subtype.graphql");
     let expected = include_str!("find_field_usages/fixtures/find_subtype.expected");
-    test_fixture(transform_fixture, "find_subtype.graphql", "find_field_usages/fixtures/find_subtype.expected", input, expected);
+    test_fixture(transform_fixture, "find_subtype.graphql", "find_field_usages/fixtures/find_subtype.expected", input, expected).await;
 }
 
-#[test]
-fn find_supertype() {
+#[tokio::test]
+async fn find_supertype() {
     let input = include_str!("find_field_usages/fixtures/find_supertype.graphql");
     let expected = include_str!("find_field_usages/fixtures/find_supertype.expected");
-    test_fixture(transform_fixture, "find_supertype.graphql", "find_field_usages/fixtures/find_supertype.expected", input, expected);
+    test_fixture(transform_fixture, "find_supertype.graphql", "find_field_usages/fixtures/find_supertype.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_field() {
+#[tokio::test]
+async fn fragment_field() {
     let input = include_str!("find_field_usages/fixtures/fragment_field.graphql");
     let expected = include_str!("find_field_usages/fixtures/fragment_field.expected");
-    test_fixture(transform_fixture, "fragment_field.graphql", "find_field_usages/fixtures/fragment_field.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_field.graphql", "find_field_usages/fixtures/fragment_field.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_field_nomatch() {
+#[tokio::test]
+async fn fragment_field_nomatch() {
     let input = include_str!("find_field_usages/fixtures/fragment_field.nomatch.graphql");
     let expected = include_str!("find_field_usages/fixtures/fragment_field.nomatch.expected");
-    test_fixture(transform_fixture, "fragment_field.nomatch.graphql", "find_field_usages/fixtures/fragment_field.nomatch.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_field.nomatch.graphql", "find_field_usages/fixtures/fragment_field.nomatch.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment() {
+#[tokio::test]
+async fn inline_fragment() {
     let input = include_str!("find_field_usages/fixtures/inline_fragment.graphql");
     let expected = include_str!("find_field_usages/fixtures/inline_fragment.expected");
-    test_fixture(transform_fixture, "inline_fragment.graphql", "find_field_usages/fixtures/inline_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "inline_fragment.graphql", "find_field_usages/fixtures/inline_fragment.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_also_matches_outer_type() {
+#[tokio::test]
+async fn inline_fragment_also_matches_outer_type() {
     let input = include_str!("find_field_usages/fixtures/inline_fragment_also_matches_outer_type.graphql");
     let expected = include_str!("find_field_usages/fixtures/inline_fragment_also_matches_outer_type.expected");
-    test_fixture(transform_fixture, "inline_fragment_also_matches_outer_type.graphql", "find_field_usages/fixtures/inline_fragment_also_matches_outer_type.expected", input, expected);
+    test_fixture(transform_fixture, "inline_fragment_also_matches_outer_type.graphql", "find_field_usages/fixtures/inline_fragment_also_matches_outer_type.expected", input, expected).await;
 }
 
-#[test]
-fn linked_field() {
+#[tokio::test]
+async fn linked_field() {
     let input = include_str!("find_field_usages/fixtures/linked_field.graphql");
     let expected = include_str!("find_field_usages/fixtures/linked_field.expected");
-    test_fixture(transform_fixture, "linked_field.graphql", "find_field_usages/fixtures/linked_field.expected", input, expected);
+    test_fixture(transform_fixture, "linked_field.graphql", "find_field_usages/fixtures/linked_field.expected", input, expected).await;
 }
 
-#[test]
-fn linked_field_nomatch() {
+#[tokio::test]
+async fn linked_field_nomatch() {
     let input = include_str!("find_field_usages/fixtures/linked_field.nomatch.graphql");
     let expected = include_str!("find_field_usages/fixtures/linked_field.nomatch.expected");
-    test_fixture(transform_fixture, "linked_field.nomatch.graphql", "find_field_usages/fixtures/linked_field.nomatch.expected", input, expected);
+    test_fixture(transform_fixture, "linked_field.nomatch.graphql", "find_field_usages/fixtures/linked_field.nomatch.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_matches() {
+#[tokio::test]
+async fn multiple_matches() {
     let input = include_str!("find_field_usages/fixtures/multiple_matches.graphql");
     let expected = include_str!("find_field_usages/fixtures/multiple_matches.expected");
-    test_fixture(transform_fixture, "multiple_matches.graphql", "find_field_usages/fixtures/multiple_matches.expected", input, expected);
+    test_fixture(transform_fixture, "multiple_matches.graphql", "find_field_usages/fixtures/multiple_matches.expected", input, expected).await;
 }
 
-#[test]
-fn query_field() {
+#[tokio::test]
+async fn query_field() {
     let input = include_str!("find_field_usages/fixtures/query_field.graphql");
     let expected = include_str!("find_field_usages/fixtures/query_field.expected");
-    test_fixture(transform_fixture, "query_field.graphql", "find_field_usages/fixtures/query_field.expected", input, expected);
+    test_fixture(transform_fixture, "query_field.graphql", "find_field_usages/fixtures/query_field.expected", input, expected).await;
 }

--- a/compiler/crates/relay-lsp/tests/hover/mod.rs
+++ b/compiler/crates/relay-lsp/tests/hover/mod.rs
@@ -24,7 +24,7 @@ use relay_test_schema::get_test_schema;
 use relay_test_schema::get_test_schema_with_extensions;
 use resolution_path::ResolvePosition;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extension%").collect();
     let (schema, document) = if let [document, extension] = parts.as_slice() {
         (get_test_schema_with_extensions(extension), *document)

--- a/compiler/crates/relay-lsp/tests/hover_test.rs
+++ b/compiler/crates/relay-lsp/tests/hover_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7e6c48eb62c1d815fb6644cb2e6e3bb3>>
+ * @generated SignedSource<<8d4de373372a0eac03b5b9a9adb2d56d>>
  */
 
 mod hover;
@@ -12,65 +12,65 @@ mod hover;
 use hover::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn double_underscore_id_field() {
+#[tokio::test]
+async fn double_underscore_id_field() {
     let input = include_str!("hover/fixtures/double_underscore_id_field.graphql");
     let expected = include_str!("hover/fixtures/double_underscore_id_field.expected");
-    test_fixture(transform_fixture, "double_underscore_id_field.graphql", "hover/fixtures/double_underscore_id_field.expected", input, expected);
+    test_fixture(transform_fixture, "double_underscore_id_field.graphql", "hover/fixtures/double_underscore_id_field.expected", input, expected).await;
 }
 
-#[test]
-fn double_underscore_typename_field() {
+#[tokio::test]
+async fn double_underscore_typename_field() {
     let input = include_str!("hover/fixtures/double_underscore_typename_field.graphql");
     let expected = include_str!("hover/fixtures/double_underscore_typename_field.expected");
-    test_fixture(transform_fixture, "double_underscore_typename_field.graphql", "hover/fixtures/double_underscore_typename_field.expected", input, expected);
+    test_fixture(transform_fixture, "double_underscore_typename_field.graphql", "hover/fixtures/double_underscore_typename_field.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_definition_name() {
+#[tokio::test]
+async fn fragment_definition_name() {
     let input = include_str!("hover/fixtures/fragment_definition_name.graphql");
     let expected = include_str!("hover/fixtures/fragment_definition_name.expected");
-    test_fixture(transform_fixture, "fragment_definition_name.graphql", "hover/fixtures/fragment_definition_name.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_definition_name.graphql", "hover/fixtures/fragment_definition_name.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread() {
+#[tokio::test]
+async fn fragment_spread() {
     let input = include_str!("hover/fixtures/fragment_spread.graphql");
     let expected = include_str!("hover/fixtures/fragment_spread.expected");
-    test_fixture(transform_fixture, "fragment_spread.graphql", "hover/fixtures/fragment_spread.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_spread.graphql", "hover/fixtures/fragment_spread.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_field_from_client_schema_extension() {
+#[tokio::test]
+async fn scalar_field_from_client_schema_extension() {
     let input = include_str!("hover/fixtures/scalar_field_from_client_schema_extension.graphql");
     let expected = include_str!("hover/fixtures/scalar_field_from_client_schema_extension.expected");
-    test_fixture(transform_fixture, "scalar_field_from_client_schema_extension.graphql", "hover/fixtures/scalar_field_from_client_schema_extension.expected", input, expected);
+    test_fixture(transform_fixture, "scalar_field_from_client_schema_extension.graphql", "hover/fixtures/scalar_field_from_client_schema_extension.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_field_from_relay_resolver() {
+#[tokio::test]
+async fn scalar_field_from_relay_resolver() {
     let input = include_str!("hover/fixtures/scalar_field_from_relay_resolver.graphql");
     let expected = include_str!("hover/fixtures/scalar_field_from_relay_resolver.expected");
-    test_fixture(transform_fixture, "scalar_field_from_relay_resolver.graphql", "hover/fixtures/scalar_field_from_relay_resolver.expected", input, expected);
+    test_fixture(transform_fixture, "scalar_field_from_relay_resolver.graphql", "hover/fixtures/scalar_field_from_relay_resolver.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_field_with_description() {
+#[tokio::test]
+async fn scalar_field_with_description() {
     let input = include_str!("hover/fixtures/scalar_field_with_description.graphql");
     let expected = include_str!("hover/fixtures/scalar_field_with_description.expected");
-    test_fixture(transform_fixture, "scalar_field_with_description.graphql", "hover/fixtures/scalar_field_with_description.expected", input, expected);
+    test_fixture(transform_fixture, "scalar_field_with_description.graphql", "hover/fixtures/scalar_field_with_description.expected", input, expected).await;
 }
 
-#[test]
-fn whitespace_after_query_selection() {
+#[tokio::test]
+async fn whitespace_after_query_selection() {
     let input = include_str!("hover/fixtures/whitespace_after_query_selection.graphql");
     let expected = include_str!("hover/fixtures/whitespace_after_query_selection.expected");
-    test_fixture(transform_fixture, "whitespace_after_query_selection.graphql", "hover/fixtures/whitespace_after_query_selection.expected", input, expected);
+    test_fixture(transform_fixture, "whitespace_after_query_selection.graphql", "hover/fixtures/whitespace_after_query_selection.expected", input, expected).await;
 }
 
-#[test]
-fn whitespace_within_linked_field_selection() {
+#[tokio::test]
+async fn whitespace_within_linked_field_selection() {
     let input = include_str!("hover/fixtures/whitespace_within_linked_field_selection.graphql");
     let expected = include_str!("hover/fixtures/whitespace_within_linked_field_selection.expected");
-    test_fixture(transform_fixture, "whitespace_within_linked_field_selection.graphql", "hover/fixtures/whitespace_within_linked_field_selection.expected", input, expected);
+    test_fixture(transform_fixture, "whitespace_within_linked_field_selection.graphql", "hover/fixtures/whitespace_within_linked_field_selection.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/Cargo.toml
+++ b/compiler/crates/relay-transforms/Cargo.toml
@@ -133,3 +133,5 @@ fixture-tests = { path = "../fixture-tests" }
 graphql-cli = { path = "../graphql-cli" }
 graphql-test-helpers = { path = "../graphql-test-helpers" }
 relay-test-schema = { path = "../relay-test-schema" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }
+

--- a/compiler/crates/relay-transforms/tests/apply_fragment_arguments/mod.rs
+++ b/compiler/crates/relay-transforms/tests/apply_fragment_arguments/mod.rs
@@ -11,7 +11,7 @@ use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::apply_fragment_arguments;
 use relay_transforms::provided_variable_fragment_transform;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         let program = provided_variable_fragment_transform(program)?;
         apply_fragment_arguments(&program, false, &FeatureFlag::Enabled, &Default::default())

--- a/compiler/crates/relay-transforms/tests/apply_fragment_arguments_test.rs
+++ b/compiler/crates/relay-transforms/tests/apply_fragment_arguments_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<31a9fd31997eea7c6c3cf9a74ddaf459>>
+ * @generated SignedSource<<07c57f12c2f1e9951496bcba385ec584>>
  */
 
 mod apply_fragment_arguments;
@@ -12,93 +12,93 @@ mod apply_fragment_arguments;
 use apply_fragment_arguments::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn deletes_empty_fragments() {
+#[tokio::test]
+async fn deletes_empty_fragments() {
     let input = include_str!("apply_fragment_arguments/fixtures/deletes-empty-fragments.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/deletes-empty-fragments.expected");
-    test_fixture(transform_fixture, "deletes-empty-fragments.graphql", "apply_fragment_arguments/fixtures/deletes-empty-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "deletes-empty-fragments.graphql", "apply_fragment_arguments/fixtures/deletes-empty-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn deletes_unreferenced_fragments() {
+#[tokio::test]
+async fn deletes_unreferenced_fragments() {
     let input = include_str!("apply_fragment_arguments/fixtures/deletes-unreferenced-fragments.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/deletes-unreferenced-fragments.expected");
-    test_fixture(transform_fixture, "deletes-unreferenced-fragments.graphql", "apply_fragment_arguments/fixtures/deletes-unreferenced-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "deletes-unreferenced-fragments.graphql", "apply_fragment_arguments/fixtures/deletes-unreferenced-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_include_with_provided_argument() {
+#[tokio::test]
+async fn fragment_include_with_provided_argument() {
     let input = include_str!("apply_fragment_arguments/fixtures/fragment-include-with-provided-argument.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/fragment-include-with-provided-argument.expected");
-    test_fixture(transform_fixture, "fragment-include-with-provided-argument.graphql", "apply_fragment_arguments/fixtures/fragment-include-with-provided-argument.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-include-with-provided-argument.graphql", "apply_fragment_arguments/fixtures/fragment-include-with-provided-argument.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_float_argument() {
+#[tokio::test]
+async fn fragment_with_float_argument() {
     let input = include_str!("apply_fragment_arguments/fixtures/fragment-with-float-argument.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/fragment-with-float-argument.expected");
-    test_fixture(transform_fixture, "fragment-with-float-argument.graphql", "apply_fragment_arguments/fixtures/fragment-with-float-argument.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-float-argument.graphql", "apply_fragment_arguments/fixtures/fragment-with-float-argument.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_with_provided_argument() {
+#[tokio::test]
+async fn inline_fragment_with_provided_argument() {
     let input = include_str!("apply_fragment_arguments/fixtures/inline-fragment-with-provided-argument.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/inline-fragment-with-provided-argument.expected");
-    test_fixture(transform_fixture, "inline-fragment-with-provided-argument.graphql", "apply_fragment_arguments/fixtures/inline-fragment-with-provided-argument.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-with-provided-argument.graphql", "apply_fragment_arguments/fixtures/inline-fragment-with-provided-argument.expected", input, expected).await;
 }
 
-#[test]
-fn inlines_fragment_arguments() {
+#[tokio::test]
+async fn inlines_fragment_arguments() {
     let input = include_str!("apply_fragment_arguments/fixtures/inlines-fragment-arguments.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/inlines-fragment-arguments.expected");
-    test_fixture(transform_fixture, "inlines-fragment-arguments.graphql", "apply_fragment_arguments/fixtures/inlines-fragment-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "inlines-fragment-arguments.graphql", "apply_fragment_arguments/fixtures/inlines-fragment-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn inlines_literal_fragment_arguments() {
+#[tokio::test]
+async fn inlines_literal_fragment_arguments() {
     let input = include_str!("apply_fragment_arguments/fixtures/inlines-literal-fragment-arguments.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/inlines-literal-fragment-arguments.expected");
-    test_fixture(transform_fixture, "inlines-literal-fragment-arguments.graphql", "apply_fragment_arguments/fixtures/inlines-literal-fragment-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "inlines-literal-fragment-arguments.graphql", "apply_fragment_arguments/fixtures/inlines-literal-fragment-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn merges_identical_fragments() {
+#[tokio::test]
+async fn merges_identical_fragments() {
     let input = include_str!("apply_fragment_arguments/fixtures/merges-identical-fragments.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/merges-identical-fragments.expected");
-    test_fixture(transform_fixture, "merges-identical-fragments.graphql", "apply_fragment_arguments/fixtures/merges-identical-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "merges-identical-fragments.graphql", "apply_fragment_arguments/fixtures/merges-identical-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn merges_identical_fragments_literal_arguments() {
+#[tokio::test]
+async fn merges_identical_fragments_literal_arguments() {
     let input = include_str!("apply_fragment_arguments/fixtures/merges-identical-fragments-literal-arguments.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/merges-identical-fragments-literal-arguments.expected");
-    test_fixture(transform_fixture, "merges-identical-fragments-literal-arguments.graphql", "apply_fragment_arguments/fixtures/merges-identical-fragments-literal-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "merges-identical-fragments-literal-arguments.graphql", "apply_fragment_arguments/fixtures/merges-identical-fragments-literal-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_queries_with_provided_argument() {
+#[tokio::test]
+async fn multiple_queries_with_provided_argument() {
     let input = include_str!("apply_fragment_arguments/fixtures/multiple-queries-with-provided-argument.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/multiple-queries-with-provided-argument.expected");
-    test_fixture(transform_fixture, "multiple-queries-with-provided-argument.graphql", "apply_fragment_arguments/fixtures/multiple-queries-with-provided-argument.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-queries-with-provided-argument.graphql", "apply_fragment_arguments/fixtures/multiple-queries-with-provided-argument.expected", input, expected).await;
 }
 
-#[test]
-fn noncyclic_fragment_with_provided_argument() {
+#[tokio::test]
+async fn noncyclic_fragment_with_provided_argument() {
     let input = include_str!("apply_fragment_arguments/fixtures/noncyclic-fragment-with-provided-argument.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/noncyclic-fragment-with-provided-argument.expected");
-    test_fixture(transform_fixture, "noncyclic-fragment-with-provided-argument.graphql", "apply_fragment_arguments/fixtures/noncyclic-fragment-with-provided-argument.expected", input, expected);
+    test_fixture(transform_fixture, "noncyclic-fragment-with-provided-argument.graphql", "apply_fragment_arguments/fixtures/noncyclic-fragment-with-provided-argument.expected", input, expected).await;
 }
 
-#[test]
-fn rejects_cyclic_fragments_invalid() {
+#[tokio::test]
+async fn rejects_cyclic_fragments_invalid() {
     let input = include_str!("apply_fragment_arguments/fixtures/rejects-cyclic-fragments.invalid.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/rejects-cyclic-fragments.invalid.expected");
-    test_fixture(transform_fixture, "rejects-cyclic-fragments.invalid.graphql", "apply_fragment_arguments/fixtures/rejects-cyclic-fragments.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "rejects-cyclic-fragments.invalid.graphql", "apply_fragment_arguments/fixtures/rejects-cyclic-fragments.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn uses_defaults_for_literal_null_arguments() {
+#[tokio::test]
+async fn uses_defaults_for_literal_null_arguments() {
     let input = include_str!("apply_fragment_arguments/fixtures/uses-defaults-for-literal-null-arguments.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/uses-defaults-for-literal-null-arguments.expected");
-    test_fixture(transform_fixture, "uses-defaults-for-literal-null-arguments.graphql", "apply_fragment_arguments/fixtures/uses-defaults-for-literal-null-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "uses-defaults-for-literal-null-arguments.graphql", "apply_fragment_arguments/fixtures/uses-defaults-for-literal-null-arguments.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/assignable_directive/mod.rs
+++ b/compiler/crates/relay-transforms/tests/assignable_directive/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_assignable_directive;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/assignable_directive_test.rs
+++ b/compiler/crates/relay-transforms/tests/assignable_directive_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b7d75b6fd50fd7b7dd28b7a17618e7b8>>
+ * @generated SignedSource<<a0eb564e9790a817cfb4ad20e6adb8a5>>
  */
 
 mod assignable_directive;
@@ -12,44 +12,44 @@ mod assignable_directive;
 use assignable_directive::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn assignable_fragment() {
+#[tokio::test]
+async fn assignable_fragment() {
     let input = include_str!("assignable_directive/fixtures/assignable-fragment.graphql");
     let expected = include_str!("assignable_directive/fixtures/assignable-fragment.expected");
-    test_fixture(transform_fixture, "assignable-fragment.graphql", "assignable_directive/fixtures/assignable-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment.graphql", "assignable_directive/fixtures/assignable-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_aliased_typename_invalid() {
+#[tokio::test]
+async fn assignable_fragment_aliased_typename_invalid() {
     let input = include_str!("assignable_directive/fixtures/assignable-fragment-aliased-typename.invalid.graphql");
     let expected = include_str!("assignable_directive/fixtures/assignable-fragment-aliased-typename.invalid.expected");
-    test_fixture(transform_fixture, "assignable-fragment-aliased-typename.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-aliased-typename.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-aliased-typename.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-aliased-typename.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_directive_on_typename_invalid() {
+#[tokio::test]
+async fn assignable_fragment_directive_on_typename_invalid() {
     let input = include_str!("assignable_directive/fixtures/assignable-fragment-directive-on-typename.invalid.graphql");
     let expected = include_str!("assignable_directive/fixtures/assignable-fragment-directive-on-typename.invalid.expected");
-    test_fixture(transform_fixture, "assignable-fragment-directive-on-typename.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-directive-on-typename.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-directive-on-typename.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-directive-on-typename.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_directive_other_directives_invalid() {
+#[tokio::test]
+async fn assignable_fragment_directive_other_directives_invalid() {
     let input = include_str!("assignable_directive/fixtures/assignable-fragment-directive-other-directives.invalid.graphql");
     let expected = include_str!("assignable_directive/fixtures/assignable-fragment-directive-other-directives.invalid.expected");
-    test_fixture(transform_fixture, "assignable-fragment-directive-other-directives.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-directive-other-directives.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-directive-other-directives.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-directive-other-directives.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_no_typename_invalid() {
+#[tokio::test]
+async fn assignable_fragment_no_typename_invalid() {
     let input = include_str!("assignable_directive/fixtures/assignable-fragment-no-typename.invalid.graphql");
     let expected = include_str!("assignable_directive/fixtures/assignable-fragment-no-typename.invalid.expected");
-    test_fixture(transform_fixture, "assignable-fragment-no-typename.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-no-typename.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-no-typename.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-no-typename.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_other_fields_invalid() {
+#[tokio::test]
+async fn assignable_fragment_other_fields_invalid() {
     let input = include_str!("assignable_directive/fixtures/assignable-fragment-other-fields.invalid.graphql");
     let expected = include_str!("assignable_directive/fixtures/assignable-fragment-other-fields.invalid.expected");
-    test_fixture(transform_fixture, "assignable-fragment-other-fields.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-other-fields.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-other-fields.invalid.graphql", "assignable_directive/fixtures/assignable-fragment-other-fields.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/assignable_fragment_spread/mod.rs
+++ b/compiler/crates/relay-transforms/tests/assignable_fragment_spread/mod.rs
@@ -15,6 +15,6 @@ fn transform(program: &Program) -> DiagnosticsResult<Program> {
     transform_assignable_fragment_spreads_in_regular_queries(program)
 }
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, transform)
 }

--- a/compiler/crates/relay-transforms/tests/assignable_fragment_spread_test.rs
+++ b/compiler/crates/relay-transforms/tests/assignable_fragment_spread_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7e199fca5115686b17339b3e81aeaf9d>>
+ * @generated SignedSource<<a2f8450ba3774265f685c6d42dd71a9a>>
  */
 
 mod assignable_fragment_spread;
@@ -12,93 +12,93 @@ mod assignable_fragment_spread;
 use assignable_fragment_spread::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn abstract_assignable_fragment_spread_on_concrete_type() {
+#[tokio::test]
+async fn abstract_assignable_fragment_spread_on_concrete_type() {
     let input = include_str!("assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-concrete-type.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-concrete-type.expected");
-    test_fixture(transform_fixture, "abstract-assignable-fragment-spread-on-concrete-type.graphql", "assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-concrete-type.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-assignable-fragment-spread-on-concrete-type.graphql", "assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-concrete-type.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_assignable_fragment_spread_on_concrete_type_in_updatable_fragment() {
+#[tokio::test]
+async fn abstract_assignable_fragment_spread_on_concrete_type_in_updatable_fragment() {
     let input = include_str!("assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-concrete-type-in-updatable-fragment.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-concrete-type-in-updatable-fragment.expected");
-    test_fixture(transform_fixture, "abstract-assignable-fragment-spread-on-concrete-type-in-updatable-fragment.graphql", "assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-concrete-type-in-updatable-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-assignable-fragment-spread-on-concrete-type-in-updatable-fragment.graphql", "assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-concrete-type-in-updatable-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_assignable_fragment_spread_on_different_abstract_type() {
+#[tokio::test]
+async fn abstract_assignable_fragment_spread_on_different_abstract_type() {
     let input = include_str!("assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-different-abstract-type.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-different-abstract-type.expected");
-    test_fixture(transform_fixture, "abstract-assignable-fragment-spread-on-different-abstract-type.graphql", "assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-different-abstract-type.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-assignable-fragment-spread-on-different-abstract-type.graphql", "assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-different-abstract-type.expected", input, expected).await;
 }
 
-#[test]
-fn abstract_assignable_fragment_spread_on_matching_abstract_type() {
+#[tokio::test]
+async fn abstract_assignable_fragment_spread_on_matching_abstract_type() {
     let input = include_str!("assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-matching-abstract-type.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-matching-abstract-type.expected");
-    test_fixture(transform_fixture, "abstract-assignable-fragment-spread-on-matching-abstract-type.graphql", "assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-matching-abstract-type.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-assignable-fragment-spread-on-matching-abstract-type.graphql", "assignable_fragment_spread/fixtures/abstract-assignable-fragment-spread-on-matching-abstract-type.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_spread_top_level_invalid() {
+#[tokio::test]
+async fn assignable_fragment_spread_top_level_invalid() {
     let input = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-top-level.invalid.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-top-level.invalid.expected");
-    test_fixture(transform_fixture, "assignable-fragment-spread-top-level.invalid.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-top-level.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-spread-top-level.invalid.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-top-level.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_spread_with_directives_invalid() {
+#[tokio::test]
+async fn assignable_fragment_spread_with_directives_invalid() {
     let input = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-with-directives.invalid.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-with-directives.invalid.expected");
-    test_fixture(transform_fixture, "assignable-fragment-spread-with-directives.invalid.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-with-directives.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-spread-with-directives.invalid.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-with-directives.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_spread_within_inline_fragment() {
+#[tokio::test]
+async fn assignable_fragment_spread_within_inline_fragment() {
     let input = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-within-inline-fragment.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-within-inline-fragment.expected");
-    test_fixture(transform_fixture, "assignable-fragment-spread-within-inline-fragment.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-within-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-spread-within-inline-fragment.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-within-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_spread_within_inline_fragment_and_linked_field() {
+#[tokio::test]
+async fn assignable_fragment_spread_within_inline_fragment_and_linked_field() {
     let input = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-within-inline-fragment-and-linked-field.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-within-inline-fragment-and-linked-field.expected");
-    test_fixture(transform_fixture, "assignable-fragment-spread-within-inline-fragment-and-linked-field.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-within-inline-fragment-and-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-spread-within-inline-fragment-and-linked-field.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-within-inline-fragment-and-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_spread_within_skipped_inline_fragment_invalid() {
+#[tokio::test]
+async fn assignable_fragment_spread_within_skipped_inline_fragment_invalid() {
     let input = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-within-skipped-inline-fragment.invalid.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/assignable-fragment-spread-within-skipped-inline-fragment.invalid.expected");
-    test_fixture(transform_fixture, "assignable-fragment-spread-within-skipped-inline-fragment.invalid.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-within-skipped-inline-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-spread-within-skipped-inline-fragment.invalid.graphql", "assignable_fragment_spread/fixtures/assignable-fragment-spread-within-skipped-inline-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn concrete_assignable_fragment_spread_on_abstract_type() {
+#[tokio::test]
+async fn concrete_assignable_fragment_spread_on_abstract_type() {
     let input = include_str!("assignable_fragment_spread/fixtures/concrete-assignable-fragment-spread-on-abstract-type.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/concrete-assignable-fragment-spread-on-abstract-type.expected");
-    test_fixture(transform_fixture, "concrete-assignable-fragment-spread-on-abstract-type.graphql", "assignable_fragment_spread/fixtures/concrete-assignable-fragment-spread-on-abstract-type.expected", input, expected);
+    test_fixture(transform_fixture, "concrete-assignable-fragment-spread-on-abstract-type.graphql", "assignable_fragment_spread/fixtures/concrete-assignable-fragment-spread-on-abstract-type.expected", input, expected).await;
 }
 
-#[test]
-fn concrete_assignable_fragment_spread_on_matching_concrete_type() {
+#[tokio::test]
+async fn concrete_assignable_fragment_spread_on_matching_concrete_type() {
     let input = include_str!("assignable_fragment_spread/fixtures/concrete-assignable-fragment-spread-on-matching-concrete-type.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/concrete-assignable-fragment-spread-on-matching-concrete-type.expected");
-    test_fixture(transform_fixture, "concrete-assignable-fragment-spread-on-matching-concrete-type.graphql", "assignable_fragment_spread/fixtures/concrete-assignable-fragment-spread-on-matching-concrete-type.expected", input, expected);
+    test_fixture(transform_fixture, "concrete-assignable-fragment-spread-on-matching-concrete-type.graphql", "assignable_fragment_spread/fixtures/concrete-assignable-fragment-spread-on-matching-concrete-type.expected", input, expected).await;
 }
 
-#[test]
-fn included_assignable_fragment_spread_invalid() {
+#[tokio::test]
+async fn included_assignable_fragment_spread_invalid() {
     let input = include_str!("assignable_fragment_spread/fixtures/included-assignable-fragment-spread.invalid.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/included-assignable-fragment-spread.invalid.expected");
-    test_fixture(transform_fixture, "included-assignable-fragment-spread.invalid.graphql", "assignable_fragment_spread/fixtures/included-assignable-fragment-spread.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "included-assignable-fragment-spread.invalid.graphql", "assignable_fragment_spread/fixtures/included-assignable-fragment-spread.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn skipped_assignable_fragment_spread_invalid() {
+#[tokio::test]
+async fn skipped_assignable_fragment_spread_invalid() {
     let input = include_str!("assignable_fragment_spread/fixtures/skipped-assignable-fragment-spread.invalid.graphql");
     let expected = include_str!("assignable_fragment_spread/fixtures/skipped-assignable-fragment-spread.invalid.expected");
-    test_fixture(transform_fixture, "skipped-assignable-fragment-spread.invalid.graphql", "assignable_fragment_spread/fixtures/skipped-assignable-fragment-spread.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "skipped-assignable-fragment-spread.invalid.graphql", "assignable_fragment_spread/fixtures/skipped-assignable-fragment-spread.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/client_edges/mod.rs
+++ b/compiler/crates/relay-transforms/tests/client_edges/mod.rs
@@ -24,7 +24,7 @@ use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::client_edges;
 use relay_transforms::relay_resolvers;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     if let [base, extensions] = parts.as_slice() {
         let source_location = SourceLocationKey::standalone(fixture.file_name);

--- a/compiler/crates/relay-transforms/tests/client_edges_test.rs
+++ b/compiler/crates/relay-transforms/tests/client_edges_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fdca76a18b1f6421d06d0dae776f25b7>>
+ * @generated SignedSource<<99b34d058f14ff49308f7597bc491467>>
  */
 
 mod client_edges;
@@ -12,114 +12,114 @@ mod client_edges;
 use client_edges::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn client_edge() {
+#[tokio::test]
+async fn client_edge() {
     let input = include_str!("client_edges/fixtures/client-edge.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge.expected");
-    test_fixture(transform_fixture, "client-edge.graphql", "client_edges/fixtures/client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge.graphql", "client_edges/fixtures/client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_inline_fragment() {
+#[tokio::test]
+async fn client_edge_inline_fragment() {
     let input = include_str!("client_edges/fixtures/client-edge-inline-fragment.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-inline-fragment.expected");
-    test_fixture(transform_fixture, "client-edge-inline-fragment.graphql", "client_edges/fixtures/client-edge-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-inline-fragment.graphql", "client_edges/fixtures/client-edge-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_inline_fragment_no_type_condition() {
+#[tokio::test]
+async fn client_edge_inline_fragment_no_type_condition() {
     let input = include_str!("client_edges/fixtures/client-edge-inline-fragment-no-type-condition.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-inline-fragment-no-type-condition.expected");
-    test_fixture(transform_fixture, "client-edge-inline-fragment-no-type-condition.graphql", "client_edges/fixtures/client-edge-inline-fragment-no-type-condition.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-inline-fragment-no-type-condition.graphql", "client_edges/fixtures/client-edge-inline-fragment-no-type-condition.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_to_client_interface() {
+#[tokio::test]
+async fn client_edge_to_client_interface() {
     let input = include_str!("client_edges/fixtures/client-edge-to-client-interface.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-to-client-interface.expected");
-    test_fixture(transform_fixture, "client-edge-to-client-interface.graphql", "client_edges/fixtures/client-edge-to-client-interface.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-to-client-interface.graphql", "client_edges/fixtures/client-edge-to-client-interface.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_to_client_interface_invalid() {
+#[tokio::test]
+async fn client_edge_to_client_interface_invalid() {
     let input = include_str!("client_edges/fixtures/client-edge-to-client-interface.invalid.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-to-client-interface.invalid.expected");
-    test_fixture(transform_fixture, "client-edge-to-client-interface.invalid.graphql", "client_edges/fixtures/client-edge-to-client-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-to-client-interface.invalid.graphql", "client_edges/fixtures/client-edge-to-client-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_to_client_object() {
+#[tokio::test]
+async fn client_edge_to_client_object() {
     let input = include_str!("client_edges/fixtures/client-edge-to-client-object.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-to-client-object.expected");
-    test_fixture(transform_fixture, "client-edge-to-client-object.graphql", "client_edges/fixtures/client-edge-to-client-object.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-to-client-object.graphql", "client_edges/fixtures/client-edge-to-client-object.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_to_client_union_invalid() {
+#[tokio::test]
+async fn client_edge_to_client_union_invalid() {
     let input = include_str!("client_edges/fixtures/client-edge-to-client-union.invalid.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-to-client-union.invalid.expected");
-    test_fixture(transform_fixture, "client-edge-to-client-union.invalid.graphql", "client_edges/fixtures/client-edge-to-client-union.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-to-client-union.invalid.graphql", "client_edges/fixtures/client-edge-to-client-union.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_variables() {
+#[tokio::test]
+async fn client_edge_variables() {
     let input = include_str!("client_edges/fixtures/client-edge-variables.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-variables.expected");
-    test_fixture(transform_fixture, "client-edge-variables.graphql", "client_edges/fixtures/client-edge-variables.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-variables.graphql", "client_edges/fixtures/client-edge-variables.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_with_required() {
+#[tokio::test]
+async fn client_edge_with_required() {
     let input = include_str!("client_edges/fixtures/client-edge-with-required.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-with-required.expected");
-    test_fixture(transform_fixture, "client-edge-with-required.graphql", "client_edges/fixtures/client-edge-with-required.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-with-required.graphql", "client_edges/fixtures/client-edge-with-required.expected", input, expected).await;
 }
 
-#[test]
-fn client_edge_within_non_client_edge() {
+#[tokio::test]
+async fn client_edge_within_non_client_edge() {
     let input = include_str!("client_edges/fixtures/client-edge-within-non-client-edge.graphql");
     let expected = include_str!("client_edges/fixtures/client-edge-within-non-client-edge.expected");
-    test_fixture(transform_fixture, "client-edge-within-non-client-edge.graphql", "client_edges/fixtures/client-edge-within-non-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "client-edge-within-non-client-edge.graphql", "client_edges/fixtures/client-edge-within-non-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn nested_client_edges() {
+#[tokio::test]
+async fn nested_client_edges() {
     let input = include_str!("client_edges/fixtures/nested-client-edges.graphql");
     let expected = include_str!("client_edges/fixtures/nested-client-edges.expected");
-    test_fixture(transform_fixture, "nested-client-edges.graphql", "client_edges/fixtures/nested-client-edges.expected", input, expected);
+    test_fixture(transform_fixture, "nested-client-edges.graphql", "client_edges/fixtures/nested-client-edges.expected", input, expected).await;
 }
 
-#[test]
-fn nested_client_edges_with_variables() {
+#[tokio::test]
+async fn nested_client_edges_with_variables() {
     let input = include_str!("client_edges/fixtures/nested-client-edges-with-variables.graphql");
     let expected = include_str!("client_edges/fixtures/nested-client-edges-with-variables.expected");
-    test_fixture(transform_fixture, "nested-client-edges-with-variables.graphql", "client_edges/fixtures/nested-client-edges-with-variables.expected", input, expected);
+    test_fixture(transform_fixture, "nested-client-edges-with-variables.graphql", "client_edges/fixtures/nested-client-edges-with-variables.expected", input, expected).await;
 }
 
-#[test]
-fn nested_path() {
+#[tokio::test]
+async fn nested_path() {
     let input = include_str!("client_edges/fixtures/nested-path.graphql");
     let expected = include_str!("client_edges/fixtures/nested-path.expected");
-    test_fixture(transform_fixture, "nested-path.graphql", "client_edges/fixtures/nested-path.expected", input, expected);
+    test_fixture(transform_fixture, "nested-path.graphql", "client_edges/fixtures/nested-path.expected", input, expected).await;
 }
 
-#[test]
-fn nested_path_with_alias() {
+#[tokio::test]
+async fn nested_path_with_alias() {
     let input = include_str!("client_edges/fixtures/nested-path-with-alias.graphql");
     let expected = include_str!("client_edges/fixtures/nested-path-with-alias.expected");
-    test_fixture(transform_fixture, "nested-path-with-alias.graphql", "client_edges/fixtures/nested-path-with-alias.expected", input, expected);
+    test_fixture(transform_fixture, "nested-path-with-alias.graphql", "client_edges/fixtures/nested-path-with-alias.expected", input, expected).await;
 }
 
-#[test]
-fn output_type() {
+#[tokio::test]
+async fn output_type() {
     let input = include_str!("client_edges/fixtures/output-type.graphql");
     let expected = include_str!("client_edges/fixtures/output-type.expected");
-    test_fixture(transform_fixture, "output-type.graphql", "client_edges/fixtures/output-type.expected", input, expected);
+    test_fixture(transform_fixture, "output-type.graphql", "client_edges/fixtures/output-type.expected", input, expected).await;
 }
 
-#[test]
-fn unexpected_waterfall_invalid() {
+#[tokio::test]
+async fn unexpected_waterfall_invalid() {
     let input = include_str!("client_edges/fixtures/unexpected-waterfall.invalid.graphql");
     let expected = include_str!("client_edges/fixtures/unexpected-waterfall.invalid.expected");
-    test_fixture(transform_fixture, "unexpected-waterfall.invalid.graphql", "client_edges/fixtures/unexpected-waterfall.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unexpected-waterfall.invalid.graphql", "client_edges/fixtures/unexpected-waterfall.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/client_extensions/mod.rs
+++ b/compiler/crates/relay-transforms/tests/client_extensions/mod.rs
@@ -18,7 +18,7 @@ use graphql_text_printer::PrinterOptions;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::client_extensions;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     if let [base, extensions] = parts.as_slice() {
         let source_location = SourceLocationKey::standalone(fixture.file_name);

--- a/compiler/crates/relay-transforms/tests/client_extensions_abstract_types/mod.rs
+++ b/compiler/crates/relay-transforms/tests/client_extensions_abstract_types/mod.rs
@@ -18,7 +18,7 @@ use graphql_text_printer::PrinterOptions;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::client_extensions_abstract_types;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     if let [base, extensions] = parts.as_slice() {
         let source_location = SourceLocationKey::standalone(fixture.file_name);

--- a/compiler/crates/relay-transforms/tests/client_extensions_abstract_types_test.rs
+++ b/compiler/crates/relay-transforms/tests/client_extensions_abstract_types_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e5c24b5453bde4b099eb2517e15d853f>>
+ * @generated SignedSource<<63af903d78866a0666372e89b633a412>>
  */
 
 mod client_extensions_abstract_types;
@@ -12,30 +12,30 @@ mod client_extensions_abstract_types;
 use client_extensions_abstract_types::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_spread_on_client_interface() {
+#[tokio::test]
+async fn fragment_spread_on_client_interface() {
     let input = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface.graphql");
     let expected = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface.expected");
-    test_fixture(transform_fixture, "fragment_spread_on_client_interface.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_spread_on_client_interface.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread_on_client_interface_transitively() {
+#[tokio::test]
+async fn fragment_spread_on_client_interface_transitively() {
     let input = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface_transitively.graphql");
     let expected = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface_transitively.expected");
-    test_fixture(transform_fixture, "fragment_spread_on_client_interface_transitively.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface_transitively.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_spread_on_client_interface_transitively.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_interface_transitively.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread_on_client_union() {
+#[tokio::test]
+async fn fragment_spread_on_client_union() {
     let input = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_union.graphql");
     let expected = include_str!("client_extensions_abstract_types/fixtures/fragment_spread_on_client_union.expected");
-    test_fixture(transform_fixture, "fragment_spread_on_client_union.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_union.expected", input, expected);
+    test_fixture(transform_fixture, "fragment_spread_on_client_union.graphql", "client_extensions_abstract_types/fixtures/fragment_spread_on_client_union.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_client_interface() {
+#[tokio::test]
+async fn inline_fragment_on_client_interface() {
     let input = include_str!("client_extensions_abstract_types/fixtures/inline_fragment_on_client_interface.graphql");
     let expected = include_str!("client_extensions_abstract_types/fixtures/inline_fragment_on_client_interface.expected");
-    test_fixture(transform_fixture, "inline_fragment_on_client_interface.graphql", "client_extensions_abstract_types/fixtures/inline_fragment_on_client_interface.expected", input, expected);
+    test_fixture(transform_fixture, "inline_fragment_on_client_interface.graphql", "client_extensions_abstract_types/fixtures/inline_fragment_on_client_interface.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/client_extensions_test.rs
+++ b/compiler/crates/relay-transforms/tests/client_extensions_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8e76da20110296ac303bd405d2001557>>
+ * @generated SignedSource<<10aec15bb433a1562ff46edfa72808b3>>
  */
 
 mod client_extensions;
@@ -12,51 +12,51 @@ mod client_extensions;
 use client_extensions::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn client_conditions() {
+#[tokio::test]
+async fn client_conditions() {
     let input = include_str!("client_extensions/fixtures/client-conditions.graphql");
     let expected = include_str!("client_extensions/fixtures/client-conditions.expected");
-    test_fixture(transform_fixture, "client-conditions.graphql", "client_extensions/fixtures/client-conditions.expected", input, expected);
+    test_fixture(transform_fixture, "client-conditions.graphql", "client_extensions/fixtures/client-conditions.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_in_inline_fragments() {
+#[tokio::test]
+async fn client_fields_in_inline_fragments() {
     let input = include_str!("client_extensions/fixtures/client-fields-in-inline-fragments.graphql");
     let expected = include_str!("client_extensions/fixtures/client-fields-in-inline-fragments.expected");
-    test_fixture(transform_fixture, "client-fields-in-inline-fragments.graphql", "client_extensions/fixtures/client-fields-in-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-in-inline-fragments.graphql", "client_extensions/fixtures/client-fields-in-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_of_client_type() {
+#[tokio::test]
+async fn client_fields_of_client_type() {
     let input = include_str!("client_extensions/fixtures/client-fields-of-client-type.graphql");
     let expected = include_str!("client_extensions/fixtures/client-fields-of-client-type.expected");
-    test_fixture(transform_fixture, "client-fields-of-client-type.graphql", "client_extensions/fixtures/client-fields-of-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-of-client-type.graphql", "client_extensions/fixtures/client-fields-of-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_on_roots() {
+#[tokio::test]
+async fn client_fields_on_roots() {
     let input = include_str!("client_extensions/fixtures/client-fields-on-roots.graphql");
     let expected = include_str!("client_extensions/fixtures/client-fields-on-roots.expected");
-    test_fixture(transform_fixture, "client-fields-on-roots.graphql", "client_extensions/fixtures/client-fields-on-roots.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-on-roots.graphql", "client_extensions/fixtures/client-fields-on-roots.expected", input, expected).await;
 }
 
-#[test]
-fn client_linked_fields() {
+#[tokio::test]
+async fn client_linked_fields() {
     let input = include_str!("client_extensions/fixtures/client-linked-fields.graphql");
     let expected = include_str!("client_extensions/fixtures/client-linked-fields.expected");
-    test_fixture(transform_fixture, "client-linked-fields.graphql", "client_extensions/fixtures/client-linked-fields.expected", input, expected);
+    test_fixture(transform_fixture, "client-linked-fields.graphql", "client_extensions/fixtures/client-linked-fields.expected", input, expected).await;
 }
 
-#[test]
-fn client_scalar_fields() {
+#[tokio::test]
+async fn client_scalar_fields() {
     let input = include_str!("client_extensions/fixtures/client-scalar-fields.graphql");
     let expected = include_str!("client_extensions/fixtures/client-scalar-fields.expected");
-    test_fixture(transform_fixture, "client-scalar-fields.graphql", "client_extensions/fixtures/client-scalar-fields.expected", input, expected);
+    test_fixture(transform_fixture, "client-scalar-fields.graphql", "client_extensions/fixtures/client-scalar-fields.expected", input, expected).await;
 }
 
-#[test]
-fn sibling_client_selections() {
+#[tokio::test]
+async fn sibling_client_selections() {
     let input = include_str!("client_extensions/fixtures/sibling-client-selections.graphql");
     let expected = include_str!("client_extensions/fixtures/sibling-client-selections.expected");
-    test_fixture(transform_fixture, "sibling-client-selections.graphql", "client_extensions/fixtures/sibling-client-selections.expected", input, expected);
+    test_fixture(transform_fixture, "sibling-client-selections.graphql", "client_extensions/fixtures/sibling-client-selections.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/declarative_connection/mod.rs
+++ b/compiler/crates/relay-transforms/tests/declarative_connection/mod.rs
@@ -10,7 +10,7 @@ use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::transform_declarative_connection;
 use relay_transforms::ConnectionInterface;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         transform_declarative_connection(program, &ConnectionInterface::default())
     })

--- a/compiler/crates/relay-transforms/tests/declarative_connection_test.rs
+++ b/compiler/crates/relay-transforms/tests/declarative_connection_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<73cfaa2e0393cd88236a48e688f50dea>>
+ * @generated SignedSource<<5127f18db4c65c3de2ffc8f2bdf42e8c>>
  */
 
 mod declarative_connection;
@@ -12,79 +12,79 @@ mod declarative_connection;
 use declarative_connection::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn append_edge() {
+#[tokio::test]
+async fn append_edge() {
     let input = include_str!("declarative_connection/fixtures/append-edge.graphql");
     let expected = include_str!("declarative_connection/fixtures/append-edge.expected");
-    test_fixture(transform_fixture, "append-edge.graphql", "declarative_connection/fixtures/append-edge.expected", input, expected);
+    test_fixture(transform_fixture, "append-edge.graphql", "declarative_connection/fixtures/append-edge.expected", input, expected).await;
 }
 
-#[test]
-fn append_edge_unspported_invalid() {
+#[tokio::test]
+async fn append_edge_unspported_invalid() {
     let input = include_str!("declarative_connection/fixtures/append-edge-unspported.invalid.graphql");
     let expected = include_str!("declarative_connection/fixtures/append-edge-unspported.invalid.expected");
-    test_fixture(transform_fixture, "append-edge-unspported.invalid.graphql", "declarative_connection/fixtures/append-edge-unspported.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "append-edge-unspported.invalid.graphql", "declarative_connection/fixtures/append-edge-unspported.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn append_node() {
+#[tokio::test]
+async fn append_node() {
     let input = include_str!("declarative_connection/fixtures/append-node.graphql");
     let expected = include_str!("declarative_connection/fixtures/append-node.expected");
-    test_fixture(transform_fixture, "append-node.graphql", "declarative_connection/fixtures/append-node.expected", input, expected);
+    test_fixture(transform_fixture, "append-node.graphql", "declarative_connection/fixtures/append-node.expected", input, expected).await;
 }
 
-#[test]
-fn append_node_edge_literal() {
+#[tokio::test]
+async fn append_node_edge_literal() {
     let input = include_str!("declarative_connection/fixtures/append-node-edge-literal.graphql");
     let expected = include_str!("declarative_connection/fixtures/append-node-edge-literal.expected");
-    test_fixture(transform_fixture, "append-node-edge-literal.graphql", "declarative_connection/fixtures/append-node-edge-literal.expected", input, expected);
+    test_fixture(transform_fixture, "append-node-edge-literal.graphql", "declarative_connection/fixtures/append-node-edge-literal.expected", input, expected).await;
 }
 
-#[test]
-fn append_node_unsupported_invalid() {
+#[tokio::test]
+async fn append_node_unsupported_invalid() {
     let input = include_str!("declarative_connection/fixtures/append-node-unsupported.invalid.graphql");
     let expected = include_str!("declarative_connection/fixtures/append-node-unsupported.invalid.expected");
-    test_fixture(transform_fixture, "append-node-unsupported.invalid.graphql", "declarative_connection/fixtures/append-node-unsupported.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "append-node-unsupported.invalid.graphql", "declarative_connection/fixtures/append-node-unsupported.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn delete_edge_from_connection() {
+#[tokio::test]
+async fn delete_edge_from_connection() {
     let input = include_str!("declarative_connection/fixtures/delete-edge-from-connection.graphql");
     let expected = include_str!("declarative_connection/fixtures/delete-edge-from-connection.expected");
-    test_fixture(transform_fixture, "delete-edge-from-connection.graphql", "declarative_connection/fixtures/delete-edge-from-connection.expected", input, expected);
+    test_fixture(transform_fixture, "delete-edge-from-connection.graphql", "declarative_connection/fixtures/delete-edge-from-connection.expected", input, expected).await;
 }
 
-#[test]
-fn delete_edge_from_connection_on_unsupported_type_invalid() {
+#[tokio::test]
+async fn delete_edge_from_connection_on_unsupported_type_invalid() {
     let input = include_str!("declarative_connection/fixtures/delete-edge-from-connection-on-unsupported-type.invalid.graphql");
     let expected = include_str!("declarative_connection/fixtures/delete-edge-from-connection-on-unsupported-type.invalid.expected");
-    test_fixture(transform_fixture, "delete-edge-from-connection-on-unsupported-type.invalid.graphql", "declarative_connection/fixtures/delete-edge-from-connection-on-unsupported-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "delete-edge-from-connection-on-unsupported-type.invalid.graphql", "declarative_connection/fixtures/delete-edge-from-connection-on-unsupported-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn delete_edge_from_connection_plural() {
+#[tokio::test]
+async fn delete_edge_from_connection_plural() {
     let input = include_str!("declarative_connection/fixtures/delete-edge-from-connection-plural.graphql");
     let expected = include_str!("declarative_connection/fixtures/delete-edge-from-connection-plural.expected");
-    test_fixture(transform_fixture, "delete-edge-from-connection-plural.graphql", "declarative_connection/fixtures/delete-edge-from-connection-plural.expected", input, expected);
+    test_fixture(transform_fixture, "delete-edge-from-connection-plural.graphql", "declarative_connection/fixtures/delete-edge-from-connection-plural.expected", input, expected).await;
 }
 
-#[test]
-fn delete_from_store() {
+#[tokio::test]
+async fn delete_from_store() {
     let input = include_str!("declarative_connection/fixtures/delete-from-store.graphql");
     let expected = include_str!("declarative_connection/fixtures/delete-from-store.expected");
-    test_fixture(transform_fixture, "delete-from-store.graphql", "declarative_connection/fixtures/delete-from-store.expected", input, expected);
+    test_fixture(transform_fixture, "delete-from-store.graphql", "declarative_connection/fixtures/delete-from-store.expected", input, expected).await;
 }
 
-#[test]
-fn delete_from_store_plural() {
+#[tokio::test]
+async fn delete_from_store_plural() {
     let input = include_str!("declarative_connection/fixtures/delete-from-store-plural.graphql");
     let expected = include_str!("declarative_connection/fixtures/delete-from-store-plural.expected");
-    test_fixture(transform_fixture, "delete-from-store-plural.graphql", "declarative_connection/fixtures/delete-from-store-plural.expected", input, expected);
+    test_fixture(transform_fixture, "delete-from-store-plural.graphql", "declarative_connection/fixtures/delete-from-store-plural.expected", input, expected).await;
 }
 
-#[test]
-fn delete_on_unspported_type_invalid() {
+#[tokio::test]
+async fn delete_on_unspported_type_invalid() {
     let input = include_str!("declarative_connection/fixtures/delete-on-unspported-type.invalid.graphql");
     let expected = include_str!("declarative_connection/fixtures/delete-on-unspported-type.invalid.expected");
-    test_fixture(transform_fixture, "delete-on-unspported-type.invalid.graphql", "declarative_connection/fixtures/delete-on-unspported-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "delete-on-unspported-type.invalid.graphql", "declarative_connection/fixtures/delete-on-unspported-type.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/mod.rs
+++ b/compiler/crates/relay-transforms/tests/defer_stream/mod.rs
@@ -10,7 +10,7 @@ use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::transform_defer_stream;
 use relay_transforms::unwrap_custom_directive_selection;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         let program = transform_defer_stream(program)?;
         let program = unwrap_custom_directive_selection(&program);

--- a/compiler/crates/relay-transforms/tests/defer_stream_test.rs
+++ b/compiler/crates/relay-transforms/tests/defer_stream_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c389b836270f13295c42ac1ed3dc1bb3>>
+ * @generated SignedSource<<017e79bd09dfef2bd42412d77ebeaa41>>
  */
 
 mod defer_stream;
@@ -12,156 +12,156 @@ mod defer_stream;
 use defer_stream::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_with_defer() {
+#[tokio::test]
+async fn fragment_with_defer() {
     let input = include_str!("defer_stream/fixtures/fragment-with-defer.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-defer.expected");
-    test_fixture(transform_fixture, "fragment-with-defer.graphql", "defer_stream/fixtures/fragment-with-defer.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer.graphql", "defer_stream/fixtures/fragment-with-defer.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_arguments() {
+#[tokio::test]
+async fn fragment_with_defer_arguments() {
     let input = include_str!("defer_stream/fixtures/fragment-with-defer-arguments.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-defer-arguments.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-arguments.graphql", "defer_stream/fixtures/fragment-with-defer-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-arguments.graphql", "defer_stream/fixtures/fragment-with-defer-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_default_label() {
+#[tokio::test]
+async fn fragment_with_defer_default_label() {
     let input = include_str!("defer_stream/fixtures/fragment-with-defer-default-label.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-defer-default-label.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-default-label.graphql", "defer_stream/fixtures/fragment-with-defer-default-label.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-default-label.graphql", "defer_stream/fixtures/fragment-with-defer-default-label.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_duplicate_label_invalid() {
+#[tokio::test]
+async fn fragment_with_defer_duplicate_label_invalid() {
     let input = include_str!("defer_stream/fixtures/fragment-with-defer-duplicate-label.invalid.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-defer-duplicate-label.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-duplicate-label.invalid.graphql", "defer_stream/fixtures/fragment-with-defer-duplicate-label.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-duplicate-label.invalid.graphql", "defer_stream/fixtures/fragment-with-defer-duplicate-label.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_if_arg() {
+#[tokio::test]
+async fn fragment_with_defer_if_arg() {
     let input = include_str!("defer_stream/fixtures/fragment-with-defer-if-arg.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-defer-if-arg.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-if-arg.graphql", "defer_stream/fixtures/fragment-with-defer-if-arg.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-if-arg.graphql", "defer_stream/fixtures/fragment-with-defer-if-arg.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_if_false() {
+#[tokio::test]
+async fn fragment_with_defer_if_false() {
     let input = include_str!("defer_stream/fixtures/fragment-with-defer-if-false.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-defer-if-false.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-if-false.graphql", "defer_stream/fixtures/fragment-with-defer-if-false.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-if-false.graphql", "defer_stream/fixtures/fragment-with-defer-if-false.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_statically_disabled() {
+#[tokio::test]
+async fn fragment_with_defer_statically_disabled() {
     let input = include_str!("defer_stream/fixtures/fragment-with-defer-statically-disabled.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-defer-statically-disabled.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-statically-disabled.graphql", "defer_stream/fixtures/fragment-with-defer-statically-disabled.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-statically-disabled.graphql", "defer_stream/fixtures/fragment-with-defer-statically-disabled.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream() {
+#[tokio::test]
+async fn fragment_with_stream() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream.expected");
-    test_fixture(transform_fixture, "fragment-with-stream.graphql", "defer_stream/fixtures/fragment-with-stream.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream.graphql", "defer_stream/fixtures/fragment-with-stream.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_default_label() {
+#[tokio::test]
+async fn fragment_with_stream_default_label() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-default-label.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-default-label.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-default-label.graphql", "defer_stream/fixtures/fragment-with-stream-default-label.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-default-label.graphql", "defer_stream/fixtures/fragment-with-stream-default-label.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_duplicate_label_invalid() {
+#[tokio::test]
+async fn fragment_with_stream_duplicate_label_invalid() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-duplicate-label.invalid.graphql", "defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-duplicate-label.invalid.graphql", "defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_if_arg() {
+#[tokio::test]
+async fn fragment_with_stream_if_arg() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-if-arg.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-if-arg.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-if-arg.graphql", "defer_stream/fixtures/fragment-with-stream-if-arg.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-if-arg.graphql", "defer_stream/fixtures/fragment-with-stream-if-arg.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_initial_count_arg() {
+#[tokio::test]
+async fn fragment_with_stream_initial_count_arg() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-initial-count-arg.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-initial-count-arg.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-initial-count-arg.graphql", "defer_stream/fixtures/fragment-with-stream-initial-count-arg.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-initial-count-arg.graphql", "defer_stream/fixtures/fragment-with-stream-initial-count-arg.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_missing_initial_count_arg_invalid() {
+#[tokio::test]
+async fn fragment_with_stream_missing_initial_count_arg_invalid() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-missing-initial-count-arg.invalid.graphql", "defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-missing-initial-count-arg.invalid.graphql", "defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_on_scalar_field_invalid() {
+#[tokio::test]
+async fn fragment_with_stream_on_scalar_field_invalid() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-on-scalar-field.invalid.graphql", "defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-on-scalar-field.invalid.graphql", "defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_statically_disabled() {
+#[tokio::test]
+async fn fragment_with_stream_statically_disabled() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-statically-disabled.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-statically-disabled.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-statically-disabled.graphql", "defer_stream/fixtures/fragment-with-stream-statically-disabled.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-statically-disabled.graphql", "defer_stream/fixtures/fragment-with-stream-statically-disabled.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_use_customized_batch_arg() {
+#[tokio::test]
+async fn fragment_with_stream_use_customized_batch_arg() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-use_customized_batch-arg.graphql", "defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-use_customized_batch-arg.graphql", "defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_variable_label_invalid() {
+#[tokio::test]
+async fn fragment_with_stream_variable_label_invalid() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-variable-label.invalid.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-variable-label.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-variable-label.invalid.graphql", "defer_stream/fixtures/fragment-with-stream-variable-label.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-variable-label.invalid.graphql", "defer_stream/fixtures/fragment-with-stream-variable-label.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_variable_label_invalid() {
+#[tokio::test]
+async fn fragment_with_variable_label_invalid() {
     let input = include_str!("defer_stream/fixtures/fragment-with-variable-label.invalid.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-variable-label.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-variable-label.invalid.graphql", "defer_stream/fixtures/fragment-with-variable-label.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-variable-label.invalid.graphql", "defer_stream/fixtures/fragment-with-variable-label.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_with_defer_invalid() {
+#[tokio::test]
+async fn inline_fragment_with_defer_invalid() {
     let input = include_str!("defer_stream/fixtures/inline-fragment-with-defer.invalid.graphql");
     let expected = include_str!("defer_stream/fixtures/inline-fragment-with-defer.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-with-defer.invalid.graphql", "defer_stream/fixtures/inline-fragment-with-defer.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-with-defer.invalid.graphql", "defer_stream/fixtures/inline-fragment-with-defer.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_defer() {
+#[tokio::test]
+async fn query_with_defer() {
     let input = include_str!("defer_stream/fixtures/query-with-defer.graphql");
     let expected = include_str!("defer_stream/fixtures/query-with-defer.expected");
-    test_fixture(transform_fixture, "query-with-defer.graphql", "defer_stream/fixtures/query-with-defer.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-defer.graphql", "defer_stream/fixtures/query-with-defer.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_stream() {
+#[tokio::test]
+async fn query_with_stream() {
     let input = include_str!("defer_stream/fixtures/query-with-stream.graphql");
     let expected = include_str!("defer_stream/fixtures/query-with-stream.expected");
-    test_fixture(transform_fixture, "query-with-stream.graphql", "defer_stream/fixtures/query-with-stream.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-stream.graphql", "defer_stream/fixtures/query-with-stream.expected", input, expected).await;
 }
 
-#[test]
-fn stream_invalid() {
+#[tokio::test]
+async fn stream_invalid() {
     let input = include_str!("defer_stream/fixtures/stream.invalid.graphql");
     let expected = include_str!("defer_stream/fixtures/stream.invalid.expected");
-    test_fixture(transform_fixture, "stream.invalid.graphql", "defer_stream/fixtures/stream.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "stream.invalid.graphql", "defer_stream/fixtures/stream.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/disallow_non_node_id_fields/mod.rs
+++ b/compiler/crates/relay-transforms/tests/disallow_non_node_id_fields/mod.rs
@@ -20,7 +20,7 @@ use relay_config::SchemaConfig;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::disallow_non_node_id_fields;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
 
     if let [base, extensions] = parts.as_slice() {

--- a/compiler/crates/relay-transforms/tests/disallow_non_node_id_fields_test.rs
+++ b/compiler/crates/relay-transforms/tests/disallow_non_node_id_fields_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f866920b35bb2c51bef0e641909def0f>>
+ * @generated SignedSource<<d2ef572d8fddee3eb2f32409fa012e46>>
  */
 
 mod disallow_non_node_id_fields;
@@ -12,37 +12,37 @@ mod disallow_non_node_id_fields;
 use disallow_non_node_id_fields::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn disallowed_definitions_invalid() {
+#[tokio::test]
+async fn disallowed_definitions_invalid() {
     let input = include_str!("disallow_non_node_id_fields/fixtures/disallowed-definitions.invalid.graphql");
     let expected = include_str!("disallow_non_node_id_fields/fixtures/disallowed-definitions.invalid.expected");
-    test_fixture(transform_fixture, "disallowed-definitions.invalid.graphql", "disallow_non_node_id_fields/fixtures/disallowed-definitions.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "disallowed-definitions.invalid.graphql", "disallow_non_node_id_fields/fixtures/disallowed-definitions.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn illegal_scalar_invalid() {
+#[tokio::test]
+async fn illegal_scalar_invalid() {
     let input = include_str!("disallow_non_node_id_fields/fixtures/illegal-scalar.invalid.graphql");
     let expected = include_str!("disallow_non_node_id_fields/fixtures/illegal-scalar.invalid.expected");
-    test_fixture(transform_fixture, "illegal-scalar.invalid.graphql", "disallow_non_node_id_fields/fixtures/illegal-scalar.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "illegal-scalar.invalid.graphql", "disallow_non_node_id_fields/fixtures/illegal-scalar.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_id_selection_allowed() {
+#[tokio::test]
+async fn invalid_id_selection_allowed() {
     let input = include_str!("disallow_non_node_id_fields/fixtures/invalid-id-selection-allowed.graphql");
     let expected = include_str!("disallow_non_node_id_fields/fixtures/invalid-id-selection-allowed.expected");
-    test_fixture(transform_fixture, "invalid-id-selection-allowed.graphql", "disallow_non_node_id_fields/fixtures/invalid-id-selection-allowed.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-id-selection-allowed.graphql", "disallow_non_node_id_fields/fixtures/invalid-id-selection-allowed.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_id_selection_disallowed_invalid() {
+#[tokio::test]
+async fn invalid_id_selection_disallowed_invalid() {
     let input = include_str!("disallow_non_node_id_fields/fixtures/invalid-id-selection-disallowed.invalid.graphql");
     let expected = include_str!("disallow_non_node_id_fields/fixtures/invalid-id-selection-disallowed.invalid.expected");
-    test_fixture(transform_fixture, "invalid-id-selection-disallowed.invalid.graphql", "disallow_non_node_id_fields/fixtures/invalid-id-selection-disallowed.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-id-selection-disallowed.invalid.graphql", "disallow_non_node_id_fields/fixtures/invalid-id-selection-disallowed.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn valid_id_selection() {
+#[tokio::test]
+async fn valid_id_selection() {
     let input = include_str!("disallow_non_node_id_fields/fixtures/valid-id-selection.graphql");
     let expected = include_str!("disallow_non_node_id_fields/fixtures/valid-id-selection.expected");
-    test_fixture(transform_fixture, "valid-id-selection.graphql", "disallow_non_node_id_fields/fixtures/valid-id-selection.expected", input, expected);
+    test_fixture(transform_fixture, "valid-id-selection.graphql", "disallow_non_node_id_fields/fixtures/valid-id-selection.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/disallow_reserved_aliases/mod.rs
+++ b/compiler/crates/relay-transforms/tests/disallow_reserved_aliases/mod.rs
@@ -14,7 +14,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::get_test_schema;
 use relay_transforms::disallow_reserved_aliases;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let schema = get_test_schema();
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/disallow_reserved_aliases_test.rs
+++ b/compiler/crates/relay-transforms/tests/disallow_reserved_aliases_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8184d04f25bd777e8ff56df2e2baff89>>
+ * @generated SignedSource<<516074a5b1c7c3213e5d92bb00c1eb46>>
  */
 
 mod disallow_reserved_aliases;
@@ -12,30 +12,30 @@ mod disallow_reserved_aliases;
 use disallow_reserved_aliases::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn id_alias() {
+#[tokio::test]
+async fn id_alias() {
     let input = include_str!("disallow_reserved_aliases/fixtures/id-alias.graphql");
     let expected = include_str!("disallow_reserved_aliases/fixtures/id-alias.expected");
-    test_fixture(transform_fixture, "id-alias.graphql", "disallow_reserved_aliases/fixtures/id-alias.expected", input, expected);
+    test_fixture(transform_fixture, "id-alias.graphql", "disallow_reserved_aliases/fixtures/id-alias.expected", input, expected).await;
 }
 
-#[test]
-fn id_alias_with_errors_invalid() {
+#[tokio::test]
+async fn id_alias_with_errors_invalid() {
     let input = include_str!("disallow_reserved_aliases/fixtures/id-alias-with-errors.invalid.graphql");
     let expected = include_str!("disallow_reserved_aliases/fixtures/id-alias-with-errors.invalid.expected");
-    test_fixture(transform_fixture, "id-alias-with-errors.invalid.graphql", "disallow_reserved_aliases/fixtures/id-alias-with-errors.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "id-alias-with-errors.invalid.graphql", "disallow_reserved_aliases/fixtures/id-alias-with-errors.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_id_alias_with_errors_invalid() {
+#[tokio::test]
+async fn relay_id_alias_with_errors_invalid() {
     let input = include_str!("disallow_reserved_aliases/fixtures/relay_id-alias-with-errors.invalid.graphql");
     let expected = include_str!("disallow_reserved_aliases/fixtures/relay_id-alias-with-errors.invalid.expected");
-    test_fixture(transform_fixture, "relay_id-alias-with-errors.invalid.graphql", "disallow_reserved_aliases/fixtures/relay_id-alias-with-errors.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay_id-alias-with-errors.invalid.graphql", "disallow_reserved_aliases/fixtures/relay_id-alias-with-errors.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn typename_alias_with_errors_invalid() {
+#[tokio::test]
+async fn typename_alias_with_errors_invalid() {
     let input = include_str!("disallow_reserved_aliases/fixtures/typename-alias-with-errors.invalid.graphql");
     let expected = include_str!("disallow_reserved_aliases/fixtures/typename-alias-with-errors.invalid.expected");
-    test_fixture(transform_fixture, "typename-alias-with-errors.invalid.graphql", "disallow_reserved_aliases/fixtures/typename-alias-with-errors.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "typename-alias-with-errors.invalid.graphql", "disallow_reserved_aliases/fixtures/typename-alias-with-errors.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/disallow_typename_on_root/mod.rs
+++ b/compiler/crates/relay-transforms/tests/disallow_typename_on_root/mod.rs
@@ -14,7 +14,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::get_test_schema;
 use relay_transforms::disallow_typename_on_root;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let schema = get_test_schema();
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/disallow_typename_on_root_test.rs
+++ b/compiler/crates/relay-transforms/tests/disallow_typename_on_root_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<39f0a34f3acf5f9d49cd579af5dbc8f8>>
+ * @generated SignedSource<<da6f57c2ba6f28453d966562bfd5c46b>>
  */
 
 mod disallow_typename_on_root;
@@ -12,30 +12,30 @@ mod disallow_typename_on_root;
 use disallow_typename_on_root::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn typename_on_fragment_invalid() {
+#[tokio::test]
+async fn typename_on_fragment_invalid() {
     let input = include_str!("disallow_typename_on_root/fixtures/typename-on-fragment.invalid.graphql");
     let expected = include_str!("disallow_typename_on_root/fixtures/typename-on-fragment.invalid.expected");
-    test_fixture(transform_fixture, "typename-on-fragment.invalid.graphql", "disallow_typename_on_root/fixtures/typename-on-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "typename-on-fragment.invalid.graphql", "disallow_typename_on_root/fixtures/typename-on-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn typename_on_mutation_invalid() {
+#[tokio::test]
+async fn typename_on_mutation_invalid() {
     let input = include_str!("disallow_typename_on_root/fixtures/typename-on-mutation.invalid.graphql");
     let expected = include_str!("disallow_typename_on_root/fixtures/typename-on-mutation.invalid.expected");
-    test_fixture(transform_fixture, "typename-on-mutation.invalid.graphql", "disallow_typename_on_root/fixtures/typename-on-mutation.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "typename-on-mutation.invalid.graphql", "disallow_typename_on_root/fixtures/typename-on-mutation.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn typename_on_query_invalid() {
+#[tokio::test]
+async fn typename_on_query_invalid() {
     let input = include_str!("disallow_typename_on_root/fixtures/typename-on-query.invalid.graphql");
     let expected = include_str!("disallow_typename_on_root/fixtures/typename-on-query.invalid.expected");
-    test_fixture(transform_fixture, "typename-on-query.invalid.graphql", "disallow_typename_on_root/fixtures/typename-on-query.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "typename-on-query.invalid.graphql", "disallow_typename_on_root/fixtures/typename-on-query.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn valid() {
+#[tokio::test]
+async fn valid() {
     let input = include_str!("disallow_typename_on_root/fixtures/valid.graphql");
     let expected = include_str!("disallow_typename_on_root/fixtures/valid.expected");
-    test_fixture(transform_fixture, "valid.graphql", "disallow_typename_on_root/fixtures/valid.expected", input, expected);
+    test_fixture(transform_fixture, "valid.graphql", "disallow_typename_on_root/fixtures/valid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/flatten/mod.rs
+++ b/compiler/crates/relay-transforms/tests/flatten/mod.rs
@@ -19,7 +19,7 @@ use graphql_text_printer::PrinterOptions;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::flatten;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let ast = parse_executable(fixture.content, source_location)
         .map_err(|diagnostics| diagnostics_to_sorted_string(fixture.content, &diagnostics))?;

--- a/compiler/crates/relay-transforms/tests/flatten_test.rs
+++ b/compiler/crates/relay-transforms/tests/flatten_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fe81a00272bc1a72fb7ed893652fd0b6>>
+ * @generated SignedSource<<d67330b0af0b121d0d54a57501731704>>
  */
 
 mod flatten;
@@ -12,93 +12,93 @@ mod flatten;
 use flatten::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn anonymous_inline_fragment_with_directives() {
+#[tokio::test]
+async fn anonymous_inline_fragment_with_directives() {
     let input = include_str!("flatten/fixtures/anonymous-inline-fragment-with-directives.graphql");
     let expected = include_str!("flatten/fixtures/anonymous-inline-fragment-with-directives.expected");
-    test_fixture(transform_fixture, "anonymous-inline-fragment-with-directives.graphql", "flatten/fixtures/anonymous-inline-fragment-with-directives.expected", input, expected);
+    test_fixture(transform_fixture, "anonymous-inline-fragment-with-directives.graphql", "flatten/fixtures/anonymous-inline-fragment-with-directives.expected", input, expected).await;
 }
 
-#[test]
-fn flatten_multiple_conditions() {
+#[tokio::test]
+async fn flatten_multiple_conditions() {
     let input = include_str!("flatten/fixtures/flatten-multiple-conditions.graphql");
     let expected = include_str!("flatten/fixtures/flatten-multiple-conditions.expected");
-    test_fixture(transform_fixture, "flatten-multiple-conditions.graphql", "flatten/fixtures/flatten-multiple-conditions.expected", input, expected);
+    test_fixture(transform_fixture, "flatten-multiple-conditions.graphql", "flatten/fixtures/flatten-multiple-conditions.expected", input, expected).await;
 }
 
-#[test]
-fn flatten_same_conditions() {
+#[tokio::test]
+async fn flatten_same_conditions() {
     let input = include_str!("flatten/fixtures/flatten-same-conditions.graphql");
     let expected = include_str!("flatten/fixtures/flatten-same-conditions.expected");
-    test_fixture(transform_fixture, "flatten-same-conditions.graphql", "flatten/fixtures/flatten-same-conditions.expected", input, expected);
+    test_fixture(transform_fixture, "flatten-same-conditions.graphql", "flatten/fixtures/flatten-same-conditions.expected", input, expected).await;
 }
 
-#[test]
-fn flatten_transform() {
+#[tokio::test]
+async fn flatten_transform() {
     let input = include_str!("flatten/fixtures/flatten-transform.graphql");
     let expected = include_str!("flatten/fixtures/flatten-transform.expected");
-    test_fixture(transform_fixture, "flatten-transform.graphql", "flatten/fixtures/flatten-transform.expected", input, expected);
+    test_fixture(transform_fixture, "flatten-transform.graphql", "flatten/fixtures/flatten-transform.expected", input, expected).await;
 }
 
-#[test]
-fn flattens_inline_inside_condition() {
+#[tokio::test]
+async fn flattens_inline_inside_condition() {
     let input = include_str!("flatten/fixtures/flattens-inline-inside-condition.graphql");
     let expected = include_str!("flatten/fixtures/flattens-inline-inside-condition.expected");
-    test_fixture(transform_fixture, "flattens-inline-inside-condition.graphql", "flatten/fixtures/flattens-inline-inside-condition.expected", input, expected);
+    test_fixture(transform_fixture, "flattens-inline-inside-condition.graphql", "flatten/fixtures/flattens-inline-inside-condition.expected", input, expected).await;
 }
 
-#[test]
-fn flattens_inside_plural() {
+#[tokio::test]
+async fn flattens_inside_plural() {
     let input = include_str!("flatten/fixtures/flattens-inside-plural.graphql");
     let expected = include_str!("flatten/fixtures/flattens-inside-plural.expected");
-    test_fixture(transform_fixture, "flattens-inside-plural.graphql", "flatten/fixtures/flattens-inside-plural.expected", input, expected);
+    test_fixture(transform_fixture, "flattens-inside-plural.graphql", "flatten/fixtures/flattens-inside-plural.expected", input, expected).await;
 }
 
-#[test]
-fn flattens_matching_fragment_types() {
+#[tokio::test]
+async fn flattens_matching_fragment_types() {
     let input = include_str!("flatten/fixtures/flattens-matching-fragment-types.graphql");
     let expected = include_str!("flatten/fixtures/flattens-matching-fragment-types.expected");
-    test_fixture(transform_fixture, "flattens-matching-fragment-types.graphql", "flatten/fixtures/flattens-matching-fragment-types.expected", input, expected);
+    test_fixture(transform_fixture, "flattens-matching-fragment-types.graphql", "flatten/fixtures/flattens-matching-fragment-types.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_with_directives() {
+#[tokio::test]
+async fn inline_fragment_with_directives() {
     let input = include_str!("flatten/fixtures/inline-fragment-with-directives.graphql");
     let expected = include_str!("flatten/fixtures/inline-fragment-with-directives.expected");
-    test_fixture(transform_fixture, "inline-fragment-with-directives.graphql", "flatten/fixtures/inline-fragment-with-directives.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-with-directives.graphql", "flatten/fixtures/inline-fragment-with-directives.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_with_directives_text() {
+#[tokio::test]
+async fn inline_fragment_with_directives_text() {
     let input = include_str!("flatten/fixtures/inline-fragment-with-directives-text.graphql");
     let expected = include_str!("flatten/fixtures/inline-fragment-with-directives-text.expected");
-    test_fixture(transform_fixture, "inline-fragment-with-directives-text.graphql", "flatten/fixtures/inline-fragment-with-directives-text.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-with-directives-text.graphql", "flatten/fixtures/inline-fragment-with-directives-text.expected", input, expected).await;
 }
 
-#[test]
-fn linked_handle_field() {
+#[tokio::test]
+async fn linked_handle_field() {
     let input = include_str!("flatten/fixtures/linked-handle-field.graphql");
     let expected = include_str!("flatten/fixtures/linked-handle-field.expected");
-    test_fixture(transform_fixture, "linked-handle-field.graphql", "flatten/fixtures/linked-handle-field.expected", input, expected);
+    test_fixture(transform_fixture, "linked-handle-field.graphql", "flatten/fixtures/linked-handle-field.expected", input, expected).await;
 }
 
-#[test]
-fn match_field() {
+#[tokio::test]
+async fn match_field() {
     let input = include_str!("flatten/fixtures/match-field.graphql");
     let expected = include_str!("flatten/fixtures/match-field.expected");
-    test_fixture(transform_fixture, "match-field.graphql", "flatten/fixtures/match-field.expected", input, expected);
+    test_fixture(transform_fixture, "match-field.graphql", "flatten/fixtures/match-field.expected", input, expected).await;
 }
 
-#[test]
-fn match_field_overlap() {
+#[tokio::test]
+async fn match_field_overlap() {
     let input = include_str!("flatten/fixtures/match-field-overlap.graphql");
     let expected = include_str!("flatten/fixtures/match-field-overlap.expected");
-    test_fixture(transform_fixture, "match-field-overlap.graphql", "flatten/fixtures/match-field-overlap.expected", input, expected);
+    test_fixture(transform_fixture, "match-field-overlap.graphql", "flatten/fixtures/match-field-overlap.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_handle_field() {
+#[tokio::test]
+async fn scalar_handle_field() {
     let input = include_str!("flatten/fixtures/scalar-handle-field.graphql");
     let expected = include_str!("flatten/fixtures/scalar-handle-field.expected");
-    test_fixture(transform_fixture, "scalar-handle-field.graphql", "flatten/fixtures/scalar-handle-field.expected", input, expected);
+    test_fixture(transform_fixture, "scalar-handle-field.graphql", "flatten/fixtures/scalar-handle-field.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/fragment_alias_directive/mod.rs
+++ b/compiler/crates/relay-transforms/tests/fragment_alias_directive/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::fragment_alias_directive;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         fragment_alias_directive(program, &FeatureFlag::Enabled)
     })

--- a/compiler/crates/relay-transforms/tests/fragment_alias_directive_test.rs
+++ b/compiler/crates/relay-transforms/tests/fragment_alias_directive_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<181f8435539d1237e4b620d14a79c100>>
+ * @generated SignedSource<<5cc403bf1dfcba9331be206b6847885e>>
  */
 
 mod fragment_alias_directive;
@@ -12,51 +12,51 @@ mod fragment_alias_directive;
 use fragment_alias_directive::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn alias_on_abstract_type() {
+#[tokio::test]
+async fn alias_on_abstract_type() {
     let input = include_str!("fragment_alias_directive/fixtures/alias_on_abstract_type.graphql");
     let expected = include_str!("fragment_alias_directive/fixtures/alias_on_abstract_type.expected");
-    test_fixture(transform_fixture, "alias_on_abstract_type.graphql", "fragment_alias_directive/fixtures/alias_on_abstract_type.expected", input, expected);
+    test_fixture(transform_fixture, "alias_on_abstract_type.graphql", "fragment_alias_directive/fixtures/alias_on_abstract_type.expected", input, expected).await;
 }
 
-#[test]
-fn alias_on_named_fragment() {
+#[tokio::test]
+async fn alias_on_named_fragment() {
     let input = include_str!("fragment_alias_directive/fixtures/alias_on_named_fragment.graphql");
     let expected = include_str!("fragment_alias_directive/fixtures/alias_on_named_fragment.expected");
-    test_fixture(transform_fixture, "alias_on_named_fragment.graphql", "fragment_alias_directive/fixtures/alias_on_named_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "alias_on_named_fragment.graphql", "fragment_alias_directive/fixtures/alias_on_named_fragment.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment() {
+#[tokio::test]
+async fn aliased_inline_fragment() {
     let input = include_str!("fragment_alias_directive/fixtures/aliased_inline_fragment.graphql");
     let expected = include_str!("fragment_alias_directive/fixtures/aliased_inline_fragment.expected");
-    test_fixture(transform_fixture, "aliased_inline_fragment.graphql", "fragment_alias_directive/fixtures/aliased_inline_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "aliased_inline_fragment.graphql", "fragment_alias_directive/fixtures/aliased_inline_fragment.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_without_type_condition() {
+#[tokio::test]
+async fn aliased_inline_fragment_without_type_condition() {
     let input = include_str!("fragment_alias_directive/fixtures/aliased_inline_fragment_without_type_condition.graphql");
     let expected = include_str!("fragment_alias_directive/fixtures/aliased_inline_fragment_without_type_condition.expected");
-    test_fixture(transform_fixture, "aliased_inline_fragment_without_type_condition.graphql", "fragment_alias_directive/fixtures/aliased_inline_fragment_without_type_condition.expected", input, expected);
+    test_fixture(transform_fixture, "aliased_inline_fragment_without_type_condition.graphql", "fragment_alias_directive/fixtures/aliased_inline_fragment_without_type_condition.expected", input, expected).await;
 }
 
-#[test]
-fn default_alias_on_fragment_spread() {
+#[tokio::test]
+async fn default_alias_on_fragment_spread() {
     let input = include_str!("fragment_alias_directive/fixtures/default_alias_on_fragment_spread.graphql");
     let expected = include_str!("fragment_alias_directive/fixtures/default_alias_on_fragment_spread.expected");
-    test_fixture(transform_fixture, "default_alias_on_fragment_spread.graphql", "fragment_alias_directive/fixtures/default_alias_on_fragment_spread.expected", input, expected);
+    test_fixture(transform_fixture, "default_alias_on_fragment_spread.graphql", "fragment_alias_directive/fixtures/default_alias_on_fragment_spread.expected", input, expected).await;
 }
 
-#[test]
-fn default_alias_on_inline_fragment() {
+#[tokio::test]
+async fn default_alias_on_inline_fragment() {
     let input = include_str!("fragment_alias_directive/fixtures/default_alias_on_inline_fragment.graphql");
     let expected = include_str!("fragment_alias_directive/fixtures/default_alias_on_inline_fragment.expected");
-    test_fixture(transform_fixture, "default_alias_on_inline_fragment.graphql", "fragment_alias_directive/fixtures/default_alias_on_inline_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "default_alias_on_inline_fragment.graphql", "fragment_alias_directive/fixtures/default_alias_on_inline_fragment.expected", input, expected).await;
 }
 
-#[test]
-fn default_alias_on_inline_fragment_without_type_invalid() {
+#[tokio::test]
+async fn default_alias_on_inline_fragment_without_type_invalid() {
     let input = include_str!("fragment_alias_directive/fixtures/default_alias_on_inline_fragment_without_type.invalid.graphql");
     let expected = include_str!("fragment_alias_directive/fixtures/default_alias_on_inline_fragment_without_type.invalid.expected");
-    test_fixture(transform_fixture, "default_alias_on_inline_fragment_without_type.invalid.graphql", "fragment_alias_directive/fixtures/default_alias_on_inline_fragment_without_type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "default_alias_on_inline_fragment_without_type.invalid.graphql", "fragment_alias_directive/fixtures/default_alias_on_inline_fragment_without_type.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/generate_data_driven_dependency_metadata/mod.rs
+++ b/compiler/crates/relay-transforms/tests/generate_data_driven_dependency_metadata/mod.rs
@@ -11,7 +11,7 @@ use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::generate_data_driven_dependency_metadata;
 use relay_transforms::transform_match;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         let flags = FeatureFlags::default();
         let program = transform_match(program, &flags, Default::default())?;

--- a/compiler/crates/relay-transforms/tests/generate_data_driven_dependency_metadata_test.rs
+++ b/compiler/crates/relay-transforms/tests/generate_data_driven_dependency_metadata_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<378ad574a05b62abf204013f996c8c8f>>
+ * @generated SignedSource<<4feaf83625f702bb8c7464e144d38f09>>
  */
 
 mod generate_data_driven_dependency_metadata;
@@ -12,65 +12,65 @@ mod generate_data_driven_dependency_metadata;
 use generate_data_driven_dependency_metadata::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn match_on_child_of_plural() {
+#[tokio::test]
+async fn match_on_child_of_plural() {
     let input = include_str!("generate_data_driven_dependency_metadata/fixtures/match-on-child-of-plural.graphql");
     let expected = include_str!("generate_data_driven_dependency_metadata/fixtures/match-on-child-of-plural.expected");
-    test_fixture(transform_fixture, "match-on-child-of-plural.graphql", "generate_data_driven_dependency_metadata/fixtures/match-on-child-of-plural.expected", input, expected);
+    test_fixture(transform_fixture, "match-on-child-of-plural.graphql", "generate_data_driven_dependency_metadata/fixtures/match-on-child-of-plural.expected", input, expected).await;
 }
 
-#[test]
-fn match_with_extra_args() {
+#[tokio::test]
+async fn match_with_extra_args() {
     let input = include_str!("generate_data_driven_dependency_metadata/fixtures/match-with-extra-args.graphql");
     let expected = include_str!("generate_data_driven_dependency_metadata/fixtures/match-with-extra-args.expected");
-    test_fixture(transform_fixture, "match-with-extra-args.graphql", "generate_data_driven_dependency_metadata/fixtures/match-with-extra-args.expected", input, expected);
+    test_fixture(transform_fixture, "match-with-extra-args.graphql", "generate_data_driven_dependency_metadata/fixtures/match-with-extra-args.expected", input, expected).await;
 }
 
-#[test]
-fn module_without_match() {
+#[tokio::test]
+async fn module_without_match() {
     let input = include_str!("generate_data_driven_dependency_metadata/fixtures/module-without-match.graphql");
     let expected = include_str!("generate_data_driven_dependency_metadata/fixtures/module-without-match.expected");
-    test_fixture(transform_fixture, "module-without-match.graphql", "generate_data_driven_dependency_metadata/fixtures/module-without-match.expected", input, expected);
+    test_fixture(transform_fixture, "module-without-match.graphql", "generate_data_driven_dependency_metadata/fixtures/module-without-match.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_direct_and_transitive_module_dep() {
+#[tokio::test]
+async fn query_with_direct_and_transitive_module_dep() {
     let input = include_str!("generate_data_driven_dependency_metadata/fixtures/query-with-direct-and-transitive-module-dep.graphql");
     let expected = include_str!("generate_data_driven_dependency_metadata/fixtures/query-with-direct-and-transitive-module-dep.expected");
-    test_fixture(transform_fixture, "query-with-direct-and-transitive-module-dep.graphql", "generate_data_driven_dependency_metadata/fixtures/query-with-direct-and-transitive-module-dep.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-direct-and-transitive-module-dep.graphql", "generate_data_driven_dependency_metadata/fixtures/query-with-direct-and-transitive-module-dep.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_direct_module_dep() {
+#[tokio::test]
+async fn query_with_direct_module_dep() {
     let input = include_str!("generate_data_driven_dependency_metadata/fixtures/query-with-direct-module-dep.graphql");
     let expected = include_str!("generate_data_driven_dependency_metadata/fixtures/query-with-direct-module-dep.expected");
-    test_fixture(transform_fixture, "query-with-direct-module-dep.graphql", "generate_data_driven_dependency_metadata/fixtures/query-with-direct-module-dep.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-direct-module-dep.graphql", "generate_data_driven_dependency_metadata/fixtures/query-with-direct-module-dep.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_transitive_module_dep() {
+#[tokio::test]
+async fn query_with_transitive_module_dep() {
     let input = include_str!("generate_data_driven_dependency_metadata/fixtures/query-with-transitive-module-dep.graphql");
     let expected = include_str!("generate_data_driven_dependency_metadata/fixtures/query-with-transitive-module-dep.expected");
-    test_fixture(transform_fixture, "query-with-transitive-module-dep.graphql", "generate_data_driven_dependency_metadata/fixtures/query-with-transitive-module-dep.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-transitive-module-dep.graphql", "generate_data_driven_dependency_metadata/fixtures/query-with-transitive-module-dep.expected", input, expected).await;
 }
 
-#[test]
-fn relay_match_on_interface() {
+#[tokio::test]
+async fn relay_match_on_interface() {
     let input = include_str!("generate_data_driven_dependency_metadata/fixtures/relay-match-on-interface.graphql");
     let expected = include_str!("generate_data_driven_dependency_metadata/fixtures/relay-match-on-interface.expected");
-    test_fixture(transform_fixture, "relay-match-on-interface.graphql", "generate_data_driven_dependency_metadata/fixtures/relay-match-on-interface.expected", input, expected);
+    test_fixture(transform_fixture, "relay-match-on-interface.graphql", "generate_data_driven_dependency_metadata/fixtures/relay-match-on-interface.expected", input, expected).await;
 }
 
-#[test]
-fn relay_match_on_union() {
+#[tokio::test]
+async fn relay_match_on_union() {
     let input = include_str!("generate_data_driven_dependency_metadata/fixtures/relay-match-on-union.graphql");
     let expected = include_str!("generate_data_driven_dependency_metadata/fixtures/relay-match-on-union.expected");
-    test_fixture(transform_fixture, "relay-match-on-union.graphql", "generate_data_driven_dependency_metadata/fixtures/relay-match-on-union.expected", input, expected);
+    test_fixture(transform_fixture, "relay-match-on-union.graphql", "generate_data_driven_dependency_metadata/fixtures/relay-match-on-union.expected", input, expected).await;
 }
 
-#[test]
-fn relay_match_on_union_plural() {
+#[tokio::test]
+async fn relay_match_on_union_plural() {
     let input = include_str!("generate_data_driven_dependency_metadata/fixtures/relay-match-on-union-plural.graphql");
     let expected = include_str!("generate_data_driven_dependency_metadata/fixtures/relay-match-on-union-plural.expected");
-    test_fixture(transform_fixture, "relay-match-on-union-plural.graphql", "generate_data_driven_dependency_metadata/fixtures/relay-match-on-union-plural.expected", input, expected);
+    test_fixture(transform_fixture, "relay-match-on-union-plural.graphql", "generate_data_driven_dependency_metadata/fixtures/relay-match-on-union-plural.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/generate_id_field/mod.rs
+++ b/compiler/crates/relay-transforms/tests/generate_id_field/mod.rs
@@ -9,7 +9,7 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::generate_id_field;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         Ok(generate_id_field(program, &Default::default()))
     })

--- a/compiler/crates/relay-transforms/tests/generate_id_field_test.rs
+++ b/compiler/crates/relay-transforms/tests/generate_id_field_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<63e612da0245a0cd1493300c56063de9>>
+ * @generated SignedSource<<fec59ecbb5dd93b9707507dd2c0dd846>>
  */
 
 mod generate_id_field;
@@ -12,30 +12,30 @@ mod generate_id_field;
 use generate_id_field::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn abstract_plural() {
+#[tokio::test]
+async fn abstract_plural() {
     let input = include_str!("generate_id_field/fixtures/abstract-plural.graphql");
     let expected = include_str!("generate_id_field/fixtures/abstract-plural.expected");
-    test_fixture(transform_fixture, "abstract-plural.graphql", "generate_id_field/fixtures/abstract-plural.expected", input, expected);
+    test_fixture(transform_fixture, "abstract-plural.graphql", "generate_id_field/fixtures/abstract-plural.expected", input, expected).await;
 }
 
-#[test]
-fn node_union() {
+#[tokio::test]
+async fn node_union() {
     let input = include_str!("generate_id_field/fixtures/node-union.graphql");
     let expected = include_str!("generate_id_field/fixtures/node-union.expected");
-    test_fixture(transform_fixture, "node-union.graphql", "generate_id_field/fixtures/node-union.expected", input, expected);
+    test_fixture(transform_fixture, "node-union.graphql", "generate_id_field/fixtures/node-union.expected", input, expected).await;
 }
 
-#[test]
-fn non_node_union() {
+#[tokio::test]
+async fn non_node_union() {
     let input = include_str!("generate_id_field/fixtures/non-node-union.graphql");
     let expected = include_str!("generate_id_field/fixtures/non-node-union.expected");
-    test_fixture(transform_fixture, "non-node-union.graphql", "generate_id_field/fixtures/non-node-union.expected", input, expected);
+    test_fixture(transform_fixture, "non-node-union.graphql", "generate_id_field/fixtures/non-node-union.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_fragment_variables() {
+#[tokio::test]
+async fn query_with_fragment_variables() {
     let input = include_str!("generate_id_field/fixtures/query-with-fragment-variables.graphql");
     let expected = include_str!("generate_id_field/fixtures/query-with-fragment-variables.expected");
-    test_fixture(transform_fixture, "query-with-fragment-variables.graphql", "generate_id_field/fixtures/query-with-fragment-variables.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-fragment-variables.graphql", "generate_id_field/fixtures/query-with-fragment-variables.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/generate_live_query_metadata/mod.rs
+++ b/compiler/crates/relay-transforms/tests/generate_live_query_metadata/mod.rs
@@ -9,6 +9,6 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::generate_live_query_metadata;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, generate_live_query_metadata)
 }

--- a/compiler/crates/relay-transforms/tests/generate_live_query_metadata_test.rs
+++ b/compiler/crates/relay-transforms/tests/generate_live_query_metadata_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9da1c41afc4ceb2bf703a95c2c85fc79>>
+ * @generated SignedSource<<f0ac66418e69113bbaeb1ce8068bba21>>
  */
 
 mod generate_live_query_metadata;
@@ -12,16 +12,16 @@ mod generate_live_query_metadata;
 use generate_live_query_metadata::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn live_by_config_id() {
+#[tokio::test]
+async fn live_by_config_id() {
     let input = include_str!("generate_live_query_metadata/fixtures/live_by_config_id.graphql");
     let expected = include_str!("generate_live_query_metadata/fixtures/live_by_config_id.expected");
-    test_fixture(transform_fixture, "live_by_config_id.graphql", "generate_live_query_metadata/fixtures/live_by_config_id.expected", input, expected);
+    test_fixture(transform_fixture, "live_by_config_id.graphql", "generate_live_query_metadata/fixtures/live_by_config_id.expected", input, expected).await;
 }
 
-#[test]
-fn live_by_polling_interval() {
+#[tokio::test]
+async fn live_by_polling_interval() {
     let input = include_str!("generate_live_query_metadata/fixtures/live_by_polling_interval.graphql");
     let expected = include_str!("generate_live_query_metadata/fixtures/live_by_polling_interval.expected");
-    test_fixture(transform_fixture, "live_by_polling_interval.graphql", "generate_live_query_metadata/fixtures/live_by_polling_interval.expected", input, expected);
+    test_fixture(transform_fixture, "live_by_polling_interval.graphql", "generate_live_query_metadata/fixtures/live_by_polling_interval.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/generate_relay_resolvers_operations_for_nested_objects/mod.rs
+++ b/compiler/crates/relay-transforms/tests/generate_relay_resolvers_operations_for_nested_objects/mod.rs
@@ -11,7 +11,7 @@ use relay_config::ProjectName;
 use relay_config::SchemaConfig;
 use relay_transforms::generate_relay_resolvers_operations_for_nested_objects;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         generate_relay_resolvers_operations_for_nested_objects(
             ProjectName::default(),

--- a/compiler/crates/relay-transforms/tests/generate_relay_resolvers_operations_for_nested_objects_test.rs
+++ b/compiler/crates/relay-transforms/tests/generate_relay_resolvers_operations_for_nested_objects_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<905ebd71110679c262b41e411ebc3fe4>>
+ * @generated SignedSource<<70e73acf448c9ef4cffde18d0d615f87>>
  */
 
 mod generate_relay_resolvers_operations_for_nested_objects;
@@ -12,121 +12,121 @@ mod generate_relay_resolvers_operations_for_nested_objects;
 use generate_relay_resolvers_operations_for_nested_objects::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn output_type_client_type() {
+#[tokio::test]
+async fn output_type_client_type() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-client-type.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-client-type.expected");
-    test_fixture(transform_fixture, "output-type-client-type.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-client-type.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_input_invalid() {
+#[tokio::test]
+async fn output_type_input_invalid() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-input.invalid.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-input.invalid.expected");
-    test_fixture(transform_fixture, "output-type-input.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-input.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-input.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-input.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_scalar() {
+#[tokio::test]
+async fn output_type_scalar() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-scalar.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-scalar.expected");
-    test_fixture(transform_fixture, "output-type-scalar.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-scalar.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-scalar.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-scalar.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_arguments() {
+#[tokio::test]
+async fn output_type_with_arguments() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-arguments.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-arguments.expected");
-    test_fixture(transform_fixture, "output-type-with-arguments.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-arguments.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_client_interface() {
+#[tokio::test]
+async fn output_type_with_client_interface() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface.expected");
-    test_fixture(transform_fixture, "output-type-with-client-interface.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-client-interface.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_client_interface_and_object_recursion_invalid() {
+#[tokio::test]
+async fn output_type_with_client_interface_and_object_recursion_invalid() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface-and-object-recursion.invalid.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface-and-object-recursion.invalid.expected");
-    test_fixture(transform_fixture, "output-type-with-client-interface-and-object-recursion.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface-and-object-recursion.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-client-interface-and-object-recursion.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface-and-object-recursion.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_client_interface_recursion_invalid() {
+#[tokio::test]
+async fn output_type_with_client_interface_recursion_invalid() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface-recursion.invalid.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface-recursion.invalid.expected");
-    test_fixture(transform_fixture, "output-type-with-client-interface-recursion.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface-recursion.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-client-interface-recursion.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-client-interface-recursion.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_id() {
+#[tokio::test]
+async fn output_type_with_id() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-id.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-id.expected");
-    test_fixture(transform_fixture, "output-type-with-id.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-id.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-id.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-id.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_interface_recursion_but_lying_client_type() {
+#[tokio::test]
+async fn output_type_with_interface_recursion_but_lying_client_type() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-interface-recursion-but-lying-client-type.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-interface-recursion-but-lying-client-type.expected");
-    test_fixture(transform_fixture, "output-type-with-interface-recursion-but-lying-client-type.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-interface-recursion-but-lying-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-interface-recursion-but-lying-client-type.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-interface-recursion-but-lying-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_nested_recursion() {
+#[tokio::test]
+async fn output_type_with_nested_recursion() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-nested-recursion.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-nested-recursion.expected");
-    test_fixture(transform_fixture, "output-type-with-nested-recursion.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-nested-recursion.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-nested-recursion.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-nested-recursion.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_nested_server_object() {
+#[tokio::test]
+async fn output_type_with_nested_server_object() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-nested-server-object.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-nested-server-object.expected");
-    test_fixture(transform_fixture, "output-type-with-nested-server-object.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-nested-server-object.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-nested-server-object.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-nested-server-object.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_recursion() {
+#[tokio::test]
+async fn output_type_with_recursion() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-recursion.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-recursion.expected");
-    test_fixture(transform_fixture, "output-type-with-recursion.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-recursion.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-recursion.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-recursion.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_relay_resolver_fields() {
+#[tokio::test]
+async fn output_type_with_relay_resolver_fields() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-relay-resolver-fields.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-relay-resolver-fields.expected");
-    test_fixture(transform_fixture, "output-type-with-relay-resolver-fields.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-relay-resolver-fields.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-relay-resolver-fields.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-relay-resolver-fields.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_server_interface_invalid() {
+#[tokio::test]
+async fn output_type_with_server_interface_invalid() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-server-interface.invalid.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-server-interface.invalid.expected");
-    test_fixture(transform_fixture, "output-type-with-server-interface.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-server-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-server-interface.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-server-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_server_object() {
+#[tokio::test]
+async fn output_type_with_server_object() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-server-object.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-server-object.expected");
-    test_fixture(transform_fixture, "output-type-with-server-object.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-server-object.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-server-object.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-server-object.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_type_with_id() {
+#[tokio::test]
+async fn output_type_with_type_with_id() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-type-with-id.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-type-with-id.expected");
-    test_fixture(transform_fixture, "output-type-with-type-with-id.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-type-with-id.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-type-with-id.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-type-with-id.expected", input, expected).await;
 }
 
-#[test]
-fn output_type_with_unimplemented_interface_invalid() {
+#[tokio::test]
+async fn output_type_with_unimplemented_interface_invalid() {
     let input = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-unimplemented-interface.invalid.graphql");
     let expected = include_str!("generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-unimplemented-interface.invalid.expected");
-    test_fixture(transform_fixture, "output-type-with-unimplemented-interface.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-unimplemented-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "output-type-with-unimplemented-interface.invalid.graphql", "generate_relay_resolvers_operations_for_nested_objects/fixtures/output-type-with-unimplemented-interface.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/generate_typename/mod.rs
+++ b/compiler/crates/relay-transforms/tests/generate_typename/mod.rs
@@ -9,6 +9,6 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::generate_typename;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| Ok(generate_typename(program, false)))
 }

--- a/compiler/crates/relay-transforms/tests/generate_typename_test.rs
+++ b/compiler/crates/relay-transforms/tests/generate_typename_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3cb2d87b70b16df6d256ff07d9daa83d>>
+ * @generated SignedSource<<ff36b75a7569d1f73cc479956be51fbe>>
  */
 
 mod generate_typename;
@@ -12,16 +12,16 @@ mod generate_typename;
 use generate_typename::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn type_name_does_not_exist() {
+#[tokio::test]
+async fn type_name_does_not_exist() {
     let input = include_str!("generate_typename/fixtures/type-name-does-not-exist.graphql");
     let expected = include_str!("generate_typename/fixtures/type-name-does-not-exist.expected");
-    test_fixture(transform_fixture, "type-name-does-not-exist.graphql", "generate_typename/fixtures/type-name-does-not-exist.expected", input, expected);
+    test_fixture(transform_fixture, "type-name-does-not-exist.graphql", "generate_typename/fixtures/type-name-does-not-exist.expected", input, expected).await;
 }
 
-#[test]
-fn type_name_exists() {
+#[tokio::test]
+async fn type_name_exists() {
     let input = include_str!("generate_typename/fixtures/type-name-exists.graphql");
     let expected = include_str!("generate_typename/fixtures/type-name-exists.expected");
-    test_fixture(transform_fixture, "type-name-exists.graphql", "generate_typename/fixtures/type-name-exists.expected", input, expected);
+    test_fixture(transform_fixture, "type-name-exists.graphql", "generate_typename/fixtures/type-name-exists.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/inline_data_fragment/mod.rs
+++ b/compiler/crates/relay-transforms/tests/inline_data_fragment/mod.rs
@@ -9,6 +9,6 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::inline_data_fragment;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, inline_data_fragment)
 }

--- a/compiler/crates/relay-transforms/tests/inline_data_fragment_test.rs
+++ b/compiler/crates/relay-transforms/tests/inline_data_fragment_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0b5686d10624fd1700d69be68ba3f437>>
+ * @generated SignedSource<<4bd25a6b39f1d887584daa0cabc1e462>>
  */
 
 mod inline_data_fragment;
@@ -12,16 +12,16 @@ mod inline_data_fragment;
 use inline_data_fragment::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn recursive() {
+#[tokio::test]
+async fn recursive() {
     let input = include_str!("inline_data_fragment/fixtures/recursive.graphql");
     let expected = include_str!("inline_data_fragment/fixtures/recursive.expected");
-    test_fixture(transform_fixture, "recursive.graphql", "inline_data_fragment/fixtures/recursive.expected", input, expected);
+    test_fixture(transform_fixture, "recursive.graphql", "inline_data_fragment/fixtures/recursive.expected", input, expected).await;
 }
 
-#[test]
-fn variables() {
+#[tokio::test]
+async fn variables() {
     let input = include_str!("inline_data_fragment/fixtures/variables.graphql");
     let expected = include_str!("inline_data_fragment/fixtures/variables.expected");
-    test_fixture(transform_fixture, "variables.graphql", "inline_data_fragment/fixtures/variables.expected", input, expected);
+    test_fixture(transform_fixture, "variables.graphql", "inline_data_fragment/fixtures/variables.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/inline_fragments/mod.rs
+++ b/compiler/crates/relay-transforms/tests/inline_fragments/mod.rs
@@ -9,7 +9,7 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::inline_fragments;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         let next_program = inline_fragments(program);
         assert_eq!(next_program.fragments().count(), 0);

--- a/compiler/crates/relay-transforms/tests/inline_fragments_test.rs
+++ b/compiler/crates/relay-transforms/tests/inline_fragments_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b479d421b643f2383902f35936c21430>>
+ * @generated SignedSource<<3d46ef5fd2e2fa8fcf424214d11318aa>>
  */
 
 mod inline_fragments;
@@ -12,16 +12,16 @@ mod inline_fragments;
 use inline_fragments::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn inlines_nested_fragments() {
+#[tokio::test]
+async fn inlines_nested_fragments() {
     let input = include_str!("inline_fragments/fixtures/inlines-nested-fragments.graphql");
     let expected = include_str!("inline_fragments/fixtures/inlines-nested-fragments.expected");
-    test_fixture(transform_fixture, "inlines-nested-fragments.graphql", "inline_fragments/fixtures/inlines-nested-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "inlines-nested-fragments.graphql", "inline_fragments/fixtures/inlines-nested-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn inlines_with_directive() {
+#[tokio::test]
+async fn inlines_with_directive() {
     let input = include_str!("inline_fragments/fixtures/inlines-with-directive.graphql");
     let expected = include_str!("inline_fragments/fixtures/inlines-with-directive.expected");
-    test_fixture(transform_fixture, "inlines-with-directive.graphql", "inline_fragments/fixtures/inlines-with-directive.expected", input, expected);
+    test_fixture(transform_fixture, "inlines-with-directive.graphql", "inline_fragments/fixtures/inlines-with-directive.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/mask/mod.rs
+++ b/compiler/crates/relay-transforms/tests/mask/mod.rs
@@ -17,7 +17,7 @@ use graphql_text_printer::PrinterOptions;
 use relay_test_schema::get_test_schema;
 use relay_transforms::mask;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let schema = get_test_schema();
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/mask_test.rs
+++ b/compiler/crates/relay-transforms/tests/mask_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<06cfcd9a6d5345cf8fba25d3382362fa>>
+ * @generated SignedSource<<e231cc226f56f4632a7064ecb30e37ee>>
  */
 
 mod mask;
@@ -12,16 +12,16 @@ mod mask;
 use mask::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn mask_mixed_null() {
+#[tokio::test]
+async fn mask_mixed_null() {
     let input = include_str!("mask/fixtures/mask-mixed-null.graphql");
     let expected = include_str!("mask/fixtures/mask-mixed-null.expected");
-    test_fixture(transform_fixture, "mask-mixed-null.graphql", "mask/fixtures/mask-mixed-null.expected", input, expected);
+    test_fixture(transform_fixture, "mask-mixed-null.graphql", "mask/fixtures/mask-mixed-null.expected", input, expected).await;
 }
 
-#[test]
-fn relay_mask_transform() {
+#[tokio::test]
+async fn relay_mask_transform() {
     let input = include_str!("mask/fixtures/relay-mask-transform.graphql");
     let expected = include_str!("mask/fixtures/relay-mask-transform.expected");
-    test_fixture(transform_fixture, "relay-mask-transform.graphql", "mask/fixtures/relay-mask-transform.expected", input, expected);
+    test_fixture(transform_fixture, "relay-mask-transform.graphql", "mask/fixtures/relay-mask-transform.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/match_transform/mod.rs
+++ b/compiler/crates/relay-transforms/tests/match_transform/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::transform_match;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let flags = FeatureFlags::default();
     apply_transform_for_test(fixture, |program| {
         transform_match(program, &flags, Default::default())

--- a/compiler/crates/relay-transforms/tests/match_transform_local/mod.rs
+++ b/compiler/crates/relay-transforms/tests/match_transform_local/mod.rs
@@ -12,7 +12,7 @@ use relay_config::DynamicModuleProvider;
 use relay_config::ModuleImportConfig;
 use relay_transforms::transform_match;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let flags = FeatureFlags::default();
     let module_import_config = ModuleImportConfig {
         dynamic_module_provider: Some(DynamicModuleProvider::JSResource),

--- a/compiler/crates/relay-transforms/tests/match_transform_local_test.rs
+++ b/compiler/crates/relay-transforms/tests/match_transform_local_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3f821e14128e35b76bc9d17c3ec8e96f>>
+ * @generated SignedSource<<ee8f5eb7708960663dcf395974e3a9bd>>
  */
 
 mod match_transform_local;
@@ -12,16 +12,16 @@ mod match_transform_local;
 use match_transform_local::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn module_on_field_without_js() {
+#[tokio::test]
+async fn module_on_field_without_js() {
     let input = include_str!("match_transform_local/fixtures/module-on-field-without-js.graphql");
     let expected = include_str!("match_transform_local/fixtures/module-on-field-without-js.expected");
-    test_fixture(transform_fixture, "module-on-field-without-js.graphql", "match_transform_local/fixtures/module-on-field-without-js.expected", input, expected);
+    test_fixture(transform_fixture, "module-on-field-without-js.graphql", "match_transform_local/fixtures/module-on-field-without-js.expected", input, expected).await;
 }
 
-#[test]
-fn module_without_match() {
+#[tokio::test]
+async fn module_without_match() {
     let input = include_str!("match_transform_local/fixtures/module-without-match.graphql");
     let expected = include_str!("match_transform_local/fixtures/module-without-match.expected");
-    test_fixture(transform_fixture, "module-without-match.graphql", "match_transform_local/fixtures/module-without-match.expected", input, expected);
+    test_fixture(transform_fixture, "module-without-match.graphql", "match_transform_local/fixtures/module-without-match.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/match_transform_test.rs
+++ b/compiler/crates/relay-transforms/tests/match_transform_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d9c1dc1b6ad85ebcbf422614fd709d3a>>
+ * @generated SignedSource<<af7428caa2ea72d612491d901578e848>>
  */
 
 mod match_transform;
@@ -12,100 +12,100 @@ mod match_transform;
 use match_transform::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn direct_js_field_invalid() {
+#[tokio::test]
+async fn direct_js_field_invalid() {
     let input = include_str!("match_transform/fixtures/direct-js-field.invalid.graphql");
     let expected = include_str!("match_transform/fixtures/direct-js-field.invalid.expected");
-    test_fixture(transform_fixture, "direct-js-field.invalid.graphql", "match_transform/fixtures/direct-js-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "direct-js-field.invalid.graphql", "match_transform/fixtures/direct-js-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_match_type() {
+#[tokio::test]
+async fn invalid_match_type() {
     let input = include_str!("match_transform/fixtures/invalid-match-type.graphql");
     let expected = include_str!("match_transform/fixtures/invalid-match-type.expected");
-    test_fixture(transform_fixture, "invalid-match-type.graphql", "match_transform/fixtures/invalid-match-type.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-match-type.graphql", "match_transform/fixtures/invalid-match-type.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_no_matches() {
+#[tokio::test]
+async fn invalid_no_matches() {
     let input = include_str!("match_transform/fixtures/invalid-no-matches.graphql");
     let expected = include_str!("match_transform/fixtures/invalid-no-matches.expected");
-    test_fixture(transform_fixture, "invalid-no-matches.graphql", "match_transform/fixtures/invalid-no-matches.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-no-matches.graphql", "match_transform/fixtures/invalid-no-matches.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_non_empty_selections() {
+#[tokio::test]
+async fn invalid_non_empty_selections() {
     let input = include_str!("match_transform/fixtures/invalid-non-empty-selections.graphql");
     let expected = include_str!("match_transform/fixtures/invalid-non-empty-selections.expected");
-    test_fixture(transform_fixture, "invalid-non-empty-selections.graphql", "match_transform/fixtures/invalid-non-empty-selections.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-non-empty-selections.graphql", "match_transform/fixtures/invalid-non-empty-selections.expected", input, expected).await;
 }
 
-#[test]
-fn match_on_child_of_plural() {
+#[tokio::test]
+async fn match_on_child_of_plural() {
     let input = include_str!("match_transform/fixtures/match-on-child-of-plural.graphql");
     let expected = include_str!("match_transform/fixtures/match-on-child-of-plural.expected");
-    test_fixture(transform_fixture, "match-on-child-of-plural.graphql", "match_transform/fixtures/match-on-child-of-plural.expected", input, expected);
+    test_fixture(transform_fixture, "match-on-child-of-plural.graphql", "match_transform/fixtures/match-on-child-of-plural.expected", input, expected).await;
 }
 
-#[test]
-fn match_with_explicit_support_arg_invalid() {
+#[tokio::test]
+async fn match_with_explicit_support_arg_invalid() {
     let input = include_str!("match_transform/fixtures/match-with-explicit-support-arg.invalid.graphql");
     let expected = include_str!("match_transform/fixtures/match-with-explicit-support-arg.invalid.expected");
-    test_fixture(transform_fixture, "match-with-explicit-support-arg.invalid.graphql", "match_transform/fixtures/match-with-explicit-support-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "match-with-explicit-support-arg.invalid.graphql", "match_transform/fixtures/match-with-explicit-support-arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn match_with_extra_args() {
+#[tokio::test]
+async fn match_with_extra_args() {
     let input = include_str!("match_transform/fixtures/match-with-extra-args.graphql");
     let expected = include_str!("match_transform/fixtures/match-with-extra-args.expected");
-    test_fixture(transform_fixture, "match-with-extra-args.graphql", "match_transform/fixtures/match-with-extra-args.expected", input, expected);
+    test_fixture(transform_fixture, "match-with-extra-args.graphql", "match_transform/fixtures/match-with-extra-args.expected", input, expected).await;
 }
 
-#[test]
-fn module_on_inline_data_invalid() {
+#[tokio::test]
+async fn module_on_inline_data_invalid() {
     let input = include_str!("match_transform/fixtures/module-on-inline-data.invalid.graphql");
     let expected = include_str!("match_transform/fixtures/module-on-inline-data.invalid.expected");
-    test_fixture(transform_fixture, "module-on-inline-data.invalid.graphql", "match_transform/fixtures/module-on-inline-data.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "module-on-inline-data.invalid.graphql", "match_transform/fixtures/module-on-inline-data.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn module_with_other_directives_invalid() {
+#[tokio::test]
+async fn module_with_other_directives_invalid() {
     let input = include_str!("match_transform/fixtures/module-with-other-directives.invalid.graphql");
     let expected = include_str!("match_transform/fixtures/module-with-other-directives.invalid.expected");
-    test_fixture(transform_fixture, "module-with-other-directives.invalid.graphql", "match_transform/fixtures/module-with-other-directives.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "module-with-other-directives.invalid.graphql", "match_transform/fixtures/module-with-other-directives.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn module_without_match() {
+#[tokio::test]
+async fn module_without_match() {
     let input = include_str!("match_transform/fixtures/module-without-match.graphql");
     let expected = include_str!("match_transform/fixtures/module-without-match.expected");
-    test_fixture(transform_fixture, "module-without-match.graphql", "match_transform/fixtures/module-without-match.expected", input, expected);
+    test_fixture(transform_fixture, "module-without-match.graphql", "match_transform/fixtures/module-without-match.expected", input, expected).await;
 }
 
-#[test]
-fn no_server_supported_arg_invalid() {
+#[tokio::test]
+async fn no_server_supported_arg_invalid() {
     let input = include_str!("match_transform/fixtures/no-server-supported-arg.invalid.graphql");
     let expected = include_str!("match_transform/fixtures/no-server-supported-arg.invalid.expected");
-    test_fixture(transform_fixture, "no-server-supported-arg.invalid.graphql", "match_transform/fixtures/no-server-supported-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "no-server-supported-arg.invalid.graphql", "match_transform/fixtures/no-server-supported-arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_match_on_interface() {
+#[tokio::test]
+async fn relay_match_on_interface() {
     let input = include_str!("match_transform/fixtures/relay-match-on-interface.graphql");
     let expected = include_str!("match_transform/fixtures/relay-match-on-interface.expected");
-    test_fixture(transform_fixture, "relay-match-on-interface.graphql", "match_transform/fixtures/relay-match-on-interface.expected", input, expected);
+    test_fixture(transform_fixture, "relay-match-on-interface.graphql", "match_transform/fixtures/relay-match-on-interface.expected", input, expected).await;
 }
 
-#[test]
-fn relay_match_on_union() {
+#[tokio::test]
+async fn relay_match_on_union() {
     let input = include_str!("match_transform/fixtures/relay-match-on-union.graphql");
     let expected = include_str!("match_transform/fixtures/relay-match-on-union.expected");
-    test_fixture(transform_fixture, "relay-match-on-union.graphql", "match_transform/fixtures/relay-match-on-union.expected", input, expected);
+    test_fixture(transform_fixture, "relay-match-on-union.graphql", "match_transform/fixtures/relay-match-on-union.expected", input, expected).await;
 }
 
-#[test]
-fn relay_match_on_union_plural() {
+#[tokio::test]
+async fn relay_match_on_union_plural() {
     let input = include_str!("match_transform/fixtures/relay-match-on-union-plural.graphql");
     let expected = include_str!("match_transform/fixtures/relay-match-on-union-plural.expected");
-    test_fixture(transform_fixture, "relay-match-on-union-plural.graphql", "match_transform/fixtures/relay-match-on-union-plural.expected", input, expected);
+    test_fixture(transform_fixture, "relay-match-on-union-plural.graphql", "match_transform/fixtures/relay-match-on-union-plural.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/provided_variable_fragment_transform/mod.rs
+++ b/compiler/crates/relay-transforms/tests/provided_variable_fragment_transform/mod.rs
@@ -9,7 +9,7 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::provided_variable_fragment_transform;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         provided_variable_fragment_transform(program)
     })

--- a/compiler/crates/relay-transforms/tests/provided_variable_fragment_transform_test.rs
+++ b/compiler/crates/relay-transforms/tests/provided_variable_fragment_transform_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ef1e560195f38ffa3dfa378616422601>>
+ * @generated SignedSource<<d0325109631e4889afe3570faf8bc86f>>
  */
 
 mod provided_variable_fragment_transform;
@@ -12,51 +12,51 @@ mod provided_variable_fragment_transform;
 use provided_variable_fragment_transform::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn anon_fragment_spread() {
+#[tokio::test]
+async fn anon_fragment_spread() {
     let input = include_str!("provided_variable_fragment_transform/fixtures/anon_fragment_spread.graphql");
     let expected = include_str!("provided_variable_fragment_transform/fixtures/anon_fragment_spread.expected");
-    test_fixture(transform_fixture, "anon_fragment_spread.graphql", "provided_variable_fragment_transform/fixtures/anon_fragment_spread.expected", input, expected);
+    test_fixture(transform_fixture, "anon_fragment_spread.graphql", "provided_variable_fragment_transform/fixtures/anon_fragment_spread.expected", input, expected).await;
 }
 
-#[test]
-fn conflict_warn_infrequent_definitions() {
+#[tokio::test]
+async fn conflict_warn_infrequent_definitions() {
     let input = include_str!("provided_variable_fragment_transform/fixtures/conflict_warn_infrequent_definitions.graphql");
     let expected = include_str!("provided_variable_fragment_transform/fixtures/conflict_warn_infrequent_definitions.expected");
-    test_fixture(transform_fixture, "conflict_warn_infrequent_definitions.graphql", "provided_variable_fragment_transform/fixtures/conflict_warn_infrequent_definitions.expected", input, expected);
+    test_fixture(transform_fixture, "conflict_warn_infrequent_definitions.graphql", "provided_variable_fragment_transform/fixtures/conflict_warn_infrequent_definitions.expected", input, expected).await;
 }
 
-#[test]
-fn conflicting_modules_invalid() {
+#[tokio::test]
+async fn conflicting_modules_invalid() {
     let input = include_str!("provided_variable_fragment_transform/fixtures/conflicting_modules_invalid.graphql");
     let expected = include_str!("provided_variable_fragment_transform/fixtures/conflicting_modules_invalid.expected");
-    test_fixture(transform_fixture, "conflicting_modules_invalid.graphql", "provided_variable_fragment_transform/fixtures/conflicting_modules_invalid.expected", input, expected);
+    test_fixture(transform_fixture, "conflicting_modules_invalid.graphql", "provided_variable_fragment_transform/fixtures/conflicting_modules_invalid.expected", input, expected).await;
 }
 
-#[test]
-fn conflicting_types_invalid() {
+#[tokio::test]
+async fn conflicting_types_invalid() {
     let input = include_str!("provided_variable_fragment_transform/fixtures/conflicting_types_invalid.graphql");
     let expected = include_str!("provided_variable_fragment_transform/fixtures/conflicting_types_invalid.expected");
-    test_fixture(transform_fixture, "conflicting_types_invalid.graphql", "provided_variable_fragment_transform/fixtures/conflicting_types_invalid.expected", input, expected);
+    test_fixture(transform_fixture, "conflicting_types_invalid.graphql", "provided_variable_fragment_transform/fixtures/conflicting_types_invalid.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_fragments() {
+#[tokio::test]
+async fn multiple_fragments() {
     let input = include_str!("provided_variable_fragment_transform/fixtures/multiple_fragments.graphql");
     let expected = include_str!("provided_variable_fragment_transform/fixtures/multiple_fragments.expected");
-    test_fixture(transform_fixture, "multiple_fragments.graphql", "provided_variable_fragment_transform/fixtures/multiple_fragments.expected", input, expected);
+    test_fixture(transform_fixture, "multiple_fragments.graphql", "provided_variable_fragment_transform/fixtures/multiple_fragments.expected", input, expected).await;
 }
 
-#[test]
-fn rename_provided_variables() {
+#[tokio::test]
+async fn rename_provided_variables() {
     let input = include_str!("provided_variable_fragment_transform/fixtures/rename_provided_variables.graphql");
     let expected = include_str!("provided_variable_fragment_transform/fixtures/rename_provided_variables.expected");
-    test_fixture(transform_fixture, "rename_provided_variables.graphql", "provided_variable_fragment_transform/fixtures/rename_provided_variables.expected", input, expected);
+    test_fixture(transform_fixture, "rename_provided_variables.graphql", "provided_variable_fragment_transform/fixtures/rename_provided_variables.expected", input, expected).await;
 }
 
-#[test]
-fn single_fragment() {
+#[tokio::test]
+async fn single_fragment() {
     let input = include_str!("provided_variable_fragment_transform/fixtures/single_fragment.graphql");
     let expected = include_str!("provided_variable_fragment_transform/fixtures/single_fragment.expected");
-    test_fixture(transform_fixture, "single_fragment.graphql", "provided_variable_fragment_transform/fixtures/single_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "single_fragment.graphql", "provided_variable_fragment_transform/fixtures/single_fragment.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/mod.rs
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/mod.rs
@@ -11,7 +11,7 @@ use relay_transforms::transform_connections;
 use relay_transforms::transform_refetchable_fragment;
 use relay_transforms::ConnectionInterface;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         let program = transform_connections(program, &ConnectionInterface::default());
         let base_fragments = Default::default();

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment_test.rs
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5d6010d9b0356775854a925e90881577>>
+ * @generated SignedSource<<24b901d880025e9056cd4d01429cb409>>
  */
 
 mod refetchable_fragment;
@@ -12,191 +12,191 @@ mod refetchable_fragment;
 use refetchable_fragment::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_on_interface_which_implementations_implement_node() {
+#[tokio::test]
+async fn fragment_on_interface_which_implementations_implement_node() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-interface-which-implementations-implement-node.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-interface-which-implementations-implement-node.expected");
-    test_fixture(transform_fixture, "fragment-on-interface-which-implementations-implement-node.graphql", "refetchable_fragment/fixtures/fragment-on-interface-which-implementations-implement-node.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-interface-which-implementations-implement-node.graphql", "refetchable_fragment/fixtures/fragment-on-interface-which-implementations-implement-node.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_interface_which_implementations_not_implement_node_invalid() {
+#[tokio::test]
+async fn fragment_on_interface_which_implementations_not_implement_node_invalid() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-interface-which-implementations-not-implement-node.invalid.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-interface-which-implementations-not-implement-node.invalid.expected");
-    test_fixture(transform_fixture, "fragment-on-interface-which-implementations-not-implement-node.invalid.graphql", "refetchable_fragment/fixtures/fragment-on-interface-which-implementations-not-implement-node.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-interface-which-implementations-not-implement-node.invalid.graphql", "refetchable_fragment/fixtures/fragment-on-interface-which-implementations-not-implement-node.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_interface_without_id() {
+#[tokio::test]
+async fn fragment_on_interface_without_id() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-interface-without-id.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-interface-without-id.expected");
-    test_fixture(transform_fixture, "fragment-on-interface-without-id.graphql", "refetchable_fragment/fixtures/fragment-on-interface-without-id.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-interface-without-id.graphql", "refetchable_fragment/fixtures/fragment-on-interface-without-id.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_node_interface() {
+#[tokio::test]
+async fn fragment_on_node_interface() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-node-interface.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-node-interface.expected");
-    test_fixture(transform_fixture, "fragment-on-node-interface.graphql", "refetchable_fragment/fixtures/fragment-on-node-interface.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-node-interface.graphql", "refetchable_fragment/fixtures/fragment-on-node-interface.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_node_interface_without_id() {
+#[tokio::test]
+async fn fragment_on_node_interface_without_id() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-node-interface-without-id.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-node-interface-without-id.expected");
-    test_fixture(transform_fixture, "fragment-on-node-interface-without-id.graphql", "refetchable_fragment/fixtures/fragment-on-node-interface-without-id.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-node-interface-without-id.graphql", "refetchable_fragment/fixtures/fragment-on-node-interface-without-id.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_node_with_id_argument_used_invalid() {
+#[tokio::test]
+async fn fragment_on_node_with_id_argument_used_invalid() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-node-with-id-argument-used.invalid.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-node-with-id-argument-used.invalid.expected");
-    test_fixture(transform_fixture, "fragment-on-node-with-id-argument-used.invalid.graphql", "refetchable_fragment/fixtures/fragment-on-node-with-id-argument-used.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-node-with-id-argument-used.invalid.graphql", "refetchable_fragment/fixtures/fragment-on-node-with-id-argument-used.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_non_node_fetchable_type() {
+#[tokio::test]
+async fn fragment_on_non_node_fetchable_type() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type.expected");
-    test_fixture(transform_fixture, "fragment-on-non-node-fetchable-type.graphql", "refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-non-node-fetchable-type.graphql", "refetchable_fragment/fixtures/fragment-on-non-node-fetchable-type.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_object_implementing_node_interface() {
+#[tokio::test]
+async fn fragment_on_object_implementing_node_interface() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface.expected");
-    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface.graphql", "refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface.graphql", "refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_object_implementing_node_interface_with_alias_id() {
+#[tokio::test]
+async fn fragment_on_object_implementing_node_interface_with_alias_id() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface-with-alias-id.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface-with-alias-id.expected");
-    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface-with-alias-id.graphql", "refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface-with-alias-id.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-object-implementing-node-interface-with-alias-id.graphql", "refetchable_fragment/fixtures/fragment-on-object-implementing-node-interface-with-alias-id.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_query() {
+#[tokio::test]
+async fn fragment_on_query() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-query.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-query.expected");
-    test_fixture(transform_fixture, "fragment-on-query.graphql", "refetchable_fragment/fixtures/fragment-on-query.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-query.graphql", "refetchable_fragment/fixtures/fragment-on-query.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_query_with_cycle() {
+#[tokio::test]
+async fn fragment_on_query_with_cycle() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-query-with-cycle.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-query-with-cycle.expected");
-    test_fixture(transform_fixture, "fragment-on-query-with-cycle.graphql", "refetchable_fragment/fixtures/fragment-on-query-with-cycle.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-query-with-cycle.graphql", "refetchable_fragment/fixtures/fragment-on-query-with-cycle.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_query_without_query_name_invalid() {
+#[tokio::test]
+async fn fragment_on_query_without_query_name_invalid() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-query-without-query-name.invalid.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-query-without-query-name.invalid.expected");
-    test_fixture(transform_fixture, "fragment-on-query-without-query-name.invalid.graphql", "refetchable_fragment/fixtures/fragment-on-query-without-query-name.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-query-without-query-name.invalid.graphql", "refetchable_fragment/fixtures/fragment-on-query-without-query-name.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_on_viewer() {
+#[tokio::test]
+async fn fragment_on_viewer() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-on-viewer.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-on-viewer.expected");
-    test_fixture(transform_fixture, "fragment-on-viewer.graphql", "refetchable_fragment/fixtures/fragment-on-viewer.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-on-viewer.graphql", "refetchable_fragment/fixtures/fragment-on-viewer.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_args_on_object_implementing_node_interface() {
+#[tokio::test]
+async fn fragment_with_args_on_object_implementing_node_interface() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-with-args-on-object-implementing-node-interface.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-with-args-on-object-implementing-node-interface.expected");
-    test_fixture(transform_fixture, "fragment-with-args-on-object-implementing-node-interface.graphql", "refetchable_fragment/fixtures/fragment-with-args-on-object-implementing-node-interface.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-args-on-object-implementing-node-interface.graphql", "refetchable_fragment/fixtures/fragment-with-args-on-object-implementing-node-interface.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_args_on_query() {
+#[tokio::test]
+async fn fragment_with_args_on_query() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-with-args-on-query.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-with-args-on-query.expected");
-    test_fixture(transform_fixture, "fragment-with-args-on-query.graphql", "refetchable_fragment/fixtures/fragment-with-args-on-query.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-args-on-query.graphql", "refetchable_fragment/fixtures/fragment-with-args-on-query.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_args_on_viewer() {
+#[tokio::test]
+async fn fragment_with_args_on_viewer() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-with-args-on-viewer.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-with-args-on-viewer.expected");
-    test_fixture(transform_fixture, "fragment-with-args-on-viewer.graphql", "refetchable_fragment/fixtures/fragment-with-args-on-viewer.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-args-on-viewer.graphql", "refetchable_fragment/fixtures/fragment-with-args-on-viewer.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_relay_plural_invalid() {
+#[tokio::test]
+async fn fragment_with_relay_plural_invalid() {
     let input = include_str!("refetchable_fragment/fixtures/fragment-with-relay-plural.invalid.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/fragment-with-relay-plural.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-relay-plural.invalid.graphql", "refetchable_fragment/fixtures/fragment-with-relay-plural.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-relay-plural.invalid.graphql", "refetchable_fragment/fixtures/fragment-with-relay-plural.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection_bidirectional() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection_bidirectional() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-bidirectional.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-bidirectional.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection-bidirectional.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-bidirectional.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection-bidirectional.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-bidirectional.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection_literal_count_invalid() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection_literal_count_invalid() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-literal-count.invalid.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-literal-count.invalid.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection-literal-count.invalid.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-literal-count.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection-literal-count.invalid.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-literal-count.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection_no_cursor_invalid() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection_no_cursor_invalid() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-no-cursor.invalid.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-no-cursor.invalid.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection-no-cursor.invalid.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-no-cursor.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection-no-cursor.invalid.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-no-cursor.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection_unstable_path_invalid() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection_unstable_path_invalid() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-unstable-path.invalid.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-unstable-path.invalid.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection-unstable-path.invalid.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-unstable-path.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection-unstable-path.invalid.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-unstable-path.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment_with_connection_with_stream() {
+#[tokio::test]
+async fn refetchable_fragment_with_connection_with_stream() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.expected");
-    test_fixture(transform_fixture, "refetchable-fragment-with-connection-with-stream.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment-with-connection-with-stream.graphql", "refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_interface() {
+#[tokio::test]
+async fn refetchable_interface() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-interface.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-interface.expected");
-    test_fixture(transform_fixture, "refetchable-interface.graphql", "refetchable_fragment/fixtures/refetchable-interface.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-interface.graphql", "refetchable_fragment/fixtures/refetchable-interface.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_interface_all_implementing_types_impl_node() {
+#[tokio::test]
+async fn refetchable_interface_all_implementing_types_impl_node() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-interface-all-implementing-types-impl-node.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-interface-all-implementing-types-impl-node.expected");
-    test_fixture(transform_fixture, "refetchable-interface-all-implementing-types-impl-node.graphql", "refetchable_fragment/fixtures/refetchable-interface-all-implementing-types-impl-node.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-interface-all-implementing-types-impl-node.graphql", "refetchable_fragment/fixtures/refetchable-interface-all-implementing-types-impl-node.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_interface_but_no_implementing_types() {
+#[tokio::test]
+async fn refetchable_interface_but_no_implementing_types() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-interface-but-no-implementing-types.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-interface-but-no-implementing-types.expected");
-    test_fixture(transform_fixture, "refetchable-interface-but-no-implementing-types.graphql", "refetchable_fragment/fixtures/refetchable-interface-but-no-implementing-types.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-interface-but-no-implementing-types.graphql", "refetchable_fragment/fixtures/refetchable-interface-but-no-implementing-types.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_interface_some_types_impl_node() {
+#[tokio::test]
+async fn refetchable_interface_some_types_impl_node() {
     let input = include_str!("refetchable_fragment/fixtures/refetchable-interface-some-types-impl-node.graphql");
     let expected = include_str!("refetchable_fragment/fixtures/refetchable-interface-some-types-impl-node.expected");
-    test_fixture(transform_fixture, "refetchable-interface-some-types-impl-node.graphql", "refetchable_fragment/fixtures/refetchable-interface-some-types-impl-node.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-interface-some-types-impl-node.graphql", "refetchable_fragment/fixtures/refetchable-interface-some-types-impl-node.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/relay_actor_change/mod.rs
+++ b/compiler/crates/relay-transforms/tests/relay_actor_change/mod.rs
@@ -10,7 +10,7 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::relay_actor_change_transform;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         relay_actor_change_transform(program, &FeatureFlag::Enabled)
     })

--- a/compiler/crates/relay-transforms/tests/relay_actor_change_test.rs
+++ b/compiler/crates/relay-transforms/tests/relay_actor_change_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0ea689df4225c0f14523b6e1d62520dd>>
+ * @generated SignedSource<<21b3f9e95f5f4094cda852fd4fc27e70>>
  */
 
 mod relay_actor_change;
@@ -12,37 +12,37 @@ mod relay_actor_change;
 use relay_actor_change::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn actor_change_invalid() {
+#[tokio::test]
+async fn actor_change_invalid() {
     let input = include_str!("relay_actor_change/fixtures/actor-change.invalid.graphql");
     let expected = include_str!("relay_actor_change/fixtures/actor-change.invalid.expected");
-    test_fixture(transform_fixture, "actor-change.invalid.graphql", "relay_actor_change/fixtures/actor-change.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "actor-change.invalid.graphql", "relay_actor_change/fixtures/actor-change.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn actor_change_no_viewer_invalid() {
+#[tokio::test]
+async fn actor_change_no_viewer_invalid() {
     let input = include_str!("relay_actor_change/fixtures/actor-change-no-viewer.invalid.graphql");
     let expected = include_str!("relay_actor_change/fixtures/actor-change-no-viewer.invalid.expected");
-    test_fixture(transform_fixture, "actor-change-no-viewer.invalid.graphql", "relay_actor_change/fixtures/actor-change-no-viewer.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "actor-change-no-viewer.invalid.graphql", "relay_actor_change/fixtures/actor-change-no-viewer.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn actor_change_pluarl_invalid() {
+#[tokio::test]
+async fn actor_change_pluarl_invalid() {
     let input = include_str!("relay_actor_change/fixtures/actor-change-pluarl.invalid.graphql");
     let expected = include_str!("relay_actor_change/fixtures/actor-change-pluarl.invalid.expected");
-    test_fixture(transform_fixture, "actor-change-pluarl.invalid.graphql", "relay_actor_change/fixtures/actor-change-pluarl.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "actor-change-pluarl.invalid.graphql", "relay_actor_change/fixtures/actor-change-pluarl.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn actor_change_wrong_viewer_invalid() {
+#[tokio::test]
+async fn actor_change_wrong_viewer_invalid() {
     let input = include_str!("relay_actor_change/fixtures/actor-change-wrong-viewer.invalid.graphql");
     let expected = include_str!("relay_actor_change/fixtures/actor-change-wrong-viewer.invalid.expected");
-    test_fixture(transform_fixture, "actor-change-wrong-viewer.invalid.graphql", "relay_actor_change/fixtures/actor-change-wrong-viewer.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "actor-change-wrong-viewer.invalid.graphql", "relay_actor_change/fixtures/actor-change-wrong-viewer.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn simple_query() {
+#[tokio::test]
+async fn simple_query() {
     let input = include_str!("relay_actor_change/fixtures/simple-query.graphql");
     let expected = include_str!("relay_actor_change/fixtures/simple-query.expected");
-    test_fixture(transform_fixture, "simple-query.graphql", "relay_actor_change/fixtures/simple-query.expected", input, expected);
+    test_fixture(transform_fixture, "simple-query.graphql", "relay_actor_change/fixtures/simple-query.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/relay_client_component/mod.rs
+++ b/compiler/crates/relay-transforms/tests/relay_client_component/mod.rs
@@ -5,8 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use common::FeatureFlags;
 use fixture_tests::Fixture;
+use graphql_test_helpers::apply_transform_for_test;
+use relay_transforms::relay_client_component;
 
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
-    Ok(fixture.content.to_uppercase())
+    let flags = FeatureFlags::default();
+    apply_transform_for_test(fixture, |program| relay_client_component(program, &flags))
 }

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/mod.rs
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/mod.rs
@@ -25,7 +25,7 @@ use relay_transforms::fragment_alias_directive;
 use relay_transforms::relay_resolvers;
 use relay_transforms::validate_resolver_fragments;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     if let [base, extensions] = parts.as_slice() {
         let graphql_location = SourceLocationKey::embedded(fixture.file_name, 0);

--- a/compiler/crates/relay-transforms/tests/relay_resolvers_test.rs
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1d04afc08ee7547cc923bc7dab37713c>>
+ * @generated SignedSource<<bc36b8794ed15edbcffd47c75921da9b>>
  */
 
 mod relay_resolvers;
@@ -12,121 +12,121 @@ mod relay_resolvers;
 use relay_resolvers::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn field_alias() {
+#[tokio::test]
+async fn field_alias() {
     let input = include_str!("relay_resolvers/fixtures/field-alias.graphql");
     let expected = include_str!("relay_resolvers/fixtures/field-alias.expected");
-    test_fixture(transform_fixture, "field-alias.graphql", "relay_resolvers/fixtures/field-alias.expected", input, expected);
+    test_fixture(transform_fixture, "field-alias.graphql", "relay_resolvers/fixtures/field-alias.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread_usage_invalid() {
+#[tokio::test]
+async fn fragment_spread_usage_invalid() {
     let input = include_str!("relay_resolvers/fixtures/fragment-spread-usage.invalid.graphql");
     let expected = include_str!("relay_resolvers/fixtures/fragment-spread-usage.invalid.expected");
-    test_fixture(transform_fixture, "fragment-spread-usage.invalid.graphql", "relay_resolvers/fixtures/fragment-spread-usage.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-spread-usage.invalid.graphql", "relay_resolvers/fixtures/fragment-spread-usage.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn missing_fragment_invalid() {
+#[tokio::test]
+async fn missing_fragment_invalid() {
     let input = include_str!("relay_resolvers/fixtures/missing-fragment.invalid.graphql");
     let expected = include_str!("relay_resolvers/fixtures/missing-fragment.invalid.expected");
-    test_fixture(transform_fixture, "missing-fragment.invalid.graphql", "relay_resolvers/fixtures/missing-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing-fragment.invalid.graphql", "relay_resolvers/fixtures/missing-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn missing_fragment_name() {
+#[tokio::test]
+async fn missing_fragment_name() {
     let input = include_str!("relay_resolvers/fixtures/missing-fragment-name.graphql");
     let expected = include_str!("relay_resolvers/fixtures/missing-fragment-name.expected");
-    test_fixture(transform_fixture, "missing-fragment-name.graphql", "relay_resolvers/fixtures/missing-fragment-name.expected", input, expected);
+    test_fixture(transform_fixture, "missing-fragment-name.graphql", "relay_resolvers/fixtures/missing-fragment-name.expected", input, expected).await;
 }
 
-#[test]
-fn missing_import_path_invalid() {
+#[tokio::test]
+async fn missing_import_path_invalid() {
     let input = include_str!("relay_resolvers/fixtures/missing-import-path.invalid.graphql");
     let expected = include_str!("relay_resolvers/fixtures/missing-import-path.invalid.expected");
-    test_fixture(transform_fixture, "missing-import-path.invalid.graphql", "relay_resolvers/fixtures/missing-import-path.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing-import-path.invalid.graphql", "relay_resolvers/fixtures/missing-import-path.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_relay_resolvers() {
+#[tokio::test]
+async fn multiple_relay_resolvers() {
     let input = include_str!("relay_resolvers/fixtures/multiple-relay-resolvers.graphql");
     let expected = include_str!("relay_resolvers/fixtures/multiple-relay-resolvers.expected");
-    test_fixture(transform_fixture, "multiple-relay-resolvers.graphql", "relay_resolvers/fixtures/multiple-relay-resolvers.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-relay-resolvers.graphql", "relay_resolvers/fixtures/multiple-relay-resolvers.expected", input, expected).await;
 }
 
-#[test]
-fn nested_relay_resolver() {
+#[tokio::test]
+async fn nested_relay_resolver() {
     let input = include_str!("relay_resolvers/fixtures/nested-relay-resolver.graphql");
     let expected = include_str!("relay_resolvers/fixtures/nested-relay-resolver.expected");
-    test_fixture(transform_fixture, "nested-relay-resolver.graphql", "relay_resolvers/fixtures/nested-relay-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "nested-relay-resolver.graphql", "relay_resolvers/fixtures/nested-relay-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver() {
+#[tokio::test]
+async fn relay_resolver() {
     let input = include_str!("relay_resolvers/fixtures/relay-resolver.graphql");
     let expected = include_str!("relay_resolvers/fixtures/relay-resolver.expected");
-    test_fixture(transform_fixture, "relay-resolver.graphql", "relay_resolvers/fixtures/relay-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver.graphql", "relay_resolvers/fixtures/relay-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_backing_client_edge() {
+#[tokio::test]
+async fn relay_resolver_backing_client_edge() {
     let input = include_str!("relay_resolvers/fixtures/relay-resolver-backing-client-edge.graphql");
     let expected = include_str!("relay_resolvers/fixtures/relay-resolver-backing-client-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-backing-client-edge.graphql", "relay_resolvers/fixtures/relay-resolver-backing-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-backing-client-edge.graphql", "relay_resolvers/fixtures/relay-resolver-backing-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_field_and_fragment_arguments() {
+#[tokio::test]
+async fn relay_resolver_field_and_fragment_arguments() {
     let input = include_str!("relay_resolvers/fixtures/relay-resolver-field-and-fragment-arguments.graphql");
     let expected = include_str!("relay_resolvers/fixtures/relay-resolver-field-and-fragment-arguments.expected");
-    test_fixture(transform_fixture, "relay-resolver-field-and-fragment-arguments.graphql", "relay_resolvers/fixtures/relay-resolver-field-and-fragment-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-field-and-fragment-arguments.graphql", "relay_resolvers/fixtures/relay-resolver-field-and-fragment-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_model() {
+#[tokio::test]
+async fn relay_resolver_model() {
     let input = include_str!("relay_resolvers/fixtures/relay-resolver-model.graphql");
     let expected = include_str!("relay_resolvers/fixtures/relay-resolver-model.expected");
-    test_fixture(transform_fixture, "relay-resolver-model.graphql", "relay_resolvers/fixtures/relay-resolver-model.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-model.graphql", "relay_resolvers/fixtures/relay-resolver-model.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_named_import() {
+#[tokio::test]
+async fn relay_resolver_named_import() {
     let input = include_str!("relay_resolvers/fixtures/relay-resolver-named-import.graphql");
     let expected = include_str!("relay_resolvers/fixtures/relay-resolver-named-import.expected");
-    test_fixture(transform_fixture, "relay-resolver-named-import.graphql", "relay_resolvers/fixtures/relay-resolver-named-import.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-named-import.graphql", "relay_resolvers/fixtures/relay-resolver-named-import.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_required() {
+#[tokio::test]
+async fn relay_resolver_required() {
     let input = include_str!("relay_resolvers/fixtures/relay-resolver-required.graphql");
     let expected = include_str!("relay_resolvers/fixtures/relay-resolver-required.expected");
-    test_fixture(transform_fixture, "relay-resolver-required.graphql", "relay_resolvers/fixtures/relay-resolver-required.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-required.graphql", "relay_resolvers/fixtures/relay-resolver-required.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_global_vars_directive_invalid() {
+#[tokio::test]
+async fn relay_resolver_with_global_vars_directive_invalid() {
     let input = include_str!("relay_resolvers/fixtures/relay-resolver-with-global-vars-directive.invalid.graphql");
     let expected = include_str!("relay_resolvers/fixtures/relay-resolver-with-global-vars-directive.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-global-vars-directive.invalid.graphql", "relay_resolvers/fixtures/relay-resolver-with-global-vars-directive.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-global-vars-directive.invalid.graphql", "relay_resolvers/fixtures/relay-resolver-with-global-vars-directive.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_global_vars_invalid() {
+#[tokio::test]
+async fn relay_resolver_with_global_vars_invalid() {
     let input = include_str!("relay_resolvers/fixtures/relay-resolver-with-global-vars.invalid.graphql");
     let expected = include_str!("relay_resolvers/fixtures/relay-resolver-with-global-vars.invalid.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-global-vars.invalid.graphql", "relay_resolvers/fixtures/relay-resolver-with-global-vars.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-global-vars.invalid.graphql", "relay_resolvers/fixtures/relay-resolver-with-global-vars.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_within_named_inline_fragment() {
+#[tokio::test]
+async fn relay_resolver_within_named_inline_fragment() {
     let input = include_str!("relay_resolvers/fixtures/relay-resolver-within-named-inline-fragment.graphql");
     let expected = include_str!("relay_resolvers/fixtures/relay-resolver-within-named-inline-fragment.expected");
-    test_fixture(transform_fixture, "relay-resolver-within-named-inline-fragment.graphql", "relay_resolvers/fixtures/relay-resolver-within-named-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-within-named-inline-fragment.graphql", "relay_resolvers/fixtures/relay-resolver-within-named-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn unexpected_directive_invalid() {
+#[tokio::test]
+async fn unexpected_directive_invalid() {
     let input = include_str!("relay_resolvers/fixtures/unexpected-directive.invalid.graphql");
     let expected = include_str!("relay_resolvers/fixtures/unexpected-directive.invalid.expected");
-    test_fixture(transform_fixture, "unexpected-directive.invalid.graphql", "relay_resolvers/fixtures/unexpected-directive.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unexpected-directive.invalid.graphql", "relay_resolvers/fixtures/unexpected-directive.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/relay_test_operation/mod.rs
+++ b/compiler/crates/relay-transforms/tests/relay_test_operation/mod.rs
@@ -20,7 +20,7 @@ use regex::Regex;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::generate_test_operation_metadata;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
 
     if let [base, extensions] = parts.as_slice() {

--- a/compiler/crates/relay-transforms/tests/relay_test_operation_test.rs
+++ b/compiler/crates/relay-transforms/tests/relay_test_operation_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8fc748d04078d4e5388f4005efcca2ad>>
+ * @generated SignedSource<<46764e8e16636a5d014c74199dec9f2a>>
  */
 
 mod relay_test_operation;
@@ -12,30 +12,30 @@ mod relay_test_operation;
 use relay_test_operation::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn prod_query_invalid() {
+#[tokio::test]
+async fn prod_query_invalid() {
     let input = include_str!("relay_test_operation/fixtures/prod_query.invalid.graphql");
     let expected = include_str!("relay_test_operation/fixtures/prod_query.invalid.expected");
-    test_fixture(transform_fixture, "prod_query.invalid.graphql", "relay_test_operation/fixtures/prod_query.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "prod_query.invalid.graphql", "relay_test_operation/fixtures/prod_query.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn test_client_fields_query() {
+#[tokio::test]
+async fn test_client_fields_query() {
     let input = include_str!("relay_test_operation/fixtures/test_client_fields_query.graphql");
     let expected = include_str!("relay_test_operation/fixtures/test_client_fields_query.expected");
-    test_fixture(transform_fixture, "test_client_fields_query.graphql", "relay_test_operation/fixtures/test_client_fields_query.expected", input, expected);
+    test_fixture(transform_fixture, "test_client_fields_query.graphql", "relay_test_operation/fixtures/test_client_fields_query.expected", input, expected).await;
 }
 
-#[test]
-fn test_query_with_enums() {
+#[tokio::test]
+async fn test_query_with_enums() {
     let input = include_str!("relay_test_operation/fixtures/test_query_with_enums.graphql");
     let expected = include_str!("relay_test_operation/fixtures/test_query_with_enums.expected");
-    test_fixture(transform_fixture, "test_query_with_enums.graphql", "relay_test_operation/fixtures/test_query_with_enums.expected", input, expected);
+    test_fixture(transform_fixture, "test_query_with_enums.graphql", "relay_test_operation/fixtures/test_query_with_enums.expected", input, expected).await;
 }
 
-#[test]
-fn test_simple_query() {
+#[tokio::test]
+async fn test_simple_query() {
     let input = include_str!("relay_test_operation/fixtures/test_simple_query.graphql");
     let expected = include_str!("relay_test_operation/fixtures/test_simple_query.expected");
-    test_fixture(transform_fixture, "test_simple_query.graphql", "relay_test_operation/fixtures/test_simple_query.expected", input, expected);
+    test_fixture(transform_fixture, "test_simple_query.graphql", "relay_test_operation/fixtures/test_simple_query.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/required_directive/mod.rs
+++ b/compiler/crates/relay-transforms/tests/required_directive/mod.rs
@@ -17,6 +17,6 @@ fn transform(program: &Program) -> DiagnosticsResult<Program> {
     required_directive(&fragment_alias_directive(program, &FeatureFlag::Enabled)?)
 }
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, transform)
 }

--- a/compiler/crates/relay-transforms/tests/required_directive_test.rs
+++ b/compiler/crates/relay-transforms/tests/required_directive_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d8711219e10b1f666a01fa60e6b5d967>>
+ * @generated SignedSource<<fda177b034f30050ab491c9d0c9accf6>>
  */
 
 mod required_directive;
@@ -12,219 +12,219 @@ mod required_directive;
 use required_directive::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn action_argument_omitted_invalid() {
+#[tokio::test]
+async fn action_argument_omitted_invalid() {
     let input = include_str!("required_directive/fixtures/action-argument-omitted.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/action-argument-omitted.invalid.expected");
-    test_fixture(transform_fixture, "action-argument-omitted.invalid.graphql", "required_directive/fixtures/action-argument-omitted.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "action-argument-omitted.invalid.graphql", "required_directive/fixtures/action-argument-omitted.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn conflicting_required_status_across_aliased_inline_fragments() {
+#[tokio::test]
+async fn conflicting_required_status_across_aliased_inline_fragments() {
     let input = include_str!("required_directive/fixtures/conflicting-required-status-across-aliased-inline-fragments.graphql");
     let expected = include_str!("required_directive/fixtures/conflicting-required-status-across-aliased-inline-fragments.expected");
-    test_fixture(transform_fixture, "conflicting-required-status-across-aliased-inline-fragments.graphql", "required_directive/fixtures/conflicting-required-status-across-aliased-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "conflicting-required-status-across-aliased-inline-fragments.graphql", "required_directive/fixtures/conflicting-required-status-across-aliased-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_field_different_actions_invalid() {
+#[tokio::test]
+async fn duplicate_field_different_actions_invalid() {
     let input = include_str!("required_directive/fixtures/duplicate-field-different-actions.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/duplicate-field-different-actions.invalid.expected");
-    test_fixture(transform_fixture, "duplicate-field-different-actions.invalid.graphql", "required_directive/fixtures/duplicate-field-different-actions.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate-field-different-actions.invalid.graphql", "required_directive/fixtures/duplicate-field-different-actions.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_field_include_directive_invalid() {
+#[tokio::test]
+async fn duplicate_field_include_directive_invalid() {
     let input = include_str!("required_directive/fixtures/duplicate-field-include-directive.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/duplicate-field-include-directive.invalid.expected");
-    test_fixture(transform_fixture, "duplicate-field-include-directive.invalid.graphql", "required_directive/fixtures/duplicate-field-include-directive.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate-field-include-directive.invalid.graphql", "required_directive/fixtures/duplicate-field-include-directive.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_field_invalid() {
+#[tokio::test]
+async fn duplicate_field_invalid() {
     let input = include_str!("required_directive/fixtures/duplicate-field.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/duplicate-field.invalid.expected");
-    test_fixture(transform_fixture, "duplicate-field.invalid.graphql", "required_directive/fixtures/duplicate-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate-field.invalid.graphql", "required_directive/fixtures/duplicate-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_field_nullable_parent_invalid() {
+#[tokio::test]
+async fn duplicate_field_nullable_parent_invalid() {
     let input = include_str!("required_directive/fixtures/duplicate-field-nullable-parent.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/duplicate-field-nullable-parent.invalid.expected");
-    test_fixture(transform_fixture, "duplicate-field-nullable-parent.invalid.graphql", "required_directive/fixtures/duplicate-field-nullable-parent.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate-field-nullable-parent.invalid.graphql", "required_directive/fixtures/duplicate-field-nullable-parent.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_field_nullable_parent_missing_first_invalid() {
+#[tokio::test]
+async fn duplicate_field_nullable_parent_missing_first_invalid() {
     let input = include_str!("required_directive/fixtures/duplicate-field-nullable-parent-missing-first.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/duplicate-field-nullable-parent-missing-first.invalid.expected");
-    test_fixture(transform_fixture, "duplicate-field-nullable-parent-missing-first.invalid.graphql", "required_directive/fixtures/duplicate-field-nullable-parent-missing-first.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate-field-nullable-parent-missing-first.invalid.graphql", "required_directive/fixtures/duplicate-field-nullable-parent-missing-first.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_field_ussage_alias() {
+#[tokio::test]
+async fn duplicate_field_ussage_alias() {
     let input = include_str!("required_directive/fixtures/duplicate-field-ussage-alias.graphql");
     let expected = include_str!("required_directive/fixtures/duplicate-field-ussage-alias.expected");
-    test_fixture(transform_fixture, "duplicate-field-ussage-alias.graphql", "required_directive/fixtures/duplicate-field-ussage-alias.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate-field-ussage-alias.graphql", "required_directive/fixtures/duplicate-field-ussage-alias.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_linked_field_different_actions_invalid() {
+#[tokio::test]
+async fn duplicate_linked_field_different_actions_invalid() {
     let input = include_str!("required_directive/fixtures/duplicate-linked-field-different-actions.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/duplicate-linked-field-different-actions.invalid.expected");
-    test_fixture(transform_fixture, "duplicate-linked-field-different-actions.invalid.graphql", "required_directive/fixtures/duplicate-linked-field-different-actions.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate-linked-field-different-actions.invalid.graphql", "required_directive/fixtures/duplicate-linked-field-different-actions.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn duplicate_linked_field_nullable_parent_invalid() {
+#[tokio::test]
+async fn duplicate_linked_field_nullable_parent_invalid() {
     let input = include_str!("required_directive/fixtures/duplicate-linked-field-nullable-parent.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/duplicate-linked-field-nullable-parent.invalid.expected");
-    test_fixture(transform_fixture, "duplicate-linked-field-nullable-parent.invalid.graphql", "required_directive/fixtures/duplicate-linked-field-nullable-parent.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "duplicate-linked-field-nullable-parent.invalid.graphql", "required_directive/fixtures/duplicate-linked-field-nullable-parent.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragments_are_isolated() {
+#[tokio::test]
+async fn fragments_are_isolated() {
     let input = include_str!("required_directive/fixtures/fragments-are-isolated.graphql");
     let expected = include_str!("required_directive/fixtures/fragments-are-isolated.expected");
-    test_fixture(transform_fixture, "fragments-are-isolated.graphql", "required_directive/fixtures/fragments-are-isolated.expected", input, expected);
+    test_fixture(transform_fixture, "fragments-are-isolated.graphql", "required_directive/fixtures/fragments-are-isolated.expected", input, expected).await;
 }
 
-#[test]
-fn inline_directive_invalid() {
+#[tokio::test]
+async fn inline_directive_invalid() {
     let input = include_str!("required_directive/fixtures/inline-directive.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/inline-directive.invalid.expected");
-    test_fixture(transform_fixture, "inline-directive.invalid.graphql", "required_directive/fixtures/inline-directive.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-directive.invalid.graphql", "required_directive/fixtures/inline-directive.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_concrete_in_interface_invalid() {
+#[tokio::test]
+async fn inline_fragment_on_concrete_in_interface_invalid() {
     let input = include_str!("required_directive/fixtures/inline-fragment-on-concrete-in-interface.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/inline-fragment-on-concrete-in-interface.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-on-concrete-in-interface.invalid.graphql", "required_directive/fixtures/inline-fragment-on-concrete-in-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-on-concrete-in-interface.invalid.graphql", "required_directive/fixtures/inline-fragment-on-concrete-in-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_interface_in_concrete_invalid() {
+#[tokio::test]
+async fn inline_fragment_on_interface_in_concrete_invalid() {
     let input = include_str!("required_directive/fixtures/inline-fragment-on-interface-in-concrete.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/inline-fragment-on-interface-in-concrete.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-on-interface-in-concrete.invalid.graphql", "required_directive/fixtures/inline-fragment-on-interface-in-concrete.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-on-interface-in-concrete.invalid.graphql", "required_directive/fixtures/inline-fragment-on-interface-in-concrete.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_interface_invalid() {
+#[tokio::test]
+async fn inline_fragment_on_interface_invalid() {
     let input = include_str!("required_directive/fixtures/inline-fragment-on-interface.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/inline-fragment-on-interface.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-on-interface.invalid.graphql", "required_directive/fixtures/inline-fragment-on-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-on-interface.invalid.graphql", "required_directive/fixtures/inline-fragment-on-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_interface_with_linked_field_invalid() {
+#[tokio::test]
+async fn inline_fragment_on_interface_with_linked_field_invalid() {
     let input = include_str!("required_directive/fixtures/inline-fragment-on-interface-with-linked-field.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/inline-fragment-on-interface-with-linked-field.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-on-interface-with-linked-field.invalid.graphql", "required_directive/fixtures/inline-fragment-on-interface-with-linked-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-on-interface-with-linked-field.invalid.graphql", "required_directive/fixtures/inline-fragment-on-interface-with-linked-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_interface_within_linked_field() {
+#[tokio::test]
+async fn inline_fragment_on_interface_within_linked_field() {
     let input = include_str!("required_directive/fixtures/inline-fragment-on-interface-within-linked-field.graphql");
     let expected = include_str!("required_directive/fixtures/inline-fragment-on-interface-within-linked-field.expected");
-    test_fixture(transform_fixture, "inline-fragment-on-interface-within-linked-field.graphql", "required_directive/fixtures/inline-fragment-on-interface-within-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-on-interface-within-linked-field.graphql", "required_directive/fixtures/inline-fragment-on-interface-within-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_on_union_invalid() {
+#[tokio::test]
+async fn inline_fragment_on_union_invalid() {
     let input = include_str!("required_directive/fixtures/inline-fragment-on-union.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/inline-fragment-on-union.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-on-union.invalid.graphql", "required_directive/fixtures/inline-fragment-on-union.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-on-union.invalid.graphql", "required_directive/fixtures/inline-fragment-on-union.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn linked_field_log() {
+#[tokio::test]
+async fn linked_field_log() {
     let input = include_str!("required_directive/fixtures/linked-field-log.graphql");
     let expected = include_str!("required_directive/fixtures/linked-field-log.expected");
-    test_fixture(transform_fixture, "linked-field-log.graphql", "required_directive/fixtures/linked-field-log.expected", input, expected);
+    test_fixture(transform_fixture, "linked-field-log.graphql", "required_directive/fixtures/linked-field-log.expected", input, expected).await;
 }
 
-#[test]
-fn linked_field_no_log() {
+#[tokio::test]
+async fn linked_field_no_log() {
     let input = include_str!("required_directive/fixtures/linked-field-no-log.graphql");
     let expected = include_str!("required_directive/fixtures/linked-field-no-log.expected");
-    test_fixture(transform_fixture, "linked-field-no-log.graphql", "required_directive/fixtures/linked-field-no-log.expected", input, expected);
+    test_fixture(transform_fixture, "linked-field-no-log.graphql", "required_directive/fixtures/linked-field-no-log.expected", input, expected).await;
 }
 
-#[test]
-fn linked_field_throw() {
+#[tokio::test]
+async fn linked_field_throw() {
     let input = include_str!("required_directive/fixtures/linked-field-throw.graphql");
     let expected = include_str!("required_directive/fixtures/linked-field-throw.expected");
-    test_fixture(transform_fixture, "linked-field-throw.graphql", "required_directive/fixtures/linked-field-throw.expected", input, expected);
+    test_fixture(transform_fixture, "linked-field-throw.graphql", "required_directive/fixtures/linked-field-throw.expected", input, expected).await;
 }
 
-#[test]
-fn log_action_bubble_to_throw_invalid() {
+#[tokio::test]
+async fn log_action_bubble_to_throw_invalid() {
     let input = include_str!("required_directive/fixtures/log-action-bubble-to-throw.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/log-action-bubble-to-throw.invalid.expected");
-    test_fixture(transform_fixture, "log-action-bubble-to-throw.invalid.graphql", "required_directive/fixtures/log-action-bubble-to-throw.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "log-action-bubble-to-throw.invalid.graphql", "required_directive/fixtures/log-action-bubble-to-throw.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn multiple_required_fields_invalid() {
+#[tokio::test]
+async fn multiple_required_fields_invalid() {
     let input = include_str!("required_directive/fixtures/multiple-required-fields.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/multiple-required-fields.invalid.expected");
-    test_fixture(transform_fixture, "multiple-required-fields.invalid.graphql", "required_directive/fixtures/multiple-required-fields.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-required-fields.invalid.graphql", "required_directive/fixtures/multiple-required-fields.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn none_action_bubble_to_log_across_inline_fragment_invalid() {
+#[tokio::test]
+async fn none_action_bubble_to_log_across_inline_fragment_invalid() {
     let input = include_str!("required_directive/fixtures/none-action-bubble-to-log-across-inline-fragment.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/none-action-bubble-to-log-across-inline-fragment.invalid.expected");
-    test_fixture(transform_fixture, "none-action-bubble-to-log-across-inline-fragment.invalid.graphql", "required_directive/fixtures/none-action-bubble-to-log-across-inline-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "none-action-bubble-to-log-across-inline-fragment.invalid.graphql", "required_directive/fixtures/none-action-bubble-to-log-across-inline-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn none_action_bubble_to_log_invalid() {
+#[tokio::test]
+async fn none_action_bubble_to_log_invalid() {
     let input = include_str!("required_directive/fixtures/none-action-bubble-to-log.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/none-action-bubble-to-log.invalid.expected");
-    test_fixture(transform_fixture, "none-action-bubble-to-log.invalid.graphql", "required_directive/fixtures/none-action-bubble-to-log.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "none-action-bubble-to-log.invalid.graphql", "required_directive/fixtures/none-action-bubble-to-log.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn none_action_bubble_to_throw_invalid() {
+#[tokio::test]
+async fn none_action_bubble_to_throw_invalid() {
     let input = include_str!("required_directive/fixtures/none-action-bubble-to-throw.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/none-action-bubble-to-throw.invalid.expected");
-    test_fixture(transform_fixture, "none-action-bubble-to-throw.invalid.graphql", "required_directive/fixtures/none-action-bubble-to-throw.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "none-action-bubble-to-throw.invalid.graphql", "required_directive/fixtures/none-action-bubble-to-throw.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn required_paths() {
+#[tokio::test]
+async fn required_paths() {
     let input = include_str!("required_directive/fixtures/required-paths.graphql");
     let expected = include_str!("required_directive/fixtures/required-paths.expected");
-    test_fixture(transform_fixture, "required-paths.graphql", "required_directive/fixtures/required-paths.expected", input, expected);
+    test_fixture(transform_fixture, "required-paths.graphql", "required_directive/fixtures/required-paths.expected", input, expected).await;
 }
 
-#[test]
-fn required_with_different_actions_invalid() {
+#[tokio::test]
+async fn required_with_different_actions_invalid() {
     let input = include_str!("required_directive/fixtures/required-with-different-actions.invalid.graphql");
     let expected = include_str!("required_directive/fixtures/required-with-different-actions.invalid.expected");
-    test_fixture(transform_fixture, "required-with-different-actions.invalid.graphql", "required_directive/fixtures/required-with-different-actions.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "required-with-different-actions.invalid.graphql", "required_directive/fixtures/required-with-different-actions.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_field_log() {
+#[tokio::test]
+async fn scalar_field_log() {
     let input = include_str!("required_directive/fixtures/scalar-field-log.graphql");
     let expected = include_str!("required_directive/fixtures/scalar-field-log.expected");
-    test_fixture(transform_fixture, "scalar-field-log.graphql", "required_directive/fixtures/scalar-field-log.expected", input, expected);
+    test_fixture(transform_fixture, "scalar-field-log.graphql", "required_directive/fixtures/scalar-field-log.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_field_no_log() {
+#[tokio::test]
+async fn scalar_field_no_log() {
     let input = include_str!("required_directive/fixtures/scalar-field-no-log.graphql");
     let expected = include_str!("required_directive/fixtures/scalar-field-no-log.expected");
-    test_fixture(transform_fixture, "scalar-field-no-log.graphql", "required_directive/fixtures/scalar-field-no-log.expected", input, expected);
+    test_fixture(transform_fixture, "scalar-field-no-log.graphql", "required_directive/fixtures/scalar-field-no-log.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_field_throw() {
+#[tokio::test]
+async fn scalar_field_throw() {
     let input = include_str!("required_directive/fixtures/scalar-field-throw.graphql");
     let expected = include_str!("required_directive/fixtures/scalar-field-throw.expected");
-    test_fixture(transform_fixture, "scalar-field-throw.graphql", "required_directive/fixtures/scalar-field-throw.expected", input, expected);
+    test_fixture(transform_fixture, "scalar-field-throw.graphql", "required_directive/fixtures/scalar-field-throw.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/skip_client_extensions/mod.rs
+++ b/compiler/crates/relay-transforms/tests/skip_client_extensions/mod.rs
@@ -18,7 +18,7 @@ use graphql_text_printer::PrinterOptions;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::skip_client_extensions;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     if let [base, extensions] = parts.as_slice() {
         let source_location = SourceLocationKey::standalone(fixture.file_name);

--- a/compiler/crates/relay-transforms/tests/skip_client_extensions_test.rs
+++ b/compiler/crates/relay-transforms/tests/skip_client_extensions_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<63a5e6c07739f57b58aebaf6414d3d8f>>
+ * @generated SignedSource<<e9cd88a52254146722f6183799c1cc92>>
  */
 
 mod skip_client_extensions;
@@ -12,100 +12,100 @@ mod skip_client_extensions;
 use skip_client_extensions::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn client_conditions() {
+#[tokio::test]
+async fn client_conditions() {
     let input = include_str!("skip_client_extensions/fixtures/client-conditions.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-conditions.expected");
-    test_fixture(transform_fixture, "client-conditions.graphql", "skip_client_extensions/fixtures/client-conditions.expected", input, expected);
+    test_fixture(transform_fixture, "client-conditions.graphql", "skip_client_extensions/fixtures/client-conditions.expected", input, expected).await;
 }
 
-#[test]
-fn client_directives() {
+#[tokio::test]
+async fn client_directives() {
     let input = include_str!("skip_client_extensions/fixtures/client-directives.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-directives.expected");
-    test_fixture(transform_fixture, "client-directives.graphql", "skip_client_extensions/fixtures/client-directives.expected", input, expected);
+    test_fixture(transform_fixture, "client-directives.graphql", "skip_client_extensions/fixtures/client-directives.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_in_inline_fragments() {
+#[tokio::test]
+async fn client_fields_in_inline_fragments() {
     let input = include_str!("skip_client_extensions/fixtures/client-fields-in-inline-fragments.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-fields-in-inline-fragments.expected");
-    test_fixture(transform_fixture, "client-fields-in-inline-fragments.graphql", "skip_client_extensions/fixtures/client-fields-in-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-in-inline-fragments.graphql", "skip_client_extensions/fixtures/client-fields-in-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_of_client_type() {
+#[tokio::test]
+async fn client_fields_of_client_type() {
     let input = include_str!("skip_client_extensions/fixtures/client-fields-of-client-type.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-fields-of-client-type.expected");
-    test_fixture(transform_fixture, "client-fields-of-client-type.graphql", "skip_client_extensions/fixtures/client-fields-of-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-of-client-type.graphql", "skip_client_extensions/fixtures/client-fields-of-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn client_fields_on_roots() {
+#[tokio::test]
+async fn client_fields_on_roots() {
     let input = include_str!("skip_client_extensions/fixtures/client-fields-on-roots.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-fields-on-roots.expected");
-    test_fixture(transform_fixture, "client-fields-on-roots.graphql", "skip_client_extensions/fixtures/client-fields-on-roots.expected", input, expected);
+    test_fixture(transform_fixture, "client-fields-on-roots.graphql", "skip_client_extensions/fixtures/client-fields-on-roots.expected", input, expected).await;
 }
 
-#[test]
-fn client_fragment_spreads() {
+#[tokio::test]
+async fn client_fragment_spreads() {
     let input = include_str!("skip_client_extensions/fixtures/client-fragment-spreads.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-fragment-spreads.expected");
-    test_fixture(transform_fixture, "client-fragment-spreads.graphql", "skip_client_extensions/fixtures/client-fragment-spreads.expected", input, expected);
+    test_fixture(transform_fixture, "client-fragment-spreads.graphql", "skip_client_extensions/fixtures/client-fragment-spreads.expected", input, expected).await;
 }
 
-#[test]
-fn client_fragment_spreads_in_query() {
+#[tokio::test]
+async fn client_fragment_spreads_in_query() {
     let input = include_str!("skip_client_extensions/fixtures/client-fragment-spreads-in-query.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-fragment-spreads-in-query.expected");
-    test_fixture(transform_fixture, "client-fragment-spreads-in-query.graphql", "skip_client_extensions/fixtures/client-fragment-spreads-in-query.expected", input, expected);
+    test_fixture(transform_fixture, "client-fragment-spreads-in-query.graphql", "skip_client_extensions/fixtures/client-fragment-spreads-in-query.expected", input, expected).await;
 }
 
-#[test]
-fn client_inline_fragments() {
+#[tokio::test]
+async fn client_inline_fragments() {
     let input = include_str!("skip_client_extensions/fixtures/client-inline-fragments.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-inline-fragments.expected");
-    test_fixture(transform_fixture, "client-inline-fragments.graphql", "skip_client_extensions/fixtures/client-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "client-inline-fragments.graphql", "skip_client_extensions/fixtures/client-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn client_inline_fragments_in_query() {
+#[tokio::test]
+async fn client_inline_fragments_in_query() {
     let input = include_str!("skip_client_extensions/fixtures/client-inline-fragments-in-query.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-inline-fragments-in-query.expected");
-    test_fixture(transform_fixture, "client-inline-fragments-in-query.graphql", "skip_client_extensions/fixtures/client-inline-fragments-in-query.expected", input, expected);
+    test_fixture(transform_fixture, "client-inline-fragments-in-query.graphql", "skip_client_extensions/fixtures/client-inline-fragments-in-query.expected", input, expected).await;
 }
 
-#[test]
-fn client_linked_fields() {
+#[tokio::test]
+async fn client_linked_fields() {
     let input = include_str!("skip_client_extensions/fixtures/client-linked-fields.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-linked-fields.expected");
-    test_fixture(transform_fixture, "client-linked-fields.graphql", "skip_client_extensions/fixtures/client-linked-fields.expected", input, expected);
+    test_fixture(transform_fixture, "client-linked-fields.graphql", "skip_client_extensions/fixtures/client-linked-fields.expected", input, expected).await;
 }
 
-#[test]
-fn client_scalar_fields() {
+#[tokio::test]
+async fn client_scalar_fields() {
     let input = include_str!("skip_client_extensions/fixtures/client-scalar-fields.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/client-scalar-fields.expected");
-    test_fixture(transform_fixture, "client-scalar-fields.graphql", "skip_client_extensions/fixtures/client-scalar-fields.expected", input, expected);
+    test_fixture(transform_fixture, "client-scalar-fields.graphql", "skip_client_extensions/fixtures/client-scalar-fields.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_only_client_fields() {
+#[tokio::test]
+async fn query_with_only_client_fields() {
     let input = include_str!("skip_client_extensions/fixtures/query-with-only-client-fields.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/query-with-only-client-fields.expected");
-    test_fixture(transform_fixture, "query-with-only-client-fields.graphql", "skip_client_extensions/fixtures/query-with-only-client-fields.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-only-client-fields.graphql", "skip_client_extensions/fixtures/query-with-only-client-fields.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_metadata() {
+#[tokio::test]
+async fn relay_resolver_metadata() {
     let input = include_str!("skip_client_extensions/fixtures/relay-resolver-metadata.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/relay-resolver-metadata.expected");
-    test_fixture(transform_fixture, "relay-resolver-metadata.graphql", "skip_client_extensions/fixtures/relay-resolver-metadata.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-metadata.graphql", "skip_client_extensions/fixtures/relay-resolver-metadata.expected", input, expected).await;
 }
 
-#[test]
-fn sibling_client_selections() {
+#[tokio::test]
+async fn sibling_client_selections() {
     let input = include_str!("skip_client_extensions/fixtures/sibling-client-selections.graphql");
     let expected = include_str!("skip_client_extensions/fixtures/sibling-client-selections.expected");
-    test_fixture(transform_fixture, "sibling-client-selections.graphql", "skip_client_extensions/fixtures/sibling-client-selections.expected", input, expected);
+    test_fixture(transform_fixture, "sibling-client-selections.graphql", "skip_client_extensions/fixtures/sibling-client-selections.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/skip_redundant_nodes/mod.rs
+++ b/compiler/crates/relay-transforms/tests/skip_redundant_nodes/mod.rs
@@ -19,7 +19,7 @@ use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::inline_fragments;
 use relay_transforms::skip_redundant_nodes;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
     let printer_options = PrinterOptions {

--- a/compiler/crates/relay-transforms/tests/skip_redundant_nodes_test.rs
+++ b/compiler/crates/relay-transforms/tests/skip_redundant_nodes_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<550822f58e01f87929cf6bd8be28dc4a>>
+ * @generated SignedSource<<69ef2cb0bf7f2575d37b8e6a75cc3fd8>>
  */
 
 mod skip_redundant_nodes;
@@ -12,79 +12,79 @@ mod skip_redundant_nodes;
 use skip_redundant_nodes::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn dont_skip_different_ids() {
+#[tokio::test]
+async fn dont_skip_different_ids() {
     let input = include_str!("skip_redundant_nodes/fixtures/dont-skip-different-ids.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/dont-skip-different-ids.expected");
-    test_fixture(transform_fixture, "dont-skip-different-ids.graphql", "skip_redundant_nodes/fixtures/dont-skip-different-ids.expected", input, expected);
+    test_fixture(transform_fixture, "dont-skip-different-ids.graphql", "skip_redundant_nodes/fixtures/dont-skip-different-ids.expected", input, expected).await;
 }
 
-#[test]
-fn dont_skip_nested_fields_across_fragments() {
+#[tokio::test]
+async fn dont_skip_nested_fields_across_fragments() {
     let input = include_str!("skip_redundant_nodes/fixtures/dont-skip-nested-fields-across-fragments.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/dont-skip-nested-fields-across-fragments.expected");
-    test_fixture(transform_fixture, "dont-skip-nested-fields-across-fragments.graphql", "skip_redundant_nodes/fixtures/dont-skip-nested-fields-across-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "dont-skip-nested-fields-across-fragments.graphql", "skip_redundant_nodes/fixtures/dont-skip-nested-fields-across-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn dont_skip_with_inline_on_diffent_types() {
+#[tokio::test]
+async fn dont_skip_with_inline_on_diffent_types() {
     let input = include_str!("skip_redundant_nodes/fixtures/dont-skip-with-inline-on-diffent-types.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/dont-skip-with-inline-on-diffent-types.expected");
-    test_fixture(transform_fixture, "dont-skip-with-inline-on-diffent-types.graphql", "skip_redundant_nodes/fixtures/dont-skip-with-inline-on-diffent-types.expected", input, expected);
+    test_fixture(transform_fixture, "dont-skip-with-inline-on-diffent-types.graphql", "skip_redundant_nodes/fixtures/dont-skip-with-inline-on-diffent-types.expected", input, expected).await;
 }
 
-#[test]
-fn redundant_selection_in_inline_fragments() {
+#[tokio::test]
+async fn redundant_selection_in_inline_fragments() {
     let input = include_str!("skip_redundant_nodes/fixtures/redundant-selection-in-inline-fragments.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/redundant-selection-in-inline-fragments.expected");
-    test_fixture(transform_fixture, "redundant-selection-in-inline-fragments.graphql", "skip_redundant_nodes/fixtures/redundant-selection-in-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "redundant-selection-in-inline-fragments.graphql", "skip_redundant_nodes/fixtures/redundant-selection-in-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn skip_nested_linked_fields() {
+#[tokio::test]
+async fn skip_nested_linked_fields() {
     let input = include_str!("skip_redundant_nodes/fixtures/skip-nested-linked-fields.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/skip-nested-linked-fields.expected");
-    test_fixture(transform_fixture, "skip-nested-linked-fields.graphql", "skip_redundant_nodes/fixtures/skip-nested-linked-fields.expected", input, expected);
+    test_fixture(transform_fixture, "skip-nested-linked-fields.graphql", "skip_redundant_nodes/fixtures/skip-nested-linked-fields.expected", input, expected).await;
 }
 
-#[test]
-fn skips_nested_fields() {
+#[tokio::test]
+async fn skips_nested_fields() {
     let input = include_str!("skip_redundant_nodes/fixtures/skips-nested-fields.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/skips-nested-fields.expected");
-    test_fixture(transform_fixture, "skips-nested-fields.graphql", "skip_redundant_nodes/fixtures/skips-nested-fields.expected", input, expected);
+    test_fixture(transform_fixture, "skips-nested-fields.graphql", "skip_redundant_nodes/fixtures/skips-nested-fields.expected", input, expected).await;
 }
 
-#[test]
-fn skips_with_client_extensions() {
+#[tokio::test]
+async fn skips_with_client_extensions() {
     let input = include_str!("skip_redundant_nodes/fixtures/skips-with-client-extensions.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/skips-with-client-extensions.expected");
-    test_fixture(transform_fixture, "skips-with-client-extensions.graphql", "skip_redundant_nodes/fixtures/skips-with-client-extensions.expected", input, expected);
+    test_fixture(transform_fixture, "skips-with-client-extensions.graphql", "skip_redundant_nodes/fixtures/skips-with-client-extensions.expected", input, expected).await;
 }
 
-#[test]
-fn skips_with_fragment() {
+#[tokio::test]
+async fn skips_with_fragment() {
     let input = include_str!("skip_redundant_nodes/fixtures/skips-with-fragment.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/skips-with-fragment.expected");
-    test_fixture(transform_fixture, "skips-with-fragment.graphql", "skip_redundant_nodes/fixtures/skips-with-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "skips-with-fragment.graphql", "skip_redundant_nodes/fixtures/skips-with-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn skips_with_module() {
+#[tokio::test]
+async fn skips_with_module() {
     let input = include_str!("skip_redundant_nodes/fixtures/skips-with-module.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/skips-with-module.expected");
-    test_fixture(transform_fixture, "skips-with-module.graphql", "skip_redundant_nodes/fixtures/skips-with-module.expected", input, expected);
+    test_fixture(transform_fixture, "skips-with-module.graphql", "skip_redundant_nodes/fixtures/skips-with-module.expected", input, expected).await;
 }
 
-#[test]
-fn skips_with_outer_fields_first() {
+#[tokio::test]
+async fn skips_with_outer_fields_first() {
     let input = include_str!("skip_redundant_nodes/fixtures/skips-with-outer-fields-first.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/skips-with-outer-fields-first.expected");
-    test_fixture(transform_fixture, "skips-with-outer-fields-first.graphql", "skip_redundant_nodes/fixtures/skips-with-outer-fields-first.expected", input, expected);
+    test_fixture(transform_fixture, "skips-with-outer-fields-first.graphql", "skip_redundant_nodes/fixtures/skips-with-outer-fields-first.expected", input, expected).await;
 }
 
-#[test]
-fn skips_with_outer_fields_last() {
+#[tokio::test]
+async fn skips_with_outer_fields_last() {
     let input = include_str!("skip_redundant_nodes/fixtures/skips-with-outer-fields-last.graphql");
     let expected = include_str!("skip_redundant_nodes/fixtures/skips-with-outer-fields-last.expected");
-    test_fixture(transform_fixture, "skips-with-outer-fields-last.graphql", "skip_redundant_nodes/fixtures/skips-with-outer-fields-last.expected", input, expected);
+    test_fixture(transform_fixture, "skips-with-outer-fields-last.graphql", "skip_redundant_nodes/fixtures/skips-with-outer-fields-last.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/mod.rs
+++ b/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/mod.rs
@@ -9,6 +9,6 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::skip_unreachable_node_strict;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, skip_unreachable_node_strict)
 }

--- a/compiler/crates/relay-transforms/tests/skip_unreachable_nodes_test.rs
+++ b/compiler/crates/relay-transforms/tests/skip_unreachable_nodes_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<92728b5919d760a08def5a55c9b9e71e>>
+ * @generated SignedSource<<90e95fbfbf9affaf1264bd92956f97cc>>
  */
 
 mod skip_unreachable_nodes;
@@ -12,37 +12,37 @@ mod skip_unreachable_nodes;
 use skip_unreachable_nodes::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn keeps_other_fields() {
+#[tokio::test]
+async fn keeps_other_fields() {
     let input = include_str!("skip_unreachable_nodes/fixtures/keeps-other-fields.graphql");
     let expected = include_str!("skip_unreachable_nodes/fixtures/keeps-other-fields.expected");
-    test_fixture(transform_fixture, "keeps-other-fields.graphql", "skip_unreachable_nodes/fixtures/keeps-other-fields.expected", input, expected);
+    test_fixture(transform_fixture, "keeps-other-fields.graphql", "skip_unreachable_nodes/fixtures/keeps-other-fields.expected", input, expected).await;
 }
 
-#[test]
-fn removes_include_false() {
+#[tokio::test]
+async fn removes_include_false() {
     let input = include_str!("skip_unreachable_nodes/fixtures/removes-include-false.graphql");
     let expected = include_str!("skip_unreachable_nodes/fixtures/removes-include-false.expected");
-    test_fixture(transform_fixture, "removes-include-false.graphql", "skip_unreachable_nodes/fixtures/removes-include-false.expected", input, expected);
+    test_fixture(transform_fixture, "removes-include-false.graphql", "skip_unreachable_nodes/fixtures/removes-include-false.expected", input, expected).await;
 }
 
-#[test]
-fn removes_recursively_empty_definitions() {
+#[tokio::test]
+async fn removes_recursively_empty_definitions() {
     let input = include_str!("skip_unreachable_nodes/fixtures/removes-recursively-empty-definitions.graphql");
     let expected = include_str!("skip_unreachable_nodes/fixtures/removes-recursively-empty-definitions.expected");
-    test_fixture(transform_fixture, "removes-recursively-empty-definitions.graphql", "skip_unreachable_nodes/fixtures/removes-recursively-empty-definitions.expected", input, expected);
+    test_fixture(transform_fixture, "removes-recursively-empty-definitions.graphql", "skip_unreachable_nodes/fixtures/removes-recursively-empty-definitions.expected", input, expected).await;
 }
 
-#[test]
-fn removes_skip_true() {
+#[tokio::test]
+async fn removes_skip_true() {
     let input = include_str!("skip_unreachable_nodes/fixtures/removes-skip-true.graphql");
     let expected = include_str!("skip_unreachable_nodes/fixtures/removes-skip-true.expected");
-    test_fixture(transform_fixture, "removes-skip-true.graphql", "skip_unreachable_nodes/fixtures/removes-skip-true.expected", input, expected);
+    test_fixture(transform_fixture, "removes-skip-true.graphql", "skip_unreachable_nodes/fixtures/removes-skip-true.expected", input, expected).await;
 }
 
-#[test]
-fn skipped_fragment() {
+#[tokio::test]
+async fn skipped_fragment() {
     let input = include_str!("skip_unreachable_nodes/fixtures/skipped-fragment.graphql");
     let expected = include_str!("skip_unreachable_nodes/fixtures/skipped-fragment.expected");
-    test_fixture(transform_fixture, "skipped-fragment.graphql", "skip_unreachable_nodes/fixtures/skipped-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "skipped-fragment.graphql", "skip_unreachable_nodes/fixtures/skipped-fragment.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/skip_unused_variables/mod.rs
+++ b/compiler/crates/relay-transforms/tests/skip_unused_variables/mod.rs
@@ -9,6 +9,6 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::validate_operation_variables;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| validate_operation_variables(program))
 }

--- a/compiler/crates/relay-transforms/tests/skip_unused_variables_test.rs
+++ b/compiler/crates/relay-transforms/tests/skip_unused_variables_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d037736d5049654d3573e54611d9e683>>
+ * @generated SignedSource<<dd7b567ef5f8af55d54a0d29093c75e4>>
  */
 
 mod skip_unused_variables;
@@ -12,16 +12,16 @@ mod skip_unused_variables;
 use skip_unused_variables::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("skip_unused_variables/fixtures/kitchen-sink.graphql");
     let expected = include_str!("skip_unused_variables/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "skip_unused_variables/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "skip_unused_variables/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn non_nullable_variable_with_default_invalid() {
+#[tokio::test]
+async fn non_nullable_variable_with_default_invalid() {
     let input = include_str!("skip_unused_variables/fixtures/non-nullable-variable-with-default.invalid.graphql");
     let expected = include_str!("skip_unused_variables/fixtures/non-nullable-variable-with-default.invalid.expected");
-    test_fixture(transform_fixture, "non-nullable-variable-with-default.invalid.graphql", "skip_unused_variables/fixtures/non-nullable-variable-with-default.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "non-nullable-variable-with-default.invalid.graphql", "skip_unused_variables/fixtures/non-nullable-variable-with-default.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/sort_selections/mod.rs
+++ b/compiler/crates/relay-transforms/tests/sort_selections/mod.rs
@@ -9,7 +9,7 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::sort_selections;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         let next_program = sort_selections(program);
         assert_eq!(

--- a/compiler/crates/relay-transforms/tests/sort_selections_test.rs
+++ b/compiler/crates/relay-transforms/tests/sort_selections_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d5c1c2d3a31832a10a654919a68a7df3>>
+ * @generated SignedSource<<4756f3936d79676febd7bddece3bdf35>>
  */
 
 mod sort_selections;
@@ -12,9 +12,9 @@ mod sort_selections;
 use sort_selections::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn sort_selections_transform() {
+#[tokio::test]
+async fn sort_selections_transform() {
     let input = include_str!("sort_selections/fixtures/sort-selections-transform.graphql");
     let expected = include_str!("sort_selections/fixtures/sort-selections-transform.expected");
-    test_fixture(transform_fixture, "sort-selections-transform.graphql", "sort_selections/fixtures/sort-selections-transform.expected", input, expected);
+    test_fixture(transform_fixture, "sort-selections-transform.graphql", "sort_selections/fixtures/sort-selections-transform.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/subscription_transform/mod.rs
+++ b/compiler/crates/relay-transforms/tests/subscription_transform/mod.rs
@@ -9,6 +9,6 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::transform_subscriptions;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| transform_subscriptions(program))
 }

--- a/compiler/crates/relay-transforms/tests/subscription_transform_test.rs
+++ b/compiler/crates/relay-transforms/tests/subscription_transform_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bcf2937e99ed9db01839f955383dbbcd>>
+ * @generated SignedSource<<53a7cd72714d74790d44c1229cfcef49>>
  */
 
 mod subscription_transform;
@@ -12,30 +12,30 @@ mod subscription_transform;
 use subscription_transform::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn subscription_transform() {
+#[tokio::test]
+async fn subscription_transform() {
     let input = include_str!("subscription_transform/fixtures/subscription_transform.graphql");
     let expected = include_str!("subscription_transform/fixtures/subscription_transform.expected");
-    test_fixture(transform_fixture, "subscription_transform.graphql", "subscription_transform/fixtures/subscription_transform.expected", input, expected);
+    test_fixture(transform_fixture, "subscription_transform.graphql", "subscription_transform/fixtures/subscription_transform.expected", input, expected).await;
 }
 
-#[test]
-fn subscription_transform_noop_no_js_field() {
+#[tokio::test]
+async fn subscription_transform_noop_no_js_field() {
     let input = include_str!("subscription_transform/fixtures/subscription_transform_noop_no_js_field.graphql");
     let expected = include_str!("subscription_transform/fixtures/subscription_transform_noop_no_js_field.expected");
-    test_fixture(transform_fixture, "subscription_transform_noop_no_js_field.graphql", "subscription_transform/fixtures/subscription_transform_noop_no_js_field.expected", input, expected);
+    test_fixture(transform_fixture, "subscription_transform_noop_no_js_field.graphql", "subscription_transform/fixtures/subscription_transform_noop_no_js_field.expected", input, expected).await;
 }
 
-#[test]
-fn subscription_transform_noop_no_spread() {
+#[tokio::test]
+async fn subscription_transform_noop_no_spread() {
     let input = include_str!("subscription_transform/fixtures/subscription_transform_noop_no_spread.graphql");
     let expected = include_str!("subscription_transform/fixtures/subscription_transform_noop_no_spread.expected");
-    test_fixture(transform_fixture, "subscription_transform_noop_no_spread.graphql", "subscription_transform/fixtures/subscription_transform_noop_no_spread.expected", input, expected);
+    test_fixture(transform_fixture, "subscription_transform_noop_no_spread.graphql", "subscription_transform/fixtures/subscription_transform_noop_no_spread.expected", input, expected).await;
 }
 
-#[test]
-fn subscription_transform_noop_two_selections() {
+#[tokio::test]
+async fn subscription_transform_noop_two_selections() {
     let input = include_str!("subscription_transform/fixtures/subscription_transform_noop_two_selections.graphql");
     let expected = include_str!("subscription_transform/fixtures/subscription_transform_noop_two_selections.expected");
-    test_fixture(transform_fixture, "subscription_transform_noop_two_selections.graphql", "subscription_transform/fixtures/subscription_transform_noop_two_selections.expected", input, expected);
+    test_fixture(transform_fixture, "subscription_transform_noop_two_selections.graphql", "subscription_transform/fixtures/subscription_transform_noop_two_selections.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/transform_connections/mod.rs
+++ b/compiler/crates/relay-transforms/tests/transform_connections/mod.rs
@@ -21,7 +21,7 @@ use relay_transforms::transform_connections;
 use relay_transforms::validate_connections;
 use relay_transforms::ConnectionInterface;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let schema = get_test_schema();

--- a/compiler/crates/relay-transforms/tests/transform_connections_test.rs
+++ b/compiler/crates/relay-transforms/tests/transform_connections_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5eb995d94b94b43b9433675f2d83cc6f>>
+ * @generated SignedSource<<6d091c495f5ba46d7c3ad183e480ebf3>>
  */
 
 mod transform_connections;
@@ -12,79 +12,79 @@ mod transform_connections;
 use transform_connections::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn connection() {
+#[tokio::test]
+async fn connection() {
     let input = include_str!("transform_connections/fixtures/connection.graphql");
     let expected = include_str!("transform_connections/fixtures/connection.expected");
-    test_fixture(transform_fixture, "connection.graphql", "transform_connections/fixtures/connection.expected", input, expected);
+    test_fixture(transform_fixture, "connection.graphql", "transform_connections/fixtures/connection.expected", input, expected).await;
 }
 
-#[test]
-fn connection_directions() {
+#[tokio::test]
+async fn connection_directions() {
     let input = include_str!("transform_connections/fixtures/connection-directions.graphql");
     let expected = include_str!("transform_connections/fixtures/connection-directions.expected");
-    test_fixture(transform_fixture, "connection-directions.graphql", "transform_connections/fixtures/connection-directions.expected", input, expected);
+    test_fixture(transform_fixture, "connection-directions.graphql", "transform_connections/fixtures/connection-directions.expected", input, expected).await;
 }
 
-#[test]
-fn connection_empty_filters() {
+#[tokio::test]
+async fn connection_empty_filters() {
     let input = include_str!("transform_connections/fixtures/connection-empty-filters.graphql");
     let expected = include_str!("transform_connections/fixtures/connection-empty-filters.expected");
-    test_fixture(transform_fixture, "connection-empty-filters.graphql", "transform_connections/fixtures/connection-empty-filters.expected", input, expected);
+    test_fixture(transform_fixture, "connection-empty-filters.graphql", "transform_connections/fixtures/connection-empty-filters.expected", input, expected).await;
 }
 
-#[test]
-fn connection_filters() {
+#[tokio::test]
+async fn connection_filters() {
     let input = include_str!("transform_connections/fixtures/connection-filters.graphql");
     let expected = include_str!("transform_connections/fixtures/connection-filters.expected");
-    test_fixture(transform_fixture, "connection-filters.graphql", "transform_connections/fixtures/connection-filters.expected", input, expected);
+    test_fixture(transform_fixture, "connection-filters.graphql", "transform_connections/fixtures/connection-filters.expected", input, expected).await;
 }
 
-#[test]
-fn connection_generate_filters() {
+#[tokio::test]
+async fn connection_generate_filters() {
     let input = include_str!("transform_connections/fixtures/connection-generate-filters.graphql");
     let expected = include_str!("transform_connections/fixtures/connection-generate-filters.expected");
-    test_fixture(transform_fixture, "connection-generate-filters.graphql", "transform_connections/fixtures/connection-generate-filters.expected", input, expected);
+    test_fixture(transform_fixture, "connection-generate-filters.graphql", "transform_connections/fixtures/connection-generate-filters.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_aliased_edges_page_info() {
+#[tokio::test]
+async fn connection_with_aliased_edges_page_info() {
     let input = include_str!("transform_connections/fixtures/connection-with-aliased-edges-page-info.graphql");
     let expected = include_str!("transform_connections/fixtures/connection-with-aliased-edges-page-info.expected");
-    test_fixture(transform_fixture, "connection-with-aliased-edges-page-info.graphql", "transform_connections/fixtures/connection-with-aliased-edges-page-info.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-aliased-edges-page-info.graphql", "transform_connections/fixtures/connection-with-aliased-edges-page-info.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_custom_handler() {
+#[tokio::test]
+async fn connection_with_custom_handler() {
     let input = include_str!("transform_connections/fixtures/connection-with-custom-handler.graphql");
     let expected = include_str!("transform_connections/fixtures/connection-with-custom-handler.expected");
-    test_fixture(transform_fixture, "connection-with-custom-handler.graphql", "transform_connections/fixtures/connection-with-custom-handler.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-custom-handler.graphql", "transform_connections/fixtures/connection-with-custom-handler.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_page_info() {
+#[tokio::test]
+async fn connection_with_page_info() {
     let input = include_str!("transform_connections/fixtures/connection-with-page-info.graphql");
     let expected = include_str!("transform_connections/fixtures/connection-with-page-info.expected");
-    test_fixture(transform_fixture, "connection-with-page-info.graphql", "transform_connections/fixtures/connection-with-page-info.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-page-info.graphql", "transform_connections/fixtures/connection-with-page-info.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_variables() {
+#[tokio::test]
+async fn connection_with_variables() {
     let input = include_str!("transform_connections/fixtures/connection-with-variables.graphql");
     let expected = include_str!("transform_connections/fixtures/connection-with-variables.expected");
-    test_fixture(transform_fixture, "connection-with-variables.graphql", "transform_connections/fixtures/connection-with-variables.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-variables.graphql", "transform_connections/fixtures/connection-with-variables.expected", input, expected).await;
 }
 
-#[test]
-fn stream_connection() {
+#[tokio::test]
+async fn stream_connection() {
     let input = include_str!("transform_connections/fixtures/stream-connection.graphql");
     let expected = include_str!("transform_connections/fixtures/stream-connection.expected");
-    test_fixture(transform_fixture, "stream-connection.graphql", "transform_connections/fixtures/stream-connection.expected", input, expected);
+    test_fixture(transform_fixture, "stream-connection.graphql", "transform_connections/fixtures/stream-connection.expected", input, expected).await;
 }
 
-#[test]
-fn stream_connection_no_label() {
+#[tokio::test]
+async fn stream_connection_no_label() {
     let input = include_str!("transform_connections/fixtures/stream-connection-no-label.graphql");
     let expected = include_str!("transform_connections/fixtures/stream-connection-no-label.expected");
-    test_fixture(transform_fixture, "stream-connection-no-label.graphql", "transform_connections/fixtures/stream-connection-no-label.expected", input, expected);
+    test_fixture(transform_fixture, "stream-connection-no-label.graphql", "transform_connections/fixtures/stream-connection-no-label.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/updatable_directive/mod.rs
+++ b/compiler/crates/relay-transforms/tests/updatable_directive/mod.rs
@@ -17,7 +17,7 @@ use relay_test_schema::get_test_schema;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::validate_updatable_directive;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let mut parts = fixture.content.split("%extensions%");

--- a/compiler/crates/relay-transforms/tests/updatable_directive_test.rs
+++ b/compiler/crates/relay-transforms/tests/updatable_directive_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<04bba5dd6952e840a3ddf09a94de7667>>
+ * @generated SignedSource<<1c81d2bd88c756192dce47251ee4bc3a>>
  */
 
 mod updatable_directive;
@@ -12,156 +12,156 @@ mod updatable_directive;
 use updatable_directive::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn assignable_fragment_spread_not_subtype_invalid() {
+#[tokio::test]
+async fn assignable_fragment_spread_not_subtype_invalid() {
     let input = include_str!("updatable_directive/fixtures/assignable-fragment-spread-not-subtype.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/assignable-fragment-spread-not-subtype.invalid.expected");
-    test_fixture(transform_fixture, "assignable-fragment-spread-not-subtype.invalid.graphql", "updatable_directive/fixtures/assignable-fragment-spread-not-subtype.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-spread-not-subtype.invalid.graphql", "updatable_directive/fixtures/assignable-fragment-spread-not-subtype.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn assignable_fragment_spreads() {
+#[tokio::test]
+async fn assignable_fragment_spreads() {
     let input = include_str!("updatable_directive/fixtures/assignable-fragment-spreads.graphql");
     let expected = include_str!("updatable_directive/fixtures/assignable-fragment-spreads.expected");
-    test_fixture(transform_fixture, "assignable-fragment-spreads.graphql", "updatable_directive/fixtures/assignable-fragment-spreads.expected", input, expected);
+    test_fixture(transform_fixture, "assignable-fragment-spreads.graphql", "updatable_directive/fixtures/assignable-fragment-spreads.expected", input, expected).await;
 }
 
-#[test]
-fn client_side_updatable() {
+#[tokio::test]
+async fn client_side_updatable() {
     let input = include_str!("updatable_directive/fixtures/client-side-updatable.graphql");
     let expected = include_str!("updatable_directive/fixtures/client-side-updatable.expected");
-    test_fixture(transform_fixture, "client-side-updatable.graphql", "updatable_directive/fixtures/client-side-updatable.expected", input, expected);
+    test_fixture(transform_fixture, "client-side-updatable.graphql", "updatable_directive/fixtures/client-side-updatable.expected", input, expected).await;
 }
 
-#[test]
-fn directive_fragment_spread_invalid() {
+#[tokio::test]
+async fn directive_fragment_spread_invalid() {
     let input = include_str!("updatable_directive/fixtures/directive-fragment-spread.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/directive-fragment-spread.invalid.expected");
-    test_fixture(transform_fixture, "directive-fragment-spread.invalid.graphql", "updatable_directive/fixtures/directive-fragment-spread.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive-fragment-spread.invalid.graphql", "updatable_directive/fixtures/directive-fragment-spread.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_inline_fragment_invalid() {
+#[tokio::test]
+async fn directive_inline_fragment_invalid() {
     let input = include_str!("updatable_directive/fixtures/directive-inline-fragment.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/directive-inline-fragment.invalid.expected");
-    test_fixture(transform_fixture, "directive-inline-fragment.invalid.graphql", "updatable_directive/fixtures/directive-inline-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive-inline-fragment.invalid.graphql", "updatable_directive/fixtures/directive-inline-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_linked_field_invalid() {
+#[tokio::test]
+async fn directive_linked_field_invalid() {
     let input = include_str!("updatable_directive/fixtures/directive-linked-field.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/directive-linked-field.invalid.expected");
-    test_fixture(transform_fixture, "directive-linked-field.invalid.graphql", "updatable_directive/fixtures/directive-linked-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive-linked-field.invalid.graphql", "updatable_directive/fixtures/directive-linked-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_query_invalid() {
+#[tokio::test]
+async fn directive_query_invalid() {
     let input = include_str!("updatable_directive/fixtures/directive-query.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/directive-query.invalid.expected");
-    test_fixture(transform_fixture, "directive-query.invalid.graphql", "updatable_directive/fixtures/directive-query.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive-query.invalid.graphql", "updatable_directive/fixtures/directive-query.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn directive_scalar_field_invalid() {
+#[tokio::test]
+async fn directive_scalar_field_invalid() {
     let input = include_str!("updatable_directive/fixtures/directive-scalar-field.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/directive-scalar-field.invalid.expected");
-    test_fixture(transform_fixture, "directive-scalar-field.invalid.graphql", "updatable_directive/fixtures/directive-scalar-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "directive-scalar-field.invalid.graphql", "updatable_directive/fixtures/directive-scalar-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn doubly_nested_fragment_spread_invalid() {
+#[tokio::test]
+async fn doubly_nested_fragment_spread_invalid() {
     let input = include_str!("updatable_directive/fixtures/doubly-nested-fragment-spread.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/doubly-nested-fragment-spread.invalid.expected");
-    test_fixture(transform_fixture, "doubly-nested-fragment-spread.invalid.graphql", "updatable_directive/fixtures/doubly-nested-fragment-spread.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "doubly-nested-fragment-spread.invalid.graphql", "updatable_directive/fixtures/doubly-nested-fragment-spread.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn include_invalid() {
+#[tokio::test]
+async fn include_invalid() {
     let input = include_str!("updatable_directive/fixtures/include.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/include.invalid.expected");
-    test_fixture(transform_fixture, "include.invalid.graphql", "updatable_directive/fixtures/include.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "include.invalid.graphql", "updatable_directive/fixtures/include.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment() {
+#[tokio::test]
+async fn inline_fragment() {
     let input = include_str!("updatable_directive/fixtures/inline-fragment.graphql");
     let expected = include_str!("updatable_directive/fixtures/inline-fragment.expected");
-    test_fixture(transform_fixture, "inline-fragment.graphql", "updatable_directive/fixtures/inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment.graphql", "updatable_directive/fixtures/inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_concrete_type_to_concrete_type_invalid() {
+#[tokio::test]
+async fn inline_fragment_concrete_type_to_concrete_type_invalid() {
     let input = include_str!("updatable_directive/fixtures/inline-fragment-concrete-type-to-concrete-type.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/inline-fragment-concrete-type-to-concrete-type.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-concrete-type-to-concrete-type.invalid.graphql", "updatable_directive/fixtures/inline-fragment-concrete-type-to-concrete-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-concrete-type-to-concrete-type.invalid.graphql", "updatable_directive/fixtures/inline-fragment-concrete-type-to-concrete-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_concrete_type_to_interface_invalid() {
+#[tokio::test]
+async fn inline_fragment_concrete_type_to_interface_invalid() {
     let input = include_str!("updatable_directive/fixtures/inline-fragment-concrete-type-to-interface.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/inline-fragment-concrete-type-to-interface.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-concrete-type-to-interface.invalid.graphql", "updatable_directive/fixtures/inline-fragment-concrete-type-to-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-concrete-type-to-interface.invalid.graphql", "updatable_directive/fixtures/inline-fragment-concrete-type-to-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_interface_to_interface_invalid() {
+#[tokio::test]
+async fn inline_fragment_interface_to_interface_invalid() {
     let input = include_str!("updatable_directive/fixtures/inline-fragment-interface-to-interface.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/inline-fragment-interface-to-interface.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-interface-to-interface.invalid.graphql", "updatable_directive/fixtures/inline-fragment-interface-to-interface.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-interface-to-interface.invalid.graphql", "updatable_directive/fixtures/inline-fragment-interface-to-interface.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment_redundant_invalid() {
+#[tokio::test]
+async fn inline_fragment_redundant_invalid() {
     let input = include_str!("updatable_directive/fixtures/inline-fragment-redundant.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/inline-fragment-redundant.invalid.expected");
-    test_fixture(transform_fixture, "inline-fragment-redundant.invalid.graphql", "updatable_directive/fixtures/inline-fragment-redundant.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment-redundant.invalid.graphql", "updatable_directive/fixtures/inline-fragment-redundant.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn non_assignable_fragment_spreads_invalid() {
+#[tokio::test]
+async fn non_assignable_fragment_spreads_invalid() {
     let input = include_str!("updatable_directive/fixtures/non-assignable-fragment-spreads.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/non-assignable-fragment-spreads.invalid.expected");
-    test_fixture(transform_fixture, "non-assignable-fragment-spreads.invalid.graphql", "updatable_directive/fixtures/non-assignable-fragment-spreads.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "non-assignable-fragment-spreads.invalid.graphql", "updatable_directive/fixtures/non-assignable-fragment-spreads.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn required_invalid() {
+#[tokio::test]
+async fn required_invalid() {
     let input = include_str!("updatable_directive/fixtures/required.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/required.invalid.expected");
-    test_fixture(transform_fixture, "required.invalid.graphql", "updatable_directive/fixtures/required.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "required.invalid.graphql", "updatable_directive/fixtures/required.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn resolver_linked_invalid() {
+#[tokio::test]
+async fn resolver_linked_invalid() {
     let input = include_str!("updatable_directive/fixtures/resolver-linked.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/resolver-linked.invalid.expected");
-    test_fixture(transform_fixture, "resolver-linked.invalid.graphql", "updatable_directive/fixtures/resolver-linked.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "resolver-linked.invalid.graphql", "updatable_directive/fixtures/resolver-linked.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn resolver_scalar_invalid() {
+#[tokio::test]
+async fn resolver_scalar_invalid() {
     let input = include_str!("updatable_directive/fixtures/resolver-scalar.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/resolver-scalar.invalid.expected");
-    test_fixture(transform_fixture, "resolver-scalar.invalid.graphql", "updatable_directive/fixtures/resolver-scalar.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "resolver-scalar.invalid.graphql", "updatable_directive/fixtures/resolver-scalar.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn skip_invalid() {
+#[tokio::test]
+async fn skip_invalid() {
     let input = include_str!("updatable_directive/fixtures/skip.invalid.graphql");
     let expected = include_str!("updatable_directive/fixtures/skip.invalid.expected");
-    test_fixture(transform_fixture, "skip.invalid.graphql", "updatable_directive/fixtures/skip.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "skip.invalid.graphql", "updatable_directive/fixtures/skip.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn type_narrowing() {
+#[tokio::test]
+async fn type_narrowing() {
     let input = include_str!("updatable_directive/fixtures/type-narrowing.graphql");
     let expected = include_str!("updatable_directive/fixtures/type-narrowing.expected");
-    test_fixture(transform_fixture, "type-narrowing.graphql", "updatable_directive/fixtures/type-narrowing.expected", input, expected);
+    test_fixture(transform_fixture, "type-narrowing.graphql", "updatable_directive/fixtures/type-narrowing.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment() {
+#[tokio::test]
+async fn updatable_fragment() {
     let input = include_str!("updatable_directive/fixtures/updatable-fragment.graphql");
     let expected = include_str!("updatable_directive/fixtures/updatable-fragment.expected");
-    test_fixture(transform_fixture, "updatable-fragment.graphql", "updatable_directive/fixtures/updatable-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment.graphql", "updatable_directive/fixtures/updatable-fragment.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/updatable_fragment_spread/mod.rs
+++ b/compiler/crates/relay-transforms/tests/updatable_fragment_spread/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_updatable_fragment_spread;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/updatable_fragment_spread_test.rs
+++ b/compiler/crates/relay-transforms/tests/updatable_fragment_spread_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<18869a0e4b56456538b89f35c173d802>>
+ * @generated SignedSource<<b6f964ec44fdc53f24f80136e02d01fa>>
  */
 
 mod updatable_fragment_spread;
@@ -12,163 +12,163 @@ mod updatable_fragment_spread;
 use updatable_fragment_spread::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn updatable_fragment_spread_abstract_in_concrete() {
+#[tokio::test]
+async fn updatable_fragment_spread_abstract_in_concrete() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_concrete.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_concrete.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_abstract_in_concrete.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_concrete.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_abstract_in_concrete.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_concrete.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_abstract_in_different_non_extending_abstract_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_abstract_in_different_non_extending_abstract_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_different_non_extending_abstract.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_different_non_extending_abstract.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_abstract_in_different_non_extending_abstract.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_different_non_extending_abstract.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_abstract_in_different_non_extending_abstract.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_different_non_extending_abstract.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_abstract_in_same_abstract() {
+#[tokio::test]
+async fn updatable_fragment_spread_abstract_in_same_abstract() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_same_abstract.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_same_abstract.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_abstract_in_same_abstract.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_same_abstract.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_abstract_in_same_abstract.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_abstract_in_same_abstract.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_concrete_in_different_concrete_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_concrete_in_different_concrete_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_different_concrete.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_different_concrete.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_concrete_in_different_concrete.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_different_concrete.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_concrete_in_different_concrete.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_different_concrete.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_concrete_in_matching_abstract_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_concrete_in_matching_abstract_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_matching_abstract.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_matching_abstract.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_concrete_in_matching_abstract.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_matching_abstract.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_concrete_in_matching_abstract.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_matching_abstract.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_concrete_in_non_matching_abstract_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_concrete_in_non_matching_abstract_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_non_matching_abstract.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_non_matching_abstract.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_concrete_in_non_matching_abstract.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_non_matching_abstract.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_concrete_in_non_matching_abstract.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_non_matching_abstract.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_concrete_in_same_concrete() {
+#[tokio::test]
+async fn updatable_fragment_spread_concrete_in_same_concrete() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_same_concrete.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_same_concrete.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_concrete_in_same_concrete.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_same_concrete.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_concrete_in_same_concrete.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_concrete_in_same_concrete.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_condition_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_condition_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_condition.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_condition.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_condition.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_condition.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_abstract_type_condition_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_abstract_type_condition_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_abstract_type_condition.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_abstract_type_condition.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_abstract_type_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_abstract_type_condition.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_abstract_type_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_abstract_type_condition.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_no_typename_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_no_typename_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_no_typename.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_no_typename.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_no_typename.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_no_typename.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_no_typename.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_no_typename.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_redundant_type_condition_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_redundant_type_condition_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_redundant_type_condition.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_redundant_type_condition.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_redundant_type_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_redundant_type_condition.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_redundant_type_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_redundant_type_condition.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_alias_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_alias_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_alias.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_alias.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_alias.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_alias.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_alias.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_alias.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_condition_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_condition_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_condition.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_condition.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_condition.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_condition.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_directives_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_directives_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_directives.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_directives.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_directives.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_directives.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_directives.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_typename_with_directives.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_with_fragment_spread_directives() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_with_fragment_spread_directives() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_with_fragment_spread_directives.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_with_fragment_spread_directives.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_with_fragment_spread_directives.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_with_fragment_spread_directives.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_with_fragment_spread_directives.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_with_fragment_spread_directives.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type_invalid_1() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type_invalid_1() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_1.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_1.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_1.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_1.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_1.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_1.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type_invalid_2() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type_invalid_2() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_2.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_2.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_2.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_2.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_2.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_2.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type_invalid_3() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type_invalid_3() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_3.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_3.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_3.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_3.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_3.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_3.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type_invalid_4() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type_invalid_4() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_4.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_4.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_4.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_4.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_4.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_other_selections_wrong_type.invalid_4.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_with_abstract_type_condition_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_with_abstract_type_condition_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_with_abstract_type_condition.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_with_abstract_type_condition.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_with_abstract_type_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_with_abstract_type_condition.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_with_abstract_type_condition.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_with_abstract_type_condition.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_in_inline_fragment_without_typename_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_in_inline_fragment_without_typename_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_without_typename.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_without_typename.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_without_typename.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_without_typename.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_in_inline_fragment_without_typename.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_in_inline_fragment_without_typename.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_top_level_invalid() {
+#[tokio::test]
+async fn updatable_fragment_spread_top_level_invalid() {
     let input = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_top_level.invalid.graphql");
     let expected = include_str!("updatable_fragment_spread/fixtures/updatable_fragment_spread_top_level.invalid.expected");
-    test_fixture(transform_fixture, "updatable_fragment_spread_top_level.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_top_level.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "updatable_fragment_spread_top_level.invalid.graphql", "updatable_fragment_spread/fixtures/updatable_fragment_spread_top_level.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_connections/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_connections/mod.rs
@@ -17,7 +17,7 @@ use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_connections;
 use relay_transforms::ConnectionInterface;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/validate_connections_schema/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_connections_schema/mod.rs
@@ -17,7 +17,7 @@ use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::validate_connections;
 use relay_transforms::ConnectionInterface;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
 
     if let [base, extensions] = parts.as_slice() {

--- a/compiler/crates/relay-transforms/tests/validate_connections_schema_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_connections_schema_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e5c9098776729989646744799f3989a5>>
+ * @generated SignedSource<<e853a618f90d71ca91e3841aecc40b00>>
  */
 
 mod validate_connections_schema;
@@ -12,37 +12,37 @@ mod validate_connections_schema;
 use validate_connections_schema::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn connection_invalid_edge_type_invalid() {
+#[tokio::test]
+async fn connection_invalid_edge_type_invalid() {
     let input = include_str!("validate_connections_schema/fixtures/connection-invalid-edge-type.invalid.graphql");
     let expected = include_str!("validate_connections_schema/fixtures/connection-invalid-edge-type.invalid.expected");
-    test_fixture(transform_fixture, "connection-invalid-edge-type.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-edge-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-invalid-edge-type.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-edge-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_invalid_edges_field_invalid() {
+#[tokio::test]
+async fn connection_invalid_edges_field_invalid() {
     let input = include_str!("validate_connections_schema/fixtures/connection-invalid-edges-field.invalid.graphql");
     let expected = include_str!("validate_connections_schema/fixtures/connection-invalid-edges-field.invalid.expected");
-    test_fixture(transform_fixture, "connection-invalid-edges-field.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-edges-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-invalid-edges-field.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-edges-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_invalid_edges_list_type_invalid() {
+#[tokio::test]
+async fn connection_invalid_edges_list_type_invalid() {
     let input = include_str!("validate_connections_schema/fixtures/connection-invalid-edges-list-type.invalid.graphql");
     let expected = include_str!("validate_connections_schema/fixtures/connection-invalid-edges-list-type.invalid.expected");
-    test_fixture(transform_fixture, "connection-invalid-edges-list-type.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-edges-list-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-invalid-edges-list-type.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-edges-list-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_invalid_no_page_info_invalid() {
+#[tokio::test]
+async fn connection_invalid_no_page_info_invalid() {
     let input = include_str!("validate_connections_schema/fixtures/connection-invalid-no-page-info.invalid.graphql");
     let expected = include_str!("validate_connections_schema/fixtures/connection-invalid-no-page-info.invalid.expected");
-    test_fixture(transform_fixture, "connection-invalid-no-page-info.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-no-page-info.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-invalid-no-page-info.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-no-page-info.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_invalid_page_info_invalid() {
+#[tokio::test]
+async fn connection_invalid_page_info_invalid() {
     let input = include_str!("validate_connections_schema/fixtures/connection-invalid-page-info.invalid.graphql");
     let expected = include_str!("validate_connections_schema/fixtures/connection-invalid-page-info.invalid.expected");
-    test_fixture(transform_fixture, "connection-invalid-page-info.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-page-info.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-invalid-page-info.invalid.graphql", "validate_connections_schema/fixtures/connection-invalid-page-info.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_connections_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_connections_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5700a721e31a6f0171af5d09f9bf1592>>
+ * @generated SignedSource<<7236a48cf9006c34c3d0b3026dec3b97>>
  */
 
 mod validate_connections;
@@ -12,142 +12,142 @@ mod validate_connections;
 use validate_connections::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn connection() {
+#[tokio::test]
+async fn connection() {
     let input = include_str!("validate_connections/fixtures/connection.graphql");
     let expected = include_str!("validate_connections/fixtures/connection.expected");
-    test_fixture(transform_fixture, "connection.graphql", "validate_connections/fixtures/connection.expected", input, expected);
+    test_fixture(transform_fixture, "connection.graphql", "validate_connections/fixtures/connection.expected", input, expected).await;
 }
 
-#[test]
-fn connection_directions() {
+#[tokio::test]
+async fn connection_directions() {
     let input = include_str!("validate_connections/fixtures/connection-directions.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-directions.expected");
-    test_fixture(transform_fixture, "connection-directions.graphql", "validate_connections/fixtures/connection-directions.expected", input, expected);
+    test_fixture(transform_fixture, "connection-directions.graphql", "validate_connections/fixtures/connection-directions.expected", input, expected).await;
 }
 
-#[test]
-fn connection_empty_filters() {
+#[tokio::test]
+async fn connection_empty_filters() {
     let input = include_str!("validate_connections/fixtures/connection-empty-filters.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-empty-filters.expected");
-    test_fixture(transform_fixture, "connection-empty-filters.graphql", "validate_connections/fixtures/connection-empty-filters.expected", input, expected);
+    test_fixture(transform_fixture, "connection-empty-filters.graphql", "validate_connections/fixtures/connection-empty-filters.expected", input, expected).await;
 }
 
-#[test]
-fn connection_filters() {
+#[tokio::test]
+async fn connection_filters() {
     let input = include_str!("validate_connections/fixtures/connection-filters.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-filters.expected");
-    test_fixture(transform_fixture, "connection-filters.graphql", "validate_connections/fixtures/connection-filters.expected", input, expected);
+    test_fixture(transform_fixture, "connection-filters.graphql", "validate_connections/fixtures/connection-filters.expected", input, expected).await;
 }
 
-#[test]
-fn connection_filters_not_a_string() {
+#[tokio::test]
+async fn connection_filters_not_a_string() {
     let input = include_str!("validate_connections/fixtures/connection-filters-not-a-string.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-filters-not-a-string.expected");
-    test_fixture(transform_fixture, "connection-filters-not-a-string.graphql", "validate_connections/fixtures/connection-filters-not-a-string.expected", input, expected);
+    test_fixture(transform_fixture, "connection-filters-not-a-string.graphql", "validate_connections/fixtures/connection-filters-not-a-string.expected", input, expected).await;
 }
 
-#[test]
-fn connection_filters_not_an_arg() {
+#[tokio::test]
+async fn connection_filters_not_an_arg() {
     let input = include_str!("validate_connections/fixtures/connection-filters-not-an-arg.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-filters-not-an-arg.expected");
-    test_fixture(transform_fixture, "connection-filters-not-an-arg.graphql", "validate_connections/fixtures/connection-filters-not-an-arg.expected", input, expected);
+    test_fixture(transform_fixture, "connection-filters-not-an-arg.graphql", "validate_connections/fixtures/connection-filters-not-an-arg.expected", input, expected).await;
 }
 
-#[test]
-fn connection_filters_null_invalid() {
+#[tokio::test]
+async fn connection_filters_null_invalid() {
     let input = include_str!("validate_connections/fixtures/connection-filters-null.invalid.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-filters-null.invalid.expected");
-    test_fixture(transform_fixture, "connection-filters-null.invalid.graphql", "validate_connections/fixtures/connection-filters-null.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-filters-null.invalid.graphql", "validate_connections/fixtures/connection-filters-null.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_generate_filters() {
+#[tokio::test]
+async fn connection_generate_filters() {
     let input = include_str!("validate_connections/fixtures/connection-generate-filters.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-generate-filters.expected");
-    test_fixture(transform_fixture, "connection-generate-filters.graphql", "validate_connections/fixtures/connection-generate-filters.expected", input, expected);
+    test_fixture(transform_fixture, "connection-generate-filters.graphql", "validate_connections/fixtures/connection-generate-filters.expected", input, expected).await;
 }
 
-#[test]
-fn connection_invalid_key_name_invalid() {
+#[tokio::test]
+async fn connection_invalid_key_name_invalid() {
     let input = include_str!("validate_connections/fixtures/connection-invalid-key-name.invalid.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-invalid-key-name.invalid.expected");
-    test_fixture(transform_fixture, "connection-invalid-key-name.invalid.graphql", "validate_connections/fixtures/connection-invalid-key-name.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-invalid-key-name.invalid.graphql", "validate_connections/fixtures/connection-invalid-key-name.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_invalid_key_type_invalid() {
+#[tokio::test]
+async fn connection_invalid_key_type_invalid() {
     let input = include_str!("validate_connections/fixtures/connection-invalid-key-type.invalid.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-invalid-key-type.invalid.expected");
-    test_fixture(transform_fixture, "connection-invalid-key-type.invalid.graphql", "validate_connections/fixtures/connection-invalid-key-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-invalid-key-type.invalid.graphql", "validate_connections/fixtures/connection-invalid-key-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_invalid_type_invalid() {
+#[tokio::test]
+async fn connection_invalid_type_invalid() {
     let input = include_str!("validate_connections/fixtures/connection-invalid-type.invalid.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-invalid-type.invalid.expected");
-    test_fixture(transform_fixture, "connection-invalid-type.invalid.graphql", "validate_connections/fixtures/connection-invalid-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-invalid-type.invalid.graphql", "validate_connections/fixtures/connection-invalid-type.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_missing_edges_selection_invalid() {
+#[tokio::test]
+async fn connection_missing_edges_selection_invalid() {
     let input = include_str!("validate_connections/fixtures/connection-missing-edges-selection.invalid.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-missing-edges-selection.invalid.expected");
-    test_fixture(transform_fixture, "connection-missing-edges-selection.invalid.graphql", "validate_connections/fixtures/connection-missing-edges-selection.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-missing-edges-selection.invalid.graphql", "validate_connections/fixtures/connection-missing-edges-selection.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_missing_first_arg_invalid() {
+#[tokio::test]
+async fn connection_missing_first_arg_invalid() {
     let input = include_str!("validate_connections/fixtures/connection-missing-first-arg.invalid.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-missing-first-arg.invalid.expected");
-    test_fixture(transform_fixture, "connection-missing-first-arg.invalid.graphql", "validate_connections/fixtures/connection-missing-first-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-missing-first-arg.invalid.graphql", "validate_connections/fixtures/connection-missing-first-arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_aliased_edges_page_info() {
+#[tokio::test]
+async fn connection_with_aliased_edges_page_info() {
     let input = include_str!("validate_connections/fixtures/connection-with-aliased-edges-page-info.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-with-aliased-edges-page-info.expected");
-    test_fixture(transform_fixture, "connection-with-aliased-edges-page-info.graphql", "validate_connections/fixtures/connection-with-aliased-edges-page-info.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-aliased-edges-page-info.graphql", "validate_connections/fixtures/connection-with-aliased-edges-page-info.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_custom_handler() {
+#[tokio::test]
+async fn connection_with_custom_handler() {
     let input = include_str!("validate_connections/fixtures/connection-with-custom-handler.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-with-custom-handler.expected");
-    test_fixture(transform_fixture, "connection-with-custom-handler.graphql", "validate_connections/fixtures/connection-with-custom-handler.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-custom-handler.graphql", "validate_connections/fixtures/connection-with-custom-handler.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_invalid_custom_handler_invalid() {
+#[tokio::test]
+async fn connection_with_invalid_custom_handler_invalid() {
     let input = include_str!("validate_connections/fixtures/connection-with-invalid-custom-handler.invalid.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-with-invalid-custom-handler.invalid.expected");
-    test_fixture(transform_fixture, "connection-with-invalid-custom-handler.invalid.graphql", "validate_connections/fixtures/connection-with-invalid-custom-handler.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-invalid-custom-handler.invalid.graphql", "validate_connections/fixtures/connection-with-invalid-custom-handler.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_page_info() {
+#[tokio::test]
+async fn connection_with_page_info() {
     let input = include_str!("validate_connections/fixtures/connection-with-page-info.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-with-page-info.expected");
-    test_fixture(transform_fixture, "connection-with-page-info.graphql", "validate_connections/fixtures/connection-with-page-info.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-page-info.graphql", "validate_connections/fixtures/connection-with-page-info.expected", input, expected).await;
 }
 
-#[test]
-fn connection_with_variables() {
+#[tokio::test]
+async fn connection_with_variables() {
     let input = include_str!("validate_connections/fixtures/connection-with-variables.graphql");
     let expected = include_str!("validate_connections/fixtures/connection-with-variables.expected");
-    test_fixture(transform_fixture, "connection-with-variables.graphql", "validate_connections/fixtures/connection-with-variables.expected", input, expected);
+    test_fixture(transform_fixture, "connection-with-variables.graphql", "validate_connections/fixtures/connection-with-variables.expected", input, expected).await;
 }
 
-#[test]
-fn stream_connection_with_aliased_edges_invalid() {
+#[tokio::test]
+async fn stream_connection_with_aliased_edges_invalid() {
     let input = include_str!("validate_connections/fixtures/stream-connection-with-aliased-edges.invalid.graphql");
     let expected = include_str!("validate_connections/fixtures/stream-connection-with-aliased-edges.invalid.expected");
-    test_fixture(transform_fixture, "stream-connection-with-aliased-edges.invalid.graphql", "validate_connections/fixtures/stream-connection-with-aliased-edges.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "stream-connection-with-aliased-edges.invalid.graphql", "validate_connections/fixtures/stream-connection-with-aliased-edges.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn stream_connection_with_aliased_page_info_invalid() {
+#[tokio::test]
+async fn stream_connection_with_aliased_page_info_invalid() {
     let input = include_str!("validate_connections/fixtures/stream-connection-with-aliased-page-info.invalid.graphql");
     let expected = include_str!("validate_connections/fixtures/stream-connection-with-aliased-page-info.invalid.expected");
-    test_fixture(transform_fixture, "stream-connection-with-aliased-page-info.invalid.graphql", "validate_connections/fixtures/stream-connection-with-aliased-page-info.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "stream-connection-with-aliased-page-info.invalid.graphql", "validate_connections/fixtures/stream-connection-with-aliased-page-info.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_deprecated_fields/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_deprecated_fields/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::deprecated_fields;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
 
     if let [base, extensions] = parts.as_slice() {

--- a/compiler/crates/relay-transforms/tests/validate_deprecated_fields_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_deprecated_fields_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fe6689a7953b227a33d0f86a2ab54818>>
+ * @generated SignedSource<<eb171feb0fa2357a885382649bdb30e9>>
  */
 
 mod validate_deprecated_fields;
@@ -12,65 +12,65 @@ mod validate_deprecated_fields;
 use validate_deprecated_fields::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn deprecated_directive_arg() {
+#[tokio::test]
+async fn deprecated_directive_arg() {
     let input = include_str!("validate_deprecated_fields/fixtures/deprecated_directive_arg.graphql");
     let expected = include_str!("validate_deprecated_fields/fixtures/deprecated_directive_arg.expected");
-    test_fixture(transform_fixture, "deprecated_directive_arg.graphql", "validate_deprecated_fields/fixtures/deprecated_directive_arg.expected", input, expected);
+    test_fixture(transform_fixture, "deprecated_directive_arg.graphql", "validate_deprecated_fields/fixtures/deprecated_directive_arg.expected", input, expected).await;
 }
 
-#[test]
-fn deprecated_directive_arg_with_reason() {
+#[tokio::test]
+async fn deprecated_directive_arg_with_reason() {
     let input = include_str!("validate_deprecated_fields/fixtures/deprecated_directive_arg_with_reason.graphql");
     let expected = include_str!("validate_deprecated_fields/fixtures/deprecated_directive_arg_with_reason.expected");
-    test_fixture(transform_fixture, "deprecated_directive_arg_with_reason.graphql", "validate_deprecated_fields/fixtures/deprecated_directive_arg_with_reason.expected", input, expected);
+    test_fixture(transform_fixture, "deprecated_directive_arg_with_reason.graphql", "validate_deprecated_fields/fixtures/deprecated_directive_arg_with_reason.expected", input, expected).await;
 }
 
-#[test]
-fn deprecated_field_arg() {
+#[tokio::test]
+async fn deprecated_field_arg() {
     let input = include_str!("validate_deprecated_fields/fixtures/deprecated_field_arg.graphql");
     let expected = include_str!("validate_deprecated_fields/fixtures/deprecated_field_arg.expected");
-    test_fixture(transform_fixture, "deprecated_field_arg.graphql", "validate_deprecated_fields/fixtures/deprecated_field_arg.expected", input, expected);
+    test_fixture(transform_fixture, "deprecated_field_arg.graphql", "validate_deprecated_fields/fixtures/deprecated_field_arg.expected", input, expected).await;
 }
 
-#[test]
-fn deprecated_field_arg_with_reason() {
+#[tokio::test]
+async fn deprecated_field_arg_with_reason() {
     let input = include_str!("validate_deprecated_fields/fixtures/deprecated_field_arg_with_reason.graphql");
     let expected = include_str!("validate_deprecated_fields/fixtures/deprecated_field_arg_with_reason.expected");
-    test_fixture(transform_fixture, "deprecated_field_arg_with_reason.graphql", "validate_deprecated_fields/fixtures/deprecated_field_arg_with_reason.expected", input, expected);
+    test_fixture(transform_fixture, "deprecated_field_arg_with_reason.graphql", "validate_deprecated_fields/fixtures/deprecated_field_arg_with_reason.expected", input, expected).await;
 }
 
-#[test]
-fn deprecated_field_with_arguments() {
+#[tokio::test]
+async fn deprecated_field_with_arguments() {
     let input = include_str!("validate_deprecated_fields/fixtures/deprecated_field_with_arguments.graphql");
     let expected = include_str!("validate_deprecated_fields/fixtures/deprecated_field_with_arguments.expected");
-    test_fixture(transform_fixture, "deprecated_field_with_arguments.graphql", "validate_deprecated_fields/fixtures/deprecated_field_with_arguments.expected", input, expected);
+    test_fixture(transform_fixture, "deprecated_field_with_arguments.graphql", "validate_deprecated_fields/fixtures/deprecated_field_with_arguments.expected", input, expected).await;
 }
 
-#[test]
-fn deprecated_field_with_reason() {
+#[tokio::test]
+async fn deprecated_field_with_reason() {
     let input = include_str!("validate_deprecated_fields/fixtures/deprecated_field_with_reason.graphql");
     let expected = include_str!("validate_deprecated_fields/fixtures/deprecated_field_with_reason.expected");
-    test_fixture(transform_fixture, "deprecated_field_with_reason.graphql", "validate_deprecated_fields/fixtures/deprecated_field_with_reason.expected", input, expected);
+    test_fixture(transform_fixture, "deprecated_field_with_reason.graphql", "validate_deprecated_fields/fixtures/deprecated_field_with_reason.expected", input, expected).await;
 }
 
-#[test]
-fn deprecated_linked_field() {
+#[tokio::test]
+async fn deprecated_linked_field() {
     let input = include_str!("validate_deprecated_fields/fixtures/deprecated_linked_field.graphql");
     let expected = include_str!("validate_deprecated_fields/fixtures/deprecated_linked_field.expected");
-    test_fixture(transform_fixture, "deprecated_linked_field.graphql", "validate_deprecated_fields/fixtures/deprecated_linked_field.expected", input, expected);
+    test_fixture(transform_fixture, "deprecated_linked_field.graphql", "validate_deprecated_fields/fixtures/deprecated_linked_field.expected", input, expected).await;
 }
 
-#[test]
-fn deprecated_scalar_field() {
+#[tokio::test]
+async fn deprecated_scalar_field() {
     let input = include_str!("validate_deprecated_fields/fixtures/deprecated_scalar_field.graphql");
     let expected = include_str!("validate_deprecated_fields/fixtures/deprecated_scalar_field.expected");
-    test_fixture(transform_fixture, "deprecated_scalar_field.graphql", "validate_deprecated_fields/fixtures/deprecated_scalar_field.expected", input, expected);
+    test_fixture(transform_fixture, "deprecated_scalar_field.graphql", "validate_deprecated_fields/fixtures/deprecated_scalar_field.expected", input, expected).await;
 }
 
-#[test]
-fn deprecated_scalar_field_within_linked_field() {
+#[tokio::test]
+async fn deprecated_scalar_field_within_linked_field() {
     let input = include_str!("validate_deprecated_fields/fixtures/deprecated_scalar_field_within_linked_field.graphql");
     let expected = include_str!("validate_deprecated_fields/fixtures/deprecated_scalar_field_within_linked_field.expected");
-    test_fixture(transform_fixture, "deprecated_scalar_field_within_linked_field.graphql", "validate_deprecated_fields/fixtures/deprecated_scalar_field_within_linked_field.expected", input, expected);
+    test_fixture(transform_fixture, "deprecated_scalar_field_within_linked_field.graphql", "validate_deprecated_fields/fixtures/deprecated_scalar_field_within_linked_field.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_global_variable_names/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_global_variable_names/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_global_variable_names;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/validate_global_variable_names_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_global_variable_names_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ffc1a0363a0a6137108787e4e848f93d>>
+ * @generated SignedSource<<84eb865f483da914802befbac064f06c>>
  */
 
 mod validate_global_variable_names;
@@ -12,9 +12,9 @@ mod validate_global_variable_names;
 use validate_global_variable_names::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn relayinternal_prefix_invalid() {
+#[tokio::test]
+async fn relayinternal_prefix_invalid() {
     let input = include_str!("validate_global_variable_names/fixtures/relayinternal_prefix_invalid.graphql");
     let expected = include_str!("validate_global_variable_names/fixtures/relayinternal_prefix_invalid.expected");
-    test_fixture(transform_fixture, "relayinternal_prefix_invalid.graphql", "validate_global_variable_names/fixtures/relayinternal_prefix_invalid.expected", input, expected);
+    test_fixture(transform_fixture, "relayinternal_prefix_invalid.graphql", "validate_global_variable_names/fixtures/relayinternal_prefix_invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_global_variables/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_global_variables/mod.rs
@@ -21,7 +21,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_global_variables;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/validate_global_variables_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_global_variables_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6103440a7211fcb7a084c2b65bdc9621>>
+ * @generated SignedSource<<2727cdaebb7d446fd26bcade2da67b8f>>
  */
 
 mod validate_global_variables;
@@ -12,30 +12,30 @@ mod validate_global_variables;
 use validate_global_variables::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_include_with_provided_argument() {
+#[tokio::test]
+async fn fragment_include_with_provided_argument() {
     let input = include_str!("validate_global_variables/fixtures/fragment-include-with-provided-argument.graphql");
     let expected = include_str!("validate_global_variables/fixtures/fragment-include-with-provided-argument.expected");
-    test_fixture(transform_fixture, "fragment-include-with-provided-argument.graphql", "validate_global_variables/fixtures/fragment-include-with-provided-argument.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-include-with-provided-argument.graphql", "validate_global_variables/fixtures/fragment-include-with-provided-argument.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_undefined_variable_invalid() {
+#[tokio::test]
+async fn fragment_with_undefined_variable_invalid() {
     let input = include_str!("validate_global_variables/fixtures/fragment-with-undefined-variable.invalid.graphql");
     let expected = include_str!("validate_global_variables/fixtures/fragment-with-undefined-variable.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-undefined-variable.invalid.graphql", "validate_global_variables/fixtures/fragment-with-undefined-variable.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-undefined-variable.invalid.graphql", "validate_global_variables/fixtures/fragment-with-undefined-variable.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_undefined_variable_invalid() {
+#[tokio::test]
+async fn query_with_undefined_variable_invalid() {
     let input = include_str!("validate_global_variables/fixtures/query-with-undefined-variable.invalid.graphql");
     let expected = include_str!("validate_global_variables/fixtures/query-with-undefined-variable.invalid.expected");
-    test_fixture(transform_fixture, "query-with-undefined-variable.invalid.graphql", "validate_global_variables/fixtures/query-with-undefined-variable.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-undefined-variable.invalid.graphql", "validate_global_variables/fixtures/query-with-undefined-variable.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_variables() {
+#[tokio::test]
+async fn query_with_variables() {
     let input = include_str!("validate_global_variables/fixtures/query-with-variables.graphql");
     let expected = include_str!("validate_global_variables/fixtures/query-with-variables.expected");
-    test_fixture(transform_fixture, "query-with-variables.graphql", "validate_global_variables/fixtures/query-with-variables.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-variables.graphql", "validate_global_variables/fixtures/query-with-variables.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_module_names/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_module_names/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_module_names;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/validate_module_names_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_module_names_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c52f1e66f39dd95f89add376b2dab414>>
+ * @generated SignedSource<<99d8c0571de566969a066829e630599d>>
  */
 
 mod validate_module_names;
@@ -12,121 +12,121 @@ mod validate_module_names;
 use validate_module_names::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_with_valid_name() {
+#[tokio::test]
+async fn fragment_with_valid_name() {
     let input = include_str!("validate_module_names/fixtures/fragment-with-valid-name.graphql");
     let expected = include_str!("validate_module_names/fixtures/fragment-with-valid-name.expected");
-    test_fixture(transform_fixture, "fragment-with-valid-name.graphql", "validate_module_names/fixtures/fragment-with-valid-name.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-valid-name.graphql", "validate_module_names/fixtures/fragment-with-valid-name.expected", input, expected).await;
 }
 
-#[test]
-fn fragmentwithinvalidlycapitalizedname_invalid() {
+#[tokio::test]
+async fn fragmentwithinvalidlycapitalizedname_invalid() {
     let input = include_str!("validate_module_names/fixtures/FragmentWithInvalidlyCapitalizedName.invalid.graphql");
     let expected = include_str!("validate_module_names/fixtures/FragmentWithInvalidlyCapitalizedName.invalid.expected");
-    test_fixture(transform_fixture, "FragmentWithInvalidlyCapitalizedName.invalid.graphql", "validate_module_names/fixtures/FragmentWithInvalidlyCapitalizedName.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "FragmentWithInvalidlyCapitalizedName.invalid.graphql", "validate_module_names/fixtures/FragmentWithInvalidlyCapitalizedName.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragmentwithinvalidname_invalid() {
+#[tokio::test]
+async fn fragmentwithinvalidname_invalid() {
     let input = include_str!("validate_module_names/fixtures/FragmentWithInvalidName.invalid.graphql");
     let expected = include_str!("validate_module_names/fixtures/FragmentWithInvalidName.invalid.expected");
-    test_fixture(transform_fixture, "FragmentWithInvalidName.invalid.graphql", "validate_module_names/fixtures/FragmentWithInvalidName.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "FragmentWithInvalidName.invalid.graphql", "validate_module_names/fixtures/FragmentWithInvalidName.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragmentwithvalidname() {
+#[tokio::test]
+async fn fragmentwithvalidname() {
     let input = include_str!("validate_module_names/fixtures/FragmentWithValidName.graphql");
     let expected = include_str!("validate_module_names/fixtures/FragmentWithValidName.expected");
-    test_fixture(transform_fixture, "FragmentWithValidName.graphql", "validate_module_names/fixtures/FragmentWithValidName.expected", input, expected);
+    test_fixture(transform_fixture, "FragmentWithValidName.graphql", "validate_module_names/fixtures/FragmentWithValidName.expected", input, expected).await;
 }
 
-#[test]
-fn fragmentwithvalidname_android() {
+#[tokio::test]
+async fn fragmentwithvalidname_android() {
     let input = include_str!("validate_module_names/fixtures/FragmentWithValidName.android.graphql");
     let expected = include_str!("validate_module_names/fixtures/FragmentWithValidName.android.expected");
-    test_fixture(transform_fixture, "FragmentWithValidName.android.graphql", "validate_module_names/fixtures/FragmentWithValidName.android.expected", input, expected);
+    test_fixture(transform_fixture, "FragmentWithValidName.android.graphql", "validate_module_names/fixtures/FragmentWithValidName.android.expected", input, expected).await;
 }
 
-#[test]
-fn fragmentwithvalidname_ios() {
+#[tokio::test]
+async fn fragmentwithvalidname_ios() {
     let input = include_str!("validate_module_names/fixtures/FragmentWithValidName.ios.graphql");
     let expected = include_str!("validate_module_names/fixtures/FragmentWithValidName.ios.expected");
-    test_fixture(transform_fixture, "FragmentWithValidName.ios.graphql", "validate_module_names/fixtures/FragmentWithValidName.ios.expected", input, expected);
+    test_fixture(transform_fixture, "FragmentWithValidName.ios.graphql", "validate_module_names/fixtures/FragmentWithValidName.ios.expected", input, expected).await;
 }
 
-#[test]
-fn fragmentwithvalidname_other_suffix() {
+#[tokio::test]
+async fn fragmentwithvalidname_other_suffix() {
     let input = include_str!("validate_module_names/fixtures/FragmentWithValidName.other-suffix.graphql");
     let expected = include_str!("validate_module_names/fixtures/FragmentWithValidName.other-suffix.expected");
-    test_fixture(transform_fixture, "FragmentWithValidName.other-suffix.graphql", "validate_module_names/fixtures/FragmentWithValidName.other-suffix.expected", input, expected);
+    test_fixture(transform_fixture, "FragmentWithValidName.other-suffix.graphql", "validate_module_names/fixtures/FragmentWithValidName.other-suffix.expected", input, expected).await;
 }
 
-#[test]
-fn fragmentwithvalidname_other_suffix_ios_and_another() {
+#[tokio::test]
+async fn fragmentwithvalidname_other_suffix_ios_and_another() {
     let input = include_str!("validate_module_names/fixtures/FragmentWithValidName.other-suffix.ios.and-another.graphql");
     let expected = include_str!("validate_module_names/fixtures/FragmentWithValidName.other-suffix.ios.and-another.expected");
-    test_fixture(transform_fixture, "FragmentWithValidName.other-suffix.ios.and-another.graphql", "validate_module_names/fixtures/FragmentWithValidName.other-suffix.ios.and-another.expected", input, expected);
+    test_fixture(transform_fixture, "FragmentWithValidName.other-suffix.ios.and-another.graphql", "validate_module_names/fixtures/FragmentWithValidName.other-suffix.ios.and-another.expected", input, expected).await;
 }
 
-#[test]
-fn mutationwithinvalidname_invalid() {
+#[tokio::test]
+async fn mutationwithinvalidname_invalid() {
     let input = include_str!("validate_module_names/fixtures/MutationWithInvalidName.invalid.graphql");
     let expected = include_str!("validate_module_names/fixtures/MutationWithInvalidName.invalid.expected");
-    test_fixture(transform_fixture, "MutationWithInvalidName.invalid.graphql", "validate_module_names/fixtures/MutationWithInvalidName.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "MutationWithInvalidName.invalid.graphql", "validate_module_names/fixtures/MutationWithInvalidName.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn mutationwithinvalidsuffix_invalid() {
+#[tokio::test]
+async fn mutationwithinvalidsuffix_invalid() {
     let input = include_str!("validate_module_names/fixtures/MutationWithInvalidSuffix.invalid.graphql");
     let expected = include_str!("validate_module_names/fixtures/MutationWithInvalidSuffix.invalid.expected");
-    test_fixture(transform_fixture, "MutationWithInvalidSuffix.invalid.graphql", "validate_module_names/fixtures/MutationWithInvalidSuffix.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "MutationWithInvalidSuffix.invalid.graphql", "validate_module_names/fixtures/MutationWithInvalidSuffix.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn mutationwithvalidname() {
+#[tokio::test]
+async fn mutationwithvalidname() {
     let input = include_str!("validate_module_names/fixtures/MutationWithValidName.graphql");
     let expected = include_str!("validate_module_names/fixtures/MutationWithValidName.expected");
-    test_fixture(transform_fixture, "MutationWithValidName.graphql", "validate_module_names/fixtures/MutationWithValidName.expected", input, expected);
+    test_fixture(transform_fixture, "MutationWithValidName.graphql", "validate_module_names/fixtures/MutationWithValidName.expected", input, expected).await;
 }
 
-#[test]
-fn querywithinvalidname_invalid() {
+#[tokio::test]
+async fn querywithinvalidname_invalid() {
     let input = include_str!("validate_module_names/fixtures/QueryWithInvalidName.invalid.graphql");
     let expected = include_str!("validate_module_names/fixtures/QueryWithInvalidName.invalid.expected");
-    test_fixture(transform_fixture, "QueryWithInvalidName.invalid.graphql", "validate_module_names/fixtures/QueryWithInvalidName.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "QueryWithInvalidName.invalid.graphql", "validate_module_names/fixtures/QueryWithInvalidName.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn querywithinvalidsuffix_invalid() {
+#[tokio::test]
+async fn querywithinvalidsuffix_invalid() {
     let input = include_str!("validate_module_names/fixtures/QueryWithInvalidSuffix.invalid.graphql");
     let expected = include_str!("validate_module_names/fixtures/QueryWithInvalidSuffix.invalid.expected");
-    test_fixture(transform_fixture, "QueryWithInvalidSuffix.invalid.graphql", "validate_module_names/fixtures/QueryWithInvalidSuffix.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "QueryWithInvalidSuffix.invalid.graphql", "validate_module_names/fixtures/QueryWithInvalidSuffix.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn querywithvalidname() {
+#[tokio::test]
+async fn querywithvalidname() {
     let input = include_str!("validate_module_names/fixtures/QueryWithValidName.graphql");
     let expected = include_str!("validate_module_names/fixtures/QueryWithValidName.expected");
-    test_fixture(transform_fixture, "QueryWithValidName.graphql", "validate_module_names/fixtures/QueryWithValidName.expected", input, expected);
+    test_fixture(transform_fixture, "QueryWithValidName.graphql", "validate_module_names/fixtures/QueryWithValidName.expected", input, expected).await;
 }
 
-#[test]
-fn subscriptionwithinvalidname_invalid() {
+#[tokio::test]
+async fn subscriptionwithinvalidname_invalid() {
     let input = include_str!("validate_module_names/fixtures/SubscriptionWithInvalidName.invalid.graphql");
     let expected = include_str!("validate_module_names/fixtures/SubscriptionWithInvalidName.invalid.expected");
-    test_fixture(transform_fixture, "SubscriptionWithInvalidName.invalid.graphql", "validate_module_names/fixtures/SubscriptionWithInvalidName.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "SubscriptionWithInvalidName.invalid.graphql", "validate_module_names/fixtures/SubscriptionWithInvalidName.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn subscriptionwithinvalidsuffix_invalid() {
+#[tokio::test]
+async fn subscriptionwithinvalidsuffix_invalid() {
     let input = include_str!("validate_module_names/fixtures/SubscriptionWithInvalidSuffix.invalid.graphql");
     let expected = include_str!("validate_module_names/fixtures/SubscriptionWithInvalidSuffix.invalid.expected");
-    test_fixture(transform_fixture, "SubscriptionWithInvalidSuffix.invalid.graphql", "validate_module_names/fixtures/SubscriptionWithInvalidSuffix.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "SubscriptionWithInvalidSuffix.invalid.graphql", "validate_module_names/fixtures/SubscriptionWithInvalidSuffix.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn subscriptionwithvalidname() {
+#[tokio::test]
+async fn subscriptionwithvalidname() {
     let input = include_str!("validate_module_names/fixtures/SubscriptionWithValidName.graphql");
     let expected = include_str!("validate_module_names/fixtures/SubscriptionWithValidName.expected");
-    test_fixture(transform_fixture, "SubscriptionWithValidName.graphql", "validate_module_names/fixtures/SubscriptionWithValidName.expected", input, expected);
+    test_fixture(transform_fixture, "SubscriptionWithValidName.graphql", "validate_module_names/fixtures/SubscriptionWithValidName.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_no_double_underscore_alias/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_no_double_underscore_alias/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_no_double_underscore_alias;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/validate_no_double_underscore_alias_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_no_double_underscore_alias_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<db6d431b8538f21d76d1e7ecd0279ed7>>
+ * @generated SignedSource<<1572c86556d4ca69f37db55f97eb7e4e>>
  */
 
 mod validate_no_double_underscore_alias;
@@ -12,16 +12,16 @@ mod validate_no_double_underscore_alias;
 use validate_no_double_underscore_alias::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn double_underscore_invalid() {
+#[tokio::test]
+async fn double_underscore_invalid() {
     let input = include_str!("validate_no_double_underscore_alias/fixtures/double_underscore.invalid.graphql");
     let expected = include_str!("validate_no_double_underscore_alias/fixtures/double_underscore.invalid.expected");
-    test_fixture(transform_fixture, "double_underscore.invalid.graphql", "validate_no_double_underscore_alias/fixtures/double_underscore.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "double_underscore.invalid.graphql", "validate_no_double_underscore_alias/fixtures/double_underscore.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn non_alias() {
+#[tokio::test]
+async fn non_alias() {
     let input = include_str!("validate_no_double_underscore_alias/fixtures/non_alias.graphql");
     let expected = include_str!("validate_no_double_underscore_alias/fixtures/non_alias.expected");
-    test_fixture(transform_fixture, "non_alias.graphql", "validate_no_double_underscore_alias/fixtures/non_alias.expected", input, expected);
+    test_fixture(transform_fixture, "non_alias.graphql", "validate_no_double_underscore_alias/fixtures/non_alias.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_no_unselectable_selections/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_no_unselectable_selections/mod.rs
@@ -9,7 +9,7 @@ use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::validate_no_unselectable_selections;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |p| {
         validate_no_unselectable_selections(p, &Default::default())?;
         Ok(p.clone())

--- a/compiler/crates/relay-transforms/tests/validate_no_unselectable_selections_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_no_unselectable_selections_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<82ae09fce8803e956efea1b568733995>>
+ * @generated SignedSource<<a776b71f292cc325da7f02c632f772f8>>
  */
 
 mod validate_no_unselectable_selections;
@@ -12,30 +12,30 @@ mod validate_no_unselectable_selections;
 use validate_no_unselectable_selections::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn multiple_unselectables_invalid() {
+#[tokio::test]
+async fn multiple_unselectables_invalid() {
     let input = include_str!("validate_no_unselectable_selections/fixtures/multiple-unselectables.invalid.graphql");
     let expected = include_str!("validate_no_unselectable_selections/fixtures/multiple-unselectables.invalid.expected");
-    test_fixture(transform_fixture, "multiple-unselectables.invalid.graphql", "validate_no_unselectable_selections/fixtures/multiple-unselectables.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "multiple-unselectables.invalid.graphql", "validate_no_unselectable_selections/fixtures/multiple-unselectables.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unselectable_linked_field_invalid() {
+#[tokio::test]
+async fn unselectable_linked_field_invalid() {
     let input = include_str!("validate_no_unselectable_selections/fixtures/unselectable-linked-field.invalid.graphql");
     let expected = include_str!("validate_no_unselectable_selections/fixtures/unselectable-linked-field.invalid.expected");
-    test_fixture(transform_fixture, "unselectable-linked-field.invalid.graphql", "validate_no_unselectable_selections/fixtures/unselectable-linked-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unselectable-linked-field.invalid.graphql", "validate_no_unselectable_selections/fixtures/unselectable-linked-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unselectable_scalar_invalid() {
+#[tokio::test]
+async fn unselectable_scalar_invalid() {
     let input = include_str!("validate_no_unselectable_selections/fixtures/unselectable-scalar.invalid.graphql");
     let expected = include_str!("validate_no_unselectable_selections/fixtures/unselectable-scalar.invalid.expected");
-    test_fixture(transform_fixture, "unselectable-scalar.invalid.graphql", "validate_no_unselectable_selections/fixtures/unselectable-scalar.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unselectable-scalar.invalid.graphql", "validate_no_unselectable_selections/fixtures/unselectable-scalar.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn valid_selection() {
+#[tokio::test]
+async fn valid_selection() {
     let input = include_str!("validate_no_unselectable_selections/fixtures/valid-selection.graphql");
     let expected = include_str!("validate_no_unselectable_selections/fixtures/valid-selection.expected");
-    test_fixture(transform_fixture, "valid-selection.graphql", "validate_no_unselectable_selections/fixtures/valid-selection.expected", input, expected);
+    test_fixture(transform_fixture, "valid-selection.graphql", "validate_no_unselectable_selections/fixtures/valid-selection.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_relay_directives/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_relay_directives/mod.rs
@@ -14,7 +14,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::get_test_schema;
 use relay_transforms::validate_relay_directives;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let schema = get_test_schema();

--- a/compiler/crates/relay-transforms/tests/validate_relay_directives_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_relay_directives_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b1eb49ef4bf04fbb6fded75198376050>>
+ * @generated SignedSource<<662fdfce50cfb52436e5d0e8bb4f053d>>
  */
 
 mod validate_relay_directives;
@@ -12,72 +12,72 @@ mod validate_relay_directives;
 use validate_relay_directives::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn mask_incompatible_type_invalid() {
+#[tokio::test]
+async fn mask_incompatible_type_invalid() {
     let input = include_str!("validate_relay_directives/fixtures/mask-incompatible-type-invalid.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/mask-incompatible-type-invalid.expected");
-    test_fixture(transform_fixture, "mask-incompatible-type-invalid.graphql", "validate_relay_directives/fixtures/mask-incompatible-type-invalid.expected", input, expected);
+    test_fixture(transform_fixture, "mask-incompatible-type-invalid.graphql", "validate_relay_directives/fixtures/mask-incompatible-type-invalid.expected", input, expected).await;
 }
 
-#[test]
-fn mask_incompatible_type_invalid2() {
+#[tokio::test]
+async fn mask_incompatible_type_invalid2() {
     let input = include_str!("validate_relay_directives/fixtures/mask-incompatible-type-invalid2.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/mask-incompatible-type-invalid2.expected");
-    test_fixture(transform_fixture, "mask-incompatible-type-invalid2.graphql", "validate_relay_directives/fixtures/mask-incompatible-type-invalid2.expected", input, expected);
+    test_fixture(transform_fixture, "mask-incompatible-type-invalid2.graphql", "validate_relay_directives/fixtures/mask-incompatible-type-invalid2.expected", input, expected).await;
 }
 
-#[test]
-fn mask_incompatible_type_query_invalid() {
+#[tokio::test]
+async fn mask_incompatible_type_query_invalid() {
     let input = include_str!("validate_relay_directives/fixtures/mask-incompatible-type-query.invalid.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/mask-incompatible-type-query.invalid.expected");
-    test_fixture(transform_fixture, "mask-incompatible-type-query.invalid.graphql", "validate_relay_directives/fixtures/mask-incompatible-type-query.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "mask-incompatible-type-query.invalid.graphql", "validate_relay_directives/fixtures/mask-incompatible-type-query.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn mask_mixed_local_root_invalid() {
+#[tokio::test]
+async fn mask_mixed_local_root_invalid() {
     let input = include_str!("validate_relay_directives/fixtures/mask-mixed-local-root-invalid.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/mask-mixed-local-root-invalid.expected");
-    test_fixture(transform_fixture, "mask-mixed-local-root-invalid.graphql", "validate_relay_directives/fixtures/mask-mixed-local-root-invalid.expected", input, expected);
+    test_fixture(transform_fixture, "mask-mixed-local-root-invalid.graphql", "validate_relay_directives/fixtures/mask-mixed-local-root-invalid.expected", input, expected).await;
 }
 
-#[test]
-fn mask_mixed_null() {
+#[tokio::test]
+async fn mask_mixed_null() {
     let input = include_str!("validate_relay_directives/fixtures/mask-mixed-null.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/mask-mixed-null.expected");
-    test_fixture(transform_fixture, "mask-mixed-null.graphql", "validate_relay_directives/fixtures/mask-mixed-null.expected", input, expected);
+    test_fixture(transform_fixture, "mask-mixed-null.graphql", "validate_relay_directives/fixtures/mask-mixed-null.expected", input, expected).await;
 }
 
-#[test]
-fn plural_fragment() {
+#[tokio::test]
+async fn plural_fragment() {
     let input = include_str!("validate_relay_directives/fixtures/plural-fragment.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/plural-fragment.expected");
-    test_fixture(transform_fixture, "plural-fragment.graphql", "validate_relay_directives/fixtures/plural-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "plural-fragment.graphql", "validate_relay_directives/fixtures/plural-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn plural_fragment_variables_invalid() {
+#[tokio::test]
+async fn plural_fragment_variables_invalid() {
     let input = include_str!("validate_relay_directives/fixtures/plural-fragment-variables.invalid.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/plural-fragment-variables.invalid.expected");
-    test_fixture(transform_fixture, "plural-fragment-variables.invalid.graphql", "validate_relay_directives/fixtures/plural-fragment-variables.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "plural-fragment-variables.invalid.graphql", "validate_relay_directives/fixtures/plural-fragment-variables.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_spread() {
+#[tokio::test]
+async fn unmasked_spread() {
     let input = include_str!("validate_relay_directives/fixtures/unmasked-spread.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/unmasked-spread.expected");
-    test_fixture(transform_fixture, "unmasked-spread.graphql", "validate_relay_directives/fixtures/unmasked-spread.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-spread.graphql", "validate_relay_directives/fixtures/unmasked-spread.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_spread_with_argument_definition_invalid() {
+#[tokio::test]
+async fn unmasked_spread_with_argument_definition_invalid() {
     let input = include_str!("validate_relay_directives/fixtures/unmasked-spread-with-argument-definition.invalid.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/unmasked-spread-with-argument-definition.invalid.expected");
-    test_fixture(transform_fixture, "unmasked-spread-with-argument-definition.invalid.graphql", "validate_relay_directives/fixtures/unmasked-spread-with-argument-definition.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-spread-with-argument-definition.invalid.graphql", "validate_relay_directives/fixtures/unmasked-spread-with-argument-definition.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_spread_with_directive_invalid() {
+#[tokio::test]
+async fn unmasked_spread_with_directive_invalid() {
     let input = include_str!("validate_relay_directives/fixtures/unmasked-spread-with-directive.invalid.graphql");
     let expected = include_str!("validate_relay_directives/fixtures/unmasked-spread-with-directive.invalid.expected");
-    test_fixture(transform_fixture, "unmasked-spread-with-directive.invalid.graphql", "validate_relay_directives/fixtures/unmasked-spread-with-directive.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-spread-with-directive.invalid.graphql", "validate_relay_directives/fixtures/unmasked-spread-with-directive.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_required_arguments/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_required_arguments/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_required_arguments;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/validate_required_arguments_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_required_arguments_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<86341e77fc38860285a555f3430c105e>>
+ * @generated SignedSource<<1a145aef78f4ae69e0bde1d0ced01dfb>>
  */
 
 mod validate_required_arguments;
@@ -12,58 +12,58 @@ mod validate_required_arguments;
 use validate_required_arguments::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn argument_on_field() {
+#[tokio::test]
+async fn argument_on_field() {
     let input = include_str!("validate_required_arguments/fixtures/argument-on-field.graphql");
     let expected = include_str!("validate_required_arguments/fixtures/argument-on-field.expected");
-    test_fixture(transform_fixture, "argument-on-field.graphql", "validate_required_arguments/fixtures/argument-on-field.expected", input, expected);
+    test_fixture(transform_fixture, "argument-on-field.graphql", "validate_required_arguments/fixtures/argument-on-field.expected", input, expected).await;
 }
 
-#[test]
-fn argument_on_linked_field() {
+#[tokio::test]
+async fn argument_on_linked_field() {
     let input = include_str!("validate_required_arguments/fixtures/argument-on-linked-field.graphql");
     let expected = include_str!("validate_required_arguments/fixtures/argument-on-linked-field.expected");
-    test_fixture(transform_fixture, "argument-on-linked-field.graphql", "validate_required_arguments/fixtures/argument-on-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "argument-on-linked-field.graphql", "validate_required_arguments/fixtures/argument-on-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn default_argument_on_field() {
+#[tokio::test]
+async fn default_argument_on_field() {
     let input = include_str!("validate_required_arguments/fixtures/default-argument-on-field.graphql");
     let expected = include_str!("validate_required_arguments/fixtures/default-argument-on-field.expected");
-    test_fixture(transform_fixture, "default-argument-on-field.graphql", "validate_required_arguments/fixtures/default-argument-on-field.expected", input, expected);
+    test_fixture(transform_fixture, "default-argument-on-field.graphql", "validate_required_arguments/fixtures/default-argument-on-field.expected", input, expected).await;
 }
 
-#[test]
-fn missing_argument_on_directive_invalid() {
+#[tokio::test]
+async fn missing_argument_on_directive_invalid() {
     let input = include_str!("validate_required_arguments/fixtures/missing-argument-on-directive.invalid.graphql");
     let expected = include_str!("validate_required_arguments/fixtures/missing-argument-on-directive.invalid.expected");
-    test_fixture(transform_fixture, "missing-argument-on-directive.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-directive.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing-argument-on-directive.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-directive.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn missing_argument_on_field_invalid() {
+#[tokio::test]
+async fn missing_argument_on_field_invalid() {
     let input = include_str!("validate_required_arguments/fixtures/missing-argument-on-field.invalid.graphql");
     let expected = include_str!("validate_required_arguments/fixtures/missing-argument-on-field.invalid.expected");
-    test_fixture(transform_fixture, "missing-argument-on-field.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing-argument-on-field.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn missing_argument_on_linked_field_in_inline_fragment_invalid() {
+#[tokio::test]
+async fn missing_argument_on_linked_field_in_inline_fragment_invalid() {
     let input = include_str!("validate_required_arguments/fixtures/missing-argument-on-linked-field-in-inline-fragment.invalid.graphql");
     let expected = include_str!("validate_required_arguments/fixtures/missing-argument-on-linked-field-in-inline-fragment.invalid.expected");
-    test_fixture(transform_fixture, "missing-argument-on-linked-field-in-inline-fragment.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-linked-field-in-inline-fragment.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing-argument-on-linked-field-in-inline-fragment.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-linked-field-in-inline-fragment.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn missing_argument_on_linked_field_invalid() {
+#[tokio::test]
+async fn missing_argument_on_linked_field_invalid() {
     let input = include_str!("validate_required_arguments/fixtures/missing-argument-on-linked-field.invalid.graphql");
     let expected = include_str!("validate_required_arguments/fixtures/missing-argument-on-linked-field.invalid.expected");
-    test_fixture(transform_fixture, "missing-argument-on-linked-field.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-linked-field.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing-argument-on-linked-field.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-linked-field.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn missing_argument_on_linked_field_on_abstract_type_invalid() {
+#[tokio::test]
+async fn missing_argument_on_linked_field_on_abstract_type_invalid() {
     let input = include_str!("validate_required_arguments/fixtures/missing-argument-on-linked-field-on-abstract-type.invalid.graphql");
     let expected = include_str!("validate_required_arguments/fixtures/missing-argument-on-linked-field-on-abstract-type.invalid.expected");
-    test_fixture(transform_fixture, "missing-argument-on-linked-field-on-abstract-type.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-linked-field-on-abstract-type.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "missing-argument-on-linked-field-on-abstract-type.invalid.graphql", "validate_required_arguments/fixtures/missing-argument-on-linked-field-on-abstract-type.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::validate_server_only_directives;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
 
     if let [base, extensions] = parts.as_slice() {

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2e68a7fab154b5051d92bf6e0b537bb5>>
+ * @generated SignedSource<<68ec087baa2851c8346c4de92e1017f2>>
  */
 
 mod validate_server_only_directives;
@@ -12,72 +12,72 @@ mod validate_server_only_directives;
 use validate_server_only_directives::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_with_client_fileds_inside_valid_fragments() {
+#[tokio::test]
+async fn fragment_with_client_fileds_inside_valid_fragments() {
     let input = include_str!("validate_server_only_directives/fixtures/fragment-with-client-fileds-inside-valid-fragments.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/fragment-with-client-fileds-inside-valid-fragments.expected");
-    test_fixture(transform_fixture, "fragment-with-client-fileds-inside-valid-fragments.graphql", "validate_server_only_directives/fixtures/fragment-with-client-fileds-inside-valid-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-client-fileds-inside-valid-fragments.graphql", "validate_server_only_directives/fixtures/fragment-with-client-fileds-inside-valid-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_on_client_invalid() {
+#[tokio::test]
+async fn fragment_with_defer_on_client_invalid() {
     let input = include_str!("validate_server_only_directives/fixtures/fragment-with-defer-on-client.invalid.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/fragment-with-defer-on-client.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-on-client.invalid.graphql", "validate_server_only_directives/fixtures/fragment-with-defer-on-client.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-on-client.invalid.graphql", "validate_server_only_directives/fixtures/fragment-with-defer-on-client.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_defer_on_fragment_with_only_client_fields_invalid() {
+#[tokio::test]
+async fn fragment_with_defer_on_fragment_with_only_client_fields_invalid() {
     let input = include_str!("validate_server_only_directives/fixtures/fragment-with-defer-on-fragment-with-only-client-fields.invalid.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/fragment-with-defer-on-fragment-with-only-client-fields.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-defer-on-fragment-with-only-client-fields.invalid.graphql", "validate_server_only_directives/fixtures/fragment-with-defer-on-fragment-with-only-client-fields.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-defer-on-fragment-with-only-client-fields.invalid.graphql", "validate_server_only_directives/fixtures/fragment-with-defer-on-fragment-with-only-client-fields.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_child_of_client_invalid() {
+#[tokio::test]
+async fn fragment_with_stream_child_of_client_invalid() {
     let input = include_str!("validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-child-of-client.invalid.graphql", "validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-child-of-client.invalid.graphql", "validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_with_stream_on_client_invalid() {
+#[tokio::test]
+async fn fragment_with_stream_on_client_invalid() {
     let input = include_str!("validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.expected");
-    test_fixture(transform_fixture, "fragment-with-stream-on-client.invalid.graphql", "validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-stream-on-client.invalid.graphql", "validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn match_() {
+#[tokio::test]
+async fn match_() {
     let input = include_str!("validate_server_only_directives/fixtures/match_.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/match_.expected");
-    test_fixture(transform_fixture, "match_.graphql", "validate_server_only_directives/fixtures/match_.expected", input, expected);
+    test_fixture(transform_fixture, "match_.graphql", "validate_server_only_directives/fixtures/match_.expected", input, expected).await;
 }
 
-#[test]
-fn module_on_child_of_client() {
+#[tokio::test]
+async fn module_on_child_of_client() {
     let input = include_str!("validate_server_only_directives/fixtures/module-on-child-of-client.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/module-on-child-of-client.expected");
-    test_fixture(transform_fixture, "module-on-child-of-client.graphql", "validate_server_only_directives/fixtures/module-on-child-of-client.expected", input, expected);
+    test_fixture(transform_fixture, "module-on-child-of-client.graphql", "validate_server_only_directives/fixtures/module-on-child-of-client.expected", input, expected).await;
 }
 
-#[test]
-fn module_on_child_of_client_in_fragment() {
+#[tokio::test]
+async fn module_on_child_of_client_in_fragment() {
     let input = include_str!("validate_server_only_directives/fixtures/module-on-child-of-client-in-fragment.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/module-on-child-of-client-in-fragment.expected");
-    test_fixture(transform_fixture, "module-on-child-of-client-in-fragment.graphql", "validate_server_only_directives/fixtures/module-on-child-of-client-in-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "module-on-child-of-client-in-fragment.graphql", "validate_server_only_directives/fixtures/module-on-child-of-client-in-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn nested_fragment_with_defer() {
+#[tokio::test]
+async fn nested_fragment_with_defer() {
     let input = include_str!("validate_server_only_directives/fixtures/nested-fragment-with-defer.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/nested-fragment-with-defer.expected");
-    test_fixture(transform_fixture, "nested-fragment-with-defer.graphql", "validate_server_only_directives/fixtures/nested-fragment-with-defer.expected", input, expected);
+    test_fixture(transform_fixture, "nested-fragment-with-defer.graphql", "validate_server_only_directives/fixtures/nested-fragment-with-defer.expected", input, expected).await;
 }
 
-#[test]
-fn stream_connection_on_client_invalid() {
+#[tokio::test]
+async fn stream_connection_on_client_invalid() {
     let input = include_str!("validate_server_only_directives/fixtures/stream-connection-on-client.invalid.graphql");
     let expected = include_str!("validate_server_only_directives/fixtures/stream-connection-on-client.invalid.expected");
-    test_fixture(transform_fixture, "stream-connection-on-client.invalid.graphql", "validate_server_only_directives/fixtures/stream-connection-on-client.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "stream-connection-on-client.invalid.graphql", "validate_server_only_directives/fixtures/stream-connection-on-client.invalid.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_static_args/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_static_args/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::validate_static_args;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split("%extensions%").collect();
 
     if let [base, extensions] = parts.as_slice() {

--- a/compiler/crates/relay-transforms/tests/validate_static_args_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_static_args_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7c97b400056e87e80acdee4470b99a05>>
+ * @generated SignedSource<<a40fdf54b3a26c24c9b3b40db78d106a>>
  */
 
 mod validate_static_args;
@@ -12,30 +12,30 @@ mod validate_static_args;
 use validate_static_args::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn match_with_dynamic_arg_invalid() {
+#[tokio::test]
+async fn match_with_dynamic_arg_invalid() {
     let input = include_str!("validate_static_args/fixtures/match-with-dynamic-arg.invalid.graphql");
     let expected = include_str!("validate_static_args/fixtures/match-with-dynamic-arg.invalid.expected");
-    test_fixture(transform_fixture, "match-with-dynamic-arg.invalid.graphql", "validate_static_args/fixtures/match-with-dynamic-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "match-with-dynamic-arg.invalid.graphql", "validate_static_args/fixtures/match-with-dynamic-arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn nonstatic_values_on_static_arg_invalid() {
+#[tokio::test]
+async fn nonstatic_values_on_static_arg_invalid() {
     let input = include_str!("validate_static_args/fixtures/nonstatic-values-on-static-arg.invalid.graphql");
     let expected = include_str!("validate_static_args/fixtures/nonstatic-values-on-static-arg.invalid.expected");
-    test_fixture(transform_fixture, "nonstatic-values-on-static-arg.invalid.graphql", "validate_static_args/fixtures/nonstatic-values-on-static-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "nonstatic-values-on-static-arg.invalid.graphql", "validate_static_args/fixtures/nonstatic-values-on-static-arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn required_with_dynamic_arg_invalid() {
+#[tokio::test]
+async fn required_with_dynamic_arg_invalid() {
     let input = include_str!("validate_static_args/fixtures/required-with-dynamic-arg.invalid.graphql");
     let expected = include_str!("validate_static_args/fixtures/required-with-dynamic-arg.invalid.expected");
-    test_fixture(transform_fixture, "required-with-dynamic-arg.invalid.graphql", "validate_static_args/fixtures/required-with-dynamic-arg.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "required-with-dynamic-arg.invalid.graphql", "validate_static_args/fixtures/required-with-dynamic-arg.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn static_only_for_constants() {
+#[tokio::test]
+async fn static_only_for_constants() {
     let input = include_str!("validate_static_args/fixtures/static-only-for-constants.graphql");
     let expected = include_str!("validate_static_args/fixtures/static-only-for-constants.expected");
-    test_fixture(transform_fixture, "static-only-for-constants.graphql", "validate_static_args/fixtures/static-only-for-constants.expected", input, expected);
+    test_fixture(transform_fixture, "static-only-for-constants.graphql", "validate_static_args/fixtures/static-only-for-constants.expected", input, expected).await;
 }

--- a/compiler/crates/relay-transforms/tests/validate_unused_variables/mod.rs
+++ b/compiler/crates/relay-transforms/tests/validate_unused_variables/mod.rs
@@ -16,7 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_test_schema::TEST_SCHEMA;
 use relay_transforms::validate_unused_variables;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let source_location = SourceLocationKey::standalone(fixture.file_name);
 
     let ast = parse_executable(fixture.content, source_location).unwrap();

--- a/compiler/crates/relay-transforms/tests/validate_unused_variables_test.rs
+++ b/compiler/crates/relay-transforms/tests/validate_unused_variables_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<620255d5fdc8dee833f3b68dc61e8fa8>>
+ * @generated SignedSource<<c53f3593ad108fb3271e79455efb8773>>
  */
 
 mod validate_unused_variables;
@@ -12,58 +12,58 @@ mod validate_unused_variables;
 use validate_unused_variables::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn fragment_with_root_arguments() {
+#[tokio::test]
+async fn fragment_with_root_arguments() {
     let input = include_str!("validate_unused_variables/fixtures/fragment-with-root-arguments.graphql");
     let expected = include_str!("validate_unused_variables/fixtures/fragment-with-root-arguments.expected");
-    test_fixture(transform_fixture, "fragment-with-root-arguments.graphql", "validate_unused_variables/fixtures/fragment-with-root-arguments.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-with-root-arguments.graphql", "validate_unused_variables/fixtures/fragment-with-root-arguments.expected", input, expected).await;
 }
 
-#[test]
-fn practically_unused_but_actually_used_variables() {
+#[tokio::test]
+async fn practically_unused_but_actually_used_variables() {
     let input = include_str!("validate_unused_variables/fixtures/practically-unused-but-actually-used-variables.graphql");
     let expected = include_str!("validate_unused_variables/fixtures/practically-unused-but-actually-used-variables.expected");
-    test_fixture(transform_fixture, "practically-unused-but-actually-used-variables.graphql", "validate_unused_variables/fixtures/practically-unused-but-actually-used-variables.expected", input, expected);
+    test_fixture(transform_fixture, "practically-unused-but-actually-used-variables.graphql", "validate_unused_variables/fixtures/practically-unused-but-actually-used-variables.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_invalid_error_suppression() {
+#[tokio::test]
+async fn query_with_invalid_error_suppression() {
     let input = include_str!("validate_unused_variables/fixtures/query-with-invalid-error-suppression.graphql");
     let expected = include_str!("validate_unused_variables/fixtures/query-with-invalid-error-suppression.expected");
-    test_fixture(transform_fixture, "query-with-invalid-error-suppression.graphql", "validate_unused_variables/fixtures/query-with-invalid-error-suppression.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-invalid-error-suppression.graphql", "validate_unused_variables/fixtures/query-with-invalid-error-suppression.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_unused_root_variable_shadowed_by_local_invalid() {
+#[tokio::test]
+async fn query_with_unused_root_variable_shadowed_by_local_invalid() {
     let input = include_str!("validate_unused_variables/fixtures/query-with-unused-root-variable-shadowed-by-local.invalid.graphql");
     let expected = include_str!("validate_unused_variables/fixtures/query-with-unused-root-variable-shadowed-by-local.invalid.expected");
-    test_fixture(transform_fixture, "query-with-unused-root-variable-shadowed-by-local.invalid.graphql", "validate_unused_variables/fixtures/query-with-unused-root-variable-shadowed-by-local.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-unused-root-variable-shadowed-by-local.invalid.graphql", "validate_unused_variables/fixtures/query-with-unused-root-variable-shadowed-by-local.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_unused_variable_error_suppressed() {
+#[tokio::test]
+async fn query_with_unused_variable_error_suppressed() {
     let input = include_str!("validate_unused_variables/fixtures/query-with-unused-variable-error-suppressed.graphql");
     let expected = include_str!("validate_unused_variables/fixtures/query-with-unused-variable-error-suppressed.expected");
-    test_fixture(transform_fixture, "query-with-unused-variable-error-suppressed.graphql", "validate_unused_variables/fixtures/query-with-unused-variable-error-suppressed.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-unused-variable-error-suppressed.graphql", "validate_unused_variables/fixtures/query-with-unused-variable-error-suppressed.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_unused_variable_invalid() {
+#[tokio::test]
+async fn query_with_unused_variable_invalid() {
     let input = include_str!("validate_unused_variables/fixtures/query-with-unused-variable.invalid.graphql");
     let expected = include_str!("validate_unused_variables/fixtures/query-with-unused-variable.invalid.expected");
-    test_fixture(transform_fixture, "query-with-unused-variable.invalid.graphql", "validate_unused_variables/fixtures/query-with-unused-variable.invalid.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-unused-variable.invalid.graphql", "validate_unused_variables/fixtures/query-with-unused-variable.invalid.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_variables_shadowed_by_local_variable_and_used_as_root_variable() {
+#[tokio::test]
+async fn query_with_variables_shadowed_by_local_variable_and_used_as_root_variable() {
     let input = include_str!("validate_unused_variables/fixtures/query-with-variables-shadowed-by-local-variable-and-used-as-root-variable.graphql");
     let expected = include_str!("validate_unused_variables/fixtures/query-with-variables-shadowed-by-local-variable-and-used-as-root-variable.expected");
-    test_fixture(transform_fixture, "query-with-variables-shadowed-by-local-variable-and-used-as-root-variable.graphql", "validate_unused_variables/fixtures/query-with-variables-shadowed-by-local-variable-and-used-as-root-variable.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-variables-shadowed-by-local-variable-and-used-as-root-variable.graphql", "validate_unused_variables/fixtures/query-with-variables-shadowed-by-local-variable-and-used-as-root-variable.expected", input, expected).await;
 }
 
-#[test]
-fn variable_in_the_complex_object_list() {
+#[tokio::test]
+async fn variable_in_the_complex_object_list() {
     let input = include_str!("validate_unused_variables/fixtures/variable-in-the-complex-object-list.graphql");
     let expected = include_str!("validate_unused_variables/fixtures/variable-in-the-complex-object-list.expected");
-    test_fixture(transform_fixture, "variable-in-the-complex-object-list.graphql", "validate_unused_variables/fixtures/variable-in-the-complex-object-list.expected", input, expected);
+    test_fixture(transform_fixture, "variable-in-the-complex-object-list.graphql", "validate_unused_variables/fixtures/variable-in-the-complex-object-list.expected", input, expected).await;
 }

--- a/compiler/crates/relay-typegen/Cargo.toml
+++ b/compiler/crates/relay-typegen/Cargo.toml
@@ -30,3 +30,4 @@ graphql-syntax = { path = "../graphql-syntax" }
 graphql-test-helpers = { path = "../graphql-test-helpers" }
 relay-codegen = { path = "../relay-codegen" }
 relay-test-schema = { path = "../relay-test-schema" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
@@ -37,7 +37,7 @@ use relay_typegen::TypegenLanguage;
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts = fixture.content.split("%extensions%").collect::<Vec<_>>();
     let (source, schema) = match parts.as_slice() {
         [source, extensions] => (source, get_test_schema_with_extensions(extensions)),

--- a/compiler/crates/relay-typegen/tests/generate_flow_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<83c7978511f69151b68e1476d398d6e3>>
+ * @generated SignedSource<<2a6d7115234d70eddda6b0eb718a7108>>
  */
 
 mod generate_flow;
@@ -12,800 +12,800 @@ mod generate_flow;
 use generate_flow::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn actor_change() {
+#[tokio::test]
+async fn actor_change() {
     let input = include_str!("generate_flow/fixtures/actor-change.graphql");
     let expected = include_str!("generate_flow/fixtures/actor-change.expected");
-    test_fixture(transform_fixture, "actor-change.graphql", "generate_flow/fixtures/actor-change.expected", input, expected);
+    test_fixture(transform_fixture, "actor-change.graphql", "generate_flow/fixtures/actor-change.expected", input, expected).await;
 }
 
-#[test]
-fn actor_change_with_query() {
+#[tokio::test]
+async fn actor_change_with_query() {
     let input = include_str!("generate_flow/fixtures/actor-change-with-query.graphql");
     let expected = include_str!("generate_flow/fixtures/actor-change-with-query.expected");
-    test_fixture(transform_fixture, "actor-change-with-query.graphql", "generate_flow/fixtures/actor-change-with-query.expected", input, expected);
+    test_fixture(transform_fixture, "actor-change-with-query.graphql", "generate_flow/fixtures/actor-change-with-query.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_fragment_raw_response_type() {
+#[tokio::test]
+async fn aliased_fragment_raw_response_type() {
     let input = include_str!("generate_flow/fixtures/aliased-fragment-raw-response-type.graphql");
     let expected = include_str!("generate_flow/fixtures/aliased-fragment-raw-response-type.expected");
-    test_fixture(transform_fixture, "aliased-fragment-raw-response-type.graphql", "generate_flow/fixtures/aliased-fragment-raw-response-type.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-fragment-raw-response-type.graphql", "generate_flow/fixtures/aliased-fragment-raw-response-type.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_fragment_spread() {
+#[tokio::test]
+async fn aliased_fragment_spread() {
     let input = include_str!("generate_flow/fixtures/aliased-fragment-spread.graphql");
     let expected = include_str!("generate_flow/fixtures/aliased-fragment-spread.expected");
-    test_fixture(transform_fixture, "aliased-fragment-spread.graphql", "generate_flow/fixtures/aliased-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-fragment-spread.graphql", "generate_flow/fixtures/aliased-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_fragment_spread_in_abstract_selection() {
+#[tokio::test]
+async fn aliased_fragment_spread_in_abstract_selection() {
     let input = include_str!("generate_flow/fixtures/aliased-fragment-spread-in-abstract-selection.graphql");
     let expected = include_str!("generate_flow/fixtures/aliased-fragment-spread-in-abstract-selection.expected");
-    test_fixture(transform_fixture, "aliased-fragment-spread-in-abstract-selection.graphql", "generate_flow/fixtures/aliased-fragment-spread-in-abstract-selection.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-fragment-spread-in-abstract-selection.graphql", "generate_flow/fixtures/aliased-fragment-spread-in-abstract-selection.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_spread() {
+#[tokio::test]
+async fn aliased_inline_fragment_spread() {
     let input = include_str!("generate_flow/fixtures/aliased-inline-fragment-spread.graphql");
     let expected = include_str!("generate_flow/fixtures/aliased-inline-fragment-spread.expected");
-    test_fixture(transform_fixture, "aliased-inline-fragment-spread.graphql", "generate_flow/fixtures/aliased-inline-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-inline-fragment-spread.graphql", "generate_flow/fixtures/aliased-inline-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_spread_without_type_condition_fragment_root() {
+#[tokio::test]
+async fn aliased_inline_fragment_spread_without_type_condition_fragment_root() {
     let input = include_str!("generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-fragment-root.graphql");
     let expected = include_str!("generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-fragment-root.expected");
-    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-fragment-root.graphql", "generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-fragment-root.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-fragment-root.graphql", "generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-fragment-root.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_spread_without_type_condition_linked_field() {
+#[tokio::test]
+async fn aliased_inline_fragment_spread_without_type_condition_linked_field() {
     let input = include_str!("generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.graphql");
     let expected = include_str!("generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.expected");
-    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-linked-field.graphql", "generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-linked-field.graphql", "generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_spread_without_type_condition_query_root() {
+#[tokio::test]
+async fn aliased_inline_fragment_spread_without_type_condition_query_root() {
     let input = include_str!("generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.graphql");
     let expected = include_str!("generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.expected");
-    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-query-root.graphql", "generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-query-root.graphql", "generate_flow/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.expected", input, expected).await;
 }
 
-#[test]
-fn conditional() {
+#[tokio::test]
+async fn conditional() {
     let input = include_str!("generate_flow/fixtures/conditional.graphql");
     let expected = include_str!("generate_flow/fixtures/conditional.expected");
-    test_fixture(transform_fixture, "conditional.graphql", "generate_flow/fixtures/conditional.expected", input, expected);
+    test_fixture(transform_fixture, "conditional.graphql", "generate_flow/fixtures/conditional.expected", input, expected).await;
 }
 
-#[test]
-fn custom_scalar_type_import() {
+#[tokio::test]
+async fn custom_scalar_type_import() {
     let input = include_str!("generate_flow/fixtures/custom-scalar-type-import.graphql");
     let expected = include_str!("generate_flow/fixtures/custom-scalar-type-import.expected");
-    test_fixture(transform_fixture, "custom-scalar-type-import.graphql", "generate_flow/fixtures/custom-scalar-type-import.expected", input, expected);
+    test_fixture(transform_fixture, "custom-scalar-type-import.graphql", "generate_flow/fixtures/custom-scalar-type-import.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread() {
+#[tokio::test]
+async fn fragment_spread() {
     let input = include_str!("generate_flow/fixtures/fragment-spread.graphql");
     let expected = include_str!("generate_flow/fixtures/fragment-spread.expected");
-    test_fixture(transform_fixture, "fragment-spread.graphql", "generate_flow/fixtures/fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-spread.graphql", "generate_flow/fixtures/fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment() {
+#[tokio::test]
+async fn inline_fragment() {
     let input = include_str!("generate_flow/fixtures/inline-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/inline-fragment.expected");
-    test_fixture(transform_fixture, "inline-fragment.graphql", "generate_flow/fixtures/inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment.graphql", "generate_flow/fixtures/inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn linked_field() {
+#[tokio::test]
+async fn linked_field() {
     let input = include_str!("generate_flow/fixtures/linked-field.graphql");
     let expected = include_str!("generate_flow/fixtures/linked-field.expected");
-    test_fixture(transform_fixture, "linked-field.graphql", "generate_flow/fixtures/linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "linked-field.graphql", "generate_flow/fixtures/linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn match_field() {
+#[tokio::test]
+async fn match_field() {
     let input = include_str!("generate_flow/fixtures/match-field.graphql");
     let expected = include_str!("generate_flow/fixtures/match-field.expected");
-    test_fixture(transform_fixture, "match-field.graphql", "generate_flow/fixtures/match-field.expected", input, expected);
+    test_fixture(transform_fixture, "match-field.graphql", "generate_flow/fixtures/match-field.expected", input, expected).await;
 }
 
-#[test]
-fn match_field_in_query() {
+#[tokio::test]
+async fn match_field_in_query() {
     let input = include_str!("generate_flow/fixtures/match-field-in-query.graphql");
     let expected = include_str!("generate_flow/fixtures/match-field-in-query.expected");
-    test_fixture(transform_fixture, "match-field-in-query.graphql", "generate_flow/fixtures/match-field-in-query.expected", input, expected);
+    test_fixture(transform_fixture, "match-field-in-query.graphql", "generate_flow/fixtures/match-field-in-query.expected", input, expected).await;
 }
 
-#[test]
-fn mutation() {
+#[tokio::test]
+async fn mutation() {
     let input = include_str!("generate_flow/fixtures/mutation.graphql");
     let expected = include_str!("generate_flow/fixtures/mutation.expected");
-    test_fixture(transform_fixture, "mutation.graphql", "generate_flow/fixtures/mutation.expected", input, expected);
+    test_fixture(transform_fixture, "mutation.graphql", "generate_flow/fixtures/mutation.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_input_has_array() {
+#[tokio::test]
+async fn mutation_input_has_array() {
     let input = include_str!("generate_flow/fixtures/mutation-input-has-array.graphql");
     let expected = include_str!("generate_flow/fixtures/mutation-input-has-array.expected");
-    test_fixture(transform_fixture, "mutation-input-has-array.graphql", "generate_flow/fixtures/mutation-input-has-array.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-input-has-array.graphql", "generate_flow/fixtures/mutation-input-has-array.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_with_client_extension() {
+#[tokio::test]
+async fn mutation_with_client_extension() {
     let input = include_str!("generate_flow/fixtures/mutation-with-client-extension.graphql");
     let expected = include_str!("generate_flow/fixtures/mutation-with-client-extension.expected");
-    test_fixture(transform_fixture, "mutation-with-client-extension.graphql", "generate_flow/fixtures/mutation-with-client-extension.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-with-client-extension.graphql", "generate_flow/fixtures/mutation-with-client-extension.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_with_enums_on_fragment() {
+#[tokio::test]
+async fn mutation_with_enums_on_fragment() {
     let input = include_str!("generate_flow/fixtures/mutation-with-enums-on-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/mutation-with-enums-on-fragment.expected");
-    test_fixture(transform_fixture, "mutation-with-enums-on-fragment.graphql", "generate_flow/fixtures/mutation-with-enums-on-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-with-enums-on-fragment.graphql", "generate_flow/fixtures/mutation-with-enums-on-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_with_nested_fragments() {
+#[tokio::test]
+async fn mutation_with_nested_fragments() {
     let input = include_str!("generate_flow/fixtures/mutation-with-nested-fragments.graphql");
     let expected = include_str!("generate_flow/fixtures/mutation-with-nested-fragments.expected");
-    test_fixture(transform_fixture, "mutation-with-nested-fragments.graphql", "generate_flow/fixtures/mutation-with-nested-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-with-nested-fragments.graphql", "generate_flow/fixtures/mutation-with-nested-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_with_response_on_inline_fragments() {
+#[tokio::test]
+async fn mutation_with_response_on_inline_fragments() {
     let input = include_str!("generate_flow/fixtures/mutation-with-response-on-inline-fragments.graphql");
     let expected = include_str!("generate_flow/fixtures/mutation-with-response-on-inline-fragments.expected");
-    test_fixture(transform_fixture, "mutation-with-response-on-inline-fragments.graphql", "generate_flow/fixtures/mutation-with-response-on-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-with-response-on-inline-fragments.graphql", "generate_flow/fixtures/mutation-with-response-on-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn no_inline_fragment() {
+#[tokio::test]
+async fn no_inline_fragment() {
     let input = include_str!("generate_flow/fixtures/no-inline-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/no-inline-fragment.expected");
-    test_fixture(transform_fixture, "no-inline-fragment.graphql", "generate_flow/fixtures/no-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "no-inline-fragment.graphql", "generate_flow/fixtures/no-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn plural_fragment() {
+#[tokio::test]
+async fn plural_fragment() {
     let input = include_str!("generate_flow/fixtures/plural-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/plural-fragment.expected");
-    test_fixture(transform_fixture, "plural-fragment.graphql", "generate_flow/fixtures/plural-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "plural-fragment.graphql", "generate_flow/fixtures/plural-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn query_mixed_provided_variables() {
+#[tokio::test]
+async fn query_mixed_provided_variables() {
     let input = include_str!("generate_flow/fixtures/query-mixed-provided-variables.graphql");
     let expected = include_str!("generate_flow/fixtures/query-mixed-provided-variables.expected");
-    test_fixture(transform_fixture, "query-mixed-provided-variables.graphql", "generate_flow/fixtures/query-mixed-provided-variables.expected", input, expected);
+    test_fixture(transform_fixture, "query-mixed-provided-variables.graphql", "generate_flow/fixtures/query-mixed-provided-variables.expected", input, expected).await;
 }
 
-#[test]
-fn query_only_provided_variables() {
+#[tokio::test]
+async fn query_only_provided_variables() {
     let input = include_str!("generate_flow/fixtures/query-only-provided-variables.graphql");
     let expected = include_str!("generate_flow/fixtures/query-only-provided-variables.expected");
-    test_fixture(transform_fixture, "query-only-provided-variables.graphql", "generate_flow/fixtures/query-only-provided-variables.expected", input, expected);
+    test_fixture(transform_fixture, "query-only-provided-variables.graphql", "generate_flow/fixtures/query-only-provided-variables.expected", input, expected).await;
 }
 
-#[test]
-fn query_provided_variables_custom_scalar() {
+#[tokio::test]
+async fn query_provided_variables_custom_scalar() {
     let input = include_str!("generate_flow/fixtures/query-provided-variables-custom-scalar.graphql");
     let expected = include_str!("generate_flow/fixtures/query-provided-variables-custom-scalar.expected");
-    test_fixture(transform_fixture, "query-provided-variables-custom-scalar.graphql", "generate_flow/fixtures/query-provided-variables-custom-scalar.expected", input, expected);
+    test_fixture(transform_fixture, "query-provided-variables-custom-scalar.graphql", "generate_flow/fixtures/query-provided-variables-custom-scalar.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_handles() {
+#[tokio::test]
+async fn query_with_handles() {
     let input = include_str!("generate_flow/fixtures/query-with-handles.graphql");
     let expected = include_str!("generate_flow/fixtures/query-with-handles.expected");
-    test_fixture(transform_fixture, "query-with-handles.graphql", "generate_flow/fixtures/query-with-handles.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-handles.graphql", "generate_flow/fixtures/query-with-handles.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_match_fields() {
+#[tokio::test]
+async fn query_with_match_fields() {
     let input = include_str!("generate_flow/fixtures/query-with-match-fields.graphql");
     let expected = include_str!("generate_flow/fixtures/query-with-match-fields.expected");
-    test_fixture(transform_fixture, "query-with-match-fields.graphql", "generate_flow/fixtures/query-with-match-fields.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-match-fields.graphql", "generate_flow/fixtures/query-with-match-fields.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_module_field() {
+#[tokio::test]
+async fn query_with_module_field() {
     let input = include_str!("generate_flow/fixtures/query-with-module-field.graphql");
     let expected = include_str!("generate_flow/fixtures/query-with-module-field.expected");
-    test_fixture(transform_fixture, "query-with-module-field.graphql", "generate_flow/fixtures/query-with-module-field.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-module-field.graphql", "generate_flow/fixtures/query-with-module-field.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_multiple_match_fields() {
+#[tokio::test]
+async fn query_with_multiple_match_fields() {
     let input = include_str!("generate_flow/fixtures/query-with-multiple-match-fields.graphql");
     let expected = include_str!("generate_flow/fixtures/query-with-multiple-match-fields.expected");
-    test_fixture(transform_fixture, "query-with-multiple-match-fields.graphql", "generate_flow/fixtures/query-with-multiple-match-fields.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-multiple-match-fields.graphql", "generate_flow/fixtures/query-with-multiple-match-fields.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_raw_response_on_conditional() {
+#[tokio::test]
+async fn query_with_raw_response_on_conditional() {
     let input = include_str!("generate_flow/fixtures/query-with-raw-response-on-conditional.graphql");
     let expected = include_str!("generate_flow/fixtures/query-with-raw-response-on-conditional.expected");
-    test_fixture(transform_fixture, "query-with-raw-response-on-conditional.graphql", "generate_flow/fixtures/query-with-raw-response-on-conditional.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-raw-response-on-conditional.graphql", "generate_flow/fixtures/query-with-raw-response-on-conditional.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_raw_response_on_literal_conditional() {
+#[tokio::test]
+async fn query_with_raw_response_on_literal_conditional() {
     let input = include_str!("generate_flow/fixtures/query-with-raw-response-on-literal-conditional.graphql");
     let expected = include_str!("generate_flow/fixtures/query-with-raw-response-on-literal-conditional.expected");
-    test_fixture(transform_fixture, "query-with-raw-response-on-literal-conditional.graphql", "generate_flow/fixtures/query-with-raw-response-on-literal-conditional.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-raw-response-on-literal-conditional.graphql", "generate_flow/fixtures/query-with-raw-response-on-literal-conditional.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_stream() {
+#[tokio::test]
+async fn query_with_stream() {
     let input = include_str!("generate_flow/fixtures/query-with-stream.graphql");
     let expected = include_str!("generate_flow/fixtures/query-with-stream.expected");
-    test_fixture(transform_fixture, "query-with-stream.graphql", "generate_flow/fixtures/query-with-stream.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-stream.graphql", "generate_flow/fixtures/query-with-stream.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_stream_connection() {
+#[tokio::test]
+async fn query_with_stream_connection() {
     let input = include_str!("generate_flow/fixtures/query-with-stream-connection.graphql");
     let expected = include_str!("generate_flow/fixtures/query-with-stream-connection.expected");
-    test_fixture(transform_fixture, "query-with-stream-connection.graphql", "generate_flow/fixtures/query-with-stream-connection.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-stream-connection.graphql", "generate_flow/fixtures/query-with-stream-connection.expected", input, expected).await;
 }
 
-#[test]
-fn recursive_fragments() {
+#[tokio::test]
+async fn recursive_fragments() {
     let input = include_str!("generate_flow/fixtures/recursive-fragments.graphql");
     let expected = include_str!("generate_flow/fixtures/recursive-fragments.expected");
-    test_fixture(transform_fixture, "recursive-fragments.graphql", "generate_flow/fixtures/recursive-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "recursive-fragments.graphql", "generate_flow/fixtures/recursive-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable() {
+#[tokio::test]
+async fn refetchable() {
     let input = include_str!("generate_flow/fixtures/refetchable.graphql");
     let expected = include_str!("generate_flow/fixtures/refetchable.expected");
-    test_fixture(transform_fixture, "refetchable.graphql", "generate_flow/fixtures/refetchable.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable.graphql", "generate_flow/fixtures/refetchable.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment() {
+#[tokio::test]
+async fn refetchable_fragment() {
     let input = include_str!("generate_flow/fixtures/refetchable-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/refetchable-fragment.expected");
-    test_fixture(transform_fixture, "refetchable-fragment.graphql", "generate_flow/fixtures/refetchable-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment.graphql", "generate_flow/fixtures/refetchable-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn regular_query_with_assignable_fragment_spread() {
+#[tokio::test]
+async fn regular_query_with_assignable_fragment_spread() {
     let input = include_str!("generate_flow/fixtures/regular-query-with-assignable-fragment-spread.graphql");
     let expected = include_str!("generate_flow/fixtures/regular-query-with-assignable-fragment-spread.expected");
-    test_fixture(transform_fixture, "regular-query-with-assignable-fragment-spread.graphql", "generate_flow/fixtures/regular-query-with-assignable-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "regular-query-with-assignable-fragment-spread.graphql", "generate_flow/fixtures/regular-query-with-assignable-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn relay_client_id_field() {
+#[tokio::test]
+async fn relay_client_id_field() {
     let input = include_str!("generate_flow/fixtures/relay-client-id-field.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-client-id-field.expected");
-    test_fixture(transform_fixture, "relay-client-id-field.graphql", "generate_flow/fixtures/relay-client-id-field.expected", input, expected);
+    test_fixture(transform_fixture, "relay-client-id-field.graphql", "generate_flow/fixtures/relay-client-id-field.expected", input, expected).await;
 }
 
-#[test]
-fn relay_live_resolver() {
+#[tokio::test]
+async fn relay_live_resolver() {
     let input = include_str!("generate_flow/fixtures/relay-live-resolver.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-live-resolver.expected");
-    test_fixture(transform_fixture, "relay-live-resolver.graphql", "generate_flow/fixtures/relay-live-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "relay-live-resolver.graphql", "generate_flow/fixtures/relay-live-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_live_resolver_no_fragment() {
+#[tokio::test]
+async fn relay_live_resolver_no_fragment() {
     let input = include_str!("generate_flow/fixtures/relay-live-resolver-no-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-live-resolver-no-fragment.expected");
-    test_fixture(transform_fixture, "relay-live-resolver-no-fragment.graphql", "generate_flow/fixtures/relay-live-resolver-no-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "relay-live-resolver-no-fragment.graphql", "generate_flow/fixtures/relay-live-resolver-no-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn relay_live_resolver_with_field_args() {
+#[tokio::test]
+async fn relay_live_resolver_with_field_args() {
     let input = include_str!("generate_flow/fixtures/relay-live-resolver-with-field-args.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-live-resolver-with-field-args.expected");
-    test_fixture(transform_fixture, "relay-live-resolver-with-field-args.graphql", "generate_flow/fixtures/relay-live-resolver-with-field-args.expected", input, expected);
+    test_fixture(transform_fixture, "relay-live-resolver-with-field-args.graphql", "generate_flow/fixtures/relay-live-resolver-with-field-args.expected", input, expected).await;
 }
 
-#[test]
-fn relay_live_resolver_with_field_args_no_fragment() {
+#[tokio::test]
+async fn relay_live_resolver_with_field_args_no_fragment() {
     let input = include_str!("generate_flow/fixtures/relay-live-resolver-with-field-args-no-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-live-resolver-with-field-args-no-fragment.expected");
-    test_fixture(transform_fixture, "relay-live-resolver-with-field-args-no-fragment.graphql", "generate_flow/fixtures/relay-live-resolver-with-field-args-no-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "relay-live-resolver-with-field-args-no-fragment.graphql", "generate_flow/fixtures/relay-live-resolver-with-field-args-no-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver() {
+#[tokio::test]
+async fn relay_resolver() {
     let input = include_str!("generate_flow/fixtures/relay-resolver.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver.expected");
-    test_fixture(transform_fixture, "relay-resolver.graphql", "generate_flow/fixtures/relay-resolver.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver.graphql", "generate_flow/fixtures/relay-resolver.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_client_edge() {
+#[tokio::test]
+async fn relay_resolver_client_edge() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-client-edge.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-client-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-client-edge.graphql", "generate_flow/fixtures/relay-resolver-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-client-edge.graphql", "generate_flow/fixtures/relay-resolver-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_client_edge_required() {
+#[tokio::test]
+async fn relay_resolver_client_edge_required() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-client-edge-required.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-client-edge-required.expected");
-    test_fixture(transform_fixture, "relay-resolver-client-edge-required.graphql", "generate_flow/fixtures/relay-resolver-client-edge-required.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-client-edge-required.graphql", "generate_flow/fixtures/relay-resolver-client-edge-required.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_client_edge_required_edge() {
+#[tokio::test]
+async fn relay_resolver_client_edge_required_edge() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-client-edge-required-edge.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-client-edge-required-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-client-edge-required-edge.graphql", "generate_flow/fixtures/relay-resolver-client-edge-required-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-client-edge-required-edge.graphql", "generate_flow/fixtures/relay-resolver-client-edge-required-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_in_fragment() {
+#[tokio::test]
+async fn relay_resolver_in_fragment() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-in-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-in-fragment.expected");
-    test_fixture(transform_fixture, "relay-resolver-in-fragment.graphql", "generate_flow/fixtures/relay-resolver-in-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-in-fragment.graphql", "generate_flow/fixtures/relay-resolver-in-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_inject_fragment_data() {
+#[tokio::test]
+async fn relay_resolver_inject_fragment_data() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-inject-fragment-data.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-inject-fragment-data.expected");
-    test_fixture(transform_fixture, "relay-resolver-inject-fragment-data.graphql", "generate_flow/fixtures/relay-resolver-inject-fragment-data.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-inject-fragment-data.graphql", "generate_flow/fixtures/relay-resolver-inject-fragment-data.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_live_client_edge() {
+#[tokio::test]
+async fn relay_resolver_live_client_edge() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-live-client-edge.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-live-client-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-live-client-edge.graphql", "generate_flow/fixtures/relay-resolver-live-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-live-client-edge.graphql", "generate_flow/fixtures/relay-resolver-live-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_multiple_consumers() {
+#[tokio::test]
+async fn relay_resolver_multiple_consumers() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-multiple-consumers.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-multiple-consumers.expected");
-    test_fixture(transform_fixture, "relay-resolver-multiple-consumers.graphql", "generate_flow/fixtures/relay-resolver-multiple-consumers.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-multiple-consumers.graphql", "generate_flow/fixtures/relay-resolver-multiple-consumers.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_named_import() {
+#[tokio::test]
+async fn relay_resolver_named_import() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-named-import.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-named-import.expected");
-    test_fixture(transform_fixture, "relay-resolver-named-import.graphql", "generate_flow/fixtures/relay-resolver-named-import.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-named-import.graphql", "generate_flow/fixtures/relay-resolver-named-import.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_plural_client_edge() {
+#[tokio::test]
+async fn relay_resolver_plural_client_edge() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-plural-client-edge.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-plural-client-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-plural-client-edge.graphql", "generate_flow/fixtures/relay-resolver-plural-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-plural-client-edge.graphql", "generate_flow/fixtures/relay-resolver-plural-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_plural_client_edge_with_required_edge() {
+#[tokio::test]
+async fn relay_resolver_plural_client_edge_with_required_edge() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-plural-client-edge-with-required-edge.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-plural-client-edge-with-required-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-plural-client-edge-with-required-edge.graphql", "generate_flow/fixtures/relay-resolver-plural-client-edge-with-required-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-plural-client-edge-with-required-edge.graphql", "generate_flow/fixtures/relay-resolver-plural-client-edge-with-required-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_plural_required_client_edge() {
+#[tokio::test]
+async fn relay_resolver_plural_required_client_edge() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-plural-required-client-edge.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-plural-required-client-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-plural-required-client-edge.graphql", "generate_flow/fixtures/relay-resolver-plural-required-client-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-plural-required-client-edge.graphql", "generate_flow/fixtures/relay-resolver-plural-required-client-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_plural_required_client_edge_with_required_edge() {
+#[tokio::test]
+async fn relay_resolver_plural_required_client_edge_with_required_edge() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-plural-required-client-edge-with-required-edge.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-plural-required-client-edge-with-required-edge.expected");
-    test_fixture(transform_fixture, "relay-resolver-plural-required-client-edge-with-required-edge.graphql", "generate_flow/fixtures/relay-resolver-plural-required-client-edge-with-required-edge.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-plural-required-client-edge-with-required-edge.graphql", "generate_flow/fixtures/relay-resolver-plural-required-client-edge-with-required-edge.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_raw_response() {
+#[tokio::test]
+async fn relay_resolver_raw_response() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-raw-response.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-raw-response.expected");
-    test_fixture(transform_fixture, "relay-resolver-raw-response.graphql", "generate_flow/fixtures/relay-resolver-raw-response.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-raw-response.graphql", "generate_flow/fixtures/relay-resolver-raw-response.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_required() {
+#[tokio::test]
+async fn relay_resolver_required() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-required.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-required.expected");
-    test_fixture(transform_fixture, "relay-resolver-required.graphql", "generate_flow/fixtures/relay-resolver-required.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-required.graphql", "generate_flow/fixtures/relay-resolver-required.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_scalar_plural() {
+#[tokio::test]
+async fn relay_resolver_scalar_plural() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-scalar-plural.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-scalar-plural.expected");
-    test_fixture(transform_fixture, "relay-resolver-scalar-plural.graphql", "generate_flow/fixtures/relay-resolver-scalar-plural.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-scalar-plural.graphql", "generate_flow/fixtures/relay-resolver-scalar-plural.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_client_interface() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_client_interface() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-client-interface.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-client-interface.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-interface.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-client-interface.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-interface.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-client-interface.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_client_object() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_client_object() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-client-object.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-client-object.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-object.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-client-object.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-object.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-client-object.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_client_object_plural() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_client_object_plural() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-client-object-plural.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-client-object-plural.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-object-plural.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-client-object-plural.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-object-plural.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-client-object-plural.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_enum() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_enum() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-enum.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-enum.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-enum.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-enum.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-enum.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-enum.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_enum_plural() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_enum_plural() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-enum-plural.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-enum-plural.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-enum-plural.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-enum-plural.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-enum-plural.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-enum-plural.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_relay_resolver_value() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_relay_resolver_value() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-relay-resolver-value.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-relay-resolver-value.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_relay_resolver_value_plural() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_relay_resolver_value_plural() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value-plural.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value-plural.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-relay-resolver-value-plural.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value-plural.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-relay-resolver-value-plural.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value-plural.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_relay_resolver_value_required() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_relay_resolver_value_required() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value-required.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value-required.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-relay-resolver-value-required.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value-required.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-relay-resolver-value-required.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-relay-resolver-value-required.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_scalar() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_scalar() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-scalar.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-scalar.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-scalar.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-scalar.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-scalar.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-scalar.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_scalar_plural() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_scalar_plural() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-scalar-plural.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-scalar-plural.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-scalar-plural.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-scalar-plural.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-scalar-plural.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-scalar-plural.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_scalar_required() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_scalar_required() {
     let input = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-scalar-required.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-resolver-with-output-type-scalar-required.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-scalar-required.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-scalar-required.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-scalar-required.graphql", "generate_flow/fixtures/relay-resolver-with-output-type-scalar-required.expected", input, expected).await;
 }
 
-#[test]
-fn relay_weak_client_type() {
+#[tokio::test]
+async fn relay_weak_client_type() {
     let input = include_str!("generate_flow/fixtures/relay-weak-client-type.graphql");
     let expected = include_str!("generate_flow/fixtures/relay-weak-client-type.expected");
-    test_fixture(transform_fixture, "relay-weak-client-type.graphql", "generate_flow/fixtures/relay-weak-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "relay-weak-client-type.graphql", "generate_flow/fixtures/relay-weak-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn required() {
+#[tokio::test]
+async fn required() {
     let input = include_str!("generate_flow/fixtures/required.graphql");
     let expected = include_str!("generate_flow/fixtures/required.expected");
-    test_fixture(transform_fixture, "required.graphql", "generate_flow/fixtures/required.expected", input, expected);
+    test_fixture(transform_fixture, "required.graphql", "generate_flow/fixtures/required.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_through_inline_fragments_to_fragment() {
+#[tokio::test]
+async fn required_bubbles_through_inline_fragments_to_fragment() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-through-inline-fragments-to-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-through-inline-fragments-to-fragment.expected");
-    test_fixture(transform_fixture, "required-bubbles-through-inline-fragments-to-fragment.graphql", "generate_flow/fixtures/required-bubbles-through-inline-fragments-to-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-through-inline-fragments-to-fragment.graphql", "generate_flow/fixtures/required-bubbles-through-inline-fragments-to-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_fragment() {
+#[tokio::test]
+async fn required_bubbles_to_fragment() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-to-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-to-fragment.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-fragment.graphql", "generate_flow/fixtures/required-bubbles-to-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-fragment.graphql", "generate_flow/fixtures/required-bubbles-to-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_item_in_plural_field() {
+#[tokio::test]
+async fn required_bubbles_to_item_in_plural_field() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-to-item-in-plural-field.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-to-item-in-plural-field.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-item-in-plural-field.graphql", "generate_flow/fixtures/required-bubbles-to-item-in-plural-field.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-item-in-plural-field.graphql", "generate_flow/fixtures/required-bubbles-to-item-in-plural-field.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_item_in_required_plural_field() {
+#[tokio::test]
+async fn required_bubbles_to_item_in_required_plural_field() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-to-item-in-required-plural-field.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-to-item-in-required-plural-field.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-item-in-required-plural-field.graphql", "generate_flow/fixtures/required-bubbles-to-item-in-required-plural-field.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-item-in-required-plural-field.graphql", "generate_flow/fixtures/required-bubbles-to-item-in-required-plural-field.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_non_null_item_in_non_null_plural_linked_field() {
+#[tokio::test]
+async fn required_bubbles_to_non_null_item_in_non_null_plural_linked_field() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-to-non-null-item-in-non-null-plural-linked-field.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-to-non-null-item-in-non-null-plural-linked-field.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-non-null-item-in-non-null-plural-linked-field.graphql", "generate_flow/fixtures/required-bubbles-to-non-null-item-in-non-null-plural-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-non-null-item-in-non-null-plural-linked-field.graphql", "generate_flow/fixtures/required-bubbles-to-non-null-item-in-non-null-plural-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_non_null_linked_field() {
+#[tokio::test]
+async fn required_bubbles_to_non_null_linked_field() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-to-non-null-linked-field.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-to-non-null-linked-field.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-non-null-linked-field.graphql", "generate_flow/fixtures/required-bubbles-to-non-null-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-non-null-linked-field.graphql", "generate_flow/fixtures/required-bubbles-to-non-null-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_non_null_linked_field_through_inline_fragment() {
+#[tokio::test]
+async fn required_bubbles_to_non_null_linked_field_through_inline_fragment() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-to-non-null-linked-field-through-inline-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-to-non-null-linked-field-through-inline-fragment.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-non-null-linked-field-through-inline-fragment.graphql", "generate_flow/fixtures/required-bubbles-to-non-null-linked-field-through-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-non-null-linked-field-through-inline-fragment.graphql", "generate_flow/fixtures/required-bubbles-to-non-null-linked-field-through-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_non_null_plural_linked_field() {
+#[tokio::test]
+async fn required_bubbles_to_non_null_plural_linked_field() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-to-non-null-plural-linked-field.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-to-non-null-plural-linked-field.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-non-null-plural-linked-field.graphql", "generate_flow/fixtures/required-bubbles-to-non-null-plural-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-non-null-plural-linked-field.graphql", "generate_flow/fixtures/required-bubbles-to-non-null-plural-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_plural_fragment_root() {
+#[tokio::test]
+async fn required_bubbles_to_plural_fragment_root() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-to-plural-fragment-root.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-to-plural-fragment-root.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-plural-fragment-root.graphql", "generate_flow/fixtures/required-bubbles-to-plural-fragment-root.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-plural-fragment-root.graphql", "generate_flow/fixtures/required-bubbles-to-plural-fragment-root.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_query() {
+#[tokio::test]
+async fn required_bubbles_to_query() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-to-query.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-to-query.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-query.graphql", "generate_flow/fixtures/required-bubbles-to-query.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-query.graphql", "generate_flow/fixtures/required-bubbles-to-query.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_up_to_mutation_response() {
+#[tokio::test]
+async fn required_bubbles_up_to_mutation_response() {
     let input = include_str!("generate_flow/fixtures/required-bubbles-up-to-mutation-response.graphql");
     let expected = include_str!("generate_flow/fixtures/required-bubbles-up-to-mutation-response.expected");
-    test_fixture(transform_fixture, "required-bubbles-up-to-mutation-response.graphql", "generate_flow/fixtures/required-bubbles-up-to-mutation-response.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-up-to-mutation-response.graphql", "generate_flow/fixtures/required-bubbles-up-to-mutation-response.expected", input, expected).await;
 }
 
-#[test]
-fn required_chain_bubbles_to_non_null_linked_field_through_inline_fragment() {
+#[tokio::test]
+async fn required_chain_bubbles_to_non_null_linked_field_through_inline_fragment() {
     let input = include_str!("generate_flow/fixtures/required-chain-bubbles-to-non-null-linked-field-through-inline-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/required-chain-bubbles-to-non-null-linked-field-through-inline-fragment.expected");
-    test_fixture(transform_fixture, "required-chain-bubbles-to-non-null-linked-field-through-inline-fragment.graphql", "generate_flow/fixtures/required-chain-bubbles-to-non-null-linked-field-through-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-chain-bubbles-to-non-null-linked-field-through-inline-fragment.graphql", "generate_flow/fixtures/required-chain-bubbles-to-non-null-linked-field-through-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_isolates_concrete_inline_fragments() {
+#[tokio::test]
+async fn required_isolates_concrete_inline_fragments() {
     let input = include_str!("generate_flow/fixtures/required-isolates-concrete-inline-fragments.graphql");
     let expected = include_str!("generate_flow/fixtures/required-isolates-concrete-inline-fragments.expected");
-    test_fixture(transform_fixture, "required-isolates-concrete-inline-fragments.graphql", "generate_flow/fixtures/required-isolates-concrete-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "required-isolates-concrete-inline-fragments.graphql", "generate_flow/fixtures/required-isolates-concrete-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn required_raw_response_type() {
+#[tokio::test]
+async fn required_raw_response_type() {
     let input = include_str!("generate_flow/fixtures/required-raw-response-type.graphql");
     let expected = include_str!("generate_flow/fixtures/required-raw-response-type.expected");
-    test_fixture(transform_fixture, "required-raw-response-type.graphql", "generate_flow/fixtures/required-raw-response-type.expected", input, expected);
+    test_fixture(transform_fixture, "required-raw-response-type.graphql", "generate_flow/fixtures/required-raw-response-type.expected", input, expected).await;
 }
 
-#[test]
-fn required_throw_doesnt_bubbles_to_fragment() {
+#[tokio::test]
+async fn required_throw_doesnt_bubbles_to_fragment() {
     let input = include_str!("generate_flow/fixtures/required-throw-doesnt-bubbles-to-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/required-throw-doesnt-bubbles-to-fragment.expected");
-    test_fixture(transform_fixture, "required-throw-doesnt-bubbles-to-fragment.graphql", "generate_flow/fixtures/required-throw-doesnt-bubbles-to-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-throw-doesnt-bubbles-to-fragment.graphql", "generate_flow/fixtures/required-throw-doesnt-bubbles-to-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_throw_doesnt_bubbles_to_query() {
+#[tokio::test]
+async fn required_throw_doesnt_bubbles_to_query() {
     let input = include_str!("generate_flow/fixtures/required-throw-doesnt-bubbles-to-query.graphql");
     let expected = include_str!("generate_flow/fixtures/required-throw-doesnt-bubbles-to-query.expected");
-    test_fixture(transform_fixture, "required-throw-doesnt-bubbles-to-query.graphql", "generate_flow/fixtures/required-throw-doesnt-bubbles-to-query.expected", input, expected);
+    test_fixture(transform_fixture, "required-throw-doesnt-bubbles-to-query.graphql", "generate_flow/fixtures/required-throw-doesnt-bubbles-to-query.expected", input, expected).await;
 }
 
-#[test]
-fn required_throws_nested() {
+#[tokio::test]
+async fn required_throws_nested() {
     let input = include_str!("generate_flow/fixtures/required-throws-nested.graphql");
     let expected = include_str!("generate_flow/fixtures/required-throws-nested.expected");
-    test_fixture(transform_fixture, "required-throws-nested.graphql", "generate_flow/fixtures/required-throws-nested.expected", input, expected);
+    test_fixture(transform_fixture, "required-throws-nested.graphql", "generate_flow/fixtures/required-throws-nested.expected", input, expected).await;
 }
 
-#[test]
-fn required_throws_within_non_null_linked_field() {
+#[tokio::test]
+async fn required_throws_within_non_null_linked_field() {
     let input = include_str!("generate_flow/fixtures/required-throws-within-non-null-linked-field.graphql");
     let expected = include_str!("generate_flow/fixtures/required-throws-within-non-null-linked-field.expected");
-    test_fixture(transform_fixture, "required-throws-within-non-null-linked-field.graphql", "generate_flow/fixtures/required-throws-within-non-null-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "required-throws-within-non-null-linked-field.graphql", "generate_flow/fixtures/required-throws-within-non-null-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn required_throws_within_non_null_plural_linked_field() {
+#[tokio::test]
+async fn required_throws_within_non_null_plural_linked_field() {
     let input = include_str!("generate_flow/fixtures/required-throws-within-non-null-plural-linked-field.graphql");
     let expected = include_str!("generate_flow/fixtures/required-throws-within-non-null-plural-linked-field.expected");
-    test_fixture(transform_fixture, "required-throws-within-non-null-plural-linked-field.graphql", "generate_flow/fixtures/required-throws-within-non-null-plural-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "required-throws-within-non-null-plural-linked-field.graphql", "generate_flow/fixtures/required-throws-within-non-null-plural-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn required_within_aliased_inline_fragment() {
+#[tokio::test]
+async fn required_within_aliased_inline_fragment() {
     let input = include_str!("generate_flow/fixtures/required-within-aliased-inline-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/required-within-aliased-inline-fragment.expected");
-    test_fixture(transform_fixture, "required-within-aliased-inline-fragment.graphql", "generate_flow/fixtures/required-within-aliased-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-within-aliased-inline-fragment.graphql", "generate_flow/fixtures/required-within-aliased-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_within_aliased_inline_fragment_on_abstract() {
+#[tokio::test]
+async fn required_within_aliased_inline_fragment_on_abstract() {
     let input = include_str!("generate_flow/fixtures/required-within-aliased-inline-fragment-on-abstract.graphql");
     let expected = include_str!("generate_flow/fixtures/required-within-aliased-inline-fragment-on-abstract.expected");
-    test_fixture(transform_fixture, "required-within-aliased-inline-fragment-on-abstract.graphql", "generate_flow/fixtures/required-within-aliased-inline-fragment-on-abstract.expected", input, expected);
+    test_fixture(transform_fixture, "required-within-aliased-inline-fragment-on-abstract.graphql", "generate_flow/fixtures/required-within-aliased-inline-fragment-on-abstract.expected", input, expected).await;
 }
 
-#[test]
-fn roots() {
+#[tokio::test]
+async fn roots() {
     let input = include_str!("generate_flow/fixtures/roots.graphql");
     let expected = include_str!("generate_flow/fixtures/roots.expected");
-    test_fixture(transform_fixture, "roots.graphql", "generate_flow/fixtures/roots.expected", input, expected);
+    test_fixture(transform_fixture, "roots.graphql", "generate_flow/fixtures/roots.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_field() {
+#[tokio::test]
+async fn scalar_field() {
     let input = include_str!("generate_flow/fixtures/scalar-field.graphql");
     let expected = include_str!("generate_flow/fixtures/scalar-field.expected");
-    test_fixture(transform_fixture, "scalar-field.graphql", "generate_flow/fixtures/scalar-field.expected", input, expected);
+    test_fixture(transform_fixture, "scalar-field.graphql", "generate_flow/fixtures/scalar-field.expected", input, expected).await;
 }
 
-#[test]
-fn simple() {
+#[tokio::test]
+async fn simple() {
     let input = include_str!("generate_flow/fixtures/simple.graphql");
     let expected = include_str!("generate_flow/fixtures/simple.expected");
-    test_fixture(transform_fixture, "simple.graphql", "generate_flow/fixtures/simple.expected", input, expected);
+    test_fixture(transform_fixture, "simple.graphql", "generate_flow/fixtures/simple.expected", input, expected).await;
 }
 
-#[test]
-fn typename_in_union_with_other_fields() {
+#[tokio::test]
+async fn typename_in_union_with_other_fields() {
     let input = include_str!("generate_flow/fixtures/typename-in-union-with-other-fields.graphql");
     let expected = include_str!("generate_flow/fixtures/typename-in-union-with-other-fields.expected");
-    test_fixture(transform_fixture, "typename-in-union-with-other-fields.graphql", "generate_flow/fixtures/typename-in-union-with-other-fields.expected", input, expected);
+    test_fixture(transform_fixture, "typename-in-union-with-other-fields.graphql", "generate_flow/fixtures/typename-in-union-with-other-fields.expected", input, expected).await;
 }
 
-#[test]
-fn typename_inside_with_overlapping_fields() {
+#[tokio::test]
+async fn typename_inside_with_overlapping_fields() {
     let input = include_str!("generate_flow/fixtures/typename-inside-with-overlapping-fields.graphql");
     let expected = include_str!("generate_flow/fixtures/typename-inside-with-overlapping-fields.expected");
-    test_fixture(transform_fixture, "typename-inside-with-overlapping-fields.graphql", "generate_flow/fixtures/typename-inside-with-overlapping-fields.expected", input, expected);
+    test_fixture(transform_fixture, "typename-inside-with-overlapping-fields.graphql", "generate_flow/fixtures/typename-inside-with-overlapping-fields.expected", input, expected).await;
 }
 
-#[test]
-fn typename_on_union() {
+#[tokio::test]
+async fn typename_on_union() {
     let input = include_str!("generate_flow/fixtures/typename-on-union.graphql");
     let expected = include_str!("generate_flow/fixtures/typename-on-union.expected");
-    test_fixture(transform_fixture, "typename-on-union.graphql", "generate_flow/fixtures/typename-on-union.expected", input, expected);
+    test_fixture(transform_fixture, "typename-on-union.graphql", "generate_flow/fixtures/typename-on-union.expected", input, expected).await;
 }
 
-#[test]
-fn typename_on_union_with_non_matching_aliases() {
+#[tokio::test]
+async fn typename_on_union_with_non_matching_aliases() {
     let input = include_str!("generate_flow/fixtures/typename-on-union-with-non-matching-aliases.graphql");
     let expected = include_str!("generate_flow/fixtures/typename-on-union-with-non-matching-aliases.expected");
-    test_fixture(transform_fixture, "typename-on-union-with-non-matching-aliases.graphql", "generate_flow/fixtures/typename-on-union-with-non-matching-aliases.expected", input, expected);
+    test_fixture(transform_fixture, "typename-on-union-with-non-matching-aliases.graphql", "generate_flow/fixtures/typename-on-union-with-non-matching-aliases.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_fragment_spreads() {
+#[tokio::test]
+async fn unmasked_fragment_spreads() {
     let input = include_str!("generate_flow/fixtures/unmasked-fragment-spreads.graphql");
     let expected = include_str!("generate_flow/fixtures/unmasked-fragment-spreads.expected");
-    test_fixture(transform_fixture, "unmasked-fragment-spreads.graphql", "generate_flow/fixtures/unmasked-fragment-spreads.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-fragment-spreads.graphql", "generate_flow/fixtures/unmasked-fragment-spreads.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread() {
+#[tokio::test]
+async fn updatable_fragment_spread() {
     let input = include_str!("generate_flow/fixtures/updatable-fragment-spread.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-fragment-spread.expected");
-    test_fixture(transform_fixture, "updatable-fragment-spread.graphql", "generate_flow/fixtures/updatable-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment-spread.graphql", "generate_flow/fixtures/updatable-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_and_regular_spread() {
+#[tokio::test]
+async fn updatable_fragment_spread_and_regular_spread() {
     let input = include_str!("generate_flow/fixtures/updatable-fragment-spread-and-regular-spread.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-fragment-spread-and-regular-spread.expected");
-    test_fixture(transform_fixture, "updatable-fragment-spread-and-regular-spread.graphql", "generate_flow/fixtures/updatable-fragment-spread-and-regular-spread.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment-spread-and-regular-spread.graphql", "generate_flow/fixtures/updatable-fragment-spread-and-regular-spread.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_fragment_spread_multiple() {
+#[tokio::test]
+async fn updatable_fragment_spread_multiple() {
     let input = include_str!("generate_flow/fixtures/updatable-fragment-spread-multiple.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-fragment-spread-multiple.expected");
-    test_fixture(transform_fixture, "updatable-fragment-spread-multiple.graphql", "generate_flow/fixtures/updatable-fragment-spread-multiple.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-fragment-spread-multiple.graphql", "generate_flow/fixtures/updatable-fragment-spread-multiple.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_operation() {
+#[tokio::test]
+async fn updatable_operation() {
     let input = include_str!("generate_flow/fixtures/updatable-operation.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-operation.expected");
-    test_fixture(transform_fixture, "updatable-operation.graphql", "generate_flow/fixtures/updatable-operation.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-operation.graphql", "generate_flow/fixtures/updatable-operation.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_operation_assignable_fragment() {
+#[tokio::test]
+async fn updatable_operation_assignable_fragment() {
     let input = include_str!("generate_flow/fixtures/updatable-operation-assignable-fragment.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-operation-assignable-fragment.expected");
-    test_fixture(transform_fixture, "updatable-operation-assignable-fragment.graphql", "generate_flow/fixtures/updatable-operation-assignable-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-operation-assignable-fragment.graphql", "generate_flow/fixtures/updatable-operation-assignable-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_operation_assignable_fragment_plural() {
+#[tokio::test]
+async fn updatable_operation_assignable_fragment_plural() {
     let input = include_str!("generate_flow/fixtures/updatable-operation-assignable-fragment-plural.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-operation-assignable-fragment-plural.expected");
-    test_fixture(transform_fixture, "updatable-operation-assignable-fragment-plural.graphql", "generate_flow/fixtures/updatable-operation-assignable-fragment-plural.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-operation-assignable-fragment-plural.graphql", "generate_flow/fixtures/updatable-operation-assignable-fragment-plural.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_operation_assignable_fragments_within_narrowing() {
+#[tokio::test]
+async fn updatable_operation_assignable_fragments_within_narrowing() {
     let input = include_str!("generate_flow/fixtures/updatable-operation-assignable-fragments-within-narrowing.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-operation-assignable-fragments-within-narrowing.expected");
-    test_fixture(transform_fixture, "updatable-operation-assignable-fragments-within-narrowing.graphql", "generate_flow/fixtures/updatable-operation-assignable-fragments-within-narrowing.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-operation-assignable-fragments-within-narrowing.graphql", "generate_flow/fixtures/updatable-operation-assignable-fragments-within-narrowing.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_operation_multiple_assignable_fragments() {
+#[tokio::test]
+async fn updatable_operation_multiple_assignable_fragments() {
     let input = include_str!("generate_flow/fixtures/updatable-operation-multiple-assignable-fragments.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-operation-multiple-assignable-fragments.expected");
-    test_fixture(transform_fixture, "updatable-operation-multiple-assignable-fragments.graphql", "generate_flow/fixtures/updatable-operation-multiple-assignable-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-operation-multiple-assignable-fragments.graphql", "generate_flow/fixtures/updatable-operation-multiple-assignable-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_operation_plural_field_no_spreads() {
+#[tokio::test]
+async fn updatable_operation_plural_field_no_spreads() {
     let input = include_str!("generate_flow/fixtures/updatable-operation-plural-field-no-spreads.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-operation-plural-field-no-spreads.expected");
-    test_fixture(transform_fixture, "updatable-operation-plural-field-no-spreads.graphql", "generate_flow/fixtures/updatable-operation-plural-field-no-spreads.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-operation-plural-field-no-spreads.graphql", "generate_flow/fixtures/updatable-operation-plural-field-no-spreads.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_operation_plural_field_with_spreads() {
+#[tokio::test]
+async fn updatable_operation_plural_field_with_spreads() {
     let input = include_str!("generate_flow/fixtures/updatable-operation-plural-field-with-spreads.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-operation-plural-field-with-spreads.expected");
-    test_fixture(transform_fixture, "updatable-operation-plural-field-with-spreads.graphql", "generate_flow/fixtures/updatable-operation-plural-field-with-spreads.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-operation-plural-field-with-spreads.graphql", "generate_flow/fixtures/updatable-operation-plural-field-with-spreads.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_operation_special_fields() {
+#[tokio::test]
+async fn updatable_operation_special_fields() {
     let input = include_str!("generate_flow/fixtures/updatable-operation-special-fields.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-operation-special-fields.expected");
-    test_fixture(transform_fixture, "updatable-operation-special-fields.graphql", "generate_flow/fixtures/updatable-operation-special-fields.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-operation-special-fields.graphql", "generate_flow/fixtures/updatable-operation-special-fields.expected", input, expected).await;
 }
 
-#[test]
-fn updatable_operation_type_refinement() {
+#[tokio::test]
+async fn updatable_operation_type_refinement() {
     let input = include_str!("generate_flow/fixtures/updatable-operation-type-refinement.graphql");
     let expected = include_str!("generate_flow/fixtures/updatable-operation-type-refinement.expected");
-    test_fixture(transform_fixture, "updatable-operation-type-refinement.graphql", "generate_flow/fixtures/updatable-operation-type-refinement.expected", input, expected);
+    test_fixture(transform_fixture, "updatable-operation-type-refinement.graphql", "generate_flow/fixtures/updatable-operation-type-refinement.expected", input, expected).await;
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/mod.rs
@@ -35,7 +35,7 @@ use relay_typegen::TypegenLanguage;
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts = fixture.content.split("%extensions%").collect::<Vec<_>>();
     let (source, schema) = match parts.as_slice() {
         [source, extensions] => (

--- a/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<404c5d236c3730337a395ae6aefa158c>>
+ * @generated SignedSource<<9be38182590fcf401a326372076d4d5f>>
  */
 
 mod generate_flow_with_custom_id;
@@ -12,16 +12,16 @@ mod generate_flow_with_custom_id;
 use generate_flow_with_custom_id::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn relay_client_id_field() {
+#[tokio::test]
+async fn relay_client_id_field() {
     let input = include_str!("generate_flow_with_custom_id/fixtures/relay-client-id-field.graphql");
     let expected = include_str!("generate_flow_with_custom_id/fixtures/relay-client-id-field.expected");
-    test_fixture(transform_fixture, "relay-client-id-field.graphql", "generate_flow_with_custom_id/fixtures/relay-client-id-field.expected", input, expected);
+    test_fixture(transform_fixture, "relay-client-id-field.graphql", "generate_flow_with_custom_id/fixtures/relay-client-id-field.expected", input, expected).await;
 }
 
-#[test]
-fn simple() {
+#[tokio::test]
+async fn simple() {
     let input = include_str!("generate_flow_with_custom_id/fixtures/simple.graphql");
     let expected = include_str!("generate_flow_with_custom_id/fixtures/simple.expected");
-    test_fixture(transform_fixture, "simple.graphql", "generate_flow_with_custom_id/fixtures/simple.expected", input, expected);
+    test_fixture(transform_fixture, "simple.graphql", "generate_flow_with_custom_id/fixtures/simple.expected", input, expected).await;
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
@@ -35,7 +35,7 @@ use relay_typegen::TypegenLanguage;
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts = fixture.content.split("%extensions%").collect::<Vec<_>>();
     let (source, schema) = match parts.as_slice() {
         [source, extensions] => (source, get_test_schema_with_extensions(extensions)),

--- a/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c12cbcb2699b05580be1a62dde8a3bcf>>
+ * @generated SignedSource<<dc250fcec79eeebf8d9776fb18a49d95>>
  */
 
 mod generate_typescript;
@@ -12,408 +12,408 @@ mod generate_typescript;
 use generate_typescript::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn aliased_fragment_raw_response_type() {
+#[tokio::test]
+async fn aliased_fragment_raw_response_type() {
     let input = include_str!("generate_typescript/fixtures/aliased-fragment-raw-response-type.graphql");
     let expected = include_str!("generate_typescript/fixtures/aliased-fragment-raw-response-type.expected");
-    test_fixture(transform_fixture, "aliased-fragment-raw-response-type.graphql", "generate_typescript/fixtures/aliased-fragment-raw-response-type.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-fragment-raw-response-type.graphql", "generate_typescript/fixtures/aliased-fragment-raw-response-type.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_fragment_spread() {
+#[tokio::test]
+async fn aliased_fragment_spread() {
     let input = include_str!("generate_typescript/fixtures/aliased-fragment-spread.graphql");
     let expected = include_str!("generate_typescript/fixtures/aliased-fragment-spread.expected");
-    test_fixture(transform_fixture, "aliased-fragment-spread.graphql", "generate_typescript/fixtures/aliased-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-fragment-spread.graphql", "generate_typescript/fixtures/aliased-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_fragment_spread_in_abstract_selection() {
+#[tokio::test]
+async fn aliased_fragment_spread_in_abstract_selection() {
     let input = include_str!("generate_typescript/fixtures/aliased-fragment-spread-in-abstract-selection.graphql");
     let expected = include_str!("generate_typescript/fixtures/aliased-fragment-spread-in-abstract-selection.expected");
-    test_fixture(transform_fixture, "aliased-fragment-spread-in-abstract-selection.graphql", "generate_typescript/fixtures/aliased-fragment-spread-in-abstract-selection.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-fragment-spread-in-abstract-selection.graphql", "generate_typescript/fixtures/aliased-fragment-spread-in-abstract-selection.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_spread() {
+#[tokio::test]
+async fn aliased_inline_fragment_spread() {
     let input = include_str!("generate_typescript/fixtures/aliased-inline-fragment-spread.graphql");
     let expected = include_str!("generate_typescript/fixtures/aliased-inline-fragment-spread.expected");
-    test_fixture(transform_fixture, "aliased-inline-fragment-spread.graphql", "generate_typescript/fixtures/aliased-inline-fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-inline-fragment-spread.graphql", "generate_typescript/fixtures/aliased-inline-fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_spread_without_type_condition_fragment_root() {
+#[tokio::test]
+async fn aliased_inline_fragment_spread_without_type_condition_fragment_root() {
     let input = include_str!("generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-fragment-root.graphql");
     let expected = include_str!("generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-fragment-root.expected");
-    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-fragment-root.graphql", "generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-fragment-root.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-fragment-root.graphql", "generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-fragment-root.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_spread_without_type_condition_linked_field() {
+#[tokio::test]
+async fn aliased_inline_fragment_spread_without_type_condition_linked_field() {
     let input = include_str!("generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.graphql");
     let expected = include_str!("generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.expected");
-    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-linked-field.graphql", "generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-linked-field.graphql", "generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn aliased_inline_fragment_spread_without_type_condition_query_root() {
+#[tokio::test]
+async fn aliased_inline_fragment_spread_without_type_condition_query_root() {
     let input = include_str!("generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.graphql");
     let expected = include_str!("generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.expected");
-    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-query-root.graphql", "generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.expected", input, expected);
+    test_fixture(transform_fixture, "aliased-inline-fragment-spread-without-type-condition-query-root.graphql", "generate_typescript/fixtures/aliased-inline-fragment-spread-without-type-condition-query-root.expected", input, expected).await;
 }
 
-#[test]
-fn conditional() {
+#[tokio::test]
+async fn conditional() {
     let input = include_str!("generate_typescript/fixtures/conditional.graphql");
     let expected = include_str!("generate_typescript/fixtures/conditional.expected");
-    test_fixture(transform_fixture, "conditional.graphql", "generate_typescript/fixtures/conditional.expected", input, expected);
+    test_fixture(transform_fixture, "conditional.graphql", "generate_typescript/fixtures/conditional.expected", input, expected).await;
 }
 
-#[test]
-fn custom_scalar_type_import() {
+#[tokio::test]
+async fn custom_scalar_type_import() {
     let input = include_str!("generate_typescript/fixtures/custom-scalar-type-import.graphql");
     let expected = include_str!("generate_typescript/fixtures/custom-scalar-type-import.expected");
-    test_fixture(transform_fixture, "custom-scalar-type-import.graphql", "generate_typescript/fixtures/custom-scalar-type-import.expected", input, expected);
+    test_fixture(transform_fixture, "custom-scalar-type-import.graphql", "generate_typescript/fixtures/custom-scalar-type-import.expected", input, expected).await;
 }
 
-#[test]
-fn fragment_spread() {
+#[tokio::test]
+async fn fragment_spread() {
     let input = include_str!("generate_typescript/fixtures/fragment-spread.graphql");
     let expected = include_str!("generate_typescript/fixtures/fragment-spread.expected");
-    test_fixture(transform_fixture, "fragment-spread.graphql", "generate_typescript/fixtures/fragment-spread.expected", input, expected);
+    test_fixture(transform_fixture, "fragment-spread.graphql", "generate_typescript/fixtures/fragment-spread.expected", input, expected).await;
 }
 
-#[test]
-fn inline_fragment() {
+#[tokio::test]
+async fn inline_fragment() {
     let input = include_str!("generate_typescript/fixtures/inline-fragment.graphql");
     let expected = include_str!("generate_typescript/fixtures/inline-fragment.expected");
-    test_fixture(transform_fixture, "inline-fragment.graphql", "generate_typescript/fixtures/inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "inline-fragment.graphql", "generate_typescript/fixtures/inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn linked_field() {
+#[tokio::test]
+async fn linked_field() {
     let input = include_str!("generate_typescript/fixtures/linked-field.graphql");
     let expected = include_str!("generate_typescript/fixtures/linked-field.expected");
-    test_fixture(transform_fixture, "linked-field.graphql", "generate_typescript/fixtures/linked-field.expected", input, expected);
+    test_fixture(transform_fixture, "linked-field.graphql", "generate_typescript/fixtures/linked-field.expected", input, expected).await;
 }
 
-#[test]
-fn match_field() {
+#[tokio::test]
+async fn match_field() {
     let input = include_str!("generate_typescript/fixtures/match-field.graphql");
     let expected = include_str!("generate_typescript/fixtures/match-field.expected");
-    test_fixture(transform_fixture, "match-field.graphql", "generate_typescript/fixtures/match-field.expected", input, expected);
+    test_fixture(transform_fixture, "match-field.graphql", "generate_typescript/fixtures/match-field.expected", input, expected).await;
 }
 
-#[test]
-fn match_field_in_query() {
+#[tokio::test]
+async fn match_field_in_query() {
     let input = include_str!("generate_typescript/fixtures/match-field-in-query.graphql");
     let expected = include_str!("generate_typescript/fixtures/match-field-in-query.expected");
-    test_fixture(transform_fixture, "match-field-in-query.graphql", "generate_typescript/fixtures/match-field-in-query.expected", input, expected);
+    test_fixture(transform_fixture, "match-field-in-query.graphql", "generate_typescript/fixtures/match-field-in-query.expected", input, expected).await;
 }
 
-#[test]
-fn mutation() {
+#[tokio::test]
+async fn mutation() {
     let input = include_str!("generate_typescript/fixtures/mutation.graphql");
     let expected = include_str!("generate_typescript/fixtures/mutation.expected");
-    test_fixture(transform_fixture, "mutation.graphql", "generate_typescript/fixtures/mutation.expected", input, expected);
+    test_fixture(transform_fixture, "mutation.graphql", "generate_typescript/fixtures/mutation.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_input_has_array() {
+#[tokio::test]
+async fn mutation_input_has_array() {
     let input = include_str!("generate_typescript/fixtures/mutation-input-has-array.graphql");
     let expected = include_str!("generate_typescript/fixtures/mutation-input-has-array.expected");
-    test_fixture(transform_fixture, "mutation-input-has-array.graphql", "generate_typescript/fixtures/mutation-input-has-array.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-input-has-array.graphql", "generate_typescript/fixtures/mutation-input-has-array.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_with_client_extension() {
+#[tokio::test]
+async fn mutation_with_client_extension() {
     let input = include_str!("generate_typescript/fixtures/mutation-with-client-extension.graphql");
     let expected = include_str!("generate_typescript/fixtures/mutation-with-client-extension.expected");
-    test_fixture(transform_fixture, "mutation-with-client-extension.graphql", "generate_typescript/fixtures/mutation-with-client-extension.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-with-client-extension.graphql", "generate_typescript/fixtures/mutation-with-client-extension.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_with_enums_on_fragment() {
+#[tokio::test]
+async fn mutation_with_enums_on_fragment() {
     let input = include_str!("generate_typescript/fixtures/mutation-with-enums-on-fragment.graphql");
     let expected = include_str!("generate_typescript/fixtures/mutation-with-enums-on-fragment.expected");
-    test_fixture(transform_fixture, "mutation-with-enums-on-fragment.graphql", "generate_typescript/fixtures/mutation-with-enums-on-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-with-enums-on-fragment.graphql", "generate_typescript/fixtures/mutation-with-enums-on-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_with_nested_fragments() {
+#[tokio::test]
+async fn mutation_with_nested_fragments() {
     let input = include_str!("generate_typescript/fixtures/mutation-with-nested-fragments.graphql");
     let expected = include_str!("generate_typescript/fixtures/mutation-with-nested-fragments.expected");
-    test_fixture(transform_fixture, "mutation-with-nested-fragments.graphql", "generate_typescript/fixtures/mutation-with-nested-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-with-nested-fragments.graphql", "generate_typescript/fixtures/mutation-with-nested-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn mutation_with_response_on_inline_fragments() {
+#[tokio::test]
+async fn mutation_with_response_on_inline_fragments() {
     let input = include_str!("generate_typescript/fixtures/mutation-with-response-on-inline-fragments.graphql");
     let expected = include_str!("generate_typescript/fixtures/mutation-with-response-on-inline-fragments.expected");
-    test_fixture(transform_fixture, "mutation-with-response-on-inline-fragments.graphql", "generate_typescript/fixtures/mutation-with-response-on-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "mutation-with-response-on-inline-fragments.graphql", "generate_typescript/fixtures/mutation-with-response-on-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn plural_fragment() {
+#[tokio::test]
+async fn plural_fragment() {
     let input = include_str!("generate_typescript/fixtures/plural-fragment.graphql");
     let expected = include_str!("generate_typescript/fixtures/plural-fragment.expected");
-    test_fixture(transform_fixture, "plural-fragment.graphql", "generate_typescript/fixtures/plural-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "plural-fragment.graphql", "generate_typescript/fixtures/plural-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_handles() {
+#[tokio::test]
+async fn query_with_handles() {
     let input = include_str!("generate_typescript/fixtures/query-with-handles.graphql");
     let expected = include_str!("generate_typescript/fixtures/query-with-handles.expected");
-    test_fixture(transform_fixture, "query-with-handles.graphql", "generate_typescript/fixtures/query-with-handles.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-handles.graphql", "generate_typescript/fixtures/query-with-handles.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_match_fields() {
+#[tokio::test]
+async fn query_with_match_fields() {
     let input = include_str!("generate_typescript/fixtures/query-with-match-fields.graphql");
     let expected = include_str!("generate_typescript/fixtures/query-with-match-fields.expected");
-    test_fixture(transform_fixture, "query-with-match-fields.graphql", "generate_typescript/fixtures/query-with-match-fields.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-match-fields.graphql", "generate_typescript/fixtures/query-with-match-fields.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_module_field() {
+#[tokio::test]
+async fn query_with_module_field() {
     let input = include_str!("generate_typescript/fixtures/query-with-module-field.graphql");
     let expected = include_str!("generate_typescript/fixtures/query-with-module-field.expected");
-    test_fixture(transform_fixture, "query-with-module-field.graphql", "generate_typescript/fixtures/query-with-module-field.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-module-field.graphql", "generate_typescript/fixtures/query-with-module-field.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_multiple_match_fields() {
+#[tokio::test]
+async fn query_with_multiple_match_fields() {
     let input = include_str!("generate_typescript/fixtures/query-with-multiple-match-fields.graphql");
     let expected = include_str!("generate_typescript/fixtures/query-with-multiple-match-fields.expected");
-    test_fixture(transform_fixture, "query-with-multiple-match-fields.graphql", "generate_typescript/fixtures/query-with-multiple-match-fields.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-multiple-match-fields.graphql", "generate_typescript/fixtures/query-with-multiple-match-fields.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_raw_response_on_conditional() {
+#[tokio::test]
+async fn query_with_raw_response_on_conditional() {
     let input = include_str!("generate_typescript/fixtures/query-with-raw-response-on-conditional.graphql");
     let expected = include_str!("generate_typescript/fixtures/query-with-raw-response-on-conditional.expected");
-    test_fixture(transform_fixture, "query-with-raw-response-on-conditional.graphql", "generate_typescript/fixtures/query-with-raw-response-on-conditional.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-raw-response-on-conditional.graphql", "generate_typescript/fixtures/query-with-raw-response-on-conditional.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_raw_response_on_literal_conditional() {
+#[tokio::test]
+async fn query_with_raw_response_on_literal_conditional() {
     let input = include_str!("generate_typescript/fixtures/query-with-raw-response-on-literal-conditional.graphql");
     let expected = include_str!("generate_typescript/fixtures/query-with-raw-response-on-literal-conditional.expected");
-    test_fixture(transform_fixture, "query-with-raw-response-on-literal-conditional.graphql", "generate_typescript/fixtures/query-with-raw-response-on-literal-conditional.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-raw-response-on-literal-conditional.graphql", "generate_typescript/fixtures/query-with-raw-response-on-literal-conditional.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_stream() {
+#[tokio::test]
+async fn query_with_stream() {
     let input = include_str!("generate_typescript/fixtures/query-with-stream.graphql");
     let expected = include_str!("generate_typescript/fixtures/query-with-stream.expected");
-    test_fixture(transform_fixture, "query-with-stream.graphql", "generate_typescript/fixtures/query-with-stream.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-stream.graphql", "generate_typescript/fixtures/query-with-stream.expected", input, expected).await;
 }
 
-#[test]
-fn query_with_stream_connection() {
+#[tokio::test]
+async fn query_with_stream_connection() {
     let input = include_str!("generate_typescript/fixtures/query-with-stream-connection.graphql");
     let expected = include_str!("generate_typescript/fixtures/query-with-stream-connection.expected");
-    test_fixture(transform_fixture, "query-with-stream-connection.graphql", "generate_typescript/fixtures/query-with-stream-connection.expected", input, expected);
+    test_fixture(transform_fixture, "query-with-stream-connection.graphql", "generate_typescript/fixtures/query-with-stream-connection.expected", input, expected).await;
 }
 
-#[test]
-fn recursive_fragments() {
+#[tokio::test]
+async fn recursive_fragments() {
     let input = include_str!("generate_typescript/fixtures/recursive-fragments.graphql");
     let expected = include_str!("generate_typescript/fixtures/recursive-fragments.expected");
-    test_fixture(transform_fixture, "recursive-fragments.graphql", "generate_typescript/fixtures/recursive-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "recursive-fragments.graphql", "generate_typescript/fixtures/recursive-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable() {
+#[tokio::test]
+async fn refetchable() {
     let input = include_str!("generate_typescript/fixtures/refetchable.graphql");
     let expected = include_str!("generate_typescript/fixtures/refetchable.expected");
-    test_fixture(transform_fixture, "refetchable.graphql", "generate_typescript/fixtures/refetchable.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable.graphql", "generate_typescript/fixtures/refetchable.expected", input, expected).await;
 }
 
-#[test]
-fn refetchable_fragment() {
+#[tokio::test]
+async fn refetchable_fragment() {
     let input = include_str!("generate_typescript/fixtures/refetchable-fragment.graphql");
     let expected = include_str!("generate_typescript/fixtures/refetchable-fragment.expected");
-    test_fixture(transform_fixture, "refetchable-fragment.graphql", "generate_typescript/fixtures/refetchable-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "refetchable-fragment.graphql", "generate_typescript/fixtures/refetchable-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn relay_client_id_field() {
+#[tokio::test]
+async fn relay_client_id_field() {
     let input = include_str!("generate_typescript/fixtures/relay-client-id-field.graphql");
     let expected = include_str!("generate_typescript/fixtures/relay-client-id-field.expected");
-    test_fixture(transform_fixture, "relay-client-id-field.graphql", "generate_typescript/fixtures/relay-client-id-field.expected", input, expected);
+    test_fixture(transform_fixture, "relay-client-id-field.graphql", "generate_typescript/fixtures/relay-client-id-field.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_client_interface() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_client_interface() {
     let input = include_str!("generate_typescript/fixtures/relay-resolver-with-output-type-client-interface.graphql");
     let expected = include_str!("generate_typescript/fixtures/relay-resolver-with-output-type-client-interface.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-interface.graphql", "generate_typescript/fixtures/relay-resolver-with-output-type-client-interface.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-interface.graphql", "generate_typescript/fixtures/relay-resolver-with-output-type-client-interface.expected", input, expected).await;
 }
 
-#[test]
-fn relay_resolver_with_output_type_client_object() {
+#[tokio::test]
+async fn relay_resolver_with_output_type_client_object() {
     let input = include_str!("generate_typescript/fixtures/relay-resolver-with-output-type-client-object.graphql");
     let expected = include_str!("generate_typescript/fixtures/relay-resolver-with-output-type-client-object.expected");
-    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-object.graphql", "generate_typescript/fixtures/relay-resolver-with-output-type-client-object.expected", input, expected);
+    test_fixture(transform_fixture, "relay-resolver-with-output-type-client-object.graphql", "generate_typescript/fixtures/relay-resolver-with-output-type-client-object.expected", input, expected).await;
 }
 
-#[test]
-fn relay_weak_client_type() {
+#[tokio::test]
+async fn relay_weak_client_type() {
     let input = include_str!("generate_typescript/fixtures/relay-weak-client-type.graphql");
     let expected = include_str!("generate_typescript/fixtures/relay-weak-client-type.expected");
-    test_fixture(transform_fixture, "relay-weak-client-type.graphql", "generate_typescript/fixtures/relay-weak-client-type.expected", input, expected);
+    test_fixture(transform_fixture, "relay-weak-client-type.graphql", "generate_typescript/fixtures/relay-weak-client-type.expected", input, expected).await;
 }
 
-#[test]
-fn required() {
+#[tokio::test]
+async fn required() {
     let input = include_str!("generate_typescript/fixtures/required.graphql");
     let expected = include_str!("generate_typescript/fixtures/required.expected");
-    test_fixture(transform_fixture, "required.graphql", "generate_typescript/fixtures/required.expected", input, expected);
+    test_fixture(transform_fixture, "required.graphql", "generate_typescript/fixtures/required.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_through_inline_fragments_to_fragment() {
+#[tokio::test]
+async fn required_bubbles_through_inline_fragments_to_fragment() {
     let input = include_str!("generate_typescript/fixtures/required-bubbles-through-inline-fragments-to-fragment.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-bubbles-through-inline-fragments-to-fragment.expected");
-    test_fixture(transform_fixture, "required-bubbles-through-inline-fragments-to-fragment.graphql", "generate_typescript/fixtures/required-bubbles-through-inline-fragments-to-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-through-inline-fragments-to-fragment.graphql", "generate_typescript/fixtures/required-bubbles-through-inline-fragments-to-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_fragment() {
+#[tokio::test]
+async fn required_bubbles_to_fragment() {
     let input = include_str!("generate_typescript/fixtures/required-bubbles-to-fragment.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-bubbles-to-fragment.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-fragment.graphql", "generate_typescript/fixtures/required-bubbles-to-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-fragment.graphql", "generate_typescript/fixtures/required-bubbles-to-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_item_in_plural_field() {
+#[tokio::test]
+async fn required_bubbles_to_item_in_plural_field() {
     let input = include_str!("generate_typescript/fixtures/required-bubbles-to-item-in-plural-field.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-bubbles-to-item-in-plural-field.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-item-in-plural-field.graphql", "generate_typescript/fixtures/required-bubbles-to-item-in-plural-field.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-item-in-plural-field.graphql", "generate_typescript/fixtures/required-bubbles-to-item-in-plural-field.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_to_query() {
+#[tokio::test]
+async fn required_bubbles_to_query() {
     let input = include_str!("generate_typescript/fixtures/required-bubbles-to-query.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-bubbles-to-query.expected");
-    test_fixture(transform_fixture, "required-bubbles-to-query.graphql", "generate_typescript/fixtures/required-bubbles-to-query.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-to-query.graphql", "generate_typescript/fixtures/required-bubbles-to-query.expected", input, expected).await;
 }
 
-#[test]
-fn required_bubbles_up_to_mutation_response() {
+#[tokio::test]
+async fn required_bubbles_up_to_mutation_response() {
     let input = include_str!("generate_typescript/fixtures/required-bubbles-up-to-mutation-response.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-bubbles-up-to-mutation-response.expected");
-    test_fixture(transform_fixture, "required-bubbles-up-to-mutation-response.graphql", "generate_typescript/fixtures/required-bubbles-up-to-mutation-response.expected", input, expected);
+    test_fixture(transform_fixture, "required-bubbles-up-to-mutation-response.graphql", "generate_typescript/fixtures/required-bubbles-up-to-mutation-response.expected", input, expected).await;
 }
 
-#[test]
-fn required_isolates_concrete_inline_fragments() {
+#[tokio::test]
+async fn required_isolates_concrete_inline_fragments() {
     let input = include_str!("generate_typescript/fixtures/required-isolates-concrete-inline-fragments.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-isolates-concrete-inline-fragments.expected");
-    test_fixture(transform_fixture, "required-isolates-concrete-inline-fragments.graphql", "generate_typescript/fixtures/required-isolates-concrete-inline-fragments.expected", input, expected);
+    test_fixture(transform_fixture, "required-isolates-concrete-inline-fragments.graphql", "generate_typescript/fixtures/required-isolates-concrete-inline-fragments.expected", input, expected).await;
 }
 
-#[test]
-fn required_raw_response_type() {
+#[tokio::test]
+async fn required_raw_response_type() {
     let input = include_str!("generate_typescript/fixtures/required-raw-response-type.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-raw-response-type.expected");
-    test_fixture(transform_fixture, "required-raw-response-type.graphql", "generate_typescript/fixtures/required-raw-response-type.expected", input, expected);
+    test_fixture(transform_fixture, "required-raw-response-type.graphql", "generate_typescript/fixtures/required-raw-response-type.expected", input, expected).await;
 }
 
-#[test]
-fn required_throw_doesnt_bubbles_to_fragment() {
+#[tokio::test]
+async fn required_throw_doesnt_bubbles_to_fragment() {
     let input = include_str!("generate_typescript/fixtures/required-throw-doesnt-bubbles-to-fragment.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-throw-doesnt-bubbles-to-fragment.expected");
-    test_fixture(transform_fixture, "required-throw-doesnt-bubbles-to-fragment.graphql", "generate_typescript/fixtures/required-throw-doesnt-bubbles-to-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-throw-doesnt-bubbles-to-fragment.graphql", "generate_typescript/fixtures/required-throw-doesnt-bubbles-to-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_throw_doesnt_bubbles_to_query() {
+#[tokio::test]
+async fn required_throw_doesnt_bubbles_to_query() {
     let input = include_str!("generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.expected");
-    test_fixture(transform_fixture, "required-throw-doesnt-bubbles-to-query.graphql", "generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.expected", input, expected);
+    test_fixture(transform_fixture, "required-throw-doesnt-bubbles-to-query.graphql", "generate_typescript/fixtures/required-throw-doesnt-bubbles-to-query.expected", input, expected).await;
 }
 
-#[test]
-fn required_throws_nested() {
+#[tokio::test]
+async fn required_throws_nested() {
     let input = include_str!("generate_typescript/fixtures/required-throws-nested.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-throws-nested.expected");
-    test_fixture(transform_fixture, "required-throws-nested.graphql", "generate_typescript/fixtures/required-throws-nested.expected", input, expected);
+    test_fixture(transform_fixture, "required-throws-nested.graphql", "generate_typescript/fixtures/required-throws-nested.expected", input, expected).await;
 }
 
-#[test]
-fn required_within_aliased_inline_fragment() {
+#[tokio::test]
+async fn required_within_aliased_inline_fragment() {
     let input = include_str!("generate_typescript/fixtures/required-within-aliased-inline-fragment.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-within-aliased-inline-fragment.expected");
-    test_fixture(transform_fixture, "required-within-aliased-inline-fragment.graphql", "generate_typescript/fixtures/required-within-aliased-inline-fragment.expected", input, expected);
+    test_fixture(transform_fixture, "required-within-aliased-inline-fragment.graphql", "generate_typescript/fixtures/required-within-aliased-inline-fragment.expected", input, expected).await;
 }
 
-#[test]
-fn required_within_aliased_inline_fragment_on_abstract() {
+#[tokio::test]
+async fn required_within_aliased_inline_fragment_on_abstract() {
     let input = include_str!("generate_typescript/fixtures/required-within-aliased-inline-fragment-on-abstract.graphql");
     let expected = include_str!("generate_typescript/fixtures/required-within-aliased-inline-fragment-on-abstract.expected");
-    test_fixture(transform_fixture, "required-within-aliased-inline-fragment-on-abstract.graphql", "generate_typescript/fixtures/required-within-aliased-inline-fragment-on-abstract.expected", input, expected);
+    test_fixture(transform_fixture, "required-within-aliased-inline-fragment-on-abstract.graphql", "generate_typescript/fixtures/required-within-aliased-inline-fragment-on-abstract.expected", input, expected).await;
 }
 
-#[test]
-fn roots() {
+#[tokio::test]
+async fn roots() {
     let input = include_str!("generate_typescript/fixtures/roots.graphql");
     let expected = include_str!("generate_typescript/fixtures/roots.expected");
-    test_fixture(transform_fixture, "roots.graphql", "generate_typescript/fixtures/roots.expected", input, expected);
+    test_fixture(transform_fixture, "roots.graphql", "generate_typescript/fixtures/roots.expected", input, expected).await;
 }
 
-#[test]
-fn scalar_field() {
+#[tokio::test]
+async fn scalar_field() {
     let input = include_str!("generate_typescript/fixtures/scalar-field.graphql");
     let expected = include_str!("generate_typescript/fixtures/scalar-field.expected");
-    test_fixture(transform_fixture, "scalar-field.graphql", "generate_typescript/fixtures/scalar-field.expected", input, expected);
+    test_fixture(transform_fixture, "scalar-field.graphql", "generate_typescript/fixtures/scalar-field.expected", input, expected).await;
 }
 
-#[test]
-fn simple() {
+#[tokio::test]
+async fn simple() {
     let input = include_str!("generate_typescript/fixtures/simple.graphql");
     let expected = include_str!("generate_typescript/fixtures/simple.expected");
-    test_fixture(transform_fixture, "simple.graphql", "generate_typescript/fixtures/simple.expected", input, expected);
+    test_fixture(transform_fixture, "simple.graphql", "generate_typescript/fixtures/simple.expected", input, expected).await;
 }
 
-#[test]
-fn simple_use_import_type_syntax() {
+#[tokio::test]
+async fn simple_use_import_type_syntax() {
     let input = include_str!("generate_typescript/fixtures/simple-use-import-type-syntax.graphql");
     let expected = include_str!("generate_typescript/fixtures/simple-use-import-type-syntax.expected");
-    test_fixture(transform_fixture, "simple-use-import-type-syntax.graphql", "generate_typescript/fixtures/simple-use-import-type-syntax.expected", input, expected);
+    test_fixture(transform_fixture, "simple-use-import-type-syntax.graphql", "generate_typescript/fixtures/simple-use-import-type-syntax.expected", input, expected).await;
 }
 
-#[test]
-fn typename_in_union_with_other_fields() {
+#[tokio::test]
+async fn typename_in_union_with_other_fields() {
     let input = include_str!("generate_typescript/fixtures/typename-in-union-with-other-fields.graphql");
     let expected = include_str!("generate_typescript/fixtures/typename-in-union-with-other-fields.expected");
-    test_fixture(transform_fixture, "typename-in-union-with-other-fields.graphql", "generate_typescript/fixtures/typename-in-union-with-other-fields.expected", input, expected);
+    test_fixture(transform_fixture, "typename-in-union-with-other-fields.graphql", "generate_typescript/fixtures/typename-in-union-with-other-fields.expected", input, expected).await;
 }
 
-#[test]
-fn typename_inside_with_overlapping_fields() {
+#[tokio::test]
+async fn typename_inside_with_overlapping_fields() {
     let input = include_str!("generate_typescript/fixtures/typename-inside-with-overlapping-fields.graphql");
     let expected = include_str!("generate_typescript/fixtures/typename-inside-with-overlapping-fields.expected");
-    test_fixture(transform_fixture, "typename-inside-with-overlapping-fields.graphql", "generate_typescript/fixtures/typename-inside-with-overlapping-fields.expected", input, expected);
+    test_fixture(transform_fixture, "typename-inside-with-overlapping-fields.graphql", "generate_typescript/fixtures/typename-inside-with-overlapping-fields.expected", input, expected).await;
 }
 
-#[test]
-fn typename_on_union() {
+#[tokio::test]
+async fn typename_on_union() {
     let input = include_str!("generate_typescript/fixtures/typename-on-union.graphql");
     let expected = include_str!("generate_typescript/fixtures/typename-on-union.expected");
-    test_fixture(transform_fixture, "typename-on-union.graphql", "generate_typescript/fixtures/typename-on-union.expected", input, expected);
+    test_fixture(transform_fixture, "typename-on-union.graphql", "generate_typescript/fixtures/typename-on-union.expected", input, expected).await;
 }
 
-#[test]
-fn typename_on_union_with_non_matching_aliases() {
+#[tokio::test]
+async fn typename_on_union_with_non_matching_aliases() {
     let input = include_str!("generate_typescript/fixtures/typename-on-union-with-non-matching-aliases.graphql");
     let expected = include_str!("generate_typescript/fixtures/typename-on-union-with-non-matching-aliases.expected");
-    test_fixture(transform_fixture, "typename-on-union-with-non-matching-aliases.graphql", "generate_typescript/fixtures/typename-on-union-with-non-matching-aliases.expected", input, expected);
+    test_fixture(transform_fixture, "typename-on-union-with-non-matching-aliases.graphql", "generate_typescript/fixtures/typename-on-union-with-non-matching-aliases.expected", input, expected).await;
 }
 
-#[test]
-fn unmasked_fragment_spreads() {
+#[tokio::test]
+async fn unmasked_fragment_spreads() {
     let input = include_str!("generate_typescript/fixtures/unmasked-fragment-spreads.graphql");
     let expected = include_str!("generate_typescript/fixtures/unmasked-fragment-spreads.expected");
-    test_fixture(transform_fixture, "unmasked-fragment-spreads.graphql", "generate_typescript/fixtures/unmasked-fragment-spreads.expected", input, expected);
+    test_fixture(transform_fixture, "unmasked-fragment-spreads.graphql", "generate_typescript/fixtures/unmasked-fragment-spreads.expected", input, expected).await;
 }

--- a/compiler/crates/schema-print/Cargo.toml
+++ b/compiler/crates/schema-print/Cargo.toml
@@ -18,3 +18,4 @@ schema = { path = "../schema" }
 
 [dev-dependencies]
 fixture-tests = { path = "../fixture-tests" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/schema-print/tests/print_schema/mod.rs
+++ b/compiler/crates/schema-print/tests/print_schema/mod.rs
@@ -11,7 +11,7 @@ use schema::build_schema;
 use schema_print::print_directives;
 use schema_print::print_types_directives_as_shards;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let schema = build_schema(fixture.content).unwrap();
     let mut type_shard_count = fnv::FnvHashMap::default();
     type_shard_count.insert("Query".intern(), 2);

--- a/compiler/crates/schema-print/tests/print_schema_test.rs
+++ b/compiler/crates/schema-print/tests/print_schema_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<08e2c143cd60aa5cd2bfbb8b67388e8b>>
+ * @generated SignedSource<<7e3cc8dc7e8627acf6d5a38887537efb>>
  */
 
 mod print_schema;
@@ -12,16 +12,16 @@ mod print_schema;
 use print_schema::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("print_schema/fixtures/kitchen-sink.graphql");
     let expected = include_str!("print_schema/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "print_schema/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "print_schema/fixtures/kitchen-sink.expected", input, expected).await;
 }
 
-#[test]
-fn no_schema() {
+#[tokio::test]
+async fn no_schema() {
     let input = include_str!("print_schema/fixtures/no-schema.graphql");
     let expected = include_str!("print_schema/fixtures/no-schema.expected");
-    test_fixture(transform_fixture, "no-schema.graphql", "print_schema/fixtures/no-schema.expected", input, expected);
+    test_fixture(transform_fixture, "no-schema.graphql", "print_schema/fixtures/no-schema.expected", input, expected).await;
 }

--- a/compiler/crates/schema-validate/Cargo.toml
+++ b/compiler/crates/schema-validate/Cargo.toml
@@ -28,3 +28,4 @@ thiserror = "1.0.43"
 
 [dev-dependencies]
 fixture-tests = { path = "../fixture-tests" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/schema-validate/tests/validate_schema/mod.rs
+++ b/compiler/crates/schema-validate/tests/validate_schema/mod.rs
@@ -9,7 +9,7 @@ use fixture_tests::Fixture;
 use schema::build_schema;
 use schema_validate_lib::validate;
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let schema = build_schema(fixture.content).unwrap();
     Ok(validate(&schema).print_errors())
 }

--- a/compiler/crates/schema-validate/tests/validate_schema_test.rs
+++ b/compiler/crates/schema-validate/tests/validate_schema_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e0f69125973077ab82c37b910a577a54>>
+ * @generated SignedSource<<89cb1d7a0e2d307e728648942907c8b0>>
  */
 
 mod validate_schema;
@@ -12,44 +12,44 @@ mod validate_schema;
 use validate_schema::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn validate_directives() {
+#[tokio::test]
+async fn validate_directives() {
     let input = include_str!("validate_schema/fixtures/validate_directives.graphql");
     let expected = include_str!("validate_schema/fixtures/validate_directives.expected");
-    test_fixture(transform_fixture, "validate_directives.graphql", "validate_schema/fixtures/validate_directives.expected", input, expected);
+    test_fixture(transform_fixture, "validate_directives.graphql", "validate_schema/fixtures/validate_directives.expected", input, expected).await;
 }
 
-#[test]
-fn validate_enum() {
+#[tokio::test]
+async fn validate_enum() {
     let input = include_str!("validate_schema/fixtures/validate_enum.graphql");
     let expected = include_str!("validate_schema/fixtures/validate_enum.expected");
-    test_fixture(transform_fixture, "validate_enum.graphql", "validate_schema/fixtures/validate_enum.expected", input, expected);
+    test_fixture(transform_fixture, "validate_enum.graphql", "validate_schema/fixtures/validate_enum.expected", input, expected).await;
 }
 
-#[test]
-fn validate_interface_implements_interface_cyclic() {
+#[tokio::test]
+async fn validate_interface_implements_interface_cyclic() {
     let input = include_str!("validate_schema/fixtures/validate_interface_implements_interface_cyclic.graphql");
     let expected = include_str!("validate_schema/fixtures/validate_interface_implements_interface_cyclic.expected");
-    test_fixture(transform_fixture, "validate_interface_implements_interface_cyclic.graphql", "validate_schema/fixtures/validate_interface_implements_interface_cyclic.expected", input, expected);
+    test_fixture(transform_fixture, "validate_interface_implements_interface_cyclic.graphql", "validate_schema/fixtures/validate_interface_implements_interface_cyclic.expected", input, expected).await;
 }
 
-#[test]
-fn validate_object() {
+#[tokio::test]
+async fn validate_object() {
     let input = include_str!("validate_schema/fixtures/validate_object.graphql");
     let expected = include_str!("validate_schema/fixtures/validate_object.expected");
-    test_fixture(transform_fixture, "validate_object.graphql", "validate_schema/fixtures/validate_object.expected", input, expected);
+    test_fixture(transform_fixture, "validate_object.graphql", "validate_schema/fixtures/validate_object.expected", input, expected).await;
 }
 
-#[test]
-fn validate_root_types() {
+#[tokio::test]
+async fn validate_root_types() {
     let input = include_str!("validate_schema/fixtures/validate_root_types.graphql");
     let expected = include_str!("validate_schema/fixtures/validate_root_types.expected");
-    test_fixture(transform_fixture, "validate_root_types.graphql", "validate_schema/fixtures/validate_root_types.expected", input, expected);
+    test_fixture(transform_fixture, "validate_root_types.graphql", "validate_schema/fixtures/validate_root_types.expected", input, expected).await;
 }
 
-#[test]
-fn validate_union() {
+#[tokio::test]
+async fn validate_union() {
     let input = include_str!("validate_schema/fixtures/validate_union.graphql");
     let expected = include_str!("validate_schema/fixtures/validate_union.expected");
-    test_fixture(transform_fixture, "validate_union.graphql", "validate_schema/fixtures/validate_union.expected", input, expected);
+    test_fixture(transform_fixture, "validate_union.graphql", "validate_schema/fixtures/validate_union.expected", input, expected).await;
 }

--- a/compiler/crates/schema/Cargo.toml
+++ b/compiler/crates/schema/Cargo.toml
@@ -26,3 +26,4 @@ thiserror = "1.0.43"
 [dev-dependencies]
 fixture-tests = { path = "../fixture-tests" }
 graphql-cli = { path = "../graphql-cli" }
+tokio = { version = "1.25.0", features = ["full", "test-util", "tracing"] }

--- a/compiler/crates/schema/tests/build_schema/mod.rs
+++ b/compiler/crates/schema/tests/build_schema/mod.rs
@@ -21,7 +21,7 @@ use schema::Type;
 
 const SCHEMA_SEPARATOR: &str = "%extensions%";
 
-pub fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let parts: Vec<_> = fixture.content.split(SCHEMA_SEPARATOR).collect();
     let result = match parts.as_slice() {
         [base] => {

--- a/compiler/crates/schema/tests/build_schema_test.rs
+++ b/compiler/crates/schema/tests/build_schema_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8634e6fbc71207f6f4bb9079d4bea17a>>
+ * @generated SignedSource<<f05f007a8104619e574a2f48fd49704e>>
  */
 
 mod build_schema;
@@ -12,135 +12,135 @@ mod build_schema;
 use build_schema::transform_fixture;
 use fixture_tests::test_fixture;
 
-#[test]
-fn directive_on_arg_def() {
+#[tokio::test]
+async fn directive_on_arg_def() {
     let input = include_str!("build_schema/fixtures/directive-on-arg-def.graphql");
     let expected = include_str!("build_schema/fixtures/directive-on-arg-def.expected");
-    test_fixture(transform_fixture, "directive-on-arg-def.graphql", "build_schema/fixtures/directive-on-arg-def.expected", input, expected);
+    test_fixture(transform_fixture, "directive-on-arg-def.graphql", "build_schema/fixtures/directive-on-arg-def.expected", input, expected).await;
 }
 
-#[test]
-fn directives_for_external_types() {
+#[tokio::test]
+async fn directives_for_external_types() {
     let input = include_str!("build_schema/fixtures/directives-for-external-types.graphql");
     let expected = include_str!("build_schema/fixtures/directives-for-external-types.expected");
-    test_fixture(transform_fixture, "directives-for-external-types.graphql", "build_schema/fixtures/directives-for-external-types.expected", input, expected);
+    test_fixture(transform_fixture, "directives-for-external-types.graphql", "build_schema/fixtures/directives-for-external-types.expected", input, expected).await;
 }
 
-#[test]
-fn extend_interface_before_define() {
+#[tokio::test]
+async fn extend_interface_before_define() {
     let input = include_str!("build_schema/fixtures/extend-interface-before-define.graphql");
     let expected = include_str!("build_schema/fixtures/extend-interface-before-define.expected");
-    test_fixture(transform_fixture, "extend-interface-before-define.graphql", "build_schema/fixtures/extend-interface-before-define.expected", input, expected);
+    test_fixture(transform_fixture, "extend-interface-before-define.graphql", "build_schema/fixtures/extend-interface-before-define.expected", input, expected).await;
 }
 
-#[test]
-fn extend_object_before_define() {
+#[tokio::test]
+async fn extend_object_before_define() {
     let input = include_str!("build_schema/fixtures/extend-object-before-define.graphql");
     let expected = include_str!("build_schema/fixtures/extend-object-before-define.expected");
-    test_fixture(transform_fixture, "extend-object-before-define.graphql", "build_schema/fixtures/extend-object-before-define.expected", input, expected);
+    test_fixture(transform_fixture, "extend-object-before-define.graphql", "build_schema/fixtures/extend-object-before-define.expected", input, expected).await;
 }
 
-#[test]
-fn field_descriptions() {
+#[tokio::test]
+async fn field_descriptions() {
     let input = include_str!("build_schema/fixtures/field-descriptions.graphql");
     let expected = include_str!("build_schema/fixtures/field-descriptions.expected");
-    test_fixture(transform_fixture, "field-descriptions.graphql", "build_schema/fixtures/field-descriptions.expected", input, expected);
+    test_fixture(transform_fixture, "field-descriptions.graphql", "build_schema/fixtures/field-descriptions.expected", input, expected).await;
 }
 
-#[test]
-fn interface_implements_interface() {
+#[tokio::test]
+async fn interface_implements_interface() {
     let input = include_str!("build_schema/fixtures/interface-implements-interface.graphql");
     let expected = include_str!("build_schema/fixtures/interface-implements-interface.expected");
-    test_fixture(transform_fixture, "interface-implements-interface.graphql", "build_schema/fixtures/interface-implements-interface.expected", input, expected);
+    test_fixture(transform_fixture, "interface-implements-interface.graphql", "build_schema/fixtures/interface-implements-interface.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_duplicate_directive() {
+#[tokio::test]
+async fn invalid_duplicate_directive() {
     let input = include_str!("build_schema/fixtures/invalid-duplicate-directive.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-duplicate-directive.expected");
-    test_fixture(transform_fixture, "invalid-duplicate-directive.graphql", "build_schema/fixtures/invalid-duplicate-directive.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-duplicate-directive.graphql", "build_schema/fixtures/invalid-duplicate-directive.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_duplicate_query_operation() {
+#[tokio::test]
+async fn invalid_duplicate_query_operation() {
     let input = include_str!("build_schema/fixtures/invalid-duplicate-query-operation.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-duplicate-query-operation.expected");
-    test_fixture(transform_fixture, "invalid-duplicate-query-operation.graphql", "build_schema/fixtures/invalid-duplicate-query-operation.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-duplicate-query-operation.graphql", "build_schema/fixtures/invalid-duplicate-query-operation.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_extension_implements_noninterface() {
+#[tokio::test]
+async fn invalid_extension_implements_noninterface() {
     let input = include_str!("build_schema/fixtures/invalid-extension-implements-noninterface.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-extension-implements-noninterface.expected");
-    test_fixture(transform_fixture, "invalid-extension-implements-noninterface.graphql", "build_schema/fixtures/invalid-extension-implements-noninterface.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-extension-implements-noninterface.graphql", "build_schema/fixtures/invalid-extension-implements-noninterface.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_implements_non_interface() {
+#[tokio::test]
+async fn invalid_implements_non_interface() {
     let input = include_str!("build_schema/fixtures/invalid-implements-non-interface.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-implements-non-interface.expected");
-    test_fixture(transform_fixture, "invalid-implements-non-interface.graphql", "build_schema/fixtures/invalid-implements-non-interface.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-implements-non-interface.graphql", "build_schema/fixtures/invalid-implements-non-interface.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_input_type() {
+#[tokio::test]
+async fn invalid_input_type() {
     let input = include_str!("build_schema/fixtures/invalid-input-type.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-input-type.expected");
-    test_fixture(transform_fixture, "invalid-input-type.graphql", "build_schema/fixtures/invalid-input-type.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-input-type.graphql", "build_schema/fixtures/invalid-input-type.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_input_type_interface() {
+#[tokio::test]
+async fn invalid_input_type_interface() {
     let input = include_str!("build_schema/fixtures/invalid-input-type-interface.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-input-type-interface.expected");
-    test_fixture(transform_fixture, "invalid-input-type-interface.graphql", "build_schema/fixtures/invalid-input-type-interface.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-input-type-interface.graphql", "build_schema/fixtures/invalid-input-type-interface.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_input_type_union() {
+#[tokio::test]
+async fn invalid_input_type_union() {
     let input = include_str!("build_schema/fixtures/invalid-input-type-union.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-input-type-union.expected");
-    test_fixture(transform_fixture, "invalid-input-type-union.graphql", "build_schema/fixtures/invalid-input-type-union.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-input-type-union.graphql", "build_schema/fixtures/invalid-input-type-union.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_interface_implements_noninterface() {
+#[tokio::test]
+async fn invalid_interface_implements_noninterface() {
     let input = include_str!("build_schema/fixtures/invalid-interface-implements-noninterface.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-interface-implements-noninterface.expected");
-    test_fixture(transform_fixture, "invalid-interface-implements-noninterface.graphql", "build_schema/fixtures/invalid-interface-implements-noninterface.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-interface-implements-noninterface.graphql", "build_schema/fixtures/invalid-interface-implements-noninterface.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_object_extension_duplicated_server_field() {
+#[tokio::test]
+async fn invalid_object_extension_duplicated_server_field() {
     let input = include_str!("build_schema/fixtures/invalid-object-extension-duplicated-server-field.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-object-extension-duplicated-server-field.expected");
-    test_fixture(transform_fixture, "invalid-object-extension-duplicated-server-field.graphql", "build_schema/fixtures/invalid-object-extension-duplicated-server-field.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-object-extension-duplicated-server-field.graphql", "build_schema/fixtures/invalid-object-extension-duplicated-server-field.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_object_extension_local_duplicated_fields() {
+#[tokio::test]
+async fn invalid_object_extension_local_duplicated_fields() {
     let input = include_str!("build_schema/fixtures/invalid-object-extension-local-duplicated-fields.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-object-extension-local-duplicated-fields.expected");
-    test_fixture(transform_fixture, "invalid-object-extension-local-duplicated-fields.graphql", "build_schema/fixtures/invalid-object-extension-local-duplicated-fields.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-object-extension-local-duplicated-fields.graphql", "build_schema/fixtures/invalid-object-extension-local-duplicated-fields.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_sdl() {
+#[tokio::test]
+async fn invalid_sdl() {
     let input = include_str!("build_schema/fixtures/invalid-sdl.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-sdl.expected");
-    test_fixture(transform_fixture, "invalid-sdl.graphql", "build_schema/fixtures/invalid-sdl.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-sdl.graphql", "build_schema/fixtures/invalid-sdl.expected", input, expected).await;
 }
 
-#[test]
-fn invalid_type_reference() {
+#[tokio::test]
+async fn invalid_type_reference() {
     let input = include_str!("build_schema/fixtures/invalid-type-reference.graphql");
     let expected = include_str!("build_schema/fixtures/invalid-type-reference.expected");
-    test_fixture(transform_fixture, "invalid-type-reference.graphql", "build_schema/fixtures/invalid-type-reference.expected", input, expected);
+    test_fixture(transform_fixture, "invalid-type-reference.graphql", "build_schema/fixtures/invalid-type-reference.expected", input, expected).await;
 }
 
-#[test]
-fn kitchen_sink() {
+#[tokio::test]
+async fn kitchen_sink() {
     let input = include_str!("build_schema/fixtures/kitchen-sink.graphql");
     let expected = include_str!("build_schema/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, "kitchen-sink.graphql", "build_schema/fixtures/kitchen-sink.expected", input, expected);
+    test_fixture(transform_fixture, "kitchen-sink.graphql", "build_schema/fixtures/kitchen-sink.expected", input, expected).await;
 }


### PR DESCRIPTION
This change makes all of our Rust fixture tests async. This is a pre-requisite to supporting integration fixture tests which run the entire compiler (including disk IO) as a fixture test.