### PR TITLE
Input fields with defaults shouldn't be required

### DIFF
--- a/compiler/crates/graphql-ir/src/build.rs
+++ b/compiler/crates/graphql-ir/src/build.rs
@@ -1569,7 +1569,7 @@ impl<'schema, 'signatures, 'options> Builder<'schema, 'signatures, 'options> {
         let mut required_fields = type_definition
             .fields
             .iter()
-            .filter(|x| x.type_.is_non_null())
+            .filter(|x| x.type_.is_non_null() && x.default_value.is_none())
             .map(|x| x.name.item.0)
             .collect::<StringKeySet>();
 
@@ -1720,7 +1720,7 @@ impl<'schema, 'signatures, 'options> Builder<'schema, 'signatures, 'options> {
         let mut required_fields = type_definition
             .fields
             .iter()
-            .filter(|x| x.type_.is_non_null())
+            .filter(|x| x.type_.is_non_null() && x.default_value.is_none())
             .map(|x| x.name.item.0)
             .collect::<StringKeySet>();
 

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/argument_with_default.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/argument_with_default.expected
@@ -1,0 +1,103 @@
+==================================== INPUT ====================================
+mutation ArgumentWithDefault {
+  feedbackUnLike(input: {feedbackId: "123"}) {
+    feedback {
+      body {
+        text
+      }
+    }
+  }
+}
+==================================== OUTPUT ===================================
+[
+    Operation(
+        OperationDefinition {
+            kind: Mutation,
+            name: WithLocation {
+                location: argument_with_default.graphql:9:28,
+                item: OperationDefinitionName(
+                    "ArgumentWithDefault",
+                ),
+            },
+            type_: Object(7),
+            variable_definitions: [],
+            directives: [],
+            selections: [
+                LinkedField {
+                    alias: None,
+                    definition: WithLocation {
+                        location: argument_with_default.graphql:33:47,
+                        item: FieldID(41),
+                    },
+                    arguments: [
+                        Argument {
+                            name: WithLocation {
+                                location: argument_with_default.graphql:48:53,
+                                item: ArgumentName(
+                                    "input",
+                                ),
+                            },
+                            value: WithLocation {
+                                location: argument_with_default.graphql:55:74,
+                                item: Constant(
+                                    Object(
+                                        [
+                                            ConstantArgument {
+                                                name: WithLocation {
+                                                    location: argument_with_default.graphql:56:66,
+                                                    item: ArgumentName(
+                                                        "feedbackId",
+                                                    ),
+                                                },
+                                                value: WithLocation {
+                                                    location: argument_with_default.graphql:68:73,
+                                                    item: String(
+                                                        "123",
+                                                    ),
+                                                },
+                                            },
+                                        ],
+                                    ),
+                                ),
+                            },
+                        },
+                    ],
+                    directives: [],
+                    selections: [
+                        LinkedField {
+                            alias: None,
+                            definition: WithLocation {
+                                location: argument_with_default.graphql:82:90,
+                                item: FieldID(168),
+                            },
+                            arguments: [],
+                            directives: [],
+                            selections: [
+                                LinkedField {
+                                    alias: None,
+                                    definition: WithLocation {
+                                        location: argument_with_default.graphql:99:103,
+                                        item: FieldID(138),
+                                    },
+                                    arguments: [],
+                                    directives: [],
+                                    selections: [
+                                        ScalarField {
+                                            alias: None,
+                                            definition: WithLocation {
+                                                location: argument_with_default.graphql:114:118,
+                                                item: FieldID(409),
+                                            },
+                                            arguments: [],
+                                            directives: [],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ),
+]

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/argument_with_default.graphql
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/argument_with_default.graphql
@@ -1,0 +1,9 @@
+mutation ArgumentWithDefault {
+  feedbackUnLike(input: {feedbackId: "123"}) {
+    feedback {
+      body {
+        text
+      }
+    }
+  }
+}

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/variable_with_default.expected
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/variable_with_default.expected
@@ -1,0 +1,134 @@
+==================================== INPUT ====================================
+mutation VariableWithDefault($input: FeedbackUnLikeInput! = { feedbackId: "123"}) {
+  feedbackUnLike(input: $input) {
+    feedback {
+      body {
+        text
+      }
+    }
+  }
+}
+==================================== OUTPUT ===================================
+[
+    Operation(
+        OperationDefinition {
+            kind: Mutation,
+            name: WithLocation {
+                location: variable_with_default.graphql:9:28,
+                item: OperationDefinitionName(
+                    "VariableWithDefault",
+                ),
+            },
+            type_: Object(7),
+            variable_definitions: [
+                VariableDefinition {
+                    name: WithLocation {
+                        location: variable_with_default.graphql:29:35,
+                        item: VariableName(
+                            "input",
+                        ),
+                    },
+                    type_: NonNull(
+                        Named(
+                            InputObject(12),
+                        ),
+                    ),
+                    default_value: Some(
+                        WithLocation {
+                            location: variable_with_default.graphql:58:80,
+                            item: Object(
+                                [
+                                    ConstantArgument {
+                                        name: WithLocation {
+                                            location: variable_with_default.graphql:62:72,
+                                            item: ArgumentName(
+                                                "feedbackId",
+                                            ),
+                                        },
+                                        value: WithLocation {
+                                            location: variable_with_default.graphql:74:79,
+                                            item: String(
+                                                "123",
+                                            ),
+                                        },
+                                    },
+                                ],
+                            ),
+                        },
+                    ),
+                    directives: [],
+                },
+            ],
+            directives: [],
+            selections: [
+                LinkedField {
+                    alias: None,
+                    definition: WithLocation {
+                        location: variable_with_default.graphql:86:100,
+                        item: FieldID(41),
+                    },
+                    arguments: [
+                        Argument {
+                            name: WithLocation {
+                                location: variable_with_default.graphql:101:106,
+                                item: ArgumentName(
+                                    "input",
+                                ),
+                            },
+                            value: WithLocation {
+                                location: variable_with_default.graphql:108:114,
+                                item: Variable(
+                                    Variable {
+                                        name: WithLocation {
+                                            location: variable_with_default.graphql:108:114,
+                                            item: VariableName(
+                                                "input",
+                                            ),
+                                        },
+                                        type_: Named(
+                                            InputObject(12),
+                                        ),
+                                    },
+                                ),
+                            },
+                        },
+                    ],
+                    directives: [],
+                    selections: [
+                        LinkedField {
+                            alias: None,
+                            definition: WithLocation {
+                                location: variable_with_default.graphql:122:130,
+                                item: FieldID(168),
+                            },
+                            arguments: [],
+                            directives: [],
+                            selections: [
+                                LinkedField {
+                                    alias: None,
+                                    definition: WithLocation {
+                                        location: variable_with_default.graphql:139:143,
+                                        item: FieldID(138),
+                                    },
+                                    arguments: [],
+                                    directives: [],
+                                    selections: [
+                                        ScalarField {
+                                            alias: None,
+                                            definition: WithLocation {
+                                                location: variable_with_default.graphql:154:158,
+                                                item: FieldID(409),
+                                            },
+                                            arguments: [],
+                                            directives: [],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ),
+]

--- a/compiler/crates/graphql-ir/tests/parse/fixtures/variable_with_default.graphql
+++ b/compiler/crates/graphql-ir/tests/parse/fixtures/variable_with_default.graphql
@@ -1,0 +1,9 @@
+mutation VariableWithDefault($input: FeedbackUnLikeInput! = { feedbackId: "123"}) {
+  feedbackUnLike(input: $input) {
+    feedback {
+      body {
+        text
+      }
+    }
+  }
+}

--- a/compiler/crates/graphql-ir/tests/parse_test.rs
+++ b/compiler/crates/graphql-ir/tests/parse_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<764976e13835b46a90a081472ca4a403>>
+ * @generated SignedSource<<c35d41452808724ef2c31f8dddea7315>>
  */
 
 mod parse;
@@ -59,6 +59,13 @@ async fn argument_definitions_typo_invalid() {
     let input = include_str!("parse/fixtures/argument_definitions_typo.invalid.graphql");
     let expected = include_str!("parse/fixtures/argument_definitions_typo.invalid.expected");
     test_fixture(transform_fixture, file!(), "argument_definitions_typo.invalid.graphql", "parse/fixtures/argument_definitions_typo.invalid.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn argument_with_default() {
+    let input = include_str!("parse/fixtures/argument_with_default.graphql");
+    let expected = include_str!("parse/fixtures/argument_with_default.expected");
+    test_fixture(transform_fixture, file!(), "argument_with_default.graphql", "parse/fixtures/argument_with_default.expected", input, expected).await;
 }
 
 #[tokio::test]
@@ -626,4 +633,11 @@ async fn unknown_fragment_type_suggestions_invalid() {
     let input = include_str!("parse/fixtures/unknown-fragment-type-suggestions.invalid.graphql");
     let expected = include_str!("parse/fixtures/unknown-fragment-type-suggestions.invalid.expected");
     test_fixture(transform_fixture, file!(), "unknown-fragment-type-suggestions.invalid.graphql", "parse/fixtures/unknown-fragment-type-suggestions.invalid.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn variable_with_default() {
+    let input = include_str!("parse/fixtures/variable_with_default.graphql");
+    let expected = include_str!("parse/fixtures/variable_with_default.expected");
+    test_fixture(transform_fixture, file!(), "variable_with_default.graphql", "parse/fixtures/variable_with_default.expected", input, expected).await;
 }


### PR DESCRIPTION
I added a new non-null input field with a default to a schema I work on, and relay started throwing an error for that field:

```
[ERROR] Error: ✖︎ Missing required fields '["kind"]' of type 'AccessTokenCreateInput'

  app/routes/_dashboard/_personal-account/settings/-access-tokens/token-form.tsx:41:30
   40 │   ) {
   41 │     accessTokenCreate(input: { name: $name, accountId: $accountId }) {
      │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   42 │       ... on AccessTokenCreateSuccess {
```

This seems to go against [the spec which says][1]:

> An input field is required if it has a non-null type and does not have
> a default value. Otherwise, the input object field is optional.

This PR updates the validation code to consider fields with default values as optional, in line with the spec.

I've added some tests for this, though I'm not familiar enough with relay to know whether I'm actually covering both of the cases I've fixed.  Please let me know if there's improvements to be made.

[1]: http://spec.graphql.org/October2021/#sec-Input-Object-Required-Fields