### PR TITLE
Fix commitLocalUpdate type

### DIFF
--- a/packages/relay-runtime/mutations/commitLocalUpdate.js
+++ b/packages/relay-runtime/mutations/commitLocalUpdate.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-import type {IEnvironment, StoreUpdater} from '../store/RelayStoreTypes';
+import type {IEnvironment, SelectorStoreUpdater} from '../store/RelayStoreTypes';
 
 function commitLocalUpdate(
   environment: IEnvironment,
-  updater: StoreUpdater,
+  updater: SelectorStoreUpdater,
 ): void {
   environment.commitUpdate(updater);
 }

--- a/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -251,7 +251,7 @@ class RelayModernEnvironment implements IEnvironment {
     }).subscribe({});
   }
 
-  commitUpdate(updater: StoreUpdater): void {
+  commitUpdate(updater: SelectorStoreUpdater): void {
     this._scheduleUpdates(() => {
       this._publishQueue.commitUpdate(updater);
       this._publishQueue.run();

--- a/packages/relay-runtime/store/RelayPublishQueue.js
+++ b/packages/relay-runtime/store/RelayPublishQueue.js
@@ -185,7 +185,7 @@ class RelayPublishQueue implements PublishQueue {
    * Schedule an updater to mutate the store on the next `run()` typically to
    * update client schema fields.
    */
-  commitUpdate(updater: StoreUpdater): void {
+  commitUpdate(updater: SelectorStoreUpdater): void {
     this._pendingBackupRebase = true;
     this._pendingData.add({
       kind: 'updater',

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -839,7 +839,7 @@ export interface IEnvironment {
    * should therefore not be used for optimistic updates. This is mainly
    * intended for updating fields from client schema extensions.
    */
-  commitUpdate(updater: StoreUpdater): void;
+  commitUpdate(updater: SelectorStoreUpdater): void;
 
   /**
    * Commit a payload to the environment using the given operation selector.
@@ -1274,7 +1274,7 @@ export interface PublishQueue {
    * Schedule an updater to mutate the store on the next `run()` typically to
    * update client schema fields.
    */
-  commitUpdate(updater: StoreUpdater): void;
+  commitUpdate(updater: SelectorStoreUpdater): void;
 
   /**
    * Schedule a publish to the store from the provided source on the next


### PR DESCRIPTION
The store received by `commitLocalUpdate` function is actually an instance of `RecordSourceSelectorProxy` and not `RecordSourceProxy` like we can see [here](https://github.com/facebook/relay/blob/d37a5aa/packages/relay-runtime/store/RelayPublishQueue.js#L414).

This fixed issue #3538