### PR TITLE
Expose Sink type from relay-runtime

### DIFF
--- a/packages/relay-runtime/index.js
+++ b/packages/relay-runtime/index.js
@@ -106,6 +106,8 @@ export type {
 export type {
   ObservableFromValue,
   Observer,
+  Sink,
+  Source,
   Subscribable,
   Subscription,
 } from './network/RelayObservable';


### PR DESCRIPTION
I want to suggest exporting `Sink` & `Source` types so they can be used to type the argument of `Observable.create`, e.g. something like this:


```js
import { Observable } from 'relay-runtime';

const responseHandler = () => {} // Here I would like to use either Source or Sink types

export const createRequestHandler =
  (customFetcher: Fetcher) =>
  (request: RequestParameters, variables: Variables, cacheConfig: CacheConfig) => {
    const observable = Observable.create(sink => {
      void customFetcher(request, variables, cacheConfig)
        .then(responseHandler(sink))
        .catch((error: Error) => {
          sink.error(error);
        })
        .then(() => {
          sink.complete();
        });
    });

    return observable;
  };
```