### PR TITLE
Experimental support for @semanticNonNull

### DIFF
--- a/compiler/crates/graphql-ir/tests/parse/fixtures/argument_definitions.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/argument_definitions.expected
@@ -87,7 +87,7 @@ fragment TestFragment on User
                     alias: None,
                     definition: WithLocation {
                         location: argument_definitions.graphql:161:171,
-                        item: FieldID(518),
+                        item: FieldID(523),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/fragment_with_arguments_defaulting.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/fragment_with_arguments_defaulting.expected
@@ -180,7 +180,7 @@ fragment F2 on Query @argumentDefinitions(
                             alias: None,
                             definition: WithLocation {
                                 location: fragment_with_arguments_defaulting.graphql:342:352,
-                                item: FieldID(518),
+                                item: FieldID(523),
                             },
                             arguments: [],
                             directives: [],

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/unknown-fragment-type-suggestions.invalid.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/unknown-fragment-type-suggestions.invalid.expected
@@ -4,7 +4,7 @@ fragment Foo on Users {
   id
 }
 ==================================== ERROR ====================================
-✖︎ Unknown type 'Users'. Did you mean `User` or `Query`?
+✖︎ Unknown type 'Users'. Did you mean `User`, `Opera`, or `Query`?
 
   unknown-fragment-type-suggestions.invalid.graphql:2:17
     1 │ # expected-to-throw

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/client-fields.expected
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/client-fields.expected
@@ -151,7 +151,7 @@ type Foo {
                     alias: None,
                     definition: WithLocation {
                         location: client-fields.graphql:226:238,
-                        item: FieldID(518),
+                        item: FieldID(523),
                     },
                     arguments: [],
                     directives: [],
@@ -228,7 +228,7 @@ type Foo {
                             alias: None,
                             definition: WithLocation {
                                 location: client-fields.graphql:367:370,
-                                item: FieldID(519),
+                                item: FieldID(524),
                             },
                             arguments: [],
                             directives: [],
@@ -245,7 +245,7 @@ type Foo {
                                 },
                                 InlineFragment {
                                     type_condition: Some(
-                                        Object(79),
+                                        Object(81),
                                     ),
                                     directives: [],
                                     selections: [
@@ -253,7 +253,7 @@ type Foo {
                                             alias: None,
                                             definition: WithLocation {
                                                 location: client-fields.graphql:470:472,
-                                                item: FieldID(520),
+                                                item: FieldID(525),
                                             },
                                             arguments: [],
                                             directives: [],
@@ -279,14 +279,14 @@ type Foo {
             },
             variable_definitions: [],
             used_global_variables: [],
-            type_condition: Object(79),
+            type_condition: Object(81),
             directives: [],
             selections: [
                 ScalarField {
                     alias: None,
                     definition: WithLocation {
                         location: client-fields.graphql:526:528,
-                        item: FieldID(520),
+                        item: FieldID(525),
                     },
                     arguments: [],
                     directives: [],

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/custom_scalar_directive_arg_variable.expected
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/custom_scalar_directive_arg_variable.expected
@@ -57,7 +57,7 @@ extend type Query {
                     alias: None,
                     definition: WithLocation {
                         location: custom_scalar_directive_arg_variable.graphql:100:115,
-                        item: FieldID(519),
+                        item: FieldID(524),
                     },
                     arguments: [],
                     directives: [
@@ -104,7 +104,7 @@ extend type Query {
                             alias: None,
                             definition: WithLocation {
                                 location: custom_scalar_directive_arg_variable.graphql:160:170,
-                                item: FieldID(521),
+                                item: FieldID(526),
                             },
                             arguments: [],
                             directives: [],
@@ -115,7 +115,7 @@ extend type Query {
                     alias: None,
                     definition: WithLocation {
                         location: custom_scalar_directive_arg_variable.graphql:181:203,
-                        item: FieldID(520),
+                        item: FieldID(525),
                     },
                     arguments: [],
                     directives: [

--- a/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/custom_scalar_variable_arg.expected
+++ b/compiler/crates/graphql-ir/tests/parse_with_extensions/fixtures/custom_scalar_variable_arg.expected
@@ -55,7 +55,7 @@ extend type Query {
                     alias: None,
                     definition: WithLocation {
                         location: custom_scalar_variable_arg.graphql:100:115,
-                        item: FieldID(519),
+                        item: FieldID(524),
                     },
                     arguments: [
                         Argument {
@@ -91,7 +91,7 @@ extend type Query {
                             alias: None,
                             definition: WithLocation {
                                 location: custom_scalar_variable_arg.graphql:151:161,
-                                item: FieldID(521),
+                                item: FieldID(526),
                             },
                             arguments: [],
                             directives: [],
@@ -102,7 +102,7 @@ extend type Query {
                     alias: None,
                     definition: WithLocation {
                         location: custom_scalar_variable_arg.graphql:172:194,
-                        item: FieldID(520),
+                        item: FieldID(525),
                     },
                     arguments: [
                         Argument {

--- a/compiler/crates/relay-config/src/typegen_config.rs
+++ b/compiler/crates/relay-config/src/typegen_config.rs
@@ -111,6 +111,14 @@ pub struct TypegenConfig {
     /// of an union with the raw type, null and undefined.
     #[serde(default)]
     pub typescript_exclude_undefined_from_nullable_union: bool,
+
+    /// If your environment is configured to handles errors out of band, either via
+    /// a network layer which discards responses with errors, or via enabling strict
+    /// error handling in the runtime, you can enable this flag to have Relay generate
+    /// non-null types for fields which are marked as semantically non-null in
+    /// the schema.
+    #[serde(default)]
+    pub emit_semantic_nullability_types: bool,
 }
 
 impl Default for TypegenConfig {

--- a/compiler/crates/relay-config/src/typegen_config.rs
+++ b/compiler/crates/relay-config/src/typegen_config.rs
@@ -137,6 +137,7 @@ impl Default for TypegenConfig {
             no_future_proof_enums: Default::default(),
             eager_es_modules: Default::default(),
             typescript_exclude_undefined_from_nullable_union: Default::default(),
+            experimental_emit_semantic_nullability_types: Default::default(),
         }
     }
 }

--- a/compiler/crates/relay-config/src/typegen_config.rs
+++ b/compiler/crates/relay-config/src/typegen_config.rs
@@ -112,13 +112,17 @@ pub struct TypegenConfig {
     #[serde(default)]
     pub typescript_exclude_undefined_from_nullable_union: bool,
 
-    /// If your environment is configured to handles errors out of band, either via
+    /// EXPERIMENTAL: If your environment is configured to handles errors out of band, either via
     /// a network layer which discards responses with errors, or via enabling strict
     /// error handling in the runtime, you can enable this flag to have Relay generate
     /// non-null types for fields which are marked as semantically non-null in
     /// the schema.
+    ///
+    /// Currently semantically non-null fields must be specified in your schema
+    /// using the `@semanticNonNull` directive as specified in:
+    /// https://github.com/apollographql/specs/pull/42
     #[serde(default)]
-    pub emit_semantic_nullability_types: bool,
+    pub experimental_emit_semantic_nullability_types: bool,
 }
 
 impl Default for TypegenConfig {

--- a/compiler/crates/relay-test-schema/src/testschema.graphql
+++ b/compiler/crates/relay-test-schema/src/testschema.graphql
@@ -1191,3 +1191,17 @@ type Settings {
 type WithWrongViewer {
   actor_key: Viewer
 }
+
+extend type Query {
+  opera: Opera
+}
+
+type Opera {
+  composer: User @semanticNonNull
+  cast: [Portrayal] @semanticNonNull(levels: [0, 1])
+}
+
+type Portrayal {
+  singer: User @semanticNonNull
+  character: String @semanticNonNull
+}

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-inline-fragment-no-type-condition.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-inline-fragment-no-type-condition.expected
@@ -38,7 +38,7 @@ fragment Foo_user on User {
      {
       ...BestFriendResolverFragment_name @__RelayResolverMetadata
       # RelayResolverMetadata {
-      #     field_id: FieldID(518),
+      #     field_id: FieldID(523),
       #     import_path: "BestFriendResolver",
       #     import_name: None,
       #     field_alias: None,
@@ -65,7 +65,7 @@ fragment Foo_user on User {
      {
       ...BestFriendResolverFragment_name @__RelayResolverMetadata
       # RelayResolverMetadata {
-      #     field_id: FieldID(518),
+      #     field_id: FieldID(523),
       #     import_path: "BestFriendResolver",
       #     import_name: None,
       #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-inline-fragment.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-inline-fragment.expected
@@ -43,7 +43,7 @@ fragment Foo_node on Node {
        {
         ...BestFriendResolverFragment_name @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(518),
+        #     field_id: FieldID(523),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,
@@ -72,7 +72,7 @@ fragment Foo_node on Node {
        {
         ...BestFriendResolverFragment_name @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(518),
+        #     field_id: FieldID(523),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-to-client-interface.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-to-client-interface.expected
@@ -42,7 +42,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(520),
+    #     field_id: FieldID(525),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-to-client-object.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-to-client-object.expected
@@ -39,7 +39,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(519),
+    #     field_id: FieldID(524),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-variables.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-variables.expected
@@ -30,7 +30,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(518),
+    #     field_id: FieldID(523),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-with-required.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-with-required.expected
@@ -34,7 +34,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(518),
+    #     field_id: FieldID(523),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-within-non-client-edge.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge-within-non-client-edge.expected
@@ -33,7 +33,7 @@ fragment Foo_user on User {
      {
       ...BestFriendResolverFragment_name @__RelayResolverMetadata
       # RelayResolverMetadata {
-      #     field_id: FieldID(518),
+      #     field_id: FieldID(523),
       #     import_path: "BestFriendResolver",
       #     import_name: None,
       #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/client-edge.expected
@@ -30,7 +30,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(518),
+    #     field_id: FieldID(523),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-client-edges-with-variables.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-client-edges-with-variables.expected
@@ -34,7 +34,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(518),
+    #     field_id: FieldID(523),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,
@@ -57,7 +57,7 @@ fragment Foo_user on User {
        {
         ...BestFriendResolverFragment_name @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(518),
+        #     field_id: FieldID(523),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,
@@ -115,7 +115,7 @@ fragment RefetchableClientEdgeQuery_Foo_user_best_friend on User @__ClientEdgeGe
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(518),
+    #     field_id: FieldID(523),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-client-edges.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-client-edges.expected
@@ -32,7 +32,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(518),
+    #     field_id: FieldID(523),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,
@@ -54,7 +54,7 @@ fragment Foo_user on User {
        {
         ...BestFriendResolverFragment_name @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(518),
+        #     field_id: FieldID(523),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,
@@ -110,7 +110,7 @@ fragment RefetchableClientEdgeQuery_Foo_user_best_friend on User @__ClientEdgeGe
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(518),
+    #     field_id: FieldID(523),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-path-with-alias.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-path-with-alias.expected
@@ -45,7 +45,7 @@ fragment Foo_user on ClientUser {
    {
     ...BestFriendFragment @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(519),
+    #     field_id: FieldID(524),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: Some(
@@ -74,7 +74,7 @@ fragment Foo_user on ClientUser {
        {
         ...BestFriendFragment @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(519),
+        #     field_id: FieldID(524),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: Some(

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-path.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/nested-path.expected
@@ -45,7 +45,7 @@ fragment Foo_user on ClientUser {
    {
     ...BestFriendFragment @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(519),
+    #     field_id: FieldID(524),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,
@@ -72,7 +72,7 @@ fragment Foo_user on ClientUser {
        {
         ...BestFriendFragment @__RelayResolverMetadata
         # RelayResolverMetadata {
-        #     field_id: FieldID(519),
+        #     field_id: FieldID(524),
         #     import_path: "BestFriendResolver",
         #     import_name: None,
         #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/client_edges/fixtures/output-type.expected
+++ b/compiler/crates/relay-transforms/tests/client_edges/fixtures/output-type.expected
@@ -39,7 +39,7 @@ fragment Foo_user on User {
    {
     ...BestFriendResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(519),
+    #     field_id: FieldID(524),
     #     import_path: "BestFriendResolver",
     #     import_name: None,
     #     field_alias: None,
@@ -48,7 +48,7 @@ fragment Foo_user on User {
     #     live: false,
     #     output_type_info: Composite(
     #         ResolverNormalizationInfo {
-    #             inner_type: Object(79),
+    #             inner_type: Object(81),
     #             plural: false,
     #             normalization_operation: WithLocation {
     #                 location: <generated>:59:70,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/field-alias.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/field-alias.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: Some(

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/missing-fragment-name.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/missing-fragment-name.expected
@@ -12,7 +12,7 @@ extend type User {
 fragment Foo_user on User {
   __id @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/multiple-relay-resolvers.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/multiple-relay-resolvers.expected
@@ -28,7 +28,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,
@@ -41,7 +41,7 @@ fragment Foo_user on User {
   
   ...HobbitNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(519),
+  #     field_id: FieldID(524),
   #     import_path: "HobbitNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/nested-relay-resolver.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/nested-relay-resolver.expected
@@ -28,7 +28,7 @@ extend type User {
 fragment Foo_user on User {
   ...HobbitNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(519),
+  #     field_id: FieldID(524),
   #     import_path: "HobbitNameResolver",
   #     import_name: None,
   #     field_alias: None,
@@ -45,7 +45,7 @@ fragment HobbitNameResolverFragment_name on User {
   name
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-backing-client-edge.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-backing-client-edge.expected
@@ -26,7 +26,7 @@ fragment BestFriendResolverFragment on User {
 fragment Foo_user on User {
   ...BestFriendResolverFragment @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "BestFriendResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-field-and-fragment-arguments.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-field-and-fragment-arguments.expected
@@ -17,7 +17,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-model.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-model.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-named-import.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-named-import.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: Some(
   #         "pop_star_name",

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-required.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-required.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-scalar-field-arguments-with-alias.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-scalar-field-arguments-with-alias.expected
@@ -13,7 +13,7 @@ extend type User {
 fragment Foo_user on User {
   __id @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,
@@ -43,7 +43,7 @@ fragment Foo_user on User {
   
   __id @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: Some(

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-scalar-field-arguments.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-scalar-field-arguments.expected
@@ -12,7 +12,7 @@ extend type User {
 fragment Foo_user on User {
   __id @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-within-named-inline-fragment.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver-within-named-inline-fragment.expected
@@ -33,7 +33,7 @@ fragment Foo_user on Node {
    {
     ...PopStarNameResolverFragment_name @__RelayResolverMetadata
     # RelayResolverMetadata {
-    #     field_id: FieldID(518),
+    #     field_id: FieldID(523),
     #     import_path: "PopStarNameResolver",
     #     import_name: None,
     #     field_alias: None,

--- a/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver.expected
+++ b/compiler/crates/relay-transforms/tests/relay_resolvers/fixtures/relay-resolver.expected
@@ -22,7 +22,7 @@ extend type User {
 fragment Foo_user on User {
   ...PopStarNameResolverFragment_name @__RelayResolverMetadata
   # RelayResolverMetadata {
-  #     field_id: FieldID(518),
+  #     field_id: FieldID(523),
   #     import_path: "PopStarNameResolver",
   #     import_name: None,
   #     field_alias: None,

--- a/compiler/crates/relay-typegen/src/visit.rs
+++ b/compiler/crates/relay-typegen/src/visit.rs
@@ -2434,7 +2434,7 @@ fn field_type(field: &Field, typegen_options: &'_ TypegenContext<'_>) -> TypeRef
     if typegen_options
         .project_config
         .typegen_config
-        .emit_semantic_nullability_types
+        .experimental_emit_semantic_nullability_types
     {
         field.semantic_type()
     } else {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_in_raw_response.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_in_raw_response.expected
@@ -1,0 +1,50 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+query MyQuery @raw_response_type {
+  opera {
+    composer {
+      name
+    }
+    cast {
+      singer {
+        name
+      }
+      character
+    }
+  }
+}
+==================================== OUTPUT ===================================
+export type MyQuery$variables = {||};
+export type MyQuery$data = {|
+  +opera: ?{|
+    +cast: $ReadOnlyArray<{|
+      +character: string,
+      +singer: {|
+        +name: ?string,
+      |},
+    |}>,
+    +composer: {|
+      +name: ?string,
+    |},
+  |},
+|};
+export type MyQuery$rawResponse = {|
+  +opera?: ?{|
+    +cast: $ReadOnlyArray<{|
+      +character: string,
+      +singer: {|
+        +id: string,
+        +name: ?string,
+      |},
+    |}>,
+    +composer: {|
+      +id: string,
+      +name: ?string,
+    |},
+  |},
+|};
+export type MyQuery = {|
+  rawResponse: MyQuery$rawResponse,
+  response: MyQuery$data,
+  variables: MyQuery$variables,
+|};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_in_raw_response.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_in_raw_response.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 query MyQuery @raw_response_type {
   opera {
     composer {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_in_raw_response.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_in_raw_response.graphql
@@ -1,0 +1,14 @@
+# relay:emit_semantic_nullability_types
+query MyQuery @raw_response_type {
+  opera {
+    composer {
+      name
+    }
+    cast {
+      singer {
+        name
+      }
+      character
+    }
+  }
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_in_raw_response.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_in_raw_response.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 query MyQuery @raw_response_type {
   opera {
     composer {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_items_in_matrix.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_items_in_matrix.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on Screen {
   pixels
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_items_in_matrix.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_items_in_matrix.expected
@@ -1,0 +1,23 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on Screen {
+  pixels
+}
+
+%extensions%
+
+type Screen {
+  pixels: [[Int]] @semanticNonNull(levels: [2])
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {|
+  +pixels: ?$ReadOnlyArray<?$ReadOnlyArray<number>>,
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_items_in_matrix.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_items_in_matrix.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on Screen {
+  pixels
+}
+
+%extensions%
+
+type Screen {
+  pixels: [[Int]] @semanticNonNull(levels: [2])
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_items_in_matrix.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_items_in_matrix.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on Screen {
   pixels
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_resolver.expected
@@ -1,0 +1,63 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  best_friend @waterfall {
+    name
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  best_friend: User @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+    )
+}
+==================================== OUTPUT ===================================
+import type { RefetchableClientEdgeQuery_MyFragment_best_friend$fragmentType } from "RefetchableClientEdgeQuery_MyFragment_best_friend.graphql";
+export type ClientEdgeQuery_MyFragment_best_friend$variables = {|
+  id: string,
+|};
+export type ClientEdgeQuery_MyFragment_best_friend$data = {|
+  +node: ?{|
+    +$fragmentSpreads: RefetchableClientEdgeQuery_MyFragment_best_friend$fragmentType,
+  |},
+|};
+export type ClientEdgeQuery_MyFragment_best_friend = {|
+  response: ClientEdgeQuery_MyFragment_best_friend$data,
+  variables: ClientEdgeQuery_MyFragment_best_friend$variables,
+|};
+-------------------------------------------------------------------------------
+import type { FragmentType, DataID } from "relay-runtime";
+import clientUserBestFriendResolverType from "bar";
+// Type assertion validating that `clientUserBestFriendResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(clientUserBestFriendResolverType: () => {|
+  +id: DataID,
+|});
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {|
+  +best_friend: {|
+    +name: ?string,
+  |},
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};
+-------------------------------------------------------------------------------
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RefetchableClientEdgeQuery_MyFragment_best_friend$fragmentType: FragmentType;
+import type { ClientEdgeQuery_MyFragment_best_friend$variables } from "ClientEdgeQuery_MyFragment_best_friend.graphql";
+export type RefetchableClientEdgeQuery_MyFragment_best_friend$data = {|
+  +id: string,
+  +name: ?string,
+  +$fragmentType: RefetchableClientEdgeQuery_MyFragment_best_friend$fragmentType,
+|};
+export type RefetchableClientEdgeQuery_MyFragment_best_friend$key = {
+  +$data?: RefetchableClientEdgeQuery_MyFragment_best_friend$data,
+  +$fragmentSpreads: RefetchableClientEdgeQuery_MyFragment_best_friend$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_resolver.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   best_friend @waterfall {
     name

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_resolver.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   best_friend @waterfall {
     name

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_resolver.graphql
@@ -1,0 +1,14 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  best_friend @waterfall {
+    name
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  best_friend: User @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+    )
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   blob {
     data

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.expected
@@ -1,0 +1,48 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  blob {
+    data
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  blob: Blob @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+      has_output_type: true
+    )
+}
+
+type Blob {
+  data: String
+}
+==================================== OUTPUT ===================================
+export type ClientUser__blob$normalization$variables = {||};
+export type ClientUser__blob$normalization$data = {|
+  +data: ?string,
+|};
+export type ClientUser__blob$normalization = {|
+  response: ClientUser__blob$normalization$data,
+  variables: ClientUser__blob$normalization$variables,
+|};
+-------------------------------------------------------------------------------
+import type { ClientUser__blob$normalization } from "ClientUser__blob$normalization.graphql";
+import type { FragmentType } from "relay-runtime";
+import clientUserBlobResolverType from "bar";
+// Type assertion validating that `clientUserBlobResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(clientUserBlobResolverType: () => ClientUser__blob$normalization);
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {|
+  +blob: {|
+    +data: ?string,
+  |},
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   blob {
     data

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.graphql
@@ -1,0 +1,19 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  blob {
+    data
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  blob: Blob @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+      has_output_type: true
+    )
+}
+
+type Blob {
+  data: String
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_linked_field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_linked_field.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   best_friend {
     name

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_linked_field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_linked_field.expected
@@ -1,0 +1,27 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  best_friend {
+    name
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  best_friend: User @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {|
+  +best_friend: {|
+    +name: ?string,
+  |},
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_linked_field.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_linked_field.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   best_friend {
     name

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_linked_field.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_linked_field.graphql
@@ -1,0 +1,12 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  best_friend {
+    name
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  best_friend: User @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_and_list_item.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_and_list_item.expected
@@ -1,0 +1,23 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  favorite_numbers
+}
+
+%extensions%
+
+type ClientUser {
+  favorite_numbers: [Int] @semanticNonNull(levels: [0, 1])
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {|
+  +favorite_numbers: $ReadOnlyArray<number>,
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_and_list_item.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_and_list_item.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   favorite_numbers
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_and_list_item.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_and_list_item.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  favorite_numbers
+}
+
+%extensions%
+
+type ClientUser {
+  favorite_numbers: [Int] @semanticNonNull(levels: [0, 1])
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_and_list_item.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_and_list_item.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   favorite_numbers
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_item.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_item.expected
@@ -1,0 +1,23 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  favorite_numbers
+}
+
+%extensions%
+
+type ClientUser {
+  favorite_numbers: [Int] @semanticNonNull(levels: [1])
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {|
+  +favorite_numbers: ?$ReadOnlyArray<number>,
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_item.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_item.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   favorite_numbers
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_item.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_item.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  favorite_numbers
+}
+
+%extensions%
+
+type ClientUser {
+  favorite_numbers: [Int] @semanticNonNull(levels: [1])
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_item.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_list_item.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   favorite_numbers
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar.expected
@@ -1,0 +1,23 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {|
+  +name: string,
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.expected
@@ -1,0 +1,23 @@
+==================================== INPUT ====================================
+# Note: No comment here enabling `emit_semantic_nullability_types`
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {|
+  +name: ?string,
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# Note: No comment here enabling `emit_semantic_nullability_types`
+# Note: No comment here enabling `experimental_emit_semantic_nullability_types`
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.graphql
@@ -1,4 +1,4 @@
-# Note: No comment here enabling `emit_semantic_nullability_types`
+# Note: No comment here enabling `experimental_emit_semantic_nullability_types`
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.graphql
@@ -1,0 +1,10 @@
+# Note: No comment here enabling `emit_semantic_nullability_types`
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_required.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name @required(action: LOG)
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_required.expected
@@ -1,0 +1,23 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name @required(action: LOG)
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = ?{|
+  +name: string,
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_required.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_required.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name @required(action: LOG)
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_required.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_required.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name @required(action: LOG)
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_resolver.expected
@@ -1,0 +1,29 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+    )
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+import clientUserNameResolverType from "bar";
+// Type assertion validating that `clientUserNameResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(clientUserNameResolverType: () => mixed);
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {|
+  +name: ?ReturnType<typeof clientUserNameResolverType>,
+  +$fragmentType: MyFragment$fragmentType,
+|};
+export type MyFragment$key = {
+  +$data?: MyFragment$data,
+  +$fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_resolver.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_resolver.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/semantic_non_null_scalar_resolver.graphql
@@ -1,0 +1,12 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+    )
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
@@ -92,6 +92,9 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
         typegen_config: TypegenConfig {
             language: TypegenLanguage::Flow,
             custom_scalar_types,
+            emit_semantic_nullability_types: fixture
+                .content
+                .contains("# relay:emit_semantic_nullability_types"),
             ..Default::default()
         },
         ..Default::default()

--- a/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow/mod.rs
@@ -92,9 +92,9 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
         typegen_config: TypegenConfig {
             language: TypegenLanguage::Flow,
             custom_scalar_types,
-            emit_semantic_nullability_types: fixture
+            experimental_emit_semantic_nullability_types: fixture
                 .content
-                .contains("# relay:emit_semantic_nullability_types"),
+                .contains("# relay:experimental_emit_semantic_nullability_types"),
             ..Default::default()
         },
         ..Default::default()

--- a/compiler/crates/relay-typegen/tests/generate_flow_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cb37c049ca89756a597dc03ff7c628ea>>
+ * @generated SignedSource<<0785113b958651724c9f7105d4f66b9a>>
  */
 
 mod generate_flow;
@@ -689,6 +689,83 @@ async fn scalar_field() {
     let input = include_str!("generate_flow/fixtures/scalar-field.graphql");
     let expected = include_str!("generate_flow/fixtures/scalar-field.expected");
     test_fixture(transform_fixture, file!(), "scalar-field.graphql", "generate_flow/fixtures/scalar-field.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_in_raw_response() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_in_raw_response.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_in_raw_response.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_in_raw_response.graphql", "generate_flow/fixtures/semantic_non_null_in_raw_response.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_items_in_matrix() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_items_in_matrix.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_items_in_matrix.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_items_in_matrix.graphql", "generate_flow/fixtures/semantic_non_null_items_in_matrix.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_liked_field_resolver() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_liked_field_resolver.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_liked_field_resolver.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_liked_field_resolver.graphql", "generate_flow/fixtures/semantic_non_null_liked_field_resolver.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_liked_field_weak_resolver() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_liked_field_weak_resolver.graphql", "generate_flow/fixtures/semantic_non_null_liked_field_weak_resolver.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_linked_field() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_linked_field.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_linked_field.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_linked_field.graphql", "generate_flow/fixtures/semantic_non_null_linked_field.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_list_and_list_item() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_list_and_list_item.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_list_and_list_item.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_list_and_list_item.graphql", "generate_flow/fixtures/semantic_non_null_list_and_list_item.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_list_item() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_list_item.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_list_item.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_list_item.graphql", "generate_flow/fixtures/semantic_non_null_list_item.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_scalar() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_scalar.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_scalar.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_scalar.graphql", "generate_flow/fixtures/semantic_non_null_scalar.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_scalar_feature_disabled() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_scalar_feature_disabled.graphql", "generate_flow/fixtures/semantic_non_null_scalar_feature_disabled.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_scalar_required() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_scalar_required.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_scalar_required.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_scalar_required.graphql", "generate_flow/fixtures/semantic_non_null_scalar_required.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_scalar_resolver() {
+    let input = include_str!("generate_flow/fixtures/semantic_non_null_scalar_resolver.graphql");
+    let expected = include_str!("generate_flow/fixtures/semantic_non_null_scalar_resolver.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_scalar_resolver.graphql", "generate_flow/fixtures/semantic_non_null_scalar_resolver.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_in_raw_response.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_in_raw_response.expected
@@ -1,0 +1,50 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+query MyQuery @raw_response_type {
+  opera {
+    composer {
+      name
+    }
+    cast {
+      singer {
+        name
+      }
+      character
+    }
+  }
+}
+==================================== OUTPUT ===================================
+export type MyQuery$variables = Record<PropertyKey, never>;
+export type MyQuery$data = {
+  readonly opera: {
+    readonly cast: ReadonlyArray<{
+      readonly character: string;
+      readonly singer: {
+        readonly name: string | null | undefined;
+      };
+    }>;
+    readonly composer: {
+      readonly name: string | null | undefined;
+    };
+  } | null | undefined;
+};
+export type MyQuery$rawResponse = {
+  readonly opera?: {
+    readonly cast: ReadonlyArray<{
+      readonly character: string;
+      readonly singer: {
+        readonly id: string;
+        readonly name: string | null | undefined;
+      };
+    }>;
+    readonly composer: {
+      readonly id: string;
+      readonly name: string | null | undefined;
+    };
+  } | null | undefined;
+};
+export type MyQuery = {
+  rawResponse: MyQuery$rawResponse;
+  response: MyQuery$data;
+  variables: MyQuery$variables;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_in_raw_response.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_in_raw_response.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 query MyQuery @raw_response_type {
   opera {
     composer {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_in_raw_response.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_in_raw_response.graphql
@@ -1,0 +1,14 @@
+# relay:emit_semantic_nullability_types
+query MyQuery @raw_response_type {
+  opera {
+    composer {
+      name
+    }
+    cast {
+      singer {
+        name
+      }
+      character
+    }
+  }
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_in_raw_response.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_in_raw_response.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 query MyQuery @raw_response_type {
   opera {
     composer {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_items_in_matrix.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_items_in_matrix.expected
@@ -1,0 +1,21 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on Screen {
+  pixels
+}
+
+%extensions%
+
+type Screen {
+  pixels: [[Int]] @semanticNonNull(levels: [2])
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly pixels: ReadonlyArray<ReadonlyArray<number> | null | undefined> | null | undefined;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_items_in_matrix.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_items_in_matrix.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on Screen {
   pixels
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_items_in_matrix.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_items_in_matrix.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on Screen {
+  pixels
+}
+
+%extensions%
+
+type Screen {
+  pixels: [[Int]] @semanticNonNull(levels: [2])
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_items_in_matrix.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_items_in_matrix.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on Screen {
   pixels
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_resolver.expected
@@ -1,0 +1,53 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  best_friend @waterfall {
+    name
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  best_friend: User @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+    )
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type ClientEdgeQuery_MyFragment_best_friend$variables = {
+  id: string;
+};
+export type ClientEdgeQuery_MyFragment_best_friend$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"RefetchableClientEdgeQuery_MyFragment_best_friend">;
+  } | null | undefined;
+};
+export type ClientEdgeQuery_MyFragment_best_friend = {
+  response: ClientEdgeQuery_MyFragment_best_friend$data;
+  variables: ClientEdgeQuery_MyFragment_best_friend$variables;
+};
+-------------------------------------------------------------------------------
+import { FragmentRefs, DataID } from "relay-runtime";
+import clientUserBestFriendResolverType from "bar";
+export type MyFragment$data = {
+  readonly best_friend: {
+    readonly name: string | null | undefined;
+  };
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};
+-------------------------------------------------------------------------------
+import { FragmentRefs } from "relay-runtime";
+export type RefetchableClientEdgeQuery_MyFragment_best_friend$data = {
+  readonly id: string;
+  readonly name: string | null | undefined;
+  readonly " $fragmentType": "RefetchableClientEdgeQuery_MyFragment_best_friend";
+};
+export type RefetchableClientEdgeQuery_MyFragment_best_friend$key = {
+  readonly " $data"?: RefetchableClientEdgeQuery_MyFragment_best_friend$data;
+  readonly " $fragmentSpreads": FragmentRefs<"RefetchableClientEdgeQuery_MyFragment_best_friend">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_resolver.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   best_friend @waterfall {
     name

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_resolver.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   best_friend @waterfall {
     name

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_resolver.graphql
@@ -1,0 +1,14 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  best_friend @waterfall {
+    name
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  best_friend: User @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+    )
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   blob {
     data

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.expected
@@ -1,0 +1,42 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  blob {
+    data
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  blob: Blob @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+      has_output_type: true
+    )
+}
+
+type Blob {
+  data: String
+}
+==================================== OUTPUT ===================================
+export type ClientUser__blob$normalization$variables = Record<PropertyKey, never>;
+export type ClientUser__blob$normalization$data = {
+  readonly data: string | null | undefined;
+};
+export type ClientUser__blob$normalization = {
+  response: ClientUser__blob$normalization$data;
+  variables: ClientUser__blob$normalization$variables;
+};
+-------------------------------------------------------------------------------
+import { FragmentRefs } from "relay-runtime";
+import clientUserBlobResolverType from "bar";
+export type MyFragment$data = {
+  readonly blob: {
+    readonly data: string | null | undefined;
+  };
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   blob {
     data

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.graphql
@@ -1,0 +1,19 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  blob {
+    data
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  blob: Blob @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+      has_output_type: true
+    )
+}
+
+type Blob {
+  data: String
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_linked_field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_linked_field.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   best_friend {
     name

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_linked_field.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_linked_field.expected
@@ -1,0 +1,25 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  best_friend {
+    name
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  best_friend: User @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly best_friend: {
+    readonly name: string | null | undefined;
+  };
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_linked_field.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_linked_field.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   best_friend {
     name

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_linked_field.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_linked_field.graphql
@@ -1,0 +1,12 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  best_friend {
+    name
+  }
+}
+
+%extensions%
+
+type ClientUser {
+  best_friend: User @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_and_list_item.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_and_list_item.expected
@@ -1,0 +1,21 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  favorite_numbers
+}
+
+%extensions%
+
+type ClientUser {
+  favorite_numbers: [Int] @semanticNonNull(levels: [0, 1])
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly favorite_numbers: ReadonlyArray<number>;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_and_list_item.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_and_list_item.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   favorite_numbers
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_and_list_item.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_and_list_item.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  favorite_numbers
+}
+
+%extensions%
+
+type ClientUser {
+  favorite_numbers: [Int] @semanticNonNull(levels: [0, 1])
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_and_list_item.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_and_list_item.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   favorite_numbers
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_item.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_item.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   favorite_numbers
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_item.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_item.expected
@@ -1,0 +1,21 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  favorite_numbers
+}
+
+%extensions%
+
+type ClientUser {
+  favorite_numbers: [Int] @semanticNonNull(levels: [1])
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly favorite_numbers: ReadonlyArray<number> | null | undefined;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_item.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_item.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  favorite_numbers
+}
+
+%extensions%
+
+type ClientUser {
+  favorite_numbers: [Int] @semanticNonNull(levels: [1])
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_item.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_list_item.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   favorite_numbers
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar.expected
@@ -1,0 +1,21 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly name: string;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# Note: No comment here enabling `emit_semantic_nullability_types`
+# Note: No comment here enabling `experimental_emit_semantic_nullability_types`
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.expected
@@ -1,0 +1,21 @@
+==================================== INPUT ====================================
+# Note: No comment here enabling `emit_semantic_nullability_types`
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly name: string | null | undefined;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.graphql
@@ -1,4 +1,4 @@
-# Note: No comment here enabling `emit_semantic_nullability_types`
+# Note: No comment here enabling `experimental_emit_semantic_nullability_types`
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.graphql
@@ -1,0 +1,10 @@
+# Note: No comment here enabling `emit_semantic_nullability_types`
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_required.expected
@@ -1,0 +1,21 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name @required(action: LOG)
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly name: string;
+  readonly " $fragmentType": "MyFragment";
+} | null | undefined;
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_required.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_required.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name @required(action: LOG)
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_required.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_required.graphql
@@ -1,0 +1,10 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name @required(action: LOG)
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_required.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_required.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name @required(action: LOG)
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_resolver.expected
@@ -1,0 +1,24 @@
+==================================== INPUT ====================================
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+    )
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+import clientUserNameResolverType from "bar";
+export type MyFragment$data = {
+  readonly name: ReturnType<typeof clientUserNameResolverType> | null | undefined;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_resolver.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_resolver.expected
@@ -1,5 +1,5 @@
 ==================================== INPUT ====================================
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_resolver.graphql
@@ -1,4 +1,4 @@
-# relay:emit_semantic_nullability_types
+# relay:experimental_emit_semantic_nullability_types
 fragment MyFragment on ClientUser {
   name
 }

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_resolver.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic_non_null_scalar_resolver.graphql
@@ -1,0 +1,12 @@
+# relay:emit_semantic_nullability_types
+fragment MyFragment on ClientUser {
+  name
+}
+
+%extensions%
+
+type ClientUser {
+  name: String @semanticNonNull @relay_resolver(
+      import_path: "./foo/bar.js"
+    )
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
@@ -72,9 +72,9 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
             use_import_type_syntax: fixture
                 .content
                 .contains("# typegen_config.use_import_type_syntax = true"),
-            emit_semantic_nullability_types: fixture
+            experimental_emit_semantic_nullability_types: fixture
                 .content
-                .contains("# relay:emit_semantic_nullability_types"),
+                .contains("# relay:experimental_emit_semantic_nullability_types"),
             ..Default::default()
         },
         feature_flags: Arc::new(FeatureFlags {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/mod.rs
@@ -72,6 +72,9 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
             use_import_type_syntax: fixture
                 .content
                 .contains("# typegen_config.use_import_type_syntax = true"),
+            emit_semantic_nullability_types: fixture
+                .content
+                .contains("# relay:emit_semantic_nullability_types"),
             ..Default::default()
         },
         feature_flags: Arc::new(FeatureFlags {

--- a/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7e6fc749e15ff3be636ff1f6b838a03b>>
+ * @generated SignedSource<<fd50a3d51a0a463eb51919b6c8aa53f8>>
  */
 
 mod generate_typescript;
@@ -395,6 +395,83 @@ async fn scalar_field() {
     let input = include_str!("generate_typescript/fixtures/scalar-field.graphql");
     let expected = include_str!("generate_typescript/fixtures/scalar-field.expected");
     test_fixture(transform_fixture, file!(), "scalar-field.graphql", "generate_typescript/fixtures/scalar-field.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_in_raw_response() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_in_raw_response.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_in_raw_response.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_in_raw_response.graphql", "generate_typescript/fixtures/semantic_non_null_in_raw_response.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_items_in_matrix() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_items_in_matrix.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_items_in_matrix.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_items_in_matrix.graphql", "generate_typescript/fixtures/semantic_non_null_items_in_matrix.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_liked_field_resolver() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_liked_field_resolver.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_liked_field_resolver.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_liked_field_resolver.graphql", "generate_typescript/fixtures/semantic_non_null_liked_field_resolver.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_liked_field_weak_resolver() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_liked_field_weak_resolver.graphql", "generate_typescript/fixtures/semantic_non_null_liked_field_weak_resolver.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_linked_field() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_linked_field.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_linked_field.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_linked_field.graphql", "generate_typescript/fixtures/semantic_non_null_linked_field.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_list_and_list_item() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_list_and_list_item.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_list_and_list_item.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_list_and_list_item.graphql", "generate_typescript/fixtures/semantic_non_null_list_and_list_item.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_list_item() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_list_item.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_list_item.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_list_item.graphql", "generate_typescript/fixtures/semantic_non_null_list_item.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_scalar() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_scalar.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_scalar.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_scalar.graphql", "generate_typescript/fixtures/semantic_non_null_scalar.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_scalar_feature_disabled() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_scalar_feature_disabled.graphql", "generate_typescript/fixtures/semantic_non_null_scalar_feature_disabled.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_scalar_required() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_scalar_required.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_scalar_required.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_scalar_required.graphql", "generate_typescript/fixtures/semantic_non_null_scalar_required.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_scalar_resolver() {
+    let input = include_str!("generate_typescript/fixtures/semantic_non_null_scalar_resolver.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic_non_null_scalar_resolver.expected");
+    test_fixture(transform_fixture, file!(), "semantic_non_null_scalar_resolver.graphql", "generate_typescript/fixtures/semantic_non_null_scalar_resolver.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/schema/src/definitions/mod.rs
+++ b/compiler/crates/schema/src/definitions/mod.rs
@@ -7,6 +7,7 @@
 
 mod interface;
 
+use core::panic;
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
@@ -221,6 +222,34 @@ impl<T: Copy> TypeReference<T> {
         }
     }
 
+    // Given a multi-dimensional list type, return a new type where the level'th nested
+    // list is non-null.
+    pub fn with_non_null_level(&self, level: i64) -> TypeReference<T> {
+        match self {
+            TypeReference::Named(_) => {
+                if level == 0 {
+                    self.non_null()
+                } else {
+                    panic!("Invalid level {} for Named type", level)
+                }
+            }
+            TypeReference::List(of) => {
+                if level == 0 {
+                    self.non_null()
+                } else {
+                    TypeReference::List(Box::new(of.with_non_null_level(level - 1)))
+                }
+            }
+            TypeReference::NonNull(of) => {
+                if level == 0 {
+                    panic!("Invalid level {} for NonNull type", level)
+                } else {
+                    TypeReference::NonNull(Box::new(of.with_non_null_level(level)))
+                }
+            }
+        }
+    }
+
     // If the type is Named or NonNull<Named> return the inner named.
     // If the type is a List or NonNull<List> returns a matching list with nullable items.
     pub fn with_nullable_item_type(&self) -> TypeReference<T> {
@@ -250,6 +279,40 @@ impl<T: Copy> TypeReference<T> {
             TypeReference::NonNull(of) => of.non_list_type(),
         }
     }
+}
+
+// Tests for TypeReference::with_non_null_level
+#[test]
+fn test_with_non_null_level() {
+    let matrix = TypeReference::List(Box::new(TypeReference::List(Box::new(
+        TypeReference::Named(Type::Scalar(ScalarID(0))),
+    ))));
+
+    assert_eq!(
+        matrix.with_non_null_level(0),
+        TypeReference::NonNull(Box::new(TypeReference::List(Box::new(
+            TypeReference::List(Box::new(TypeReference::Named(Type::Scalar(ScalarID(0)))))
+        ))))
+    );
+
+    assert_eq!(
+        matrix.with_non_null_level(1),
+        TypeReference::List(Box::new(TypeReference::NonNull(Box::new(
+            TypeReference::List(Box::new(TypeReference::Named(Type::Scalar(ScalarID(0)))))
+        ))))
+    );
+
+    assert_eq!(
+        matrix.with_non_null_level(0),
+        TypeReference::NonNull(Box::new(TypeReference::List(Box::new(
+            TypeReference::List(Box::new(TypeReference::Named(Type::Scalar(ScalarID(0)))))
+        ))))
+    );
+
+    assert_eq!(
+        TypeReference::Named(Type::Scalar(ScalarID(0))).with_non_null_level(0),
+        TypeReference::NonNull(Box::new(TypeReference::Named(Type::Scalar(ScalarID(0))))),
+    );
 }
 
 impl<T> TypeReference<T> {
@@ -395,6 +458,30 @@ impl Field {
                     .and_then(|reason| reason.value.get_string_literal()),
             })
     }
+    pub fn semantic_type(&self) -> TypeReference<Type> {
+        match self
+            .directives
+            .named(DirectiveName("semanticNonNull".intern()))
+        {
+            Some(directive) => {
+                match directive
+                    .arguments
+                    .named(ArgumentName("levels".intern()))
+                    .map(|levels| levels.expect_int_list())
+                {
+                    Some(levels) => {
+                        let mut type_ = self.type_.clone();
+                        for level in levels {
+                            type_ = type_.with_non_null_level(level);
+                        }
+                        type_
+                    }
+                    None => self.type_.non_null(),
+                }
+            }
+            None => self.type_.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -447,6 +534,24 @@ impl ArgumentValue {
         self.get_string_literal().unwrap_or_else(|| {
             panic!("expected a string literal, got {:?}", self);
         })
+    }
+    /// Return the constant string literal of this value.
+    /// Panics if the value is not a constant string literal.
+    pub fn expect_int_list(&self) -> Vec<i64> {
+        if let ConstantValue::List(list) = &self.value {
+            list.items
+                .iter()
+                .map(|item| {
+                    if let ConstantValue::Int(int) = item {
+                        int.value
+                    } else {
+                        panic!("expected a int literal, got {:?}", item);
+                    }
+                })
+                .collect()
+        } else {
+            panic!("expected a list, got {:?}", self);
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds experimental support for `@semanticNonNull` as described in https://github.com/apollographql/specs/pull/42. Which is part of a broader effort to explore semantic nullability in GraphQL as explored in [RFC: SemanticNonNull type (null only on error) ](https://github.com/graphql/graphql-spec/pull/1065). This directive-based approach should allow us to experiment with the concepts and identify issues as we work to understand the viability of semantic nullability in GraphQL.

## Experimental

As this is still an experimental implementation, it's designed to be minimally invasive rather than ideal in terms of architecture or performance. As the feature/RFCs stabilize I would imagine we would bake this into the schema crate and data structures as a first class concept.

This flag will not be broadly safe to enable in Relay since by default fields that are null due to error are still surfaced to the user. This is only safe to enable if:

1. Your network layer discards all payloads that have any field errors
2. You enable our [explicit error handling feature](https://github.com/facebook/relay/issues/4416), which is still itself experimental.

## Missing Pieces

- [ ] Documentation about how to use this feature (purposeful, since this is experimental)
- [ ] Support for `@semanticNonNullField` which allows a patching an existing type to define it's field's semantic nullability
- [ ] Validation
  - [ ] Invalid use of `levels` will simply panic.
  - [ ] Uses of `@semanticNonNullField` will simply be ignored
  - [ ] There is no schema validation ensuring interface types have type-compatible semantic nullability

## Test Plan

```
cargo test
```

I also spun up a version of [`grats-relay-example`](https://github.com/captbaritone/grats-relay-example) using Grat's [experimental support for `@semanticNonNull`](https://grats.capt.dev/docs/guides/strict-semantic-nullability/) and was able to see it working end to end.

https://github.com/facebook/relay/assets/162735/dc979a58-95f3-4e55-9d9b-577afdd798ca


