### PR TITLE
Fix missing space in diagnostic location print

### DIFF
--- a/compiler/crates/common/src/diagnostic.rs
+++ b/compiler/crates/common/src/diagnostic.rs
@@ -225,7 +225,7 @@ impl Diagnostic {
         let mut result = String::new();
         writeln!(
             result,
-            "{message}:{location:?}",
+            "{message}: {location:?}",
             message = &self.0.message,
             location = self.0.location
         )


### PR DESCRIPTION
Fix missing space in diagnostic location print

A space was missing between the error message and location in Diagnostic.print_without_source, which made it harder to open the file from terminal output with tools like vscode.

See https://github.com/facebook/relay/issues/4571

# Test Plan

Confirmed that now the path is outputted in a format that vscode can parse out:
```
[ERROR] Compilation failed.
[ERROR] Unable to run relay compiler. Error details:
Failed to build:
 - Validation errors:
 - The type `Company` has no field `metric`. Did you mean `metrics`?
See https://relay.dev/docs/error-reference/unknown-field/: client/components/console/pulse/details_dialog/PulseMetricDetailsDialog.tsx:465:471
```

Note that the line range is still incorrect (it is using the character span instead of linenumber:character), but this seems much trickier to fix.
