### PR TITLE
Allow configurable `@defer`/`@stream` names

### DIFF
--- a/compiler/crates/common/src/named_item.rs
+++ b/compiler/crates/common/src/named_item.rs
@@ -63,7 +63,18 @@ impl FromStr for DirectiveName {
 }
 
 impl_lookup!(DirectiveName);
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize
+)]
 pub struct ArgumentName(pub StringKey);
 
 impl fmt::Display for ArgumentName {

--- a/compiler/crates/relay-codegen/tests/connections/mod.rs
+++ b/compiler/crates/relay-codegen/tests/connections/mod.rs
@@ -18,6 +18,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use relay_codegen::build_request_params;
 use relay_codegen::JsModuleFormat;
 use relay_codegen::Printer;
+use relay_config::DeferStreamInterface;
 use relay_config::ProjectConfig;
 use relay_test_schema::get_test_schema;
 use relay_transforms::transform_connections;
@@ -41,11 +42,13 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
     let program = Program::from_definitions(Arc::clone(&schema), ir);
 
     let connection_interface = ConnectionInterface::default();
+    let defer_stream_interface = DeferStreamInterface::default();
 
     validate_connections(&program, &connection_interface)
         .map_err(|diagnostics| diagnostics_to_sorted_string(fixture.content, &diagnostics))?;
 
-    let next_program = transform_connections(&program, &connection_interface);
+    let next_program =
+        transform_connections(&program, &connection_interface, &defer_stream_interface);
 
     let mut printed = next_program
         .operations()

--- a/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-default-label.expected
+++ b/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-default-label.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1) {
+  actors @stream(initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-default-label.graphql
+++ b/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-default-label.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1) {
+  actors @stream(initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-codegen/tests/defer_stream/mod.rs
+++ b/compiler/crates/relay-codegen/tests/defer_stream/mod.rs
@@ -15,6 +15,7 @@ use graphql_syntax::parse_executable;
 use relay_codegen::print_fragment;
 use relay_codegen::print_operation;
 use relay_codegen::JsModuleFormat;
+use relay_config::DeferStreamInterface;
 use relay_config::ProjectConfig;
 use relay_test_schema::get_test_schema;
 use relay_transforms::sort_selections;
@@ -29,7 +30,9 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
     let schema = get_test_schema();
     let ir = build(&schema, &ast.definitions).unwrap();
     let program = Program::from_definitions(Arc::clone(&schema), ir);
-    let next_program = sort_selections(&transform_defer_stream(&program).unwrap());
+    let defer_stream_interface = DeferStreamInterface::default();
+    let next_program =
+        sort_selections(&transform_defer_stream(&program, &defer_stream_interface).unwrap());
     let mut result = next_program
         .fragments()
         .map(|def| {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected
@@ -8,7 +8,7 @@ query fragmentWithDeferInStream_QueryWithFragmentWithStreamQuery($id: ID!) {
 
 fragment fragmentWithDeferInStream_FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     ...fragmentWithDeferInStream_ActorFragment @defer
   }
 }
@@ -194,7 +194,7 @@ fragment fragmentWithDeferInStream_ActorFragment on Actor {
 
 fragment fragmentWithDeferInStream_FeedbackFragment on Feedback {
   id
-  actors @stream(label: "fragmentWithDeferInStream_FeedbackFragment$stream$StreamedActorsLabel", initial_count: 1) {
+  actors @stream(label: "fragmentWithDeferInStream_FeedbackFragment$stream$StreamedActorsLabel", initialCount: 1) {
     __typename
     ...fragmentWithDeferInStream_ActorFragment @defer(label: "fragmentWithDeferInStream_FeedbackFragment$defer$fragmentWithDeferInStream_ActorFragment")
     id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.graphql
@@ -7,7 +7,7 @@ query fragmentWithDeferInStream_QueryWithFragmentWithStreamQuery($id: ID!) {
 
 fragment fragmentWithDeferInStream_FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     ...fragmentWithDeferInStream_ActorFragment @defer
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.expected
@@ -8,7 +8,7 @@ query fragmentWithStream_QueryWithFragmentWithStreamQuery($id: ID!) {
 
 fragment fragmentWithStream_FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     name
   }
 }
@@ -174,7 +174,7 @@ query fragmentWithStream_QueryWithFragmentWithStreamQuery(
 
 fragment fragmentWithStream_FeedbackFragment on Feedback {
   id
-  actors @stream(label: "fragmentWithStream_FeedbackFragment$stream$StreamedActorsLabel", initial_count: 1) {
+  actors @stream(label: "fragmentWithStream_FeedbackFragment$stream$StreamedActorsLabel", initialCount: 1) {
     __typename
     name
     id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.graphql
@@ -7,7 +7,7 @@ query fragmentWithStream_QueryWithFragmentWithStreamQuery($id: ID!) {
 
 fragment fragmentWithStream_FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     name
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-with-connection-with-stream.expected
@@ -306,7 +306,7 @@ fragment refetchableFragmentWithConnectionWithStream_PaginationFragment_1G22uz o
   ... on User {
     name
     friends(after: $cursor, first: $count) {
-      edges @stream(label: "refetchableFragmentWithConnectionWithStream_PaginationFragment$stream$PaginationFragment_friends", initial_count: 1) {
+      edges @stream(label: "refetchableFragmentWithConnectionWithStream_PaginationFragment$stream$PaginationFragment_friends", initialCount: 1) {
         node {
           id
           __typename

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.expected
@@ -5,7 +5,7 @@ query selectionSetConflictInconsistentStreamUsage1Query {
     ... on User {
       friends {
         ... on FriendsConnection {
-          edges @stream(label: "hdijf", initial_count: 1) {
+          edges @stream(label: "hdijf", initialCount: 1) {
             node {
               name
             }
@@ -25,7 +25,7 @@ query selectionSetConflictInconsistentStreamUsage1Query {
 
   selection_set_conflict_inconsistent_stream_usage_1.graphql:7:11
     6 │         ... on FriendsConnection {
-    7 │           edges @stream(label: "hdijf", initial_count: 1) {
+    7 │           edges @stream(label: "hdijf", initialCount: 1) {
       │           ^^^^^
     8 │             node {
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_1.graphql
@@ -4,7 +4,7 @@ query selectionSetConflictInconsistentStreamUsage1Query {
     ... on User {
       friends {
         ... on FriendsConnection {
-          edges @stream(label: "hdijf", initial_count: 1) {
+          edges @stream(label: "hdijf", initialCount: 1) {
             node {
               name
             }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.expected
@@ -5,13 +5,13 @@ query selectionSetConflictInconsistentStreamUsage2Query {
     ... on User {
       friends {
         ... on FriendsConnection {
-          edges @stream(label: "hdijf", initial_count: 1) {
+          edges @stream(label: "hdijf", initialCount: 1) {
             node {
               name
             }
           }
         }
-        edges @stream(label: "hkjdf", initial_count: 2) {
+        edges @stream(label: "hkjdf", initialCount: 2) {
           node {
             id
           }
@@ -25,7 +25,7 @@ query selectionSetConflictInconsistentStreamUsage2Query {
 
   selection_set_conflict_inconsistent_stream_usage_2.graphql:7:11
     6 │         ... on FriendsConnection {
-    7 │           edges @stream(label: "hdijf", initial_count: 1) {
+    7 │           edges @stream(label: "hdijf", initialCount: 1) {
       │           ^^^^^
     8 │             node {
 
@@ -33,6 +33,6 @@ query selectionSetConflictInconsistentStreamUsage2Query {
 
   selection_set_conflict_inconsistent_stream_usage_2.graphql:13:9
    12 │         }
-   13 │         edges @stream(label: "hkjdf", initial_count: 2) {
+   13 │         edges @stream(label: "hkjdf", initialCount: 2) {
       │         ^^^^^
    14 │           node {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_inconsistent_stream_usage_2.graphql
@@ -4,13 +4,13 @@ query selectionSetConflictInconsistentStreamUsage2Query {
     ... on User {
       friends {
         ... on FriendsConnection {
-          edges @stream(label: "hdijf", initial_count: 1) {
+          edges @stream(label: "hdijf", initialCount: 1) {
             node {
               name
             }
           }
         }
-        edges @stream(label: "hkjdf", initial_count: 2) {
+        edges @stream(label: "hkjdf", initialCount: 2) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.expected
@@ -3,7 +3,7 @@ query selectionSetConflictStreamOnNodesOrEdgesQuery {
   me {
     ... on User {
       friends {
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }
@@ -168,7 +168,7 @@ QUERY:
 query selectionSetConflictStreamOnNodesOrEdgesQuery {
   me {
     friends {
-      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesQuery$stream$b", initial_count: 1) {
+      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesQuery$stream$b", initialCount: 1) {
         node {
           id
         }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges.graphql
@@ -2,7 +2,7 @@ query selectionSetConflictStreamOnNodesOrEdgesQuery {
   me {
     ... on User {
       friends {
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.expected
@@ -9,7 +9,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery {
             hasNextPage
           }
         }
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }
@@ -213,7 +213,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery {
       pageInfo {
         hasNextPage
       }
-      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery$stream$b", initial_count: 1) {
+      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery$stream$b", initialCount: 1) {
         node {
           id
         }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info.graphql
@@ -8,7 +8,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoQuery {
             hasNextPage
           }
         }
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.expected
@@ -9,7 +9,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoA
             hasNextPage
           }
         }
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }
@@ -213,7 +213,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoA
       pagination: pageInfo {
         hasNextPage
       }
-      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoAliasQuery$stream$b", initial_count: 1) {
+      edges @stream(label: "selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoAliasQuery$stream$b", initialCount: 1) {
         node {
           id
         }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_stream_on_nodes_or_edges_without_defer_on_page_info_and_page_info_alias.graphql
@@ -8,7 +8,7 @@ query selectionSetConflictStreamOnNodesOrEdgesWithoutDeferOnPageInfoAndPageInfoA
             hasNextPage
           }
         }
-        edges @stream(label: "b", initial_count: 1) {
+        edges @stream(label: "b", initialCount: 1) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.expected
@@ -3,7 +3,7 @@ query selectionSetConflictValidStreamQuery {
   me {
     ... on User {
       friends {
-        edges @stream(label: "jkdhg", initial_count: 0) {
+        edges @stream(label: "jkdhg", initialCount: 0) {
           node {
             id
           }
@@ -168,7 +168,7 @@ QUERY:
 query selectionSetConflictValidStreamQuery {
   me {
     friends {
-      edges @stream(label: "selectionSetConflictValidStreamQuery$stream$jkdhg", initial_count: 0) {
+      edges @stream(label: "selectionSetConflictValidStreamQuery$stream$jkdhg", initialCount: 0) {
         node {
           id
         }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selection_set_conflict_valid_stream.graphql
@@ -2,7 +2,7 @@ query selectionSetConflictValidStreamQuery {
   me {
     ... on User {
       friends {
-        edges @stream(label: "jkdhg", initial_count: 0) {
+        edges @stream(label: "jkdhg", initialCount: 0) {
           node {
             id
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.expected
@@ -7,7 +7,7 @@ query streamAndHandleQuery {
 
 fragment streamAndHandleFragment on Feedback {
   actors
-    @stream(label: "actors", if: true, initial_count: 0)
+    @stream(label: "actors", if: true, initialCount: 0)
     @__clientField(handle: "actors_handler") {
     name @__clientField(handle: "name_handler")
   }
@@ -170,7 +170,7 @@ query streamAndHandleQuery {
 }
 
 fragment streamAndHandleFragment on Feedback {
-  actors @stream(label: "streamAndHandleFragment$stream$actors", if: true, initial_count: 0) {
+  actors @stream(label: "streamAndHandleFragment$stream$actors", if: true, initialCount: 0) {
     __typename
     name
     id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.graphql
@@ -6,7 +6,7 @@ query streamAndHandleQuery {
 
 fragment streamAndHandleFragment on Feedback {
   actors
-    @stream(label: "actors", if: true, initial_count: 0)
+    @stream(label: "actors", if: true, initialCount: 0)
     @__clientField(handle: "actors_handler") {
     name @__clientField(handle: "name_handler")
   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection-conditional.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection-conditional.expected
@@ -360,7 +360,7 @@ query streamConnectionConditionalQuery(
     id
     ... on Story {
       comments(first: 10) {
-        edges @stream(label: "streamConnectionConditionalQuery$stream$NodeQuery_comments", if: $cond, initial_count: 0, use_customized_batch: $cond) {
+        edges @stream(label: "streamConnectionConditionalQuery$stream$NodeQuery_comments", if: $cond, initialCount: 0, useCustomizedBatch: $cond) {
           node {
             __typename
             id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-connection.expected
@@ -400,7 +400,7 @@ query streamConnection_NodeQuery(
     id
     ... on Story {
       comments(first: 10) {
-        edges @stream(label: "streamConnection_NodeQuery$stream$NodeQuery_comments", initial_count: 0) {
+        edges @stream(label: "streamConnection_NodeQuery$stream$NodeQuery_comments", initialCount: 0) {
           node {
             actor {
               __typename

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream_if_arguments.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream_if_arguments.expected
@@ -19,27 +19,27 @@ fragment streamIfArgumentsFragment on User
   setToFalse: { type: "Boolean", defaultValue: false }
 ) {
   withDefaultTrue: tasks
-    @stream(initial_count: 1, if: $defaultsToTrue, label: "defaultTrue") {
+    @stream(initialCount: 1, if: $defaultsToTrue, label: "defaultTrue") {
     __typename
   }
   withDefaultFalse: tasks
-    @stream(initial_count: 1, if: $defaultsToFalse, label: "defaultFalse") {
+    @stream(initialCount: 1, if: $defaultsToFalse, label: "defaultFalse") {
     __typename
   }
   setToTrue: tasks
-    @stream(initial_count: 1, if: $setToTrue, label: "setToTrue") {
+    @stream(initialCount: 1, if: $setToTrue, label: "setToTrue") {
     __typename
   }
   setToFalse: tasks
-    @stream(initial_count: 1, if: $setToFalse, label: "setToFalse") {
+    @stream(initialCount: 1, if: $setToFalse, label: "setToFalse") {
     __typename
   }
   withValueFromQueryDirectly: tasks
-    @stream(initial_count: 1, if: $valueFromQuery, label: "fromQueryDirectly") {
+    @stream(initialCount: 1, if: $valueFromQuery, label: "fromQueryDirectly") {
     __typename
   }
   withValueFromQueryViaArgDef: tasks
-    @stream(initial_count: 1, if: $setToValue, label: "fromQueryViaArg") {
+    @stream(initialCount: 1, if: $setToValue, label: "fromQueryViaArg") {
     __typename
   }
 }
@@ -283,22 +283,22 @@ query streamIfArgumentsQuery(
 }
 
 fragment streamIfArgumentsFragment_39RTKZ on User {
-  withDefaultTrue: tasks @stream(label: "streamIfArgumentsFragment$stream$defaultTrue", if: true, initial_count: 1) {
+  withDefaultTrue: tasks @stream(label: "streamIfArgumentsFragment$stream$defaultTrue", if: true, initialCount: 1) {
     __typename
   }
   withDefaultFalse: tasks {
     __typename
   }
-  setToTrue: tasks @stream(label: "streamIfArgumentsFragment$stream$setToTrue", if: true, initial_count: 1) {
+  setToTrue: tasks @stream(label: "streamIfArgumentsFragment$stream$setToTrue", if: true, initialCount: 1) {
     __typename
   }
   setToFalse: tasks {
     __typename
   }
-  withValueFromQueryDirectly: tasks @stream(label: "streamIfArgumentsFragment$stream$fromQueryDirectly", if: $valueFromQuery, initial_count: 1) {
+  withValueFromQueryDirectly: tasks @stream(label: "streamIfArgumentsFragment$stream$fromQueryDirectly", if: $valueFromQuery, initialCount: 1) {
     __typename
   }
-  withValueFromQueryViaArgDef: tasks @stream(label: "streamIfArgumentsFragment$stream$fromQueryViaArg", if: $valueFromQuery, initial_count: 1) {
+  withValueFromQueryViaArgDef: tasks @stream(label: "streamIfArgumentsFragment$stream$fromQueryViaArg", if: $valueFromQuery, initialCount: 1) {
     __typename
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream_if_arguments.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream_if_arguments.graphql
@@ -18,27 +18,27 @@ fragment streamIfArgumentsFragment on User
   setToFalse: { type: "Boolean", defaultValue: false }
 ) {
   withDefaultTrue: tasks
-    @stream(initial_count: 1, if: $defaultsToTrue, label: "defaultTrue") {
+    @stream(initialCount: 1, if: $defaultsToTrue, label: "defaultTrue") {
     __typename
   }
   withDefaultFalse: tasks
-    @stream(initial_count: 1, if: $defaultsToFalse, label: "defaultFalse") {
+    @stream(initialCount: 1, if: $defaultsToFalse, label: "defaultFalse") {
     __typename
   }
   setToTrue: tasks
-    @stream(initial_count: 1, if: $setToTrue, label: "setToTrue") {
+    @stream(initialCount: 1, if: $setToTrue, label: "setToTrue") {
     __typename
   }
   setToFalse: tasks
-    @stream(initial_count: 1, if: $setToFalse, label: "setToFalse") {
+    @stream(initialCount: 1, if: $setToFalse, label: "setToFalse") {
     __typename
   }
   withValueFromQueryDirectly: tasks
-    @stream(initial_count: 1, if: $valueFromQuery, label: "fromQueryDirectly") {
+    @stream(initialCount: 1, if: $valueFromQuery, label: "fromQueryDirectly") {
     __typename
   }
   withValueFromQueryViaArgDef: tasks
-    @stream(initial_count: 1, if: $setToValue, label: "fromQueryViaArg") {
+    @stream(initialCount: 1, if: $setToValue, label: "fromQueryViaArg") {
     __typename
   }
 }

--- a/compiler/crates/relay-config/src/defer_stream_interface.rs
+++ b/compiler/crates/relay-config/src/defer_stream_interface.rs
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use common::ArgumentName;
+use common::DirectiveName;
+use intern::string_key::Intern;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Configuration where Relay should expect some fields in the schema.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DeferStreamInterface {
+    pub defer_name: DirectiveName,
+    pub stream_name: DirectiveName,
+    pub if_arg: ArgumentName,
+    pub label_arg: ArgumentName,
+    pub initial_count_arg: ArgumentName,
+    pub use_customized_batch_arg: ArgumentName,
+}
+
+impl Default for DeferStreamInterface {
+    fn default() -> Self {
+        DeferStreamInterface {
+            defer_name: DirectiveName("defer".intern()),
+            stream_name: DirectiveName("stream".intern()),
+            if_arg: ArgumentName("if".intern()),
+            label_arg: ArgumentName("label".intern()),
+            initial_count_arg: ArgumentName("initial_count".intern()),
+            use_customized_batch_arg: ArgumentName("use_customized_batch".intern()),
+        }
+    }
+}

--- a/compiler/crates/relay-config/src/defer_stream_interface.rs
+++ b/compiler/crates/relay-config/src/defer_stream_interface.rs
@@ -30,8 +30,8 @@ impl Default for DeferStreamInterface {
             stream_name: DirectiveName("stream".intern()),
             if_arg: ArgumentName("if".intern()),
             label_arg: ArgumentName("label".intern()),
-            initial_count_arg: ArgumentName("initial_count".intern()),
-            use_customized_batch_arg: ArgumentName("use_customized_batch".intern()),
+            initial_count_arg: ArgumentName("initialCount".intern()),
+            use_customized_batch_arg: ArgumentName("useCustomizedBatch".intern()),
         }
     }
 }

--- a/compiler/crates/relay-config/src/lib.rs
+++ b/compiler/crates/relay-config/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(clippy::all)]
 
 mod connection_interface;
+mod defer_stream_interface;
 mod diagnostic_report_config;
 mod js_module_format;
 mod module_import_config;
@@ -19,6 +20,7 @@ mod project_name;
 mod typegen_config;
 
 pub use connection_interface::ConnectionInterface;
+pub use defer_stream_interface::DeferStreamInterface;
 pub use diagnostic_report_config::DiagnosticLevel;
 pub use diagnostic_report_config::DiagnosticReportConfig;
 pub use js_module_format::JsModuleFormat;

--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -31,6 +31,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::connection_interface::ConnectionInterface;
+use crate::defer_stream_interface::DeferStreamInterface;
 use crate::diagnostic_report_config::DiagnosticReportConfig;
 use crate::module_import_config::ModuleImportConfig;
 use crate::non_node_id_fields_config::NonNodeIdFieldsConfig;
@@ -170,6 +171,9 @@ pub struct SchemaConfig {
     #[serde(default = "default_node_interface_id_field")]
     pub node_interface_id_field: StringKey,
 
+    #[serde(default)]
+    pub defer_stream_interface: DeferStreamInterface,
+
     /// The name of the variable expected by the `node` query.
     #[serde(default = "default_node_interface_id_variable_name")]
     pub node_interface_id_variable_name: StringKey,
@@ -198,6 +202,7 @@ impl Default for SchemaConfig {
     fn default() -> Self {
         Self {
             connection_interface: ConnectionInterface::default(),
+            defer_stream_interface: DeferStreamInterface::default(),
             node_interface_id_field: default_node_interface_id_field(),
             node_interface_id_variable_name: default_node_interface_id_variable_name(),
             non_node_id_fields: None,

--- a/compiler/crates/relay-lsp/src/completion/test.rs
+++ b/compiler/crates/relay-lsp/src/completion/test.rs
@@ -456,7 +456,7 @@ fn empty_argument_list() {
     );
     assert_labels(
         items.unwrap(),
-        vec!["label", "initial_count", "if", "use_customized_batch"],
+        vec!["label", "initialCount", "if", "useCustomizedBatch"],
     );
 }
 
@@ -474,7 +474,7 @@ fn argument_name_without_value() {
     );
     assert_labels(
         items.unwrap(),
-        vec!["label", "initial_count", "if", "use_customized_batch"],
+        vec!["label", "initialCount", "if", "useCustomizedBatch"],
     );
 }
 
@@ -495,7 +495,7 @@ fn argument_name_with_existing_name() {
     );
     assert_labels(
         items.unwrap(),
-        vec!["label", "initial_count", "use_customized_batch"],
+        vec!["label", "initialCount", "useCustomizedBatch"],
     );
 }
 

--- a/compiler/crates/relay-test-schema/src/testschema.graphql
+++ b/compiler/crates/relay-test-schema/src/testschema.graphql
@@ -25,9 +25,9 @@ directive @defer(
 
 directive @stream(
   label: String!
-  initial_count: Int!
+  initialCount: Int!
   if: Boolean = true
-  use_customized_batch: Boolean = false
+  useCustomizedBatch: Boolean = false
 ) on FIELD
 
 directive @fetchable(field_name: String!) on OBJECT

--- a/compiler/crates/relay-test-schema/src/testschema_with_custom_id.graphql
+++ b/compiler/crates/relay-test-schema/src/testschema_with_custom_id.graphql
@@ -25,9 +25,9 @@ directive @defer(
 
 directive @stream(
   label: String!
-  initial_count: Int!
+  initialCount: Int!
   if: Boolean = true
-  use_customized_batch: Boolean = false
+  useCustomizedBatch: Boolean = false
 ) on FIELD
 
 directive @fetchable(field_name: String!) on OBJECT

--- a/compiler/crates/relay-transforms/src/apply_transforms.rs
+++ b/compiler/crates/relay-transforms/src/apply_transforms.rs
@@ -155,17 +155,25 @@ fn apply_common_transforms(
     )?;
 
     program = log_event.time("transform_connections", || {
-        transform_connections(&program, &project_config.schema_config.connection_interface)
+        transform_connections(
+            &program,
+            &project_config.schema_config.connection_interface,
+            &project_config.schema_config.defer_stream_interface,
+        )
     });
     program = log_event.time("mask", || mask(&program));
     program = log_event.time("transform_defer_stream", || {
-        transform_defer_stream(&program)
+        transform_defer_stream(
+            &program,
+            &project_config.schema_config.defer_stream_interface,
+        )
     })?;
     program = log_event.time("transform_match", || {
         transform_match(
             &program,
             &project_config.feature_flags,
             project_config.module_import_config,
+            project_config.schema_config.defer_stream_interface,
         )
     })?;
     program = log_event.time("transform_subscriptions", || {
@@ -281,14 +289,22 @@ fn apply_reader_transforms(
 
     program = log_event.time("inline_data_fragment", || inline_data_fragment(&program))?;
     program = log_event.time("skip_unreachable_node", || {
-        skip_unreachable_node_strict(&program)
+        skip_unreachable_node_strict(
+            &program,
+            project_config.schema_config.defer_stream_interface,
+        )
     })?;
     program = log_event.time("remove_base_fragments", || {
         remove_base_fragments(&program, &base_fragment_names)
     });
 
     log_event.time("flatten", || flatten(&mut program, true, false))?;
-    program = log_event.time("skip_redundant_nodes", || skip_redundant_nodes(&program));
+    program = log_event.time("skip_redundant_nodes", || {
+        skip_redundant_nodes(
+            &program,
+            project_config.schema_config.defer_stream_interface,
+        )
+    });
     program = log_event.time("generate_data_driven_dependency_metadata", || {
         generate_data_driven_dependency_metadata(&program)
     });
@@ -445,7 +461,10 @@ fn apply_normalization_transforms(
     }
 
     program = log_event.time("skip_unreachable_node", || {
-        skip_unreachable_node_strict(&program)
+        skip_unreachable_node_strict(
+            &program,
+            project_config.schema_config.defer_stream_interface,
+        )
     })?;
     if let Some(print_stats) = maybe_print_stats {
         print_stats("skip_unreachable_node", &program);
@@ -471,7 +490,12 @@ fn apply_normalization_transforms(
         print_stats("flatten", &program);
     }
 
-    program = log_event.time("skip_redundant_nodes", || skip_redundant_nodes(&program));
+    program = log_event.time("skip_redundant_nodes", || {
+        skip_redundant_nodes(
+            &program,
+            project_config.schema_config.defer_stream_interface,
+        )
+    });
     if let Some(print_stats) = maybe_print_stats {
         print_stats("skip_redundant_nodes", &program);
     }
@@ -545,7 +569,10 @@ fn apply_operation_text_transforms(
 
     program = log_event.time("skip_split_operation", || skip_split_operation(&program));
     program = log_event.time("skip_unreachable_node_strict", || {
-        skip_unreachable_node_strict(&program)
+        skip_unreachable_node_strict(
+            &program,
+            project_config.schema_config.defer_stream_interface,
+        )
     })?;
     program = log_event.time("skip_null_arguments_transform", || {
         skip_null_arguments_transform(&program)
@@ -559,7 +586,10 @@ fn apply_operation_text_transforms(
         skip_client_extensions(&program)
     });
     program = log_event.time("skip_unreachable_node_loose", || {
-        skip_unreachable_node_loose(&program)
+        skip_unreachable_node_loose(
+            &program,
+            project_config.schema_config.defer_stream_interface,
+        )
     });
 
     program = log_event.time("generate_typename", || generate_typename(&program, false));
@@ -574,7 +604,10 @@ fn apply_operation_text_transforms(
         validate_required_arguments(&program)
     })?;
     program = log_event.time("unwrap_custom_directive_selection", || {
-        unwrap_custom_directive_selection(&program)
+        unwrap_custom_directive_selection(
+            &program,
+            project_config.schema_config.defer_stream_interface,
+        )
     });
 
     program = apply_after_custom_transforms(
@@ -624,6 +657,7 @@ fn apply_typegen_transforms(
             &program,
             &project_config.feature_flags,
             project_config.module_import_config,
+            project_config.schema_config.defer_stream_interface,
         )
     })?;
     program = log_event.time("transform_subscriptions", || {

--- a/compiler/crates/relay-transforms/src/connections/connection_constants.rs
+++ b/compiler/crates/relay-transforms/src/connections/connection_constants.rs
@@ -14,6 +14,10 @@ use intern::string_key::StringKey;
 pub struct ConnectionConstants {
     pub connection_directive_name: DirectiveName,
     pub stream_connection_directive_name: DirectiveName,
+    pub stream_connection_if_arg: ArgumentName,
+    pub stream_connection_label_arg: ArgumentName,
+    pub stream_connection_initial_count_arg: ArgumentName,
+    pub stream_connection_use_customized_batch_arg: ArgumentName,
 
     pub direction_forward: StringKey,
     pub direction_backward: StringKey,
@@ -43,6 +47,12 @@ impl Default for ConnectionConstants {
         Self {
             connection_directive_name: DirectiveName("connection".intern()),
             stream_connection_directive_name: DirectiveName("stream_connection".intern()),
+            stream_connection_if_arg: ArgumentName("if".intern()),
+            stream_connection_label_arg: ArgumentName("label".intern()),
+            stream_connection_initial_count_arg: ArgumentName("initial_count".intern()),
+            stream_connection_use_customized_batch_arg: ArgumentName(
+                "use_customized_batch".intern(),
+            ),
 
             direction_forward: "forward".intern(),
             direction_backward: "backward".intern(),

--- a/compiler/crates/relay-transforms/src/defer_stream/directives.rs
+++ b/compiler/crates/relay-transforms/src/defer_stream/directives.rs
@@ -7,8 +7,7 @@
 
 use graphql_ir::Argument;
 use graphql_ir::Directive;
-
-use super::DEFER_STREAM_CONSTANTS;
+use relay_config::DeferStreamInterface;
 
 /// Utility to access the arguments of the @defer directive.
 pub struct DeferDirective<'a> {
@@ -20,13 +19,13 @@ impl<'a> DeferDirective<'a> {
     /// Extracts the arguments from the given directive assumed to be a @defer
     /// directive.
     /// Panics on any unexpected arguments.
-    pub fn from(directive: &'a Directive) -> Self {
+    pub fn from(directive: &'a Directive, defer_stream_interface: &DeferStreamInterface) -> Self {
         let mut if_arg = None;
         let mut label_arg = None;
         for arg in &directive.arguments {
-            if arg.name.item == DEFER_STREAM_CONSTANTS.if_arg {
+            if arg.name.item == defer_stream_interface.if_arg {
                 if_arg = Some(arg);
-            } else if arg.name.item == DEFER_STREAM_CONSTANTS.label_arg {
+            } else if arg.name.item == defer_stream_interface.label_arg {
                 label_arg = Some(arg);
             } else {
                 panic!("Unexpected argument to @defer: {}", arg.name.item);
@@ -48,19 +47,19 @@ impl<'a> StreamDirective<'a> {
     /// Extracts the arguments from the given directive assumed to be a @stream
     /// directive.
     /// Panics on any unexpected arguments.
-    pub fn from(directive: &'a Directive) -> Self {
+    pub fn from(directive: &'a Directive, defer_stream_interface: &DeferStreamInterface) -> Self {
         let mut if_arg = None;
         let mut label_arg = None;
         let mut initial_count_arg = None;
         let mut use_customized_batch_arg = None;
         for arg in &directive.arguments {
-            if arg.name.item == DEFER_STREAM_CONSTANTS.if_arg {
+            if arg.name.item == defer_stream_interface.if_arg {
                 if_arg = Some(arg);
-            } else if arg.name.item == DEFER_STREAM_CONSTANTS.label_arg {
+            } else if arg.name.item == defer_stream_interface.label_arg {
                 label_arg = Some(arg);
-            } else if arg.name.item == DEFER_STREAM_CONSTANTS.initial_count_arg {
+            } else if arg.name.item == defer_stream_interface.initial_count_arg {
                 initial_count_arg = Some(arg);
-            } else if arg.name.item == DEFER_STREAM_CONSTANTS.use_customized_batch_arg {
+            } else if arg.name.item == defer_stream_interface.use_customized_batch_arg {
                 use_customized_batch_arg = Some(arg);
             } else {
                 panic!("Unexpected argument to @stream: {}", arg.name.item);

--- a/compiler/crates/relay-transforms/src/defer_stream/mod.rs
+++ b/compiler/crates/relay-transforms/src/defer_stream/mod.rs
@@ -38,7 +38,7 @@ use graphql_ir::Value;
 use intern::string_key::Intern;
 use intern::string_key::StringKey;
 use intern::Lookup;
-use lazy_static::lazy_static;
+use relay_config::DeferStreamInterface;
 use schema::Schema;
 use thiserror::Error;
 
@@ -46,38 +46,16 @@ use super::get_applied_fragment_name;
 use crate::util::remove_directive;
 use crate::util::replace_directive;
 
-pub struct DeferStreamConstants {
-    pub defer_name: DirectiveName,
-    pub stream_name: DirectiveName,
-    pub if_arg: ArgumentName,
-    pub label_arg: ArgumentName,
-    pub initial_count_arg: ArgumentName,
-    pub use_customized_batch_arg: ArgumentName,
-}
-
-impl Default for DeferStreamConstants {
-    fn default() -> Self {
-        Self {
-            defer_name: DirectiveName("defer".intern()),
-            stream_name: DirectiveName("stream".intern()),
-            if_arg: ArgumentName("if".intern()),
-            label_arg: ArgumentName("label".intern()),
-            initial_count_arg: ArgumentName("initial_count".intern()),
-            use_customized_batch_arg: ArgumentName("use_customized_batch".intern()),
-        }
-    }
-}
-
-lazy_static! {
-    pub static ref DEFER_STREAM_CONSTANTS: DeferStreamConstants = Default::default();
-}
-
-pub fn transform_defer_stream(program: &Program) -> DiagnosticsResult<Program> {
+pub fn transform_defer_stream(
+    program: &Program,
+    defer_stream_interface: &DeferStreamInterface,
+) -> DiagnosticsResult<Program> {
     let mut transformer = DeferStreamTransform {
         program,
         current_document_name: None,
         labels: Default::default(),
         errors: Default::default(),
+        defer_stream_interface,
     };
     let next_program = transformer.transform_program(program);
 
@@ -93,6 +71,7 @@ struct DeferStreamTransform<'s> {
     current_document_name: Option<StringKey>,
     labels: HashMap<StringKey, Directive>,
     errors: Vec<Diagnostic>,
+    defer_stream_interface: &'s DeferStreamInterface,
 }
 
 impl DeferStreamTransform<'_> {
@@ -100,14 +79,19 @@ impl DeferStreamTransform<'_> {
         self.current_document_name = Some(document_name)
     }
 
-    fn record_label(&mut self, label: StringKey, directive: &Directive) {
+    fn record_label(
+        &mut self,
+        label: StringKey,
+        directive: &Directive,
+        defer_stream_interface: &DeferStreamInterface,
+    ) {
         let prev_directive = self.labels.get(&label);
         match prev_directive {
             Some(prev) => {
                 self.errors.push(
                     Diagnostic::error(
                         ValidationMessage::LabelNotUniqueForDeferStream {
-                            directive_name: DEFER_STREAM_CONSTANTS.defer_name,
+                            directive_name: defer_stream_interface.defer_name,
                         },
                         prev.name.location,
                     )
@@ -124,8 +108,10 @@ impl DeferStreamTransform<'_> {
         &mut self,
         spread: &FragmentSpread,
         defer: &Directive,
+        defer_stream_interface: &DeferStreamInterface,
     ) -> Result<Transformed<Selection>, Diagnostic> {
-        let DeferDirective { if_arg, label_arg } = DeferDirective::from(defer);
+        let DeferDirective { if_arg, label_arg } =
+            DeferDirective::from(defer, defer_stream_interface);
 
         if is_literal_false_arg(if_arg) {
             return Ok(Transformed::Replace(Selection::FragmentSpread(Arc::new(
@@ -143,14 +129,14 @@ impl DeferStreamTransform<'_> {
         let transformed_label = transform_label(
             self.current_document_name
                 .expect("We expect the parent name to be defined here."),
-            DEFER_STREAM_CONSTANTS.defer_name,
+            defer_stream_interface.defer_name,
             label,
         );
-        self.record_label(transformed_label, defer);
+        self.record_label(transformed_label, defer, defer_stream_interface);
         let next_label_value = Value::Constant(ConstantValue::String(transformed_label));
         let next_label_arg = Argument {
             name: WithLocation {
-                item: DEFER_STREAM_CONSTANTS.label_arg,
+                item: defer_stream_interface.label_arg,
                 location: label_arg.map_or(defer.name.location, |arg| arg.name.location),
             },
             value: WithLocation {
@@ -188,6 +174,7 @@ impl DeferStreamTransform<'_> {
         &mut self,
         linked_field: &LinkedField,
         stream: &Directive,
+        defer_stream_interface: &DeferStreamInterface,
     ) -> Result<Transformed<Selection>, Diagnostic> {
         let schema_field = self.program.schema.field(linked_field.definition.item);
         if !schema_field.type_.is_list() {
@@ -204,7 +191,7 @@ impl DeferStreamTransform<'_> {
             label_arg,
             initial_count_arg,
             use_customized_batch_arg,
-        } = StreamDirective::from(stream);
+        } = StreamDirective::from(stream, defer_stream_interface);
 
         let transformed_linked_field = self.default_transform_linked_field(linked_field);
         let get_next_selection = |directives| match transformed_linked_field {
@@ -245,14 +232,14 @@ impl DeferStreamTransform<'_> {
         let transformed_label = transform_label(
             self.current_document_name
                 .expect("We expect the parent name to be defined here."),
-            DEFER_STREAM_CONSTANTS.stream_name,
+            defer_stream_interface.stream_name,
             label,
         );
-        self.record_label(transformed_label, stream);
+        self.record_label(transformed_label, stream, defer_stream_interface);
         let next_label_value = Value::Constant(ConstantValue::String(transformed_label));
         let next_label_arg = Argument {
             name: WithLocation {
-                item: DEFER_STREAM_CONSTANTS.label_arg,
+                item: defer_stream_interface.label_arg,
                 location: label_arg.map_or(stream.name.location, |arg| arg.name.location),
             },
             value: WithLocation {
@@ -314,10 +301,13 @@ impl<'s> Transformer for DeferStreamTransform<'s> {
     ) -> Transformed<Selection> {
         let defer_directive = inline_fragment
             .directives
-            .named(DEFER_STREAM_CONSTANTS.defer_name);
+            .named(self.defer_stream_interface.defer_name);
         if let Some(directive) = defer_directive {
             // Special case for @defer generated by transform_connection
-            if let Some(label) = directive.arguments.named(DEFER_STREAM_CONSTANTS.label_arg) {
+            if let Some(label) = directive
+                .arguments
+                .named(self.defer_stream_interface.label_arg)
+            {
                 if let Some(label) = label.value.item.get_string_literal() {
                     if label.lookup().contains("$defer$") {
                         return self.default_transform_inline_fragment(inline_fragment);
@@ -335,9 +325,11 @@ impl<'s> Transformer for DeferStreamTransform<'s> {
 
     /// Transform of fragment spread with @defer is delegated to `transform_defer`.
     fn transform_fragment_spread(&mut self, spread: &FragmentSpread) -> Transformed<Selection> {
-        let defer_directive = spread.directives.named(DEFER_STREAM_CONSTANTS.defer_name);
+        let defer_directive = spread
+            .directives
+            .named(self.defer_stream_interface.defer_name);
         if let Some(defer) = defer_directive {
-            match self.transform_defer(spread, defer) {
+            match self.transform_defer(spread, defer, self.defer_stream_interface) {
                 Ok(transformed) => transformed,
                 Err(err) => {
                     self.errors.push(err);
@@ -353,7 +345,7 @@ impl<'s> Transformer for DeferStreamTransform<'s> {
     fn transform_scalar_field(&mut self, scalar_field: &ScalarField) -> Transformed<Selection> {
         let stream_directive = &scalar_field
             .directives
-            .named(DEFER_STREAM_CONSTANTS.stream_name);
+            .named(self.defer_stream_interface.stream_name);
         if let Some(directive) = stream_directive {
             self.errors.push(Diagnostic::error(
                 ValidationMessage::InvalidStreamOnScalarField {
@@ -369,9 +361,9 @@ impl<'s> Transformer for DeferStreamTransform<'s> {
     fn transform_linked_field(&mut self, linked_field: &LinkedField) -> Transformed<Selection> {
         let stream_directive = linked_field
             .directives
-            .named(DEFER_STREAM_CONSTANTS.stream_name);
+            .named(self.defer_stream_interface.stream_name);
         if let Some(stream) = stream_directive {
-            match self.transform_stream(linked_field, stream) {
+            match self.transform_stream(linked_field, stream, self.defer_stream_interface) {
                 Ok(transformed) => transformed,
                 Err(err) => {
                     self.errors.push(err);

--- a/compiler/crates/relay-transforms/src/lib.rs
+++ b/compiler/crates/relay-transforms/src/lib.rs
@@ -119,7 +119,6 @@ pub use declarative_connection::transform_declarative_connection;
 pub use defer_stream::transform_defer_stream;
 pub use defer_stream::DeferDirective;
 pub use defer_stream::StreamDirective;
-pub use defer_stream::DEFER_STREAM_CONSTANTS;
 pub use directive_finder::DirectiveFinder;
 pub use flatten::flatten;
 pub use fragment_alias_directive::fragment_alias_directive;

--- a/compiler/crates/relay-transforms/src/match_/match_transform.rs
+++ b/compiler/crates/relay-transforms/src/match_/match_transform.rs
@@ -44,6 +44,7 @@ use indexmap::IndexSet;
 use intern::string_key::Intern;
 use intern::string_key::StringKey;
 use intern::Lookup;
+use relay_config::DeferStreamInterface;
 use relay_config::ModuleImportConfig;
 use schema::FieldID;
 use schema::ScalarID;
@@ -52,7 +53,6 @@ use schema::Type;
 use schema::TypeReference;
 
 use super::validation_message::ValidationMessage;
-use crate::defer_stream::DEFER_STREAM_CONSTANTS;
 use crate::inline_data_fragment::INLINE_DIRECTIVE_NAME;
 use crate::match_::MATCH_CONSTANTS;
 use crate::no_inline::attach_no_inline_directives_to_fragments;
@@ -64,8 +64,14 @@ pub fn transform_match(
     program: &Program,
     feature_flags: &FeatureFlags,
     module_import_config: ModuleImportConfig,
+    defer_stream_interface: DeferStreamInterface,
 ) -> DiagnosticsResult<Program> {
-    let mut transformer = MatchTransform::new(program, feature_flags, module_import_config);
+    let mut transformer = MatchTransform::new(
+        program,
+        feature_flags,
+        module_import_config,
+        defer_stream_interface,
+    );
     let next_program = transformer.transform_program(program);
     if transformer.errors.is_empty() {
         Ok(next_program.replace_or_else(|| program.clone()))
@@ -113,6 +119,7 @@ pub struct MatchTransform<'program, 'flag> {
     // Stores the fragments that should use @no_inline and their parent document name
     no_inline_fragments: FragmentDefinitionNameMap<Vec<ExecutableDefinitionName>>,
     module_import_config: ModuleImportConfig,
+    defer_stream_interface: DeferStreamInterface,
 }
 
 impl<'program, 'flag> MatchTransform<'program, 'flag> {
@@ -120,6 +127,7 @@ impl<'program, 'flag> MatchTransform<'program, 'flag> {
         program: &'program Program,
         feature_flags: &'flag FeatureFlags,
         module_import_config: ModuleImportConfig,
+        defer_stream_interface: DeferStreamInterface,
     ) -> Self {
         Self {
             program,
@@ -136,6 +144,7 @@ impl<'program, 'flag> MatchTransform<'program, 'flag> {
             no_inline_flag: &feature_flags.no_inline,
             no_inline_fragments: Default::default(),
             module_import_config,
+            defer_stream_interface,
         }
     }
 
@@ -317,7 +326,7 @@ impl<'program, 'flag> MatchTransform<'program, 'flag> {
                 && !(spread.directives.len() == 2
                     && spread
                         .directives
-                        .named(DEFER_STREAM_CONSTANTS.defer_name)
+                        .named(self.defer_stream_interface.defer_name)
                         .is_some())
             {
                 // allow @defer and @module in typegen transforms

--- a/compiler/crates/relay-transforms/src/skip_redundant_nodes.rs
+++ b/compiler/crates/relay-transforms/src/skip_redundant_nodes.rs
@@ -21,11 +21,11 @@ use graphql_ir::Program;
 use graphql_ir::Selection;
 use graphql_ir::Transformed;
 use graphql_ir::TransformedValue;
+use relay_config::DeferStreamInterface;
 use schema::SDLSchema;
 
 use crate::util::is_relay_custom_inline_fragment_directive;
 use crate::RelayLocationAgnosticBehavior;
-use crate::DEFER_STREAM_CONSTANTS;
 
 /**
  * A transform that removes redundant fields and fragment spreads. Redundancy is
@@ -118,8 +118,11 @@ use crate::DEFER_STREAM_CONSTANTS;
  *
  * 1 can be skipped because it is already fetched at the outer level.
  */
-pub fn skip_redundant_nodes(program: &Program) -> Program {
-    let transform = SkipRedundantNodesTransform::new(program);
+pub fn skip_redundant_nodes(
+    program: &Program,
+    defer_stream_interface: DeferStreamInterface,
+) -> Program {
+    let transform = SkipRedundantNodesTransform::new(program, defer_stream_interface);
     transform
         .transform_program(program)
         .replace_or_else(|| program.clone())
@@ -133,20 +136,26 @@ type Cache = DashMap<PointerAddress, (Transformed<Selection>, SelectionMap)>;
 pub struct SkipRedundantNodesTransform {
     schema: Arc<SDLSchema>,
     cache: Cache,
+    defer_stream_interface: DeferStreamInterface,
 }
 
 impl<'s> SkipRedundantNodesTransform {
-    fn new(program: &'_ Program) -> Self {
+    fn new(program: &'_ Program, defer_stream_interface: DeferStreamInterface) -> Self {
         Self {
             schema: Arc::clone(&program.schema),
             cache: DashMap::new(),
+            defer_stream_interface,
         }
     }
 
-    pub fn from_schema(schema: &Arc<SDLSchema>) -> Self {
+    pub fn from_schema(
+        schema: &Arc<SDLSchema>,
+        defer_stream_interface: DeferStreamInterface,
+    ) -> Self {
         Self {
             schema: Arc::clone(schema),
             cache: DashMap::new(),
+            defer_stream_interface,
         }
     }
 
@@ -346,7 +355,7 @@ impl<'s> SkipRedundantNodesTransform {
         }
         let mut result: Vec<Selection> = Vec::new();
         let mut has_changes = false;
-        let selections = get_partitioned_selections(selections);
+        let selections = get_partitioned_selections(selections, self.defer_stream_interface);
 
         for (index, prev_item) in selections.iter().enumerate() {
             let next_item = self.transform_selection(prev_item, selection_map);
@@ -445,16 +454,19 @@ impl<'s> SkipRedundantNodesTransform {
  * guaranteed to be fetched are encountered prior to any duplicates that may be
  * fetched within a conditional.
  */
-fn get_partitioned_selections(selections: &[Selection]) -> Vec<&Selection> {
+fn get_partitioned_selections(
+    selections: &[Selection],
+    defer_stream_interface: DeferStreamInterface,
+) -> Vec<&Selection> {
     let mut result = Vec::with_capacity(selections.len());
     unsafe { result.set_len(selections.len()) };
     let mut non_field_index = selections
         .iter()
-        .filter(|sel| is_selection_linked_or_scalar(sel))
+        .filter(|sel| is_selection_linked_or_scalar(sel, defer_stream_interface))
         .count();
     let mut field_index = 0;
     for sel in selections.iter() {
-        if is_selection_linked_or_scalar(sel) {
+        if is_selection_linked_or_scalar(sel, defer_stream_interface) {
             result[field_index] = sel;
             field_index += 1;
         } else {
@@ -465,11 +477,14 @@ fn get_partitioned_selections(selections: &[Selection]) -> Vec<&Selection> {
     result
 }
 
-fn is_selection_linked_or_scalar(selection: &Selection) -> bool {
+fn is_selection_linked_or_scalar(
+    selection: &Selection,
+    defer_stream_interface: DeferStreamInterface,
+) -> bool {
     match selection {
         Selection::LinkedField(field) => field
             .directives
-            .named(DEFER_STREAM_CONSTANTS.stream_name)
+            .named(defer_stream_interface.stream_name)
             .is_none(),
         Selection::ScalarField(_) => true,
         _ => false,

--- a/compiler/crates/relay-transforms/src/skip_unreachable_node.rs
+++ b/compiler/crates/relay-transforms/src/skip_unreachable_node.rs
@@ -28,9 +28,9 @@ use graphql_ir::TransformedValue;
 use graphql_ir::Transformer;
 use graphql_ir::Value;
 use intern::string_key::StringKey;
+use relay_config::DeferStreamInterface;
 use thiserror::Error;
 
-use super::defer_stream::DEFER_STREAM_CONSTANTS;
 use crate::DeferDirective;
 use crate::NoInlineFragmentSpreadMetadata;
 use crate::StreamDirective;
@@ -40,10 +40,13 @@ enum ValidationMode {
     Loose,
 }
 
-pub fn skip_unreachable_node_strict(program: &Program) -> DiagnosticsResult<Program> {
+pub fn skip_unreachable_node_strict(
+    program: &Program,
+    defer_stream_interface: DeferStreamInterface,
+) -> DiagnosticsResult<Program> {
     let errors = vec![];
     let mut validation_mode = ValidationMode::Strict(errors);
-    let next_program = skip_unreachable_node(program, &mut validation_mode);
+    let next_program = skip_unreachable_node(program, &mut validation_mode, defer_stream_interface);
 
     if let ValidationMode::Strict(errors) = validation_mode {
         if !errors.is_empty() {
@@ -53,14 +56,21 @@ pub fn skip_unreachable_node_strict(program: &Program) -> DiagnosticsResult<Prog
     Ok(next_program)
 }
 
-pub fn skip_unreachable_node_loose(program: &Program) -> Program {
+pub fn skip_unreachable_node_loose(
+    program: &Program,
+    defer_stream_interface: DeferStreamInterface,
+) -> Program {
     let mut validation_mode = ValidationMode::Loose;
-    skip_unreachable_node(program, &mut validation_mode)
+    skip_unreachable_node(program, &mut validation_mode, defer_stream_interface)
 }
 
-fn skip_unreachable_node(program: &Program, validation_mode: &mut ValidationMode) -> Program {
+fn skip_unreachable_node(
+    program: &Program,
+    validation_mode: &mut ValidationMode,
+    defer_stream_interface: DeferStreamInterface,
+) -> Program {
     let mut skip_unreachable_node_transform =
-        SkipUnreachableNodeTransform::new(program, validation_mode);
+        SkipUnreachableNodeTransform::new(program, validation_mode, defer_stream_interface);
     let transformed = skip_unreachable_node_transform.transform_program(program);
 
     transformed.replace_or_else(|| program.clone())
@@ -73,6 +83,7 @@ pub struct SkipUnreachableNodeTransform<'s> {
     visited_fragments: VisitedFragments,
     program: &'s Program,
     validation_mode: &'s mut ValidationMode,
+    defer_stream_interface: DeferStreamInterface,
 }
 
 impl<'s> Transformer for SkipUnreachableNodeTransform<'s> {
@@ -213,8 +224,13 @@ impl<'s> Transformer for SkipUnreachableNodeTransform<'s> {
 
     fn transform_linked_field(&mut self, field: &LinkedField) -> Transformed<Selection> {
         let transformed_field = self.default_transform_linked_field(field);
-        if let Some(directive) = field.directives.named(DEFER_STREAM_CONSTANTS.stream_name) {
-            if let Some(if_arg) = StreamDirective::from(directive).if_arg {
+        if let Some(directive) = field
+            .directives
+            .named(self.defer_stream_interface.stream_name)
+        {
+            if let Some(if_arg) =
+                StreamDirective::from(directive, &self.defer_stream_interface).if_arg
+            {
                 if let Value::Constant(ConstantValue::Boolean(false)) = &if_arg.value.item {
                     let mut next_field = match transformed_field {
                         Transformed::Delete => return Transformed::Delete,
@@ -228,7 +244,7 @@ impl<'s> Transformer for SkipUnreachableNodeTransform<'s> {
                     Arc::make_mut(&mut next_field)
                         .directives
                         .retain(|directive| {
-                            directive.name.item != DEFER_STREAM_CONSTANTS.stream_name
+                            directive.name.item != self.defer_stream_interface.stream_name
                         });
                     assert_eq!(
                         previous_directive_len,
@@ -244,11 +260,16 @@ impl<'s> Transformer for SkipUnreachableNodeTransform<'s> {
 }
 
 impl<'s> SkipUnreachableNodeTransform<'s> {
-    fn new(program: &'s Program, validation_mode: &'s mut ValidationMode) -> Self {
+    fn new(
+        program: &'s Program,
+        validation_mode: &'s mut ValidationMode,
+        defer_stream_interface: DeferStreamInterface,
+    ) -> Self {
         Self {
             visited_fragments: Default::default(),
             program,
             validation_mode,
+            defer_stream_interface,
         }
     }
 
@@ -292,10 +313,12 @@ impl<'s> SkipUnreachableNodeTransform<'s> {
     ) -> TransformedMulti<Selection> {
         if let Some(directive) = inline_fragment
             .directives
-            .named(DEFER_STREAM_CONSTANTS.defer_name)
+            .named(self.defer_stream_interface.defer_name)
         {
             assert!(inline_fragment.directives.len() == 1);
-            if let Some(if_arg) = DeferDirective::from(directive).if_arg {
+            if let Some(if_arg) =
+                DeferDirective::from(directive, &self.defer_stream_interface).if_arg
+            {
                 if let Value::Constant(ConstantValue::Boolean(false)) = &if_arg.value.item {
                     return TransformedMulti::ReplaceMultiple(
                         self.transform_selections(&inline_fragment.selections)

--- a/compiler/crates/relay-transforms/src/transform_connections.rs
+++ b/compiler/crates/relay-transforms/src/transform_connections.rs
@@ -25,6 +25,7 @@ use graphql_ir::Value;
 use intern::string_key::Intern;
 use intern::string_key::StringKey;
 use intern::Lookup;
+use relay_config::DeferStreamInterface;
 use schema::Schema;
 
 use crate::connections::assert_connection_selections;
@@ -37,15 +38,16 @@ use crate::connections::ConnectionConstants;
 use crate::connections::ConnectionInterface;
 use crate::connections::ConnectionMetadata;
 use crate::connections::ConnectionMetadataDirective;
-use crate::defer_stream::DEFER_STREAM_CONSTANTS;
 use crate::handle_fields::build_handle_field_directive_from_connection_directive;
 use crate::handle_fields::KEY_ARG_NAME;
 
 pub fn transform_connections(
     program: &Program,
     connection_interface: &ConnectionInterface,
+    defer_stream_interface: &DeferStreamInterface,
 ) -> Program {
-    let mut transform = ConnectionTransform::new(program, connection_interface);
+    let mut transform =
+        ConnectionTransform::new(program, connection_interface, defer_stream_interface);
     transform
         .transform_program(program)
         .replace_or_else(|| program.clone())
@@ -58,10 +60,15 @@ struct ConnectionTransform<'s> {
     current_connection_metadata: Vec<ConnectionMetadata>,
     current_document_name: StringKey,
     program: &'s Program,
+    defer_stream_interface: &'s DeferStreamInterface,
 }
 
 impl<'s> ConnectionTransform<'s> {
-    fn new(program: &'s Program, connection_interface: &'s ConnectionInterface) -> Self {
+    fn new(
+        program: &'s Program,
+        connection_interface: &'s ConnectionInterface,
+        defer_stream_interface: &'s DeferStreamInterface,
+    ) -> Self {
         Self {
             connection_constants: ConnectionConstants::default(),
             connection_interface,
@@ -69,6 +76,7 @@ impl<'s> ConnectionTransform<'s> {
             current_document_name: connection_interface.cursor, // Set an arbitrary value to avoid Option
             current_connection_metadata: Vec::new(),
             program,
+            defer_stream_interface,
         }
     }
 
@@ -132,16 +140,43 @@ impl<'s> ConnectionTransform<'s> {
         if is_stream_connection {
             let mut arguments = vec![];
             for arg in &connection_directive.arguments {
-                if arg.name.item == DEFER_STREAM_CONSTANTS.if_arg
-                    || arg.name.item == DEFER_STREAM_CONSTANTS.initial_count_arg
-                    || arg.name.item == DEFER_STREAM_CONSTANTS.use_customized_batch_arg
+                if arg.name.item == self.connection_constants.stream_connection_if_arg {
+                    arguments.push(Argument {
+                        name: WithLocation::new(
+                            arg.name.location,
+                            self.defer_stream_interface.if_arg,
+                        ),
+                        value: arg.value.clone(),
+                    });
+                } else if arg.name.item
+                    == self
+                        .connection_constants
+                        .stream_connection_initial_count_arg
                 {
-                    arguments.push(arg.clone());
+                    arguments.push(Argument {
+                        name: WithLocation::new(
+                            arg.name.location,
+                            self.defer_stream_interface.initial_count_arg,
+                        ),
+                        value: arg.value.clone(),
+                    });
+                } else if arg.name.item
+                    == self
+                        .connection_constants
+                        .stream_connection_use_customized_batch_arg
+                {
+                    arguments.push(Argument {
+                        name: WithLocation::new(
+                            arg.name.location,
+                            self.defer_stream_interface.use_customized_batch_arg,
+                        ),
+                        value: arg.value.clone(),
+                    });
                 } else if arg.name.item == *KEY_ARG_NAME {
                     arguments.push(Argument {
                         name: WithLocation::new(
                             arg.name.location,
-                            DEFER_STREAM_CONSTANTS.label_arg,
+                            self.defer_stream_interface.label_arg,
                         ),
                         value: arg.value.clone(),
                     });
@@ -150,7 +185,7 @@ impl<'s> ConnectionTransform<'s> {
             transformed_edges_field.directives.push(Directive {
                 name: WithLocation::new(
                     connection_directive.name.location,
-                    DEFER_STREAM_CONSTANTS.stream_name,
+                    self.defer_stream_interface.stream_name,
                 ),
                 arguments,
                 data: None,
@@ -218,7 +253,7 @@ impl<'s> ConnectionTransform<'s> {
                 arguments.push(Argument {
                     name: WithLocation::new(
                         key_arg.name.location,
-                        DEFER_STREAM_CONSTANTS.label_arg,
+                        self.defer_stream_interface.label_arg,
                     ),
                     value: WithLocation::new(
                         key_arg.value.location,
@@ -234,8 +269,16 @@ impl<'s> ConnectionTransform<'s> {
                     ),
                 });
             }
-            if let Some(if_arg) = connection_args.named(DEFER_STREAM_CONSTANTS.if_arg) {
-                arguments.push(if_arg.clone());
+            if let Some(if_arg) =
+                connection_args.named(self.connection_constants.stream_connection_if_arg)
+            {
+                arguments.push(Argument {
+                    name: WithLocation::new(
+                        if_arg.name.location,
+                        self.defer_stream_interface.if_arg,
+                    ),
+                    value: if_arg.value.clone(),
+                })
             }
             Selection::InlineFragment(Arc::new(InlineFragment {
                 type_condition: None,
@@ -245,7 +288,7 @@ impl<'s> ConnectionTransform<'s> {
                 directives: vec![Directive {
                     name: WithLocation::new(
                         connection_directive.name.location,
-                        DEFER_STREAM_CONSTANTS.defer_name,
+                        self.defer_stream_interface.defer_name,
                     ),
                     arguments,
                     data: None,

--- a/compiler/crates/relay-transforms/src/unwrap_custom_directive_selection.rs
+++ b/compiler/crates/relay-transforms/src/unwrap_custom_directive_selection.rs
@@ -15,19 +15,31 @@ use graphql_ir::Program;
 use graphql_ir::Selection;
 use graphql_ir::Transformed;
 use graphql_ir::Transformer;
-
-use crate::DEFER_STREAM_CONSTANTS;
+use relay_config::DeferStreamInterface;
 
 /// Transform to unwrap selections wrapped in a InlineFragment with custom
 /// directive for printing
-pub fn unwrap_custom_directive_selection(program: &Program) -> Program {
-    let mut transform = UnwrapCustomDirectiveSelection;
+pub fn unwrap_custom_directive_selection(
+    program: &Program,
+    defer_stream_interface: DeferStreamInterface,
+) -> Program {
+    let mut transform = UnwrapCustomDirectiveSelection::new(defer_stream_interface);
     transform
         .transform_program(program)
         .replace_or_else(|| program.clone())
 }
 
-struct UnwrapCustomDirectiveSelection;
+struct UnwrapCustomDirectiveSelection {
+    defer_stream_interface: DeferStreamInterface,
+}
+
+impl<'s> UnwrapCustomDirectiveSelection {
+    fn new(defer_stream_interface: DeferStreamInterface) -> Self {
+        Self {
+            defer_stream_interface,
+        }
+    }
+}
 
 impl Transformer for UnwrapCustomDirectiveSelection {
     const NAME: &'static str = "UnwrapCustomDirectiveSelection";
@@ -37,7 +49,9 @@ impl Transformer for UnwrapCustomDirectiveSelection {
     fn transform_inline_fragment(&mut self, fragment: &InlineFragment) -> Transformed<Selection> {
         if fragment.type_condition.is_none() {
             // Remove the wrapping `... @defer` for `@defer` on fragment spreads.
-            let defer = fragment.directives.named(DEFER_STREAM_CONSTANTS.defer_name);
+            let defer = fragment
+                .directives
+                .named(self.defer_stream_interface.defer_name);
             if let Some(defer) = defer {
                 if let Selection::FragmentSpread(frag_spread) = &fragment.selections[0] {
                     return Transformed::Replace(Selection::FragmentSpread(Arc::new(

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-default-label.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-default-label.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1) {
+  actors @stream(initialCount: 1) {
     name
   }
 }
@@ -24,7 +24,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$actors", initial_count: 1) {
+  actors @stream(label: "FeedbackFragment$stream$actors", initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-default-label.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-default-label.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1) {
+  actors @stream(initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.expected
@@ -9,10 +9,10 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "actors") {
+  actors @stream(initialCount: 1, label: "actors") {
     name
   }
-  otherActors: actors @stream(initial_count: 1, label: "actors") {
+  otherActors: actors @stream(initialCount: 1, label: "actors") {
     # invalid: duplicate label
     name
   }
@@ -22,7 +22,7 @@ fragment FeedbackFragment on Feedback {
 
   fragment-with-stream-duplicate-label.invalid.graphql:11:10
    10 │   id
-   11 │   actors @stream(initial_count: 1, label: "actors") {
+   11 │   actors @stream(initialCount: 1, label: "actors") {
       │          ^^^^^^^
    12 │     name
 
@@ -30,6 +30,6 @@ fragment FeedbackFragment on Feedback {
 
   fragment-with-stream-duplicate-label.invalid.graphql:14:23
    13 │   }
-   14 │   otherActors: actors @stream(initial_count: 1, label: "actors") {
+   14 │   otherActors: actors @stream(initialCount: 1, label: "actors") {
       │                       ^^^^^^^
    15 │     # invalid: duplicate label

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-duplicate-label.invalid.graphql
@@ -8,10 +8,10 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "actors") {
+  actors @stream(initialCount: 1, label: "actors") {
     name
   }
-  otherActors: actors @stream(initial_count: 1, label: "actors") {
+  otherActors: actors @stream(initialCount: 1, label: "actors") {
     # invalid: duplicate label
     name
   }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-if-arg.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-if-arg.expected
@@ -9,7 +9,7 @@ query QueryWithFragmentWithStream($id: ID!, $enableStream: Boolean) {
 fragment FeedbackFragment on Feedback {
   id
   actors
-    @stream(initial_count: 1, label: "StreamedActorsLabel", if: $enableStream) {
+    @stream(initialCount: 1, label: "StreamedActorsLabel", if: $enableStream) {
     name
   }
 }
@@ -26,7 +26,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", if: $enableStream, initial_count: 1) {
+  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", if: $enableStream, initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-if-arg.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-if-arg.graphql
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!, $enableStream: Boolean) {
 fragment FeedbackFragment on Feedback {
   id
   actors
-    @stream(initial_count: 1, label: "StreamedActorsLabel", if: $enableStream) {
+    @stream(initialCount: 1, label: "StreamedActorsLabel", if: $enableStream) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-initial-count-arg.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-initial-count-arg.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!, $initialCount: Int) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: $initialCount, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: $initialCount, label: "StreamedActorsLabel") {
     name
   }
 }
@@ -25,7 +25,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", initial_count: $initialCount) {
+  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", initialCount: $initialCount) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-initial-count-arg.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-initial-count-arg.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!, $initialCount: Int) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: $initialCount, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: $initialCount, label: "StreamedActorsLabel") {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.expected
@@ -10,15 +10,15 @@ query QueryWithFragmentWithStream($id: ID!, $initialCount: Int) {
 fragment FeedbackFragment on Feedback {
   id
   actors @stream(label: "StreamedActorsLabel") {
-    # invalid: missing initial_count
+    # invalid: missing initialCount
     name
   }
 }
 ==================================== ERROR ====================================
-✖︎ Missing required argument: `initial_count`
+✖︎ Missing required argument: `initialCount`
 
   fragment-with-stream-missing-initial-count-arg.invalid.graphql:11:11
    10 │   id
    11 │   actors @stream(label: "StreamedActorsLabel") {
       │           ^^^^^^
-   12 │     # invalid: missing initial_count
+   12 │     # invalid: missing initialCount

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-missing-initial-count-arg.invalid.graphql
@@ -9,7 +9,7 @@ query QueryWithFragmentWithStream($id: ID!, $initialCount: Int) {
 fragment FeedbackFragment on Feedback {
   id
   actors @stream(label: "StreamedActorsLabel") {
-    # invalid: missing initial_count
+    # invalid: missing initialCount
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected
@@ -9,13 +9,13 @@ query QueryWithFragmentWithStream($id: ID!, $label: String!) {
 
 fragment UserFragment on User {
   id
-  name @stream(initial_count: 1, label: $label)
+  name @stream(initialCount: 1, label: $label)
 }
 ==================================== ERROR ====================================
 ✖︎ Invalid use of @stream on scalar field 'name'
 
   fragment-with-stream-on-scalar-field.invalid.graphql:11:8
    10 │   id
-   11 │   name @stream(initial_count: 1, label: $label)
+   11 │   name @stream(initialCount: 1, label: $label)
       │        ^^^^^^^
    12 │ }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.graphql
@@ -8,5 +8,5 @@ query QueryWithFragmentWithStream($id: ID!, $label: String!) {
 
 fragment UserFragment on User {
   id
-  name @stream(initial_count: 1, label: $label)
+  name @stream(initialCount: 1, label: $label)
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-statically-disabled.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-statically-disabled.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel", if: false) {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel", if: false) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-statically-disabled.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-statically-disabled.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel", if: false) {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel", if: false) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.expected
@@ -11,9 +11,9 @@ fragment FeedbackFragment on Feedback {
   actors
     @stream(
       if: true
-      initial_count: 1
+      initialCount: 1
       label: "StreamedActorsLabel"
-      use_customized_batch: $useCustomizedBatch
+      useCustomizedBatch: $useCustomizedBatch
     ) {
     name
   }
@@ -31,7 +31,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", if: true, initial_count: 1, use_customized_batch: $useCustomizedBatch) {
+  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", if: true, initialCount: 1, useCustomizedBatch: $useCustomizedBatch) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-use_customized_batch-arg.graphql
@@ -10,9 +10,9 @@ fragment FeedbackFragment on Feedback {
   actors
     @stream(
       if: true
-      initial_count: 1
+      initialCount: 1
       label: "StreamedActorsLabel"
-      use_customized_batch: $useCustomizedBatch
+      useCustomizedBatch: $useCustomizedBatch
     ) {
     name
   }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-variable-label.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-variable-label.invalid.expected
@@ -9,7 +9,7 @@ query QueryWithFragmentWithStream($id: ID!, $label: String!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: $label) {
+  actors @stream(initialCount: 1, label: $label) {
     name
   }
 }
@@ -18,6 +18,6 @@ fragment FeedbackFragment on Feedback {
 
   fragment-with-stream-variable-label.invalid.graphql:11:10
    10 │   id
-   11 │   actors @stream(initial_count: 1, label: $label) {
+   11 │   actors @stream(initialCount: 1, label: $label) {
       │          ^^^^^^^
    12 │     name

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-variable-label.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-variable-label.invalid.graphql
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!, $label: String!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: $label) {
+  actors @stream(initialCount: 1, label: $label) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream.expected
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     name
   }
 }
@@ -24,7 +24,7 @@ query QueryWithFragmentWithStream(
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", initial_count: 1) {
+  actors @stream(label: "FeedbackFragment$stream$StreamedActorsLabel", initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream.graphql
@@ -7,7 +7,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/query-with-stream.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/query-with-stream.expected
@@ -2,7 +2,7 @@
 query QueryWithStream($id: ID!) {
   node(id: $id) {
     ... on Feedback {
-      actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+      actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
         name
       }
     }
@@ -14,7 +14,7 @@ query QueryWithStream(
 ) {
   node(id: $id) {
     ... on Feedback {
-      actors @stream(label: "QueryWithStream$stream$StreamedActorsLabel", initial_count: 1) {
+      actors @stream(label: "QueryWithStream$stream$StreamedActorsLabel", initialCount: 1) {
         name
       }
     }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/query-with-stream.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/query-with-stream.graphql
@@ -1,7 +1,7 @@
 query QueryWithStream($id: ID!) {
   node(id: $id) {
     ... on Feedback {
-      actors @stream(initial_count: 1, label: "StreamedActorsLabel") {
+      actors @stream(initialCount: 1, label: "StreamedActorsLabel") {
         name
       }
     }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/stream.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/stream.invalid.expected
@@ -3,7 +3,7 @@
 
 fragment FeedbackFragment on Feedback {
   id
-  actor @stream(initial_count: 1) {
+  actor @stream(initialCount: 1) {
     name
   }
 }
@@ -12,6 +12,6 @@ fragment FeedbackFragment on Feedback {
 
   stream.invalid.graphql:5:9
     4 │   id
-    5 │   actor @stream(initial_count: 1) {
+    5 │   actor @stream(initialCount: 1) {
       │         ^^^^^^^
     6 │     name

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/stream.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/stream.invalid.graphql
@@ -2,7 +2,7 @@
 
 fragment FeedbackFragment on Feedback {
   id
-  actor @stream(initial_count: 1) {
+  actor @stream(initialCount: 1) {
     name
   }
 }

--- a/compiler/crates/relay-transforms/tests/defer_stream/mod.rs
+++ b/compiler/crates/relay-transforms/tests/defer_stream/mod.rs
@@ -7,13 +7,15 @@
 
 use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
+use relay_config::DeferStreamInterface;
 use relay_transforms::transform_defer_stream;
 use relay_transforms::unwrap_custom_directive_selection;
 
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
+    let defer_stream_interface = DeferStreamInterface::default();
     apply_transform_for_test(fixture, |program| {
-        let program = transform_defer_stream(program)?;
-        let program = unwrap_custom_directive_selection(&program);
+        let program = transform_defer_stream(program, &defer_stream_interface)?;
+        let program = unwrap_custom_directive_selection(&program, defer_stream_interface);
         Ok(program)
     })
 }

--- a/compiler/crates/relay-transforms/tests/generate_data_driven_dependency_metadata/mod.rs
+++ b/compiler/crates/relay-transforms/tests/generate_data_driven_dependency_metadata/mod.rs
@@ -14,7 +14,7 @@ use relay_transforms::transform_match;
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
         let flags = FeatureFlags::default();
-        let program = transform_match(program, &flags, Default::default())?;
+        let program = transform_match(program, &flags, Default::default(), Default::default())?;
         let program = generate_data_driven_dependency_metadata(&program);
         Ok(program)
     })

--- a/compiler/crates/relay-transforms/tests/match_transform/mod.rs
+++ b/compiler/crates/relay-transforms/tests/match_transform/mod.rs
@@ -13,6 +13,6 @@ use relay_transforms::transform_match;
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let flags = FeatureFlags::default();
     apply_transform_for_test(fixture, |program| {
-        transform_match(program, &flags, Default::default())
+        transform_match(program, &flags, Default::default(), Default::default())
     })
 }

--- a/compiler/crates/relay-transforms/tests/match_transform_local/mod.rs
+++ b/compiler/crates/relay-transforms/tests/match_transform_local/mod.rs
@@ -8,6 +8,7 @@
 use common::FeatureFlags;
 use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
+use relay_config::DeferStreamInterface;
 use relay_config::DynamicModuleProvider;
 use relay_config::ModuleImportConfig;
 use relay_transforms::transform_match;
@@ -17,7 +18,13 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
     let module_import_config = ModuleImportConfig {
         dynamic_module_provider: Some(DynamicModuleProvider::JSResource),
     };
+    let defer_stream_interface = DeferStreamInterface::default();
     apply_transform_for_test(fixture, |program| {
-        transform_match(program, &flags, module_import_config)
+        transform_match(
+            program,
+            &flags,
+            module_import_config,
+            defer_stream_interface,
+        )
     })
 }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.expected
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/fixtures/refetchable-fragment-with-connection-with-stream.expected
@@ -80,7 +80,7 @@ fragment PaginationFragment on Node @refetchable(queryName: "RefetchableFragment
   ... on User {
     name
     friends(after: $cursor, first: $count) @__clientField(key: "PaginationFragment_friends", handle: "connection", filters: null, dynamicKey_UNSTABLE: null) {
-      edges @stream(label: "PaginationFragment_friends", initial_count: 1) {
+      edges @stream(label: "PaginationFragment_friends", initialCount: 1) {
         node {
           id
         }

--- a/compiler/crates/relay-transforms/tests/refetchable_fragment/mod.rs
+++ b/compiler/crates/relay-transforms/tests/refetchable_fragment/mod.rs
@@ -7,13 +7,18 @@
 
 use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
+use relay_config::DeferStreamInterface;
 use relay_transforms::transform_connections;
 use relay_transforms::transform_refetchable_fragment;
 use relay_transforms::ConnectionInterface;
 
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
-        let program = transform_connections(program, &ConnectionInterface::default());
+        let program = transform_connections(
+            program,
+            &ConnectionInterface::default(),
+            &DeferStreamInterface::default(),
+        );
         let base_fragments = Default::default();
         transform_refetchable_fragment(&program, &Default::default(), &base_fragments, false)
     })

--- a/compiler/crates/relay-transforms/tests/skip_redundant_nodes/mod.rs
+++ b/compiler/crates/relay-transforms/tests/skip_redundant_nodes/mod.rs
@@ -14,6 +14,7 @@ use graphql_ir::Program;
 use graphql_syntax::parse_executable;
 use graphql_text_printer::print_operation;
 use graphql_text_printer::PrinterOptions;
+use relay_config::DeferStreamInterface;
 use relay_test_schema::get_test_schema;
 use relay_test_schema::get_test_schema_with_extensions;
 use relay_transforms::inline_fragments;
@@ -26,12 +27,14 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
         debug_directive_data: true,
         ..Default::default()
     };
+    let defer_stream_interface = DeferStreamInterface::default();
     let mut printed = if let [base, extensions] = parts.as_slice() {
         let ast = parse_executable(base, source_location).unwrap();
         let schema = get_test_schema_with_extensions(extensions);
         let ir = build(&schema, &ast.definitions).unwrap();
         let program = Program::from_definitions(Arc::clone(&schema), ir);
-        let next_program = skip_redundant_nodes(&inline_fragments(&program));
+        let next_program =
+            skip_redundant_nodes(&inline_fragments(&program), defer_stream_interface);
         next_program
             .operations()
             .map(|def| print_operation(&schema, def, printer_options.clone()))
@@ -41,7 +44,8 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
         let ast = parse_executable(fixture.content, source_location).unwrap();
         let ir = build(&schema, &ast.definitions).unwrap();
         let program = Program::from_definitions(Arc::clone(&schema), ir);
-        let next_program = skip_redundant_nodes(&inline_fragments(&program));
+        let next_program =
+            skip_redundant_nodes(&inline_fragments(&program), defer_stream_interface);
         next_program
             .operations()
             .map(|def| print_operation(&schema, def, printer_options.clone()))

--- a/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/mod.rs
+++ b/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/mod.rs
@@ -7,8 +7,12 @@
 
 use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
+use relay_config::DeferStreamInterface;
 use relay_transforms::skip_unreachable_node_strict;
 
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
-    apply_transform_for_test(fixture, skip_unreachable_node_strict)
+    let defer_stream_interface = DeferStreamInterface::default();
+    apply_transform_for_test(fixture, |program| {
+        skip_unreachable_node_strict(program, defer_stream_interface)
+    })
 }

--- a/compiler/crates/relay-transforms/tests/skip_unused_variables/fixtures/kitchen-sink.expected
+++ b/compiler/crates/relay-transforms/tests/skip_unused_variables/fixtures/kitchen-sink.expected
@@ -54,7 +54,7 @@ query StreamQuerry($RELAY_INCREMENTAL_DELIVERY: Boolean!) {
   node(id: 4) {
     id
     ... on Feedback {
-      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initial_count: 3) {
+      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initialCount: 3) {
         name
       }
     }
@@ -78,7 +78,7 @@ query StreamQuerry(
   node(id: 4) {
     id
     ... on Feedback {
-      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initial_count: 3) {
+      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initialCount: 3) {
         name
       }
     }

--- a/compiler/crates/relay-transforms/tests/skip_unused_variables/fixtures/kitchen-sink.graphql
+++ b/compiler/crates/relay-transforms/tests/skip_unused_variables/fixtures/kitchen-sink.graphql
@@ -53,7 +53,7 @@ query StreamQuerry($RELAY_INCREMENTAL_DELIVERY: Boolean!) {
   node(id: 4) {
     id
     ... on Feedback {
-      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initial_count: 3) {
+      actors @stream(if: $RELAY_INCREMENTAL_DELIVERY, label: "foo", initialCount: 3) {
         name
       }
     }

--- a/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection-no-label.expected
+++ b/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection-no-label.expected
@@ -47,7 +47,7 @@ query NodeQuery(
     id
     ... on Story {
       comments(first: 10) @__clientField(key: "NodeQuery_comments", handle: "connection", filters: null, dynamicKey_UNSTABLE: null) {
-        edges @stream(label: "NodeQuery_comments", initial_count: 0) {
+        edges @stream(label: "NodeQuery_comments", initialCount: 0) {
           node {
             actor {
               name

--- a/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection.expected
+++ b/compiler/crates/relay-transforms/tests/transform_connections/fixtures/stream-connection.expected
@@ -51,7 +51,7 @@ query NodeQuery(
     id
     ... on Story {
       comments(first: 10) @__clientField(key: "NodeQuery_comments", handle: "connection", filters: null, dynamicKey_UNSTABLE: null) {
-        edges @stream(label: "NodeQuery_comments", initial_count: 0) {
+        edges @stream(label: "NodeQuery_comments", initialCount: 0) {
           node {
             actor {
               name

--- a/compiler/crates/relay-transforms/tests/transform_connections/mod.rs
+++ b/compiler/crates/relay-transforms/tests/transform_connections/mod.rs
@@ -16,6 +16,7 @@ use graphql_test_helpers::diagnostics_to_sorted_string;
 use graphql_text_printer::print_fragment;
 use graphql_text_printer::print_operation;
 use graphql_text_printer::PrinterOptions;
+use relay_config::DeferStreamInterface;
 use relay_test_schema::get_test_schema;
 use relay_transforms::transform_connections;
 use relay_transforms::validate_connections;
@@ -33,11 +34,13 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
     let program = Program::from_definitions(Arc::clone(&schema), ir);
 
     let connection_interface = ConnectionInterface::default();
+    let defer_stream_interface = DeferStreamInterface::default();
 
     validate_connections(&program, &connection_interface)
         .map_err(|diagnostics| diagnostics_to_sorted_string(fixture.content, &diagnostics))?;
 
-    let next_program = transform_connections(&program, &connection_interface);
+    let next_program =
+        transform_connections(&program, &connection_interface, &defer_stream_interface);
 
     let printer_options = PrinterOptions {
         debug_directive_data: true,

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.expected
@@ -11,7 +11,7 @@ fragment FeedbackFragment on Feedback {
   id
   foo {
     bar {
-      users @stream(initial_count: 1, label: "StreamedActorsLabel") {
+      users @stream(initialCount: 1, label: "StreamedActorsLabel") {
         id
         name
       }
@@ -36,7 +36,7 @@ type Bar {
 
   fragment-with-stream-child-of-client.invalid.graphql:13:13
    12 │     bar {
-   13 │       users @stream(initial_count: 1, label: "StreamedActorsLabel") {
+   13 │       users @stream(initialCount: 1, label: "StreamedActorsLabel") {
       │             ^^^^^^^
    14 │         id
 

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-child-of-client.invalid.graphql
@@ -10,7 +10,7 @@ fragment FeedbackFragment on Feedback {
   id
   foo {
     bar {
-      users @stream(initial_count: 1, label: "StreamedActorsLabel") {
+      users @stream(initialCount: 1, label: "StreamedActorsLabel") {
         id
         name
       }

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.expected
@@ -9,7 +9,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  foos @stream(initialCount: 1, label: "StreamedActorsLabel") {
     bar
   }
 }
@@ -28,7 +28,7 @@ type Foo {
 
   fragment-with-stream-on-client.invalid.graphql:11:8
    10 │   id
-   11 │   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+   11 │   foos @stream(initialCount: 1, label: "StreamedActorsLabel") {
       │        ^^^^^^^
    12 │     bar
 
@@ -36,6 +36,6 @@ type Foo {
 
   fragment-with-stream-on-client.invalid.graphql:11:3
    10 │   id
-   11 │   foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+   11 │   foos @stream(initialCount: 1, label: "StreamedActorsLabel") {
       │   ^^^^
    12 │     bar

--- a/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.graphql
+++ b/compiler/crates/relay-transforms/tests/validate_server_only_directives/fixtures/fragment-with-stream-on-client.invalid.graphql
@@ -8,7 +8,7 @@ query QueryWithFragmentWithStream($id: ID!) {
 
 fragment FeedbackFragment on Feedback {
   id
-  foos @stream(initial_count: 1, label: "StreamedActorsLabel") {
+  foos @stream(initialCount: 1, label: "StreamedActorsLabel") {
     bar
   }
 }

--- a/scripts/config.tests.json
+++ b/scripts/config.tests.json
@@ -26,6 +26,16 @@
         "OpaqueScalarType": {"name": "OpaqueScalarType", "path": "../OpaqueScalarType"}
       },
       "jsModuleFormat": "commonjs",
+      "schemaConfig": {
+        "deferStreamInterface": {
+          "deferName": "defer",
+          "streamName": "stream",
+          "ifArg": "if",
+          "labelArg": "label",
+          "initialCountArg": "initial_count",
+          "useCustomizedBatchArg": "use_customized_batch"
+        }
+      },
       "featureFlags": {
         "enable_relay_resolver_transform": true,
         "no_inline": {


### PR DESCRIPTION
This is not an attempt to get Relay to conform to the current defer/stream spec draft, but rather just a small step in that direction by allowing configurable directive & argument names. 

Currently Relay requires the argument `initial_count` on `@stream`, but the GraphQL spec uses camelCase for all names.

This PR updates Relay compiler to follow the same pattern used by `ConnectionInterface`, introducing `DeferStreamInterface` to allow configuring the names and arguments of the defer & stream directive.

The first commit adds the configuration updating all touch points to reference the configuration. 

The second commit changes the defaults to camelCase, to match the defaults used in `ConnectionInterface`. This makes the diff substantially larger as many tests and fixtures need to be updated. I'm happy to remove this commit from this PR if desired.