### PR TITLE
Refine generated type for assignable fragments on abstract types

### DIFF
--- a/compiler/crates/relay-typegen/src/visit.rs
+++ b/compiler/crates/relay-typegen/src/visit.rs
@@ -799,18 +799,33 @@ fn visit_inline_fragment(
             })]
         } else {
             // If the inline fragment is on an abstract type, its selections must be
-            // made nullable since the type condition may not match, and
-            // there will be no way for the user to refine the type to
-            // ensure it did match. However, inline fragments with @alias are
-            // not subject to this limitation since RelayReader will make the field null
-            // if the type does not match, allowing the user to perform a
-            // field (alias) null check to ensure the type matched.
+            // made nullable since the type condition may not match, and there will be
+            // no way for the user to refine the type to ensure it did match. 
+            //
+            // There is an exception to this rule. If we can prove that the type condition 
+            // will always match, then we can leave the selections as is. This is the case
+            // when the parent object is a member of the type condition union, or it 
+            // implements the type condition interface.
+            // It is safe to assume unconditional conformace, since the only way the type
+            // will not satisfy the type condition is if the interface conformace is removed
+            // or the type is removed from the union, both of which are breaking changes
+            // to the schema.
+            //
+            // Inline fragments with @alias are not subject to this limitation since 
+            // RelayReader will make the field null if the type does not match, allowing the
+            // user to perform a field (alias) null check to ensure the type matched.
             if let Some(type_condition) = inline_fragment.type_condition {
-                for selection in &mut inline_selections {
-                    if type_condition.is_abstract_type() {
-                        selection.set_conditional(true);
-                    } else {
+                if !type_condition.is_abstract_type() {
+                    for selection in &mut inline_selections {
                         selection.set_concrete_type(type_condition);
+                    }
+                } else if !type_condition_always_satisfied(
+                    &typegen_context.schema,
+                    type_condition,
+                    enclosing_linked_field_concrete_type,
+                ) {
+                    for selection in &mut inline_selections {
+                        selection.set_conditional(true);
                     }
                 }
             }
@@ -818,6 +833,29 @@ fn visit_inline_fragment(
             inline_selections
         };
         type_selections.append(&mut selections);
+    }
+}
+
+/// Checks if type_condition is a supertype (union or interface) of the
+/// given enclosing type. If so, we can safely assume that the type condition
+/// will always match, given that removing interface conformance or union
+/// membership is a breaking change anyway.
+fn type_condition_always_satisfied(
+    schema: &SDLSchema,
+    type_condition: Type,
+    enclosing_linked_field_concrete_type: Option<Type>,
+) -> bool {
+    match (type_condition, enclosing_linked_field_concrete_type) {
+        (Type::Interface(interface_id), Some(Type::Object(enclosing_object_id))) => {
+            let enclosing_object = schema.object(enclosing_object_id);
+            enclosing_object.interfaces.contains(&interface_id)
+        }
+        (Type::Union(union_id), Some(Type::Object(enclosing_object_id))) => {
+            let union = schema.union(union_id);
+            union.members.contains(&enclosing_object_id)
+        }
+        (Type::Union(_) | Type::Interface(_), _)  => false,
+        _ => true,
     }
 }
 

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/assignable-conformant-interface-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/assignable-conformant-interface-fragment.expected
@@ -1,0 +1,30 @@
+==================================== INPUT ====================================
+fragment Assignable_feed_unit on FeedUnit @assignable {
+  __typename
+}
+
+fragment StoryFragment on Query {
+  story {
+    ...Assignable_feed_unit
+  }
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+declare export opaque type Assignable_feed_unit$fragmentType: FragmentType;
+-------------------------------------------------------------------------------
+import type { Assignable_feed_unit$fragmentType } from "Assignable_feed_unit.graphql";
+import type { FragmentType } from "relay-runtime";
+declare export opaque type StoryFragment$fragmentType: FragmentType;
+export type StoryFragment$data = {|
+  +story: ?{|
+    +__id: string,
+    +__isAssignable_feed_unit: "Story",
+    +$fragmentSpreads: Assignable_feed_unit$fragmentType,
+  |},
+  +$fragmentType: StoryFragment$fragmentType,
+|};
+export type StoryFragment$key = {
+  +$data?: StoryFragment$data,
+  +$fragmentSpreads: StoryFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/assignable-conformant-interface-fragment.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/assignable-conformant-interface-fragment.graphql
@@ -1,0 +1,9 @@
+fragment Assignable_feed_unit on FeedUnit @assignable {
+  __typename
+}
+
+fragment StoryFragment on Query {
+  story {
+    ...Assignable_feed_unit
+  }
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/assignable-conformant-union-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/assignable-conformant-union-fragment.expected
@@ -1,0 +1,35 @@
+==================================== INPUT ====================================
+fragment Assignable_comment_body on CommentBody @assignable {
+  __typename
+}
+
+fragment CommentFragment on Comment {
+  plainBody {
+    ...Assignable_comment_body
+  }
+}
+
+# %extensions%
+extend type Comment {
+  plainBody: PlainCommentBody
+}
+==================================== OUTPUT ===================================
+import type { FragmentType } from "relay-runtime";
+declare export opaque type Assignable_comment_body$fragmentType: FragmentType;
+-------------------------------------------------------------------------------
+import type { Assignable_comment_body$fragmentType } from "Assignable_comment_body.graphql";
+import type { FragmentType } from "relay-runtime";
+declare export opaque type CommentFragment$fragmentType: FragmentType;
+export type CommentFragment$data = {|
+  +plainBody: ?{|
+    +__id: string,
+    +__isAssignable_comment_body: "PlainCommentBody",
+    +$fragmentSpreads: Assignable_comment_body$fragmentType,
+  |},
+  +$fragmentType: CommentFragment$fragmentType,
+|};
+export type CommentFragment$key = {
+  +$data?: CommentFragment$data,
+  +$fragmentSpreads: CommentFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/assignable-conformant-union-fragment.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/assignable-conformant-union-fragment.graphql
@@ -1,0 +1,14 @@
+fragment Assignable_comment_body on CommentBody @assignable {
+  __typename
+}
+
+fragment CommentFragment on Comment {
+  plainBody {
+    ...Assignable_comment_body
+  }
+}
+
+# %extensions%
+extend type Comment {
+  plainBody: PlainCommentBody
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow_test.rs
@@ -816,3 +816,17 @@ async fn updatable_operation_type_refinement() {
     let expected = include_str!("generate_flow/fixtures/updatable-operation-type-refinement.expected");
     test_fixture(transform_fixture, file!(), "updatable-operation-type-refinement.graphql", "generate_flow/fixtures/updatable-operation-type-refinement.expected", input, expected).await;
 }
+
+#[tokio::test]
+async fn assignable_conformant_union_fragment() {
+    let input = include_str!("generate_flow/fixtures/assignable-conformant-union-fragment.graphql");
+    let expected = include_str!("generate_flow/fixtures/assignable-conformant-union-fragment.expected");
+    test_fixture(transform_fixture, file!(), "assignable-conformant-union-fragment.graphql", "generate_flow/fixtures/assignable-conformant-union-fragment.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn assignable_conformant_interface_fragment() {
+    let input = include_str!("generate_flow/fixtures/assignable-conformant-interface-fragment.graphql");
+    let expected = include_str!("generate_flow/fixtures/assignable-conformant-interface-fragment.expected");
+    test_fixture(transform_fixture, file!(), "assignable-conformant-interface-fragment.graphql", "generate_flow/fixtures/assignable-conformant-interface-fragment.expected", input, expected).await;
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/assignable-conformant-interface-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/assignable-conformant-interface-fragment.expected
@@ -1,0 +1,26 @@
+==================================== INPUT ====================================
+fragment Assignable_feed_unit on FeedUnit @assignable {
+  __typename
+}
+
+fragment StoryFragment on Query {
+  story {
+    ...Assignable_feed_unit
+  }
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+-------------------------------------------------------------------------------
+import { FragmentRefs } from "relay-runtime";
+export type StoryFragment$data = {
+  readonly story: {
+    readonly __id: string;
+    readonly __isAssignable_feed_unit: "Story";
+    readonly " $fragmentSpreads": FragmentRefs<"Assignable_feed_unit">;
+  } | null | undefined;
+  readonly " $fragmentType": "StoryFragment";
+};
+export type StoryFragment$key = {
+  readonly " $data"?: StoryFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"StoryFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/assignable-conformant-interface-fragment.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/assignable-conformant-interface-fragment.graphql
@@ -1,0 +1,9 @@
+fragment Assignable_feed_unit on FeedUnit @assignable {
+  __typename
+}
+
+fragment StoryFragment on Query {
+  story {
+    ...Assignable_feed_unit
+  }
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/assignable-conformant-union-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/assignable-conformant-union-fragment.expected
@@ -1,0 +1,31 @@
+==================================== INPUT ====================================
+fragment Assignable_comment_body on CommentBody @assignable {
+  __typename
+}
+
+fragment CommentFragment on Comment {
+  plainBody {
+    ...Assignable_comment_body
+  }
+}
+
+# %extensions%
+extend type Comment {
+  plainBody: PlainCommentBody
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+-------------------------------------------------------------------------------
+import { FragmentRefs } from "relay-runtime";
+export type CommentFragment$data = {
+  readonly plainBody: {
+    readonly __id: string;
+    readonly __isAssignable_comment_body: "PlainCommentBody";
+    readonly " $fragmentSpreads": FragmentRefs<"Assignable_comment_body">;
+  } | null | undefined;
+  readonly " $fragmentType": "CommentFragment";
+};
+export type CommentFragment$key = {
+  readonly " $data"?: CommentFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"CommentFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/assignable-conformant-union-fragment.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/assignable-conformant-union-fragment.graphql
@@ -1,0 +1,14 @@
+fragment Assignable_comment_body on CommentBody @assignable {
+  __typename
+}
+
+fragment CommentFragment on Comment {
+  plainBody {
+    ...Assignable_comment_body
+  }
+}
+
+# %extensions%
+extend type Comment {
+  plainBody: PlainCommentBody
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
@@ -529,3 +529,18 @@ async fn updatable_operation_type_refinement() {
     let expected = include_str!("generate_typescript/fixtures/updatable-operation-type-refinement.expected");
     test_fixture(transform_fixture, file!(), "updatable-operation-type-refinement.graphql", "generate_typescript/fixtures/updatable-operation-type-refinement.expected", input, expected).await;
 }
+
+#[tokio::test]
+async fn assignable_conformant_union_fragment() {
+    let input = include_str!("generate_typescript/fixtures/assignable-conformant-union-fragment.graphql");
+    let expected = include_str!("generate_typescript/fixtures/assignable-conformant-union-fragment.expected");
+    test_fixture(transform_fixture, file!(), "assignable-conformant-union-fragment.graphql", "generate_typescript/fixtures/assignable-conformant-union-fragment.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn assignable_conformant_interface_fragment() {
+    let input = include_str!("generate_typescript/fixtures/assignable-conformant-interface-fragment.graphql");
+    let expected = include_str!("generate_typescript/fixtures/assignable-conformant-interface-fragment.expected");
+    test_fixture(transform_fixture, file!(), "assignable-conformant-interface-fragment.graphql", "generate_typescript/fixtures/assignable-conformant-interface-fragment.expected", input, expected).await;
+}
+


### PR DESCRIPTION
Closes #4560 

This is quality-of-life change to the type generation for the assignable fragments (aka. typesafe updaters). For the cases where the assignable fragment is defined on the abstract type, and is spread on a concrete implementation of that type. Issue #4560 has a more true-to-life example. But the minimal case is:

```graphql
type A {}
type B {}
union C = A | B

type Query {
  a: A
}

fragment Assignable_c on C @assignable {
  __typename
}

fragment Foo on Query {
  a {
    ...Assignable_c
  }
}
```

_Same applies to the interfaces as well._

Previously, the generated type for fragment `Foo` would include `__isAssignable_c?: "A"` (since the assignable fragment is defined on an abstract type). In some sense, this type is misleading. `__isAssignable_c` can never be undefined, since `A` always implements (is member of) abstract type `C`. This would require writing a [gnarly validator](https://relay.dev/docs/next/guided-tour/updating-data/imperatively-modifying-linked-fields/#introducing-validators). The validator turns out to be redundant in the end, and is just there to satisfy the type system. 

This is a small patch that checks if the abstract type spread is done on the concrete subtype of the supertype (ie. fragment of union `C` is spread its member `A`). If the check is successful, the optionality of `__isAssignable_c?: "A"` is removed. This is a safe assumption, since the only way for `A` not to be a subtype of `C`:
- is to it remove `A` as a member of union `C` (if C is a union)
- or to remove conformance of `A` to the interface `C` (if C is an interface)

[Both of which are breaking schema changes](https://github.com/graphql/graphql-js/blob/9c90a23dd430ba7b9db3d566b084e9f66aded346/src/utilities/findBreakingChanges.ts#L37) anyhow.
