### PR TITLE
Add SchemaDocument go to definition LSP support

### DIFF
--- a/compiler/crates/relay-lsp/src/goto_definition.rs
+++ b/compiler/crates/relay-lsp/src/goto_definition.rs
@@ -31,6 +31,7 @@ use serde::Serialize;
 
 use self::goto_docblock_definition::get_docblock_definition_description;
 use self::goto_graphql_definition::get_graphql_definition_description;
+use self::goto_graphql_definition::get_graphql_schema_definition_description;
 use crate::location::transform_relay_location_on_disk_to_lsp_location;
 use crate::lsp_runtime_error::LSPRuntimeError;
 use crate::lsp_runtime_error::LSPRuntimeResult;
@@ -85,7 +86,9 @@ pub fn on_goto_definition(
         crate::Feature::DocblockIr(docblock_ir) => {
             get_docblock_definition_description(&docblock_ir, position_span)?
         }
-        crate::Feature::SchemaDocument(_) => Err(LSPRuntimeError::ExpectedError)?,
+        crate::Feature::SchemaDocument(document) => {
+            get_graphql_schema_definition_description(document, position_span)?
+        }
     };
 
     let extra_data_provider = state.get_extra_data_provider();


### PR DESCRIPTION
Adds go to definition support for types and directives within a `.graphql` file.