### PR TITLE
[relay] Add areEqualOwners to check for structural equality of fragment owners.

### DIFF
--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTestIdentityTestFragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTestIdentityTestFragment.graphql.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<5ab2198beca4c50643d04bfb5df90de3>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type useRefetchableFragmentNodeTestIdentityTestFragment$fragmentType: FragmentType;
+type useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery$variables = any;
+export type useRefetchableFragmentNodeTestIdentityTestFragment$data = {|
+  +id: string,
+  +name: ?string,
+  +profile_picture: ?{|
+    +uri: ?string,
+  |},
+  +$fragmentType: useRefetchableFragmentNodeTestIdentityTestFragment$fragmentType,
+|};
+export type useRefetchableFragmentNodeTestIdentityTestFragment$key = {
+  +$data?: useRefetchableFragmentNodeTestIdentityTestFragment$data,
+  +$fragmentSpreads: useRefetchableFragmentNodeTestIdentityTestFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "scale"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": require('./useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery.graphql'),
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "useRefetchableFragmentNodeTestIdentityTestFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "scale",
+          "variableName": "scale"
+        }
+      ],
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "profile_picture",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "uri",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "0b309ceb5fea8ea44abb827cce31328b";
+}
+
+module.exports = ((node/*: any*/)/*: RefetchableFragment<
+  useRefetchableFragmentNodeTestIdentityTestFragment$fragmentType,
+  useRefetchableFragmentNodeTestIdentityTestFragment$data,
+  useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery$variables,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery.graphql.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<ae064e52237c0ba0536ef06ccae46845>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+import type { useRefetchableFragmentNodeTestIdentityTestFragment$fragmentType } from "./useRefetchableFragmentNodeTestIdentityTestFragment.graphql";
+export type useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery$variables = {|
+  id: string,
+  scale?: ?number,
+|};
+export type useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery$data = {|
+  +node: ?{|
+    +$fragmentSpreads: useRefetchableFragmentNodeTestIdentityTestFragment$fragmentType,
+  |},
+|};
+export type useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery = {|
+  response: useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery$data,
+  variables: useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "scale"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "useRefetchableFragmentNodeTestIdentityTestFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "scale",
+                    "variableName": "scale"
+                  }
+                ],
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "profile_picture",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "uri",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "56cdd0ad080963adb4022f3886d0a160",
+    "id": null,
+    "metadata": {},
+    "name": "useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery",
+    "operationKind": "query",
+    "text": "query useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery(\n  $scale: Float\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useRefetchableFragmentNodeTestIdentityTestFragment\n    id\n  }\n}\n\nfragment useRefetchableFragmentNodeTestIdentityTestFragment on User {\n  id\n  name\n  profile_picture(scale: $scale) {\n    uri\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "0b309ceb5fea8ea44abb827cce31328b";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery$variables,
+  useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-test.js
@@ -40,6 +40,7 @@ import type {Query} from 'relay-runtime/util/RelayRuntimeTypes';
 
 const {useTrackLoadQueryInRender} = require('../loadQuery');
 const useRefetchableFragmentInternal_REACT_CACHE = require('../react-cache/useRefetchableFragmentInternal_REACT_CACHE');
+const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const useRefetchableFragmentNode_LEGACY = require('../useRefetchableFragmentNode');
 const invariant = require('invariant');
 const React = require('react');
@@ -1393,7 +1394,7 @@ describe.each([
         ]);
       });
 
-      it('warns if data retured has different __typename', () => {
+      it('warns if data returned has different __typename', () => {
         const warning = require('warning');
         // $FlowFixMe[prop-missing]
         warning.mockClear();
@@ -1985,7 +1986,7 @@ describe.each([
             {force: true},
           );
 
-          // Assert we suspend on intial refetch request
+          // Assert we suspend on initial refetch request
           expectFragmentIsRefetching(renderer, {
             refetchQuery: refetchQuery1,
             refetchVariables: refetchVariables1,
@@ -2153,6 +2154,75 @@ describe.each([
           expect(renderer.toJSON()).toEqual('Fallback');
 
           expect(fetchSpy).toBeCalledTimes(4);
+        });
+
+        it('preserve the referential equality after refetch if the data/variables have not changed', async () => {
+          let refetchCount = 0;
+          const ComponentWithUseEffectRefetch = (props: {
+            fragmentKey: any,
+          }): null => {
+            const {fragmentData, refetch} = useRefetchableFragmentNode(
+              graphql`
+                fragment useRefetchableFragmentNodeTestIdentityTestFragment on User
+                @refetchable(
+                  queryName: "useRefetchableFragmentNodeTestIdentityTestFragmentRefetchQuery"
+                ) {
+                  id
+                  name
+                  profile_picture(scale: $scale) {
+                    uri
+                  }
+                }
+              `,
+              props.fragmentKey,
+            );
+            if (refetchCount > 2) {
+              throw new Error('Detected refetch loop.');
+            }
+            useEffect(() => {
+              refetchCount++;
+              refetch(fragmentData.id);
+            }, [fragmentData, refetch]);
+
+            return null;
+          };
+
+          const variables = {id: '1', scale: 16};
+          const query = createOperationDescriptor(
+            gqlRefetchQuery,
+            variables,
+            {},
+          );
+          environment.commitPayload(query, {
+            node: {
+              __typename: 'User',
+              id: '1',
+              name: 'Alice',
+              profile_picture: null,
+            },
+          });
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <ErrorBoundary fallback={({error}) => `Error: ${error.message}`}>
+                <React.Suspense fallback={'Loading'}>
+                  <RelayEnvironmentProvider environment={environment}>
+                    <ComponentWithUseEffectRefetch
+                      fragmentKey={createFragmentRef(
+                        '1',
+                        query,
+                        'useRefetchableFragmentNodeTestIdentityTestFragment',
+                      )}
+                    />
+                  </RelayEnvironmentProvider>
+                </React.Suspense>
+              </ErrorBoundary>,
+              // $FlowFixMe[prop-missing] - error revealed when flow-typing ReactTestRenderer
+              {unstable_isConcurrent: true},
+            );
+            jest.runAllImmediates();
+          });
+          expect(renderer?.toJSON()).toBe(null);
         });
       });
 

--- a/packages/react-relay/relay-hooks/react-cache/useFragmentInternal_REACT_CACHE.js
+++ b/packages/react-relay/relay-hooks/react-cache/useFragmentInternal_REACT_CACHE.js
@@ -435,7 +435,7 @@ function useFragmentInternal_REACT_CACHE(
   // The purpose of this is to detect whether we have ever committed, because we
   // don't suspend on store updates, only when the component either is first trying
   // to mount or when the our selector changes. The selector change in particular is
-  // how we suspend for pagination and refetech. Also, fragment selector can be null
+  // how we suspend for pagination and refetch. Also, fragment selector can be null
   // or undefined, so we use false as a special value to distinguish from all fragment
   // selectors; false means that the component hasn't mounted yet.
   const committedFragmentSelectorRef = useRef<false | ?ReaderSelector>(false);
@@ -551,7 +551,7 @@ function useFragmentInternal_REACT_CACHE(
 
   let data: ?SelectorData | Array<?SelectorData>;
   if (isPlural) {
-    // Plural fragments require allocating an array of the snasphot data values,
+    // Plural fragments require allocating an array of the snapshot data values,
     // which has to be memoized to avoid triggering downstream re-renders.
     //
     // Note that isPlural is a constant property of the fragment and does not change

--- a/packages/react-relay/relay-hooks/react-cache/useRefetchableFragmentInternal_REACT_CACHE.js
+++ b/packages/react-relay/relay-hooks/react-cache/useRefetchableFragmentInternal_REACT_CACHE.js
@@ -481,11 +481,13 @@ function useRefetchFunction<TQuery: OperationType>(
       const refetchQuery = createOperationDescriptor(
         refetchableRequest,
         refetchVariables,
-        {force: true},
+        {
+          force: true,
+        },
       );
 
       // We call loadQuery which will start a network request if necessary
-      // and update the querRef from useQueryLoader.
+      // and update the queryRef from useQueryLoader.
       // Note the following:
       // - loadQuery will dispose of any previously refetched queries.
       // - We use the variables extracted off the OperationDescriptor

--- a/packages/relay-runtime/store/RelayModernSelector.js
+++ b/packages/relay-runtime/store/RelayModernSelector.js
@@ -409,11 +409,31 @@ function areEqualSingularSelectors(
   thatSelector: SingularReaderSelector,
 ): boolean {
   return (
-    thisSelector.owner === thatSelector.owner &&
     thisSelector.dataID === thatSelector.dataID &&
     thisSelector.node === thatSelector.node &&
-    areEqual(thisSelector.variables, thatSelector.variables)
+    areEqual(thisSelector.variables, thatSelector.variables) &&
+    areEqualOwners(thisSelector.owner, thatSelector.owner)
   );
+}
+
+function areEqualOwners(
+  thisOwner: ?RequestDescriptor,
+  thatOwner: ?RequestDescriptor,
+): boolean {
+  if (thisOwner == null) {
+    return thatOwner == null;
+  } else if (thatOwner == null) {
+    return thisOwner == null;
+  } else if (thisOwner === thatOwner) {
+    return true;
+  } else {
+    return (
+      thisOwner.identifier === thatOwner.identifier &&
+      thisOwner.node === thatOwner.node &&
+      areEqual(thisOwner.cacheConfig, thatOwner.cacheConfig) &&
+      areEqual(thisOwner.variables, thatOwner.variables)
+    );
+  }
 }
 
 /**

--- a/packages/relay-runtime/store/__tests__/RelayModernSelector-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernSelector-test.js
@@ -681,6 +681,28 @@ describe('RelayModernSelector', () => {
     it('returns false for equivalent selectors but with different owners', () => {
       const queryNode = UserQuery;
       owner = createOperationDescriptor(queryNode, operationVariables);
+      const newOwner = createOperationDescriptor(queryNode, {
+        ...operationVariables,
+        size: '16',
+      });
+      const selector = createReaderSelector(
+        UserFragment,
+        '4',
+        variables,
+        owner.request,
+      );
+      // When the owner is different, areEqualSelectors should return false
+      // even if the 2 selectors represent the same selection
+      const differentOwner = {
+        ...selector,
+        owner: newOwner.request,
+      };
+      expect(areEqualSelectors(selector, differentOwner)).toBe(false);
+    });
+
+    it('returns true for equivalent selectors and structurally similar owners', () => {
+      const queryNode = UserQuery;
+      owner = createOperationDescriptor(queryNode, operationVariables);
       const selector = createReaderSelector(
         UserFragment,
         '4',
@@ -693,7 +715,7 @@ describe('RelayModernSelector', () => {
         ...selector,
         owner: {...owner.request},
       };
-      expect(areEqualSelectors(selector, differentOwner)).toBe(false);
+      expect(areEqualSelectors(selector, differentOwner)).toBe(true);
     });
 
     it('returns true for equivalent selectors with same owners', () => {
@@ -744,6 +766,10 @@ describe('RelayModernSelector', () => {
     it('returns false for different selectors with owners', () => {
       const queryNode = UserQuery;
       owner = createOperationDescriptor(queryNode, operationVariables);
+      const newOwner = createOperationDescriptor(queryNode, {
+        ...operationVariables,
+        size: '16',
+      });
       const selector = createReaderSelector(
         UserFragment,
         '4',
@@ -764,7 +790,7 @@ describe('RelayModernSelector', () => {
       };
       const differentOwner = {
         ...selector,
-        owner: {...owner.request},
+        owner: newOwner.request,
       };
       expect(areEqualSelectors(selector, differentID)).toBe(false);
       expect(areEqualSelectors(selector, differentNode)).toBe(false);


### PR DESCRIPTION
There is a bug in the experimental hooks implementation.

useRefetchableFragment will return a new data object every time the refetch function is called, even if the data has not changed. This is because refetch creates a new fragment owner with createOperationDescriptor and refetch variables, and passes it to useFragmentInternal as part of the fragment key.

Later in useFragmentInternal, we call areEqualSelectors to check if the fragment selector has changed. The owner is part of the selector, but we only check if the owner is the same object. However, it's possible that the owner is the same but just a new instance of the same object.

Proposed fix:
* Add areEqualOwners to check that owners have the same structure. This would prevent an endless loop of refetch/setState between components using useRefetchableFragment and the refetch call in the useEffect.
Test Plan:
* New unit test
* Updated tests for RelayModernSelector.