### PR TITLE
Validate edgeTypeName argument points to an existing type

### DIFF
--- a/compiler/crates/common/src/feature_flags.rs
+++ b/compiler/crates/common/src/feature_flags.rs
@@ -123,6 +123,10 @@ pub struct FeatureFlags {
     /// in @refetchable transform
     #[serde(default)]
     pub prefer_fetchable_in_refetch_queries: bool,
+
+    /// Disable validation of the `edgeTypeName` argument on `@prependNode` and `@appendNode`.
+    #[serde(default)]
+    pub disable_edge_type_name_validation_on_declerative_connection_directives: FeatureFlag,
 }
 
 fn default_as_true() -> bool {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.expected
@@ -7,16 +7,16 @@ mutation appendNodeLiteralEdgeTypeNameInvalidCommentCreateMutation(
 ) {
   commentCreate(input: $input) {
     comment
-      @appendNode(connections: $connections, edgeTypeName: "NonExistentEdgeType") {
+      @appendNode(connections: $connections, edgeTypeName: "CommentEdge") {
       id
     }
   }
 }
 ==================================== ERROR ====================================
-✖︎ Expected the 'edgeTypeName' argument value on @appendNode to be the name of an object type. 'NonExistentEdgeType' does not refer to an object type within the schema.
+✖︎ Expected the 'edgeTypeName' argument value on @appendNode to be the name of an object type. 'CommentEdge' does not refer to a known object type. Did you mean `CommentsEdge`, `Comment`, or `SegmentsEdge`?
 
   append-node-literal-edge-type-name-invalid.graphql:9:60
     8 │     comment
-    9 │       @appendNode(connections: $connections, edgeTypeName: "NonExistentEdgeType") {
-      │                                                            ^^^^^^^^^^^^^^^^^^^^^
+    9 │       @appendNode(connections: $connections, edgeTypeName: "CommentEdge") {
+      │                                                            ^^^^^^^^^^^^^
    10 │       id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.expected
@@ -1,0 +1,22 @@
+==================================== INPUT ====================================
+# expected-to-throw
+
+mutation appendNodeLiteralEdgeTypeNameInvalidCommentCreateMutation(
+  $connections: [ID!]!
+  $input: CommentCreateInput
+) {
+  commentCreate(input: $input) {
+    comment
+      @appendNode(connections: $connections, edgeTypeName: "NonExistentEdgeType") {
+      id
+    }
+  }
+}
+==================================== ERROR ====================================
+✖︎ Expected the 'edgeTypeName' argument value on @appendNode to be the name of an object type. 'NonExistentEdgeType' does not refer to an object type within the schema.
+
+  append-node-literal-edge-type-name-invalid.graphql:9:60
+    8 │     comment
+    9 │       @appendNode(connections: $connections, edgeTypeName: "NonExistentEdgeType") {
+      │                                                            ^^^^^^^^^^^^^^^^^^^^^
+   10 │       id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.graphql
@@ -1,0 +1,13 @@
+# expected-to-throw
+
+mutation appendNodeLiteralEdgeTypeNameInvalidCommentCreateMutation(
+  $connections: [ID!]!
+  $input: CommentCreateInput
+) {
+  commentCreate(input: $input) {
+    comment
+      @appendNode(connections: $connections, edgeTypeName: "NonExistentEdgeType") {
+      id
+    }
+  }
+}

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.graphql
@@ -6,7 +6,7 @@ mutation appendNodeLiteralEdgeTypeNameInvalidCommentCreateMutation(
 ) {
   commentCreate(input: $input) {
     comment
-      @appendNode(connections: $connections, edgeTypeName: "NonExistentEdgeType") {
+      @appendNode(connections: $connections, edgeTypeName: "CommentEdge") {
       id
     }
   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.expected
@@ -13,7 +13,7 @@ mutation appendNodeLiteralEdgeTypeNameNotObjectTypeMutation(
   }
 }
 ==================================== ERROR ====================================
-✖︎ Expected the 'edgeTypeName' argument value on @appendNode to be the name of an object type. 'Node' does not refer to an object type within the schema.
+✖︎ Expected the 'edgeTypeName' argument value on @appendNode to be the name of an object type. 'Node' does not refer to a known object type.
 
   append-node-literal-edge-type-name-not-object-type.graphql:9:60
     8 │     comment

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.expected
@@ -1,0 +1,22 @@
+==================================== INPUT ====================================
+# expected-to-throw
+
+mutation appendNodeLiteralEdgeTypeNameNotObjectTypeMutation(
+  $connections: [ID!]!
+  $input: CommentCreateInput
+) {
+  commentCreate(input: $input) {
+    comment
+      @appendNode(connections: $connections, edgeTypeName: "Node") {
+      id
+    }
+  }
+}
+==================================== ERROR ====================================
+✖︎ Expected the 'edgeTypeName' argument value on @appendNode to be the name of an object type. 'Node' does not refer to an object type within the schema.
+
+  append-node-literal-edge-type-name-not-object-type.graphql:9:60
+    8 │     comment
+    9 │       @appendNode(connections: $connections, edgeTypeName: "Node") {
+      │                                                            ^^^^^^
+   10 │       id

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.graphql
@@ -1,0 +1,13 @@
+# expected-to-throw
+
+mutation appendNodeLiteralEdgeTypeNameNotObjectTypeMutation(
+  $connections: [ID!]!
+  $input: CommentCreateInput
+) {
+  commentCreate(input: $input) {
+    comment
+      @appendNode(connections: $connections, edgeTypeName: "Node") {
+      id
+    }
+  }
+}

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-variable.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-variable.expected
@@ -1,0 +1,177 @@
+==================================== INPUT ====================================
+mutation appendNodeLiteralEdgeTypeNameVariableMutation(
+  $connections: [ID!]!
+  $input: CommentCreateInput
+  $edgeTypeName: String!
+) {
+  commentCreate(input: $input) {
+    comment
+      @appendNode(connections: $connections, edgeTypeName: $edgeTypeName) {
+      id
+    }
+  }
+}
+==================================== OUTPUT ===================================
+{
+  "fragment": {
+    "argumentDefinitions": [
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "connections"
+      },
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "edgeTypeName"
+      },
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "input"
+      }
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "appendNodeLiteralEdgeTypeNameVariableMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "input",
+            "variableName": "input"
+          }
+        ],
+        "concreteType": "CommentCreateResponsePayload",
+        "kind": "LinkedField",
+        "name": "commentCreate",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Comment",
+            "kind": "LinkedField",
+            "name": "comment",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "connections"
+      },
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "input"
+      },
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "edgeTypeName"
+      }
+    ],
+    "kind": "Operation",
+    "name": "appendNodeLiteralEdgeTypeNameVariableMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "input",
+            "variableName": "input"
+          }
+        ],
+        "concreteType": "CommentCreateResponsePayload",
+        "kind": "LinkedField",
+        "name": "commentCreate",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Comment",
+            "kind": "LinkedField",
+            "name": "comment",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "appendNode",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "comment",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              },
+              {
+                "kind": "Variable",
+                "name": "edgeTypeName",
+                "variableName": "edgeTypeName"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c6c4a56d7ea1db74c1935491b7a2e10a",
+    "id": null,
+    "metadata": {},
+    "name": "appendNodeLiteralEdgeTypeNameVariableMutation",
+    "operationKind": "mutation",
+    "text": null
+  }
+}
+
+QUERY:
+
+mutation appendNodeLiteralEdgeTypeNameVariableMutation(
+  $input: CommentCreateInput
+) {
+  commentCreate(input: $input) {
+    comment {
+      id
+    }
+  }
+}

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-variable.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-variable.graphql
@@ -1,0 +1,12 @@
+mutation appendNodeLiteralEdgeTypeNameVariableMutation(
+  $connections: [ID!]!
+  $input: CommentCreateInput
+  $edgeTypeName: String!
+) {
+  commentCreate(input: $input) {
+    comment
+      @appendNode(connections: $connections, edgeTypeName: $edgeTypeName) {
+      id
+    }
+  }
+}

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.expected
@@ -5,7 +5,7 @@ mutation appendNodeLiteralEdgeTypeNameCommentCreateMutation(
 ) {
   commentCreate(input: $input) {
     comment
-      @appendNode(connections: $connections, edgeTypeName: "CommentEdge") {
+      @appendNode(connections: $connections, edgeTypeName: "CommentsEdge") {
       id
     }
   }
@@ -134,7 +134,7 @@ mutation appendNodeLiteralEdgeTypeNameCommentCreateMutation(
               {
                 "kind": "Literal",
                 "name": "edgeTypeName",
-                "value": "CommentEdge"
+                "value": "CommentsEdge"
               }
             ]
           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.graphql
@@ -4,7 +4,7 @@ mutation appendNodeLiteralEdgeTypeNameCommentCreateMutation(
 ) {
   commentCreate(input: $input) {
     comment
-      @appendNode(connections: $connections, edgeTypeName: "CommentEdge") {
+      @appendNode(connections: $connections, edgeTypeName: "CommentsEdge") {
       id
     }
   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8a09ce6acc7e554856ffda29bab1161c>>
+ * @generated SignedSource<<a462cf5b6b402f99514438fe2a6c56fe>>
  */
 
 mod compile_relay_artifacts;
@@ -157,6 +157,13 @@ async fn append_node_literal_edge_type_name_not_object_type() {
     let input = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.expected");
     test_fixture(transform_fixture, file!(), "append-node-literal-edge-type-name-not-object-type.graphql", "compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn append_node_literal_edge_type_name_variable() {
+    let input = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-variable.graphql");
+    let expected = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-variable.expected");
+    test_fixture(transform_fixture, file!(), "append-node-literal-edge-type-name-variable.graphql", "compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-variable.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<baabe93535dccf880b3a7a35bf13244a>>
+ * @generated SignedSource<<8a09ce6acc7e554856ffda29bab1161c>>
  */
 
 mod compile_relay_artifacts;
@@ -150,6 +150,13 @@ async fn append_node_literal_edge_type_name_invalid() {
     let input = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.expected");
     test_fixture(transform_fixture, file!(), "append-node-literal-edge-type-name-invalid.graphql", "compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn append_node_literal_edge_type_name_not_object_type() {
+    let input = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.graphql");
+    let expected = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.expected");
+    test_fixture(transform_fixture, file!(), "append-node-literal-edge-type-name-not-object-type.graphql", "compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-not-object-type.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<742eb57a3eb061bcf247ff05572ac49d>>
+ * @generated SignedSource<<baabe93535dccf880b3a7a35bf13244a>>
  */
 
 mod compile_relay_artifacts;
@@ -143,6 +143,13 @@ async fn append_node_literal_edge_type_name() {
     let input = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.expected");
     test_fixture(transform_fixture, file!(), "append-node-literal-edge-type-name.graphql", "compile_relay_artifacts/fixtures/append-node-literal-edge-type-name.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn append_node_literal_edge_type_name_invalid() {
+    let input = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.graphql");
+    let expected = include_str!("compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.expected");
+    test_fixture(transform_fixture, file!(), "append-node-literal-edge-type-name-invalid.graphql", "compile_relay_artifacts/fixtures/append-node-literal-edge-type-name-invalid.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/relay-transforms/src/apply_transforms.rs
+++ b/compiler/crates/relay-transforms/src/apply_transforms.rs
@@ -392,6 +392,7 @@ fn apply_operation_transforms(
         transform_declarative_connection(
             &program,
             &project_config.schema_config.connection_interface,
+            &project_config.feature_flags,
         )
     })?;
 

--- a/compiler/crates/relay-transforms/src/declarative_connection.rs
+++ b/compiler/crates/relay-transforms/src/declarative_connection.rs
@@ -279,13 +279,15 @@ impl Transformer for DeclarativeConnectionMutationTransform<'_> {
                                 .get_constant()
                                 .and_then(|c| c.get_string_literal())
                             {
-                                let edge_type = self.schema.get_type(edge_typename_value);
+                                let is_not_object_type = self
+                                    .schema
+                                    .get_type(edge_typename_value)
+                                    .map_or(true, |edge_type| !edge_type.is_object());
 
-                                if edge_type.is_none() {
+                                if is_not_object_type {
                                     self.errors.push(Diagnostic::error(
                                         ValidationMessage::InvalidEdgeTypeName {
                                             directive_name: node_directive.name.item,
-                                            field_name: field.alias_or_name(self.schema),
                                             edge_typename: edge_typename_value,
                                         },
                                         edge_typename_arg.value.location,
@@ -427,7 +429,6 @@ enum ValidationMessage {
     )]
     InvalidEdgeTypeName {
         directive_name: DirectiveName,
-        field_name: StringKey,
         edge_typename: StringKey,
     },
 }

--- a/compiler/crates/relay-transforms/src/declarative_connection.rs
+++ b/compiler/crates/relay-transforms/src/declarative_connection.rs
@@ -422,7 +422,9 @@ enum ValidationMessage {
         field_name: StringKey,
         current_type: String,
     },
-    #[error("Expected the 'edgeTypeName' argument value on @{directive_name} to be the name of an object type. '{edge_typename}' does not refer to an object type within the schema.")]
+    #[error(
+        "Expected the 'edgeTypeName' argument value on @{directive_name} to be the name of an object type. '{edge_typename}' does not refer to an object type within the schema."
+    )]
     InvalidEdgeTypeName {
         directive_name: DirectiveName,
         field_name: StringKey,

--- a/compiler/crates/relay-transforms/tests/declarative_connection.rs
+++ b/compiler/crates/relay-transforms/tests/declarative_connection.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use common::FeatureFlags;
 use fixture_tests::Fixture;
 use graphql_test_helpers::apply_transform_for_test;
 use relay_transforms::transform_declarative_connection;
@@ -12,6 +13,10 @@ use relay_transforms::ConnectionInterface;
 
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     apply_transform_for_test(fixture, |program| {
-        transform_declarative_connection(program, &ConnectionInterface::default())
+        transform_declarative_connection(
+            program,
+            &ConnectionInterface::default(),
+            &FeatureFlags::default(),
+        )
     })
 }

--- a/compiler/crates/relay-transforms/tests/declarative_connection/fixtures/append-node-edge-literal.expected
+++ b/compiler/crates/relay-transforms/tests/declarative_connection/fixtures/append-node-edge-literal.expected
@@ -5,7 +5,7 @@ mutation CommentCreateMutation(
 ) {
   commentCreate(input: $input) {
     comment
-      @appendNode(connections: $connections, edgeTypeName: "CommentEdge") {
+      @appendNode(connections: $connections, edgeTypeName: "CommentsEdge") {
       id
     }
   }
@@ -16,7 +16,7 @@ mutation CommentCreateMutation(
   $input: CommentCreateInput
 ) {
   commentCreate(input: $input) {
-    comment @__clientField(key: "", handle: "appendNode", filters: null, dynamicKey_UNSTABLE: null, handleArgs: {connections: $connections, edgeTypeName: "CommentEdge"}) {
+    comment @__clientField(key: "", handle: "appendNode", filters: null, dynamicKey_UNSTABLE: null, handleArgs: {connections: $connections, edgeTypeName: "CommentsEdge"}) {
       id
     }
   }

--- a/compiler/crates/relay-transforms/tests/declarative_connection/fixtures/append-node-edge-literal.graphql
+++ b/compiler/crates/relay-transforms/tests/declarative_connection/fixtures/append-node-edge-literal.graphql
@@ -4,7 +4,7 @@ mutation CommentCreateMutation(
 ) {
   commentCreate(input: $input) {
     comment
-      @appendNode(connections: $connections, edgeTypeName: "CommentEdge") {
+      @appendNode(connections: $connections, edgeTypeName: "CommentsEdge") {
       id
     }
   }


### PR DESCRIPTION
Currently you can input any string for the `edgeTypeName` argument on the `@prependNode` and `@appendNode` directives. 

This change enforces that the value you supply points to an existing object type within the schema.