### PR TITLE
[relay-lsp] Calculate LSP locations from cached JavaScriptSourceFeatures

### DIFF
--- a/compiler/crates/relay-lsp/src/find_field_usages.rs
+++ b/compiler/crates/relay-lsp/src/find_field_usages.rs
@@ -31,7 +31,6 @@ use schema::Type;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::location::transform_relay_location_to_lsp_location;
 use crate::server::GlobalState;
 use crate::LSPRuntimeError;
 use crate::LSPRuntimeResult;
@@ -80,13 +79,12 @@ pub fn on_find_field_usages(
 
     let schema = state.get_schema(&schema_name)?;
     let program = state.get_program(&schema_name)?;
-    let root_dir = &state.root_dir();
 
     let ir_locations = get_usages(&program, &schema, type_name, field_name)?;
     let lsp_locations = ir_locations
         .into_iter()
         .map(|(label, ir_location)| {
-            let lsp_location = transform_relay_location_to_lsp_location(root_dir, ir_location)?;
+            let lsp_location = state.get_lsp_location(ir_location)?;
             Ok(FindFieldUsageResultItem {
                 location_uri: lsp_location.uri.to_string(),
                 location_range: lsp_location.range,


### PR DESCRIPTION
Currently, when transforming a location to an LSP location, JavaScriptSourceFeatures are extracted from the corresponding file and then used to calculate the LSP location.
The problem is that what's on disk doesn't necessarily match the current document state. If you have unsaved changes in your editor, locations will be calculated on the older (persisted-to-disk) file content.

This PR tries to get the JavaScriptSourceFeatures from the synced sources first (which represent the current document state) and if it can't, falls back to reading from disk.

