### PR TITLE
Allow diagnosticReportConfig in SingleProjectConfig

### DIFF
--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -726,6 +726,9 @@ pub struct SingleProjectConfigFile {
 
     #[serde(default)]
     pub resolvers_schema_module: Option<ResolversSchemaModuleConfig>,
+
+    #[serde(default)]
+    pub diagnostic_report_config: DiagnosticReportConfig,
 }
 
 impl Default for SingleProjectConfigFile {
@@ -749,6 +752,7 @@ impl Default for SingleProjectConfigFile {
             feature_flags: None,
             module_import_config: Default::default(),
             resolvers_schema_module: Default::default(),
+            diagnostic_report_config: Default::default(),
         }
     }
 }
@@ -854,6 +858,7 @@ impl SingleProjectConfigFile {
             feature_flags: self.feature_flags,
             module_import_config: self.module_import_config,
             resolvers_schema_module: self.resolvers_schema_module,
+            diagnostic_report_config: self.diagnostic_report_config,
             ..Default::default()
         };
 


### PR DESCRIPTION
Although currently, Relay doesn't have diagnostic levels other than `error`. This PR allows `diagnosticReportConfig` to be assigned for a single-project project.

It clears confusion and aligns with multi-project projects.

Fixes #4130