### PR TITLE
Reuse TypegenConfig for SingleProjectConfigFile

### DIFF
--- a/compiler/crates/relay-config/src/lib.rs
+++ b/compiler/crates/relay-config/src/lib.rs
@@ -40,6 +40,5 @@ pub use project_name::ProjectName;
 pub use resolvers_schema_module_config::ResolversSchemaModuleConfig;
 pub use typegen_config::CustomScalarType;
 pub use typegen_config::CustomScalarTypeImport;
-pub use typegen_config::FlowTypegenConfig;
 pub use typegen_config::TypegenConfig;
 pub use typegen_config::TypegenLanguage;

--- a/compiler/crates/relay-config/src/typegen_config.rs
+++ b/compiler/crates/relay-config/src/typegen_config.rs
@@ -101,9 +101,12 @@ pub struct TypegenConfig {
     #[serde(default)]
     pub require_custom_scalar_types: bool,
 
-    /// Work in progress new Flow type definitions
+    /// This option controls whether or not a catch-all entry is added to enum type definitions
+    /// for values that may be added in the future. Enabling this means you will have to update
+    /// your application whenever the GraphQL server schema adds new enum values to prevent it
+    /// from breaking.
     #[serde(default)]
-    pub flow_typegen: FlowTypegenConfig,
+    pub no_future_proof_enums: bool,
 
     /// This option enables emitting es modules artifacts.
     #[serde(default)]
@@ -114,15 +117,4 @@ pub struct TypegenConfig {
     /// of an union with the raw type, null and undefined.
     #[serde(default)]
     pub typescript_exclude_undefined_from_nullable_union: bool,
-}
-
-#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy)]
-#[serde(deny_unknown_fields, tag = "phase")]
-pub struct FlowTypegenConfig {
-    /// This option controls whether or not a catch-all entry is added to enum type definitions
-    /// for values that may be added in the future. Enabling this means you will have to update
-    /// your application whenever the GraphQL server schema adds new enum values to prevent it
-    /// from breaking.
-    #[serde(default)]
-    pub no_future_proof_enums: bool,
 }

--- a/compiler/crates/relay-typegen/src/write.rs
+++ b/compiler/crates/relay-typegen/src/write.rs
@@ -655,7 +655,6 @@ fn write_enum_definitions(
             if !typegen_context
                 .project_config
                 .typegen_config
-                .flow_typegen
                 .no_future_proof_enums
             {
                 members.push(AST::StringLiteral(StringLiteral(*FUTURE_ENUM_VALUE)));

--- a/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow_with_custom_id/mod.rs
@@ -81,7 +81,6 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
         typegen_config: TypegenConfig {
             language: TypegenLanguage::Flow,
             custom_scalar_types,
-            flow_typegen: Default::default(),
             ..Default::default()
         },
         ..Default::default()


### PR DESCRIPTION
There are some slight discrepancies between multi- and single-project configs at the moment, with some options only being configurable from multi-project configs, even though the compiler could read and support the same settings from both type of configs (examples: `use_import_type_syntax`, `require_custom_scalar_types`, etc.).

## Changes

- Flatten `TypegenConfig` in `SingleProjectConfigFile` and remove duplicated options
- Inlines `no_future_proof_enums` from `FlowTypegenConfig` into `TypegenConfig` and removes `FlowTypegenConfig` as it's now no longer required
- When parsing of the config file fails, show the single-project config error first, since that is the configuration most people use

## ⚠️ Breaking change

This change is a breaking change, as the `custom_scalars` config option in the single-project config must now be specified as `custom_scalar_types`.