### PR TITLE
Build compiler playground as part of GitHub CI (take 2)

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-compiler-explorer:
     name: Build Compiler Explorer
-    runs-on: macos-latest # wasm-pack not working on Ubuntu https://github.com/rustwasm/wasm-pack/issues/781
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -21,7 +21,7 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: "Build Compiler Playground Wasm NPM package"
-        run: wasm-pack build --target web
+        run: RUST_LOG=debug wasm-pack build --target web
         working-directory: ./compiler/crates/relay-compiler-playground
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -6,10 +6,7 @@
 name: Docusaurus
 
 on:
-  push:
-    branches:
-      - main
-      - pull_request
+  pull_request
 
 jobs:
   build-compiler-explorer:

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.72.1
+          toolchain: 1.73.0
           override: true
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -11,17 +11,48 @@ on:
       - main
 
 jobs:
+  build-compiler-explorer:
+    name: Build Compiler Explorer
+    runs-on: macos-latest # wasm-pack not working on Ubuntu https://github.com/rustwasm/wasm-pack/issues/781
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.0
+          override: true
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: "Build Compiler Playground Wasm NPM package"
+        run: wasm-pack build --target web
+        working-directory: ./compiler/crates/relay-compiler-playground
+      - uses: actions/upload-artifact@v3
+        with:
+          name: compiler-playground-package
+          path: compiler/crates/relay-compiler-playground/pkg/
+
   build-and-deploy:
     runs-on: ubuntu-latest
+    needs: [build-compiler-explorer]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
 
+      - name: Download Compiler Explorer
+        uses: actions/download-artifact@v2
+        with:
+          name: compiler-playground-package
+          path: tmp/compiler-playground-package
+
+      - name: Link Compiler Explorer
+        run: yarn link
+        working-directory: tmp/compiler-playground-package
+
       - name: Install and Build
         run: |
           yarn
+          yarn link relay-compiler-playground
           yarn build
         working-directory: website/
 

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -6,7 +6,9 @@
 name: Docusaurus
 
 on:
-  pull_request
+  push:
+    branches:
+      - main
 
 jobs:
   build-compiler-explorer:
@@ -16,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.73.0
+          toolchain: 1.73.0 # We hit an LLVM error building Wasm on 1.72
           override: true
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - pull_request
 
 jobs:
   build-compiler-explorer:

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.72.0
+          toolchain: 1.72.1
           override: true
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.58.0
+          toolchain: 1.72.0
           override: true
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
We reverted this in https://github.com/facebook/relay/commit/6911daa825956038ba3b12286eda1d5776f31992 because it was failing in CI. Can't repro locally, so trying again on GitHub to see what the error looks like.