### PR TITLE
[github ci] update rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-06-26
+          toolchain: nightly-2023-11-11
           override: true
           components: rustfmt
       - name: "rustfmt"


### PR DESCRIPTION
github ci rustfmt started failing in 0e963dd4208e453b904f45418b8c22e77243b89e. updating version to match the one used internally and get github ci back to green.