### PR TITLE
relay-compiler diagnostic errors logging improvements

### DIFF
--- a/compiler/crates/common/src/diagnostic.rs
+++ b/compiler/crates/common/src/diagnostic.rs
@@ -225,19 +225,19 @@ impl Diagnostic {
         let mut result = String::new();
         writeln!(
             result,
-            "{message}: {location:?}",
+            "{message}: {location}",
             message = &self.0.message,
-            location = self.0.location
+            location = self.0.location.source_location().path()
         )
         .unwrap();
         if !self.0.related_information.is_empty() {
             for (ix, related) in self.0.related_information.iter().enumerate() {
                 writeln!(
                     result,
-                    "[related {ix}] {message}:{location:?}",
+                    "[related {ix}] {message}:{location}",
                     ix = ix + 1,
                     message = related.message,
-                    location = related.location
+                    location = related.location.source_location().path()
                 )
                 .unwrap();
             }

--- a/compiler/crates/relay-compiler/src/errors.rs
+++ b/compiler/crates/relay-compiler/src/errors.rs
@@ -229,12 +229,9 @@ pub enum ConfigValidationError {
 #[derive(Debug, Error)]
 pub enum BuildProjectError {
     #[error(
-        "Validation errors:{}",
+        "Validation errors: {} error(s) encountered above.",
         errors
-            .iter()
-            .map(|err| format!("\n - {}", err.print_without_source()))
-            .collect::<Vec<_>>()
-            .join("")
+            .len()
     )]
     ValidationErrors {
         errors: Vec<Diagnostic>,


### PR DESCRIPTION
Couple of improvements to relay compiler error output to address issues from https://github.com/facebook/relay/issues/4571

1. Update diagnostic.print_without_source() to no longer include character ranges since the formatting of startchar:endchar doesnt match the standard expectation of linenumber:character (and thus editors will interpret it wrong)
2. Updated the ValidationErrors to no longer enumerate all errors, and instead show the count (since the actual errors are shown above anyway)

# Test Plan

Confirmed the new formatting of .print_without_source() is correct with no character ranges (tested via ValidationError since I'm not sure how to generate a DiagnosticsError, but this will no longer be triggered due to the summarization change):
```
[INFO] Querying files to compile...
[INFO] [default] compiling...
[ERROR] Error: ✖︎ The type `CustomMetric` has no field `test`.
See https://relay.dev/docs/error-reference/unknown-field/

  client/components/console/metrics_catalog/MetricDefinitionDebugDialog.tsx:20:7
   19 │       configuration_json
   20 │       test
      │       ^^^^
   21 │     }

[ERROR] Compilation failed.
[ERROR] Unable to run relay compiler. Error details:
Failed to build:
 - Validation errors:
 - The type `CustomMetric` has no field `test`.
See https://relay.dev/docs/error-reference/unknown-field/: client/components/console/metrics_catalog/MetricDefinitionDebugDialog.tsx
```

Confirmed the count shows instead of the individual errors now:
```
[INFO] Querying files to compile...
[INFO] [default] compiling...
[ERROR] Error: ✖︎ The type `CustomMetric` has no field `test`.
See https://relay.dev/docs/error-reference/unknown-field/

  client/components/console/metrics_catalog/MetricDefinitionDebugDialog.tsx:20:7
   19 │       configuration_json
   20 │       test
      │       ^^^^
   21 │     }

[ERROR] Compilation failed.
[ERROR] Unable to run relay compiler. Error details:
Failed to build:
 - Validation errors: 1 error(s) encountered above.

```

Also confirmed that config errors still showed up correctly:
```
[ERROR] Config `/Users/alex/dev/statsig/console/relay.config.js` is invalid:
 - The `schema` configured for project `default` does not exist at `./server/lib/graphql/schedma.graphql`.
