### PR TITLE
Fixed example code in infinite scroll section of the tutorial

### DIFF
--- a/website/docs/tutorial/arrays-lists.md
+++ b/website/docs/tutorial/arrays-lists.md
@@ -111,7 +111,7 @@ export default function Newsfeed({}) {
           key={story.id}
           story={story}
         />
-      )}
+      ))}
     </div>
   );
 }

--- a/website/docs/tutorial/connections-pagination.md
+++ b/website/docs/tutorial/connections-pagination.md
@@ -267,7 +267,7 @@ function StoryCommentsSection({story}) {
         />
       )}
       // change-line
-      {isPending && <CommentsLoadingSpinner />}
+      {isPending && <Small Spinner />}
     </>
   );
 }
@@ -327,7 +327,7 @@ We need to modify the Newsfeed component to map over the edges and render each n
 
 ```
 function Newsfeed() {
-  const data = useLazyLoadQuery(NewsfeedQuery, {});
+  const data = useLazyLoadQuery<NewsfeedQueryType>(NewsfeedQuery, {});
   // change-line
   const storyEdges = data.viewer.newsfeedStories.edges;
   return (
@@ -374,12 +374,17 @@ This is a good time to mention that every GraphQL schema contains a type called 
 Within `Newsfeed`, we can call both `useLazyLoadQuery` and `useFragment`, though in real life these would generally be in different components:
 
 ```
+import type {NewsfeedQuery as NewsfeedQueryType} from './__generated__/NewsfeedQuery.graphql';
+import { NewsfeedContentsFragment$key } from "./__generated__/NewsfeedContentsFragment.graphql";
+
+...
+
 export default function Newsfeed() {
   // change-line
-  const queryData = useLazyLoadQuery(NewsfeedQuery, {});
+  const queryData = useLazyLoadQuery<NewsfeedQueryType>(NewsfeedQuery, {});
   // change-line
-  const data = useFragment(NewsfeedContentsFragment, queryData);
-  const storyEdges = data.newsfeedStories.edges;
+  const data = useFragment<NewsfeedContentsFragment$key>(NewsfeedContentsFragment, queryData);
+  const storyEdges = data.viewer.newsfeedStories.edges;
   ...
 }
 ```
@@ -422,13 +427,14 @@ const NewsfeedContentsFragment = graphql`
 
 ### Step 5 — Call usePaginationFragment
 
-Now we need to modify the `NewsfeedContents` component to call `usePaginationFragment:`
+Now we need to modify the `Newsfeed` component to call `usePaginationFragment:`
 
 ```
-function NewsfeedContents({viewer}) {
+export default function Newsfeed({}) {
+  const queryData = useLazyLoadQuery<NewsfeedQueryType>(NewsfeedQuery, {});
   // change-line
-  const {data, loadNext} = usePaginationFragment(NewsfeedFragment, viewer);
-  const storyEdges = data.newsfeedStories.edges;
+  const {data, loadNext} = usePaginationFragment<OperationType, NewsfeedContentsFragment$key>(NewsfeedContentsFragment, queryData);
+  const storyEdges = data.viewer.newsfeedStories.edges;
   return (
     <>
       {storyEdges.map(storyEdge =>
@@ -444,7 +450,8 @@ function NewsfeedContents({viewer}) {
 We’ve prepared a component called `InfiniteScrollTrigger` that detects when the bottom of the page is reached — we can use this to call `loadNext` at the appropriate time. It needs to know whether more pages exist and whether we’re currently loading the next page — we can retrieve these from the return value of `usePaginationFragment`:
 
 ```
-function NewsfeedContents({query}) {
+export default function Newsfeed({}) {
+  const queryData = useLazyLoadQuery<NewsfeedQueryType>(NewsfeedQuery, {});
   const {
     data,
     loadNext,
@@ -452,7 +459,7 @@ function NewsfeedContents({query}) {
     hasNext,
     // change-line
     isLoadingNext,
-  } = usePaginationFragment(NewsfeedContentsFragment, query);
+  } = usePaginationFragment<OperationType, NewsfeedContentsFragment$key>(NewsfeedContentsFragment, queryData);
   // change
   function onEndReached() {
     loadNext(3);


### PR DESCRIPTION
The tutorial seemed to have originally broken out a `NewsfeedContents` component to house the `NewsfeedContentsFragment` but then it was decided that that was too much work/too confusing for the tutorials purposes. ✅ However some of the old code and references were left in the instructions making that section hard to follow. 

Also added here are the return types on `useLazyLoadQuery`, `useFragment` and `usePaginationFragment` because they are a little hard to find and having the correct types makes the tutorial much smoother and easier to follow. 