### PR TITLE
fix(docs): add instructions about installing watchman if necessary in the tutorial

### DIFF
--- a/website/docs/tutorial/intro.md
+++ b/website/docs/tutorial/intro.md
@@ -36,6 +36,8 @@ When you run `npm run dev`, several processes are started:
 
 In the terminal output, these three processes’ log output are marked with tags: `[webpack]` in yellow, `[server]` in green, and `[relay]` in blue. Keep a look out for errors marked with `[relay]` as these are helpful if your GraphQL has any mistakes.
 
+If you encounter errors in the `[relay]` process indicating: ```[relay] thread 'main' panicked at 'Cannot run relay in watch mode if `watchman` is not available (or explicitly disabled).'```, this means watchman is not installed or available on your system. To resolve this, you may need to [install watchman separately](https://facebook.github.io/watchman/docs/install). After installing watchman, try running `npm run dev` again.
+
 Now that these processes are running, you should be able to open [http://localhost:3000](http://localhost:3000/) in your browser.
 
 ![Screenshot](/img/docs/tutorial/intro-screenshot-placeholder.png)

--- a/website/versioned_docs/version-v16.0.0/tutorial/intro.md
+++ b/website/versioned_docs/version-v16.0.0/tutorial/intro.md
@@ -36,6 +36,8 @@ When you run `npm run dev`, several processes are started:
 
 In the terminal output, these three processes’ log output are marked with tags: `[webpack]` in yellow, `[server]` in green, and `[relay]` in blue. Keep a look out for errors marked with `[relay]` as these are helpful if your GraphQL has any mistakes.
 
+If you encounter errors in the `[relay]` process indicating: ```[relay] thread 'main' panicked at 'Cannot run relay in watch mode if `watchman` is not available (or explicitly disabled).'```, this means watchman is not installed or available on your system. To resolve this, you may need to [install watchman separately](https://facebook.github.io/watchman/docs/install). After installing watchman, try running `npm run dev` again.
+
 Now that these processes are running, you should be able to open [http://localhost:3000](http://localhost:3000/) in your browser.
 
 ![Screenshot](/img/docs/tutorial/intro-screenshot-placeholder.png)


### PR DESCRIPTION
Address issues like https://github.com/facebook/relay/issues/4301 and https://github.com/facebook/relay/issues/4242

Add instructions for installing watchman to the tutorial.

Testing:
<img width="1308" alt="image" src="https://github.com/facebook/relay/assets/3454734/035b07db-30d0-4867-9246-7c400d8af3bf">
<img width="1323" alt="image" src="https://github.com/facebook/relay/assets/3454734/23d0e393-4144-49e5-8b95-9d306a98e033">
