### PR TITLE
FIX(Graphql): Add support for input with default values

### DIFF
--- a/compiler/crates/graphql-ir/tests/parse/fixtures/argument_definitions.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/argument_definitions.expected
@@ -69,7 +69,7 @@ fragment TestFragment on User
                 },
             ],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -87,7 +87,7 @@ fragment TestFragment on User
                     alias: None,
                     definition: WithLocation {
                         location: argument_definitions.graphql:161:171,
-                        item: FieldID(516),
+                        item: FieldID(518),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/directive-generic.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/directive-generic.expected
@@ -14,14 +14,14 @@ fragment TestFragment on User {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: directive-generic.graphql:34:36,
-                        item: FieldID(459),
+                        item: FieldID(461),
                     },
                     arguments: [],
                     directives: [

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/directive-include.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/directive-include.expected
@@ -38,7 +38,7 @@ fragment Foo on User {
                     directives: [],
                 },
             ],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 Condition {
@@ -47,7 +47,7 @@ fragment Foo on User {
                             alias: None,
                             definition: WithLocation {
                                 location: directive-include.graphql:34:36,
-                                item: FieldID(459),
+                                item: FieldID(461),
                             },
                             arguments: [],
                             directives: [],
@@ -75,7 +75,7 @@ fragment Foo on User {
                     selections: [
                         InlineFragment {
                             type_condition: Some(
-                                Object(69),
+                                Object(70),
                             ),
                             directives: [],
                             selections: [
@@ -83,7 +83,7 @@ fragment Foo on User {
                                     alias: None,
                                     definition: WithLocation {
                                         location: directive-include.graphql:97:106,
-                                        item: FieldID(456),
+                                        item: FieldID(458),
                                     },
                                     arguments: [],
                                     directives: [],
@@ -154,14 +154,14 @@ fragment Foo on User {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: directive-include.graphql:168:170,
-                        item: FieldID(459),
+                        item: FieldID(461),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/enum-values.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/enum-values.expected
@@ -34,7 +34,7 @@ query EnumValueQuery {
                             alias: None,
                             definition: WithLocation {
                                 location: enum-values.graphql:34:48,
-                                item: FieldID(473),
+                                item: FieldID(475),
                             },
                             arguments: [
                                 Argument {
@@ -60,7 +60,7 @@ query EnumValueQuery {
                                     alias: None,
                                     definition: WithLocation {
                                         location: enum-values.graphql:72:75,
-                                        item: FieldID(179),
+                                        item: FieldID(181),
                                     },
                                     arguments: [],
                                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/field-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/field-arguments.expected
@@ -92,7 +92,7 @@ query TestQuery {
                             alias: None,
                             definition: WithLocation {
                                 location: field-arguments.graphql:89:107,
-                                item: FieldID(513),
+                                item: FieldID(515),
                             },
                             arguments: [],
                             directives: [],
@@ -144,7 +144,7 @@ query TestQuery {
                             alias: None,
                             definition: WithLocation {
                                 location: field-arguments.graphql:164:169,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fixme_fat_interface_on_union.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fixme_fat_interface_on_union.expected
@@ -33,7 +33,7 @@ query Test {
                             alias: None,
                             definition: WithLocation {
                                 location: fixme_fat_interface_on_union.graphql:51:53,
-                                item: FieldID(377),
+                                item: FieldID(379),
                             },
                             arguments: [],
                             directives: [

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-arguments-syntax.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-arguments-syntax.expected
@@ -85,14 +85,14 @@ fragment Foo($localId: ID!) on User {
                     directives: [],
                 },
             ],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 LinkedField {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-arguments-syntax.graphql:71:85,
-                        item: FieldID(473),
+                        item: FieldID(475),
                     },
                     arguments: [
                         Argument {
@@ -128,7 +128,7 @@ fragment Foo($localId: ID!) on User {
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-arguments-syntax.graphql:112:115,
-                                item: FieldID(179),
+                                item: FieldID(181),
                             },
                             arguments: [],
                             directives: [],
@@ -144,7 +144,7 @@ fragment Foo($localId: ID!) on User {
                     ),
                     definition: WithLocation {
                         location: fragment-with-arguments-syntax.graphql:138:152,
-                        item: FieldID(473),
+                        item: FieldID(475),
                     },
                     arguments: [
                         Argument {
@@ -180,7 +180,7 @@ fragment Foo($localId: ID!) on User {
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-arguments-syntax.graphql:172:175,
-                                item: FieldID(179),
+                                item: FieldID(181),
                             },
                             arguments: [],
                             directives: [],
@@ -253,14 +253,14 @@ fragment Foo($localId: ID!) on User {
                 },
             ],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-arguments-syntax.graphql:246:248,
-                        item: FieldID(459),
+                        item: FieldID(461),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-arguments.expected
@@ -86,7 +86,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                     directives: [],
                 },
             ],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -104,7 +104,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-arguments.graphql:131:145,
-                        item: FieldID(473),
+                        item: FieldID(475),
                     },
                     arguments: [
                         Argument {
@@ -140,7 +140,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-arguments.graphql:172:175,
-                                item: FieldID(179),
+                                item: FieldID(181),
                             },
                             arguments: [],
                             directives: [],
@@ -156,7 +156,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                     ),
                     definition: WithLocation {
                         location: fragment-with-arguments.graphql:198:212,
-                        item: FieldID(473),
+                        item: FieldID(475),
                     },
                     arguments: [
                         Argument {
@@ -192,7 +192,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-arguments.graphql:232:235,
-                                item: FieldID(179),
+                                item: FieldID(181),
                             },
                             arguments: [],
                             directives: [],
@@ -265,7 +265,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                 },
             ],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -283,7 +283,7 @@ fragment Foo on User @argumentDefinitions(localId: {type: "ID!"}) {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-arguments.graphql:347:349,
-                        item: FieldID(459),
+                        item: FieldID(461),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-arguments.expected
@@ -21,7 +21,7 @@ fragment ChildFragment on User
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 FragmentSpread {
@@ -84,7 +84,7 @@ fragment ChildFragment on User
                 },
             ],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -102,7 +102,7 @@ fragment ChildFragment on User
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-literal-arguments.graphql:174:188,
-                        item: FieldID(473),
+                        item: FieldID(475),
                     },
                     arguments: [
                         Argument {
@@ -138,7 +138,7 @@ fragment ChildFragment on User
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-arguments.graphql:215:218,
-                                item: FieldID(179),
+                                item: FieldID(181),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-arguments-into-enum-list.expected
@@ -24,7 +24,7 @@ fragment ChildFragment on User
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 LinkedField {
@@ -36,7 +36,7 @@ fragment ChildFragment on User
                     ),
                     definition: WithLocation {
                         location: fragment-with-literal-enum-arguments-into-enum-list.graphql:53:61,
-                        item: FieldID(450),
+                        item: FieldID(452),
                     },
                     arguments: [
                         Argument {
@@ -66,7 +66,7 @@ fragment ChildFragment on User
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-enum-arguments-into-enum-list.graphql:92:97,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],
@@ -133,7 +133,7 @@ fragment ChildFragment on User
                 },
             ],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -151,7 +151,7 @@ fragment ChildFragment on User
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-literal-enum-arguments-into-enum-list.graphql:253:261,
-                        item: FieldID(450),
+                        item: FieldID(452),
                     },
                     arguments: [
                         Argument {
@@ -191,7 +191,7 @@ fragment ChildFragment on User
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-enum-arguments-into-enum-list.graphql:297:302,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-arguments.expected
@@ -62,7 +62,7 @@ fragment ChildFragment on Query
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-enum-arguments.graphql:90:98,
-                                item: FieldID(512),
+                                item: FieldID(514),
                             },
                             arguments: [],
                             directives: [],
@@ -177,7 +177,7 @@ fragment ChildFragment on Query
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-enum-arguments.graphql:292:300,
-                                item: FieldID(512),
+                                item: FieldID(514),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-list-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-enum-list-arguments.expected
@@ -24,7 +24,7 @@ fragment ChildFragment on User
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 LinkedField {
@@ -36,7 +36,7 @@ fragment ChildFragment on User
                     ),
                     definition: WithLocation {
                         location: fragment-with-literal-enum-list-arguments.graphql:53:61,
-                        item: FieldID(450),
+                        item: FieldID(452),
                     },
                     arguments: [
                         Argument {
@@ -66,7 +66,7 @@ fragment ChildFragment on User
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-enum-list-arguments.graphql:92:97,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],
@@ -137,7 +137,7 @@ fragment ChildFragment on User
                 },
             ],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -155,7 +155,7 @@ fragment ChildFragment on User
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-literal-enum-list-arguments.graphql:255:263,
-                        item: FieldID(450),
+                        item: FieldID(452),
                     },
                     arguments: [
                         Argument {
@@ -195,7 +195,7 @@ fragment ChildFragment on User
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-enum-list-arguments.graphql:299:304,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-object-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-object-arguments.expected
@@ -77,7 +77,7 @@ fragment ChildFragment on Query
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-object-arguments.graphql:105:110,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],
@@ -147,7 +147,7 @@ fragment ChildFragment on Query
                     },
                     type_: NonNull(
                         Named(
-                            InputObject(16),
+                            InputObject(17),
                         ),
                     ),
                     default_value: None,
@@ -194,7 +194,7 @@ fragment ChildFragment on Query
                                             ),
                                         },
                                         type_: Named(
-                                            InputObject(16),
+                                            InputObject(17),
                                         ),
                                     },
                                 ),
@@ -207,7 +207,7 @@ fragment ChildFragment on Query
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-object-arguments.graphql:308:313,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-object-list-arguments.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-literal-object-list-arguments.expected
@@ -77,7 +77,7 @@ fragment ChildFragment on Query
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-object-list-arguments.graphql:105:110,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],
@@ -153,7 +153,7 @@ fragment ChildFragment on Query
                         List(
                             NonNull(
                                 Named(
-                                    InputObject(16),
+                                    InputObject(17),
                                 ),
                             ),
                         ),
@@ -230,7 +230,7 @@ fragment ChildFragment on Query
                                                         },
                                                         type_: List(
                                                             Named(
-                                                                InputObject(16),
+                                                                InputObject(17),
                                                             ),
                                                         ),
                                                     },
@@ -248,7 +248,7 @@ fragment ChildFragment on Query
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-literal-object-list-arguments.graphql:340:345,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-variable-definitions-syntax.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment-with-variable-definitions-syntax.expected
@@ -86,7 +86,7 @@ fragment Foo($localId: ID!) on User {
                     directives: [],
                 },
             ],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -104,7 +104,7 @@ fragment Foo($localId: ID!) on User {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-variable-definitions-syntax.graphql:131:145,
-                        item: FieldID(473),
+                        item: FieldID(475),
                     },
                     arguments: [
                         Argument {
@@ -140,7 +140,7 @@ fragment Foo($localId: ID!) on User {
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-variable-definitions-syntax.graphql:172:175,
-                                item: FieldID(179),
+                                item: FieldID(181),
                             },
                             arguments: [],
                             directives: [],
@@ -156,7 +156,7 @@ fragment Foo($localId: ID!) on User {
                     ),
                     definition: WithLocation {
                         location: fragment-with-variable-definitions-syntax.graphql:198:212,
-                        item: FieldID(473),
+                        item: FieldID(475),
                     },
                     arguments: [
                         Argument {
@@ -192,7 +192,7 @@ fragment Foo($localId: ID!) on User {
                             alias: None,
                             definition: WithLocation {
                                 location: fragment-with-variable-definitions-syntax.graphql:232:235,
-                                item: FieldID(179),
+                                item: FieldID(181),
                             },
                             arguments: [],
                             directives: [],
@@ -265,14 +265,14 @@ fragment Foo($localId: ID!) on User {
                 },
             ],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: fragment-with-variable-definitions-syntax.graphql:317:319,
-                        item: FieldID(459),
+                        item: FieldID(461),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment_with_arguments_defaulting.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment_with_arguments_defaulting.expected
@@ -180,7 +180,7 @@ fragment F2 on Query @argumentDefinitions(
                             alias: None,
                             definition: WithLocation {
                                 location: fragment_with_arguments_defaulting.graphql:342:352,
-                                item: FieldID(516),
+                                item: FieldID(518),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/inline-untyped-fragment.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/inline-untyped-fragment.expected
@@ -16,7 +16,7 @@ fragment InlineUntypedFragment on User {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 InlineFragment {
@@ -27,7 +27,7 @@ fragment InlineUntypedFragment on User {
                             alias: None,
                             definition: WithLocation {
                                 location: inline-untyped-fragment.graphql:53:57,
-                                item: FieldID(465),
+                                item: FieldID(467),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field-with-filters.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field-with-filters.expected
@@ -33,14 +33,14 @@ fragment LinkedHandleField on User {
                     directives: [],
                 },
             ],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 LinkedField {
                     alias: None,
                     definition: WithLocation {
                         location: linked-handle-field-with-filters.graphql:39:46,
-                        item: FieldID(457),
+                        item: FieldID(459),
                     },
                     arguments: [
                         Argument {
@@ -143,7 +143,7 @@ fragment LinkedHandleField on User {
                             alias: None,
                             definition: WithLocation {
                                 location: linked-handle-field-with-filters.graphql:158:163,
-                                item: FieldID(173),
+                                item: FieldID(175),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field-with-key.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field-with-key.expected
@@ -17,14 +17,14 @@ fragment LinkedHandleField on User {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 LinkedField {
                     alias: None,
                     definition: WithLocation {
                         location: linked-handle-field-with-key.graphql:39:46,
-                        item: FieldID(457),
+                        item: FieldID(459),
                     },
                     arguments: [
                         Argument {
@@ -94,7 +94,7 @@ fragment LinkedHandleField on User {
                             alias: None,
                             definition: WithLocation {
                                 location: linked-handle-field-with-key.graphql:142:147,
-                                item: FieldID(173),
+                                item: FieldID(175),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-field.expected
@@ -18,14 +18,14 @@ fragment LinkedHandleField on User {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 LinkedField {
                     alias: None,
                     definition: WithLocation {
                         location: linked-handle-field.graphql:39:46,
-                        item: FieldID(457),
+                        item: FieldID(459),
                     },
                     arguments: [
                         Argument {
@@ -106,7 +106,7 @@ fragment LinkedHandleField on User {
                             alias: None,
                             definition: WithLocation {
                                 location: linked-handle-field.graphql:151:156,
-                                item: FieldID(173),
+                                item: FieldID(175),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-filter.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/linked-handle-filter.expected
@@ -18,14 +18,14 @@ fragment LinkedHandleField on User {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 LinkedField {
                     alias: None,
                     definition: WithLocation {
                         location: linked-handle-filter.graphql:39:46,
-                        item: FieldID(457),
+                        item: FieldID(459),
                     },
                     arguments: [
                         Argument {
@@ -126,7 +126,7 @@ fragment LinkedHandleField on User {
                             alias: None,
                             definition: WithLocation {
                                 location: linked-handle-filter.graphql:171:176,
-                                item: FieldID(173),
+                                item: FieldID(175),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/list-of-enums.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/list-of-enums.expected
@@ -14,14 +14,14 @@ fragment TestFragment on User {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: list-of-enums.graphql:34:40,
-                        item: FieldID(482),
+                        item: FieldID(484),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/literal-object-argument.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/literal-object-argument.expected
@@ -64,7 +64,7 @@ query LiteralObjectArgument {
                             alias: None,
                             definition: WithLocation {
                                 location: literal-object-argument.graphql:85:90,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/null-values.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/null-values.expected
@@ -62,7 +62,7 @@ query NullValuesQuery {
                             alias: None,
                             definition: WithLocation {
                                 location: null-values.graphql:60:64,
-                                item: FieldID(493),
+                                item: FieldID(495),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/object-argument.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/object-argument.expected
@@ -88,7 +88,7 @@ query ObjectArgument($text: String!) {
                             alias: None,
                             definition: WithLocation {
                                 location: object-argument.graphql:89:94,
-                                item: FieldID(54),
+                                item: FieldID(55),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/scalar-handle-field.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/scalar-handle-field.expected
@@ -16,14 +16,14 @@ fragment ScalarHandleField on User {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: scalar-handle-field.graphql:39:43,
-                        item: FieldID(465),
+                        item: FieldID(467),
                     },
                     arguments: [],
                     directives: [

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/simple-fragment.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/simple-fragment.expected
@@ -14,14 +14,14 @@ fragment TestFragment on User {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: simple-fragment.graphql:34:36,
-                        item: FieldID(459),
+                        item: FieldID(461),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/simple-query.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/simple-query.expected
@@ -78,7 +78,7 @@ query TestQuery($id: ID!) {
                             alias: None,
                             definition: WithLocation {
                                 location: simple-query.graphql:55:57,
-                                item: FieldID(214),
+                                item: FieldID(216),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/client-fields.expected
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/client-fields.expected
@@ -135,14 +135,14 @@ type Foo {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: client-fields.graphql:171:173,
-                        item: FieldID(459),
+                        item: FieldID(461),
                     },
                     arguments: [],
                     directives: [],
@@ -151,7 +151,7 @@ type Foo {
                     alias: None,
                     definition: WithLocation {
                         location: client-fields.graphql:226:238,
-                        item: FieldID(516),
+                        item: FieldID(518),
                     },
                     arguments: [],
                     directives: [],
@@ -160,7 +160,7 @@ type Foo {
                             alias: None,
                             definition: WithLocation {
                                 location: client-fields.graphql:245:250,
-                                item: FieldID(174),
+                                item: FieldID(176),
                             },
                             arguments: [],
                             directives: [],
@@ -169,7 +169,7 @@ type Foo {
                                     alias: None,
                                     definition: WithLocation {
                                         location: client-fields.graphql:259:265,
-                                        item: FieldID(176),
+                                        item: FieldID(178),
                                     },
                                     arguments: [],
                                     directives: [],
@@ -178,7 +178,7 @@ type Foo {
                                     alias: None,
                                     definition: WithLocation {
                                         location: client-fields.graphql:272:276,
-                                        item: FieldID(177),
+                                        item: FieldID(179),
                                     },
                                     arguments: [],
                                     directives: [],
@@ -187,7 +187,7 @@ type Foo {
                                             alias: None,
                                             definition: WithLocation {
                                                 location: client-fields.graphql:287:289,
-                                                item: FieldID(459),
+                                                item: FieldID(461),
                                             },
                                             arguments: [],
                                             directives: [],
@@ -200,7 +200,7 @@ type Foo {
                             alias: None,
                             definition: WithLocation {
                                 location: client-fields.graphql:308:316,
-                                item: FieldID(175),
+                                item: FieldID(177),
                             },
                             arguments: [],
                             directives: [],
@@ -209,7 +209,7 @@ type Foo {
                                     alias: None,
                                     definition: WithLocation {
                                         location: client-fields.graphql:325:336,
-                                        item: FieldID(294),
+                                        item: FieldID(296),
                                     },
                                     arguments: [],
                                     directives: [],
@@ -220,7 +220,7 @@ type Foo {
                 },
                 InlineFragment {
                     type_condition: Some(
-                        Object(69),
+                        Object(70),
                     ),
                     directives: [],
                     selections: [
@@ -228,7 +228,7 @@ type Foo {
                             alias: None,
                             definition: WithLocation {
                                 location: client-fields.graphql:367:370,
-                                item: FieldID(517),
+                                item: FieldID(519),
                             },
                             arguments: [],
                             directives: [],
@@ -245,7 +245,7 @@ type Foo {
                                 },
                                 InlineFragment {
                                     type_condition: Some(
-                                        Object(78),
+                                        Object(79),
                                     ),
                                     directives: [],
                                     selections: [
@@ -253,7 +253,7 @@ type Foo {
                                             alias: None,
                                             definition: WithLocation {
                                                 location: client-fields.graphql:470:472,
-                                                item: FieldID(518),
+                                                item: FieldID(520),
                                             },
                                             arguments: [],
                                             directives: [],
@@ -279,14 +279,14 @@ type Foo {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(78),
+            type_condition: Object(79),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: client-fields.graphql:526:528,
-                        item: FieldID(518),
+                        item: FieldID(520),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/custom_scalar_directive_arg_variable.expected
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/custom_scalar_directive_arg_variable.expected
@@ -57,7 +57,7 @@ extend type Query {
                     alias: None,
                     definition: WithLocation {
                         location: custom_scalar_directive_arg_variable.graphql:100:115,
-                        item: FieldID(517),
+                        item: FieldID(519),
                     },
                     arguments: [],
                     directives: [
@@ -104,7 +104,7 @@ extend type Query {
                             alias: None,
                             definition: WithLocation {
                                 location: custom_scalar_directive_arg_variable.graphql:160:170,
-                                item: FieldID(519),
+                                item: FieldID(521),
                             },
                             arguments: [],
                             directives: [],
@@ -115,7 +115,7 @@ extend type Query {
                     alias: None,
                     definition: WithLocation {
                         location: custom_scalar_directive_arg_variable.graphql:181:203,
-                        item: FieldID(518),
+                        item: FieldID(520),
                     },
                     arguments: [],
                     directives: [

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/custom_scalar_variable_arg.expected
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/custom_scalar_variable_arg.expected
@@ -55,7 +55,7 @@ extend type Query {
                     alias: None,
                     definition: WithLocation {
                         location: custom_scalar_variable_arg.graphql:100:115,
-                        item: FieldID(517),
+                        item: FieldID(519),
                     },
                     arguments: [
                         Argument {
@@ -91,7 +91,7 @@ extend type Query {
                             alias: None,
                             definition: WithLocation {
                                 location: custom_scalar_variable_arg.graphql:151:161,
-                                item: FieldID(519),
+                                item: FieldID(521),
                             },
                             arguments: [],
                             directives: [],
@@ -102,7 +102,7 @@ extend type Query {
                     alias: None,
                     definition: WithLocation {
                         location: custom_scalar_variable_arg.graphql:172:194,
-                        item: FieldID(518),
+                        item: FieldID(520),
                     },
                     arguments: [
                         Argument {

--- a/compiler/crates/graphql-ir/tests/parse_with_provider/fixtures/fragment_with_valid_provider.expected
+++ b/compiler/crates/graphql-ir/tests/parse_with_provider/fixtures/fragment_with_valid_provider.expected
@@ -113,7 +113,7 @@ fragment TestFragment on User
                     directives: [],
                 },
             ],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -131,7 +131,7 @@ fragment TestFragment on User
                     alias: None,
                     definition: WithLocation {
                         location: fragment_with_valid_provider.graphql:210:224,
-                        item: FieldID(473),
+                        item: FieldID(475),
                     },
                     arguments: [
                         Argument {
@@ -167,7 +167,7 @@ fragment TestFragment on User
                             alias: None,
                             definition: WithLocation {
                                 location: fragment_with_valid_provider.graphql:251:254,
-                                item: FieldID(179),
+                                item: FieldID(181),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse_with_provider/fixtures/use_fragment_spread_with_provider.expected
+++ b/compiler/crates/graphql-ir/tests/parse_with_provider/fixtures/use_fragment_spread_with_provider.expected
@@ -34,7 +34,7 @@ fragment ChildFragment2 on User
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [],
             selections: [
                 FragmentSpread {
@@ -143,7 +143,7 @@ fragment ChildFragment2 on User
                 },
             ],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -161,7 +161,7 @@ fragment ChildFragment2 on User
                     alias: None,
                     definition: WithLocation {
                         location: use_fragment_spread_with_provider.graphql:286:300,
-                        item: FieldID(473),
+                        item: FieldID(475),
                     },
                     arguments: [
                         Argument {
@@ -199,7 +199,7 @@ fragment ChildFragment2 on User
                                     alias: None,
                                     definition: WithLocation {
                                         location: use_fragment_spread_with_provider.graphql:327:330,
-                                        item: FieldID(179),
+                                        item: FieldID(181),
                                     },
                                     arguments: [],
                                     directives: [],
@@ -275,7 +275,7 @@ fragment ChildFragment2 on User
                 },
             ],
             used_global_variables: [],
-            type_condition: Object(69),
+            type_condition: Object(70),
             directives: [
                 Directive {
                     name: WithLocation {
@@ -295,7 +295,7 @@ fragment ChildFragment2 on User
                             alias: None,
                             definition: WithLocation {
                                 location: use_fragment_spread_with_provider.graphql:526:532,
-                                item: FieldID(482),
+                                item: FieldID(484),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/relay-test-schema/src/testschema.graphql
+++ b/compiler/crates/relay-test-schema/src/testschema.graphql
@@ -120,6 +120,7 @@ type Mutation {
   commentDelete(input: CommentDeleteInput): CommentDeleteResponsePayload
   commentsDelete(input: CommentsDeleteInput): CommentsDeleteResponsePayload
   feedbackLike(input: FeedbackLikeInput): FeedbackLikeResponsePayload
+  feedbackUnLike(input: FeedbackUnLikeInput): FeedbackUnLikeResponsePayload
   feedbackLikeStrict(
     input: FeedbackLikeInputStrict!
   ): FeedbackLikeResponsePayload
@@ -186,6 +187,11 @@ input CommentsDeleteInput {
 
 input FeedbackLikeInput {
   feedbackId: ID
+}
+
+input FeedbackUnLikeInput {
+  feedbackId: ID
+  silent: Boolean! = false
 }
 
 input FeedbackLikeInputStrict {
@@ -449,6 +455,10 @@ type Feedback implements Node {
 }
 
 type FeedbackLikeResponsePayload {
+  feedback: Feedback
+}
+
+type FeedbackUnLikeResponsePayload {
   feedback: Feedback
 }
 

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-inline-fragment-no-type-condition.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-inline-fragment-no-type-condition.expected
@@ -38,7 +38,7 @@ fragment Foo_user on User {
      {
       ...BestFriendResolverFragment_name @__RelayResolverMetadata
       # RelayResolverMetadata {
-      #     field_id: FieldID(516),
+      #     field_id: FieldID(518),
       #     import_path: "BestFriendResolver",
       #     import_name: None,
       #     field_alias: None,
@@ -65,7 +65,7 @@ fragment Foo_user on User {
      {
       ...BestFriendResolverFragment_name @__RelayResolverMetadata
       # RelayResolverMetadata {
-      #     field_id: FieldID(516),
+      #     field_id: FieldID(518),
       #     import_path: "BestFriendResolver",
       #     import_name: None,
       #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-inline-fragment.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-inline-fragment.expected
@@ -43,7 +43,7 @@ fragment Foo_node on Node {
        {
         ...BestFriendResolverFragment_name @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(516),
+        #     field_id: FieldID(518),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,
@@ -72,7 +72,7 @@ fragment Foo_node on Node {
        {
         ...BestFriendResolverFragment_name @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(516),
+        #     field_id: FieldID(518),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-to-client-interface.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-to-client-interface.expected
@@ -42,7 +42,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(518),
+    #     field_id: FieldID(520),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-to-client-object.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-to-client-object.expected
@@ -39,7 +39,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(517),
+    #     field_id: FieldID(519),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-variables.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-variables.expected
@@ -30,7 +30,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(516),
+    #     field_id: FieldID(518),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-with-required.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-with-required.expected
@@ -34,7 +34,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(516),
+    #     field_id: FieldID(518),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-within-non-client-edge.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-within-non-client-edge.expected
@@ -33,7 +33,7 @@ fragment Foo_user on User {
      {
       ...BestFriendResolverFragment_name @__RelayResolverMetadata
       # RelayResolverMetadata {
-      #     field_id: FieldID(516),
+      #     field_id: FieldID(518),
       #     import_path: "BestFriendResolver",
       #     import_name: None,
       #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge.expected
@@ -30,7 +30,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(516),
+    #     field_id: FieldID(518),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-client-edges-with-variables.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-client-edges-with-variables.expected
@@ -34,7 +34,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(516),
+    #     field_id: FieldID(518),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,
@@ -57,7 +57,7 @@ fragment Foo_user on User {
        {
         ...BestFriendResolverFragment_name @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(516),
+        #     field_id: FieldID(518),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,
@@ -115,7 +115,7 @@ fragment RefetchableClientEdgeQuery_Foo_user_best_friend on User @__ClientEdgeGe
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(516),
+    #     field_id: FieldID(518),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-client-edges.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-client-edges.expected
@@ -32,7 +32,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(516),
+    #     field_id: FieldID(518),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,
@@ -54,7 +54,7 @@ fragment Foo_user on User {
        {
         ...BestFriendResolverFragment_name @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(516),
+        #     field_id: FieldID(518),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,
@@ -110,7 +110,7 @@ fragment RefetchableClientEdgeQuery_Foo_user_best_friend on User @__ClientEdgeGe
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(516),
+    #     field_id: FieldID(518),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-path-with-alias.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-path-with-alias.expected
@@ -45,7 +45,7 @@ fragment Foo_user on ClientUser {
    {
     ...BestFriendFragment @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(517),
+    #     field_id: FieldID(519),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: Some(
@@ -74,7 +74,7 @@ fragment Foo_user on ClientUser {
        {
         ...BestFriendFragment @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(517),
+        #     field_id: FieldID(519),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: Some(

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-path.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-path.expected
@@ -45,7 +45,7 @@ fragment Foo_user on ClientUser {
    {
     ...BestFriendFragment @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(517),
+    #     field_id: FieldID(519),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,
@@ -72,7 +72,7 @@ fragment Foo_user on ClientUser {
        {
         ...BestFriendFragment @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(517),
+        #     field_id: FieldID(519),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/output-type.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/output-type.expected
@@ -39,7 +39,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(517),
+    #     field_id: FieldID(519),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,
@@ -48,7 +48,7 @@ fragment Foo_user on User {
     #     live: false,
     #     output_type_info: Composite(
     #         ResolverNormalizationInfo {
-    #             inner_type: Object(78),
+    #             inner_type: Object(79),
     #             plural: false,
     #             normalization_operation: WithLocation {
     #                 location: <generated>:59:70,

--- a/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/alias_on_named_fragment.expected
+++ b/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/alias_on_named_fragment.expected
@@ -18,9 +18,9 @@ query RelayReaderNamedFragmentsTest2Query {
     #         item: "aliased_fragment",
     #     },
     #     type_condition: Some(
-    #         Object(69),
+    #         Object(70),
     #     ),
-    #     selection_type: Object(69),
+    #     selection_type: Object(70),
     # }
     
   }

--- a/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/aliased_inline_fragment.expected
+++ b/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/aliased_inline_fragment.expected
@@ -18,9 +18,9 @@ query RelayReaderNamedFragmentsTest2Query {
     #         item: "aliased_fragment",
     #     },
     #     type_condition: Some(
-    #         Object(69),
+    #         Object(70),
     #     ),
-    #     selection_type: Object(69),
+    #     selection_type: Object(70),
     # }
      {
       name

--- a/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/aliased_inline_fragment_without_type_condition.expected
+++ b/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/aliased_inline_fragment_without_type_condition.expected
@@ -18,7 +18,7 @@ query RelayReaderNamedFragmentsTest2Query {
     #         item: "aliased_fragment",
     #     },
     #     type_condition: None,
-    #     selection_type: Object(69),
+    #     selection_type: Object(70),
     # }
      {
       name

--- a/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/default_alias_on_fragment_spread.expected
+++ b/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/default_alias_on_fragment_spread.expected
@@ -18,9 +18,9 @@ query RelayReaderNamedFragmentsTest2Query {
     #         item: "RelayReaderNamedFragmentsTest_user",
     #     },
     #     type_condition: Some(
-    #         Object(69),
+    #         Object(70),
     #     ),
-    #     selection_type: Object(69),
+    #     selection_type: Object(70),
     # }
     
   }

--- a/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/default_alias_on_inline_fragment.expected
+++ b/compiler/crates/relay-transforms/tests/fragment_alias_directive/fixtures/default_alias_on_inline_fragment.expected
@@ -13,9 +13,9 @@ fragment Foo on Node {
   #         item: "User",
   #     },
   #     type_condition: Some(
-  #         Object(69),
+  #         Object(70),
   #     ),
-  #     selection_type: Object(69),
+  #     selection_type: Object(70),
   # }
    {
     name

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/field-alias.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/field-alias.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: Some(

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/missing-fragment-name.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/missing-fragment-name.expected
@@ -12,7 +12,7 @@ extend type User {
 fragment Foo_user on User {
   __id @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/multiple-relay-resolvers.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/multiple-relay-resolvers.expected
@@ -28,7 +28,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,
@@ -41,7 +41,7 @@ fragment Foo_user on User {
   
   ...HobbitNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(517),
+  #     field_id: FieldID(519),
   #     import_path: "HobbitNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/nested-relay-resolver.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/nested-relay-resolver.expected
@@ -28,7 +28,7 @@ extend type User {
 fragment Foo_user on User {
   ...HobbitNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(517),
+  #     field_id: FieldID(519),
   #     import_path: "HobbitNameResolver",
   #     import_name: None,
   #     field_alias: None,
@@ -45,7 +45,7 @@ fragment HobbitNameResolverFragment_name on User {
   name
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-backing-client-edge.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-backing-client-edge.expected
@@ -26,7 +26,7 @@ fragment BestFriendResolverFragment on User {
 fragment Foo_user on User {
   ...BestFriendResolverFragment @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "BestFriendResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-field-and-fragment-arguments.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-field-and-fragment-arguments.expected
@@ -17,7 +17,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-model.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-model.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-named-import.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-named-import.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: Some(
   #         "pop_star_name",

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-required.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-required.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-scalar-field-arguments-with-alias.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-scalar-field-arguments-with-alias.expected
@@ -13,7 +13,7 @@ extend type User {
 fragment Foo_user on User {
   __id @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,
@@ -43,7 +43,7 @@ fragment Foo_user on User {
   
   __id @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: Some(

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-scalar-field-arguments.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-scalar-field-arguments.expected
@@ -12,7 +12,7 @@ extend type User {
 fragment Foo_user on User {
   __id @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-within-named-inline-fragment.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-within-named-inline-fragment.expected
@@ -26,14 +26,14 @@ fragment Foo_user on Node {
   #         item: "aliased_fragment",
   #     },
   #     type_condition: Some(
-  #         Object(69),
+  #         Object(70),
   #     ),
-  #     selection_type: Object(69),
+  #     selection_type: Object(70),
   # }
    {
     ...PopStarNameResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(516),
+    #     field_id: FieldID(518),
     #     import_path: "PopStarNameResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(516),
+  #     field_id: FieldID(518),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-typegen/src/visit.rs
+++ b/compiler/crates/relay-typegen/src/visit.rs
@@ -2016,7 +2016,8 @@ fn transform_non_nullable_input_type(
                                             .project_config
                                             .typegen_config
                                             .optional_input_fields
-                                            .contains(&field.name.0),
+                                            .contains(&field.name.0)
+                                        ||  field.default_value.is_some(),
                                     value: transform_input_type(
                                         typegen_context,
                                         &field.type_,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/default-input.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/default-input.expected
@@ -1,0 +1,27 @@
+==================================== INPUT ====================================
+mutation feedbackUnLikeMutation($input: FeedbackUnLikeInput) {
+  feedbackUnLike(input: $input) {
+    feedback {
+      id
+    }
+  }
+}
+==================================== OUTPUT ===================================
+export type FeedbackUnLikeInput = {|
+  feedbackId?: ?string,
+  silent?: CustomBoolean,
+|};
+export type feedbackUnLikeMutation$variables = {|
+  input?: ?FeedbackUnLikeInput,
+|};
+export type feedbackUnLikeMutation$data = {|
+  +feedbackUnLike: ?{|
+    +feedback: ?{|
+      +id: string,
+    |},
+  |},
+|};
+export type feedbackUnLikeMutation = {|
+  response: feedbackUnLikeMutation$data,
+  variables: feedbackUnLikeMutation$variables,
+|};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/default-input.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/default-input.graphql
@@ -1,0 +1,7 @@
+mutation feedbackUnLikeMutation($input: FeedbackUnLikeInput) {
+  feedbackUnLike(input: $input) {
+    feedback {
+      id
+    }
+  }
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<76805290dabf356c1c992e82c61e7144>>
+ * @generated SignedSource<<cb37c049ca89756a597dc03ff7c628ea>>
  */
 
 mod generate_flow;
@@ -87,6 +87,13 @@ async fn custom_scalar_type_import() {
     let input = include_str!("generate_flow/fixtures/custom-scalar-type-import.graphql");
     let expected = include_str!("generate_flow/fixtures/custom-scalar-type-import.expected");
     test_fixture(transform_fixture, file!(), "custom-scalar-type-import.graphql", "generate_flow/fixtures/custom-scalar-type-import.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn default_input() {
+    let input = include_str!("generate_flow/fixtures/default-input.graphql");
+    let expected = include_str!("generate_flow/fixtures/default-input.expected");
+    test_fixture(transform_fixture, file!(), "default-input.graphql", "generate_flow/fixtures/default-input.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/default-input.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/default-input.expected
@@ -1,0 +1,27 @@
+==================================== INPUT ====================================
+mutation feedbackUnLikeMutation($input: FeedbackUnLikeInput) {
+  feedbackUnLike(input: $input) {
+    feedback {
+      id
+    }
+  }
+}
+==================================== OUTPUT ===================================
+export type FeedbackUnLikeInput = {
+  feedbackId?: string | null | undefined;
+  silent?: boolean;
+};
+export type feedbackUnLikeMutation$variables = {
+  input?: FeedbackUnLikeInput | null | undefined;
+};
+export type feedbackUnLikeMutation$data = {
+  readonly feedbackUnLike: {
+    readonly feedback: {
+      readonly id: string;
+    } | null | undefined;
+  } | null | undefined;
+};
+export type feedbackUnLikeMutation = {
+  response: feedbackUnLikeMutation$data;
+  variables: feedbackUnLikeMutation$variables;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/default-input.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/default-input.graphql
@@ -1,0 +1,7 @@
+mutation feedbackUnLikeMutation($input: FeedbackUnLikeInput) {
+  feedbackUnLike(input: $input) {
+    feedback {
+      id
+    }
+  }
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2c1dbb584a83d9b797c9286e6ce088cb>>
+ * @generated SignedSource<<7e6fc749e15ff3be636ff1f6b838a03b>>
  */
 
 mod generate_typescript;
@@ -73,6 +73,13 @@ async fn custom_scalar_type_import() {
     let input = include_str!("generate_typescript/fixtures/custom-scalar-type-import.graphql");
     let expected = include_str!("generate_typescript/fixtures/custom-scalar-type-import.expected");
     test_fixture(transform_fixture, file!(), "custom-scalar-type-import.graphql", "generate_typescript/fixtures/custom-scalar-type-import.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn default_input() {
+    let input = include_str!("generate_typescript/fixtures/default-input.graphql");
+    let expected = include_str!("generate_typescript/fixtures/default-input.expected");
+    test_fixture(transform_fixture, file!(), "default-input.graphql", "generate_typescript/fixtures/default-input.expected", input, expected).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
Hello here 👋 


We have a few inputs with default required fields that have default values like here :

```graphql
input StoryPinInput {
  id: ID!
  isGlobal: Boolean! = false
}
```

but the TS generated for this look like 
```ts
export type StoryPinInput = {
  id: string;
  isGlobal: boolean;
};
```
which is not ideal ... 

so i marked the field as optional if it has a default :) 


