### PR TITLE
Experimental feature to validate composite schema

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1688,6 +1688,7 @@ dependencies = [
  "rustc-hash",
  "schema",
  "schema-diff",
+ "schema-validate-lib",
  "serde",
  "serde_bser",
  "serde_json",

--- a/compiler/crates/common/src/feature_flags.rs
+++ b/compiler/crates/common/src/feature_flags.rs
@@ -104,6 +104,11 @@ pub struct FeatureFlags {
     /// Allow non-nullable return types from resolvers.
     #[serde(default)]
     pub allow_resolver_non_nullable_return_type: FeatureFlag,
+
+    /// Enable validating the composite schema (server, client schema
+    /// extensions, Relay Resolvers) after its built.
+    #[serde(default)]
+    pub enable_experimental_schema_validation: bool,
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize, Default)]

--- a/compiler/crates/relay-compiler/Cargo.toml
+++ b/compiler/crates/relay-compiler/Cargo.toml
@@ -59,6 +59,7 @@ relay-typegen = { path = "../relay-typegen" }
 rustc-hash = "1.1.0"
 schema = { path = "../schema" }
 schema-diff = { path = "../schema-diff" }
+schema-validate-lib = { path = "../schema-validate" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_bser = "0.3"
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts.rs
@@ -124,14 +124,7 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
         enable_resolver_normalization_ast: fixture
             .content
             .contains("# enable_resolver_normalization_ast"),
-        relay_resolvers_allow_legacy_verbose_syntax: FeatureFlag::Disabled,
-        enable_relay_resolver_mutations: false,
-        enable_strict_custom_scalars: false,
-        allow_required_in_mutation_response: FeatureFlag::Disabled,
-        allow_resolvers_in_mutation_response: FeatureFlag::Disabled,
-        disable_resolver_reader_ast: false,
-        enable_fragment_argument_transform: false,
-        allow_resolver_non_nullable_return_type: FeatureFlag::Disabled,
+        ..Default::default()
     };
 
     let default_project_config = ProjectConfig {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_with_custom_id.rs
@@ -94,16 +94,7 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
         enable_fragment_aliases: FeatureFlag::Enabled,
         compact_query_text: FeatureFlag::Disabled,
         emit_normalization_nodes_for_client_edges: true,
-        relay_resolver_enable_interface_output_type: FeatureFlag::Disabled,
-        enable_resolver_normalization_ast: false,
-        relay_resolvers_allow_legacy_verbose_syntax: FeatureFlag::Disabled,
-        enable_relay_resolver_mutations: false,
-        enable_strict_custom_scalars: false,
-        allow_required_in_mutation_response: FeatureFlag::Disabled,
-        allow_resolvers_in_mutation_response: FeatureFlag::Disabled,
-        disable_resolver_reader_ast: false,
-        enable_fragment_argument_transform: false,
-        allow_resolver_non_nullable_return_type: FeatureFlag::Disabled,
+        ..Default::default()
     };
 
     let default_schema_config = SchemaConfig::default();

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_extension.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_extension.expected
@@ -19,7 +19,12 @@ graphql`mutation barMutation {
 
 //- schema.graphql
 
-type Mutation
+type Mutation {
+   some_mutation: Boolean
+}
+type Query {
+   greeting: String
+}
 
 
 //- extensions.graphql

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_extension.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_extension.input
@@ -18,7 +18,12 @@ graphql`mutation barMutation {
 
 //- schema.graphql
 
-type Mutation
+type Mutation {
+   some_mutation: Boolean
+}
+type Query {
+   greeting: String
+}
 
 
 //- extensions.graphql

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_resolver.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_resolver.expected
@@ -22,7 +22,13 @@ graphql`mutation barMutation {
 
 //- schema.graphql
 
-type Mutation
+type Mutation {
+   some_field: Boolean
+}
+
+type Query {
+   some_field: Boolean
+}
 ==================================== OUTPUT ===================================
 //- __generated__/barMutation.graphql.js
 /**

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_resolver.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_resolver.input
@@ -21,4 +21,10 @@ graphql`mutation barMutation {
 
 //- schema.graphql
 
-type Mutation
+type Mutation {
+   some_field: Boolean
+}
+
+type Query {
+   some_field: Boolean
+}

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_resolver_different_mutation_ok.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_resolver_different_mutation_ok.expected
@@ -29,11 +29,17 @@ graphql`mutation barMutation {
 
 //- schema.graphql
 
-type Mutation
+type Mutation {
+   some_field: Boolean
+}
 
-type NotCalledMutation
+type NotCalledMutation {
+   some_field: Boolean
+}
 
-type Query
+type Query {
+   some_field: Boolean
+}
 
 schema {
    query: Query,

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_resolver_different_mutation_ok.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/client_mutation_resolver_different_mutation_ok.input
@@ -28,11 +28,17 @@ graphql`mutation barMutation {
 
 //- schema.graphql
 
-type Mutation
+type Mutation {
+   some_field: Boolean
+}
 
-type NotCalledMutation
+type NotCalledMutation {
+   some_field: Boolean
+}
 
-type Query
+type Query {
+   some_field: Boolean
+}
 
 schema {
    query: Query,

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/live_resolver_implements_interface_field.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/live_resolver_implements_interface_field.expected
@@ -41,7 +41,9 @@ graphql`fragment PersonComponentFragment on IPerson {
 }
 
 //- schema.graphql
-# Empty server schema
+type Query {
+  some_field: Boolean
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/live_resolver_implements_interface_field.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/live_resolver_implements_interface_field.input
@@ -40,7 +40,9 @@ graphql`fragment PersonComponentFragment on IPerson {
 }
 
 //- schema.graphql
-# Empty server schema
+type Query {
+  some_field: Boolean
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface.expected
@@ -38,7 +38,9 @@ graphql`fragment PersonComponentFragment on IPerson {
 }
 
 //- schema.graphql
-# Empty server schema
+type Query {
+  some_field: Boolean
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface.input
@@ -37,7 +37,9 @@ graphql`fragment PersonComponentFragment on IPerson {
 }
 
 //- schema.graphql
-# Empty server schema
+type Query {
+  some_field: Boolean
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type.expected
@@ -36,6 +36,9 @@ graphql`fragment PersonComponentFragment on IPerson {
 }
 
 //- schema.graphql
+type Query {
+  some_field: Boolean
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type.input
@@ -35,6 +35,9 @@ graphql`fragment PersonComponentFragment on IPerson {
 }
 
 //- schema.graphql
+type Query {
+  some_field: Boolean
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type_including_cse.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type_including_cse.expected
@@ -36,6 +36,9 @@ graphql`fragment PersonComponentFragment on IPerson {
 }
 
 //- schema.graphql
+type Query {
+  greeting: String
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type_including_cse.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type_including_cse.input
@@ -35,6 +35,9 @@ graphql`fragment PersonComponentFragment on IPerson {
 }
 
 //- schema.graphql
+type Query {
+  greeting: String
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type_with_root_fragment.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type_with_root_fragment.expected
@@ -38,6 +38,9 @@ graphql`fragment IPersonResolversFragment on IPerson {
 }
 
 //- schema.graphql
+type Query {
+  greeting: String
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type_with_root_fragment.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_strong_model_type_with_root_fragment.input
@@ -37,6 +37,9 @@ graphql`fragment IPersonResolversFragment on IPerson {
 }
 
 //- schema.graphql
+type Query {
+  greeting: String
+}
 
 //- schema-extensions/extension.graphql
 interface IPerson {

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_weak_model_type.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_weak_model_type.expected
@@ -40,9 +40,10 @@ graphql`fragment PersonComponentFragment on IPerson {
 //- schema.graphql
 
 //- schema-extensions/extension.graphql
-interface IPerson {
-  id: ID!
-}
+type Query { me: IPerson }
+
+# Fields to be added later by resolvers
+interface IPerson
 ==================================== OUTPUT ===================================
 //- __generated__/Admin____relay_model_instance.graphql.js
 /**

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_weak_model_type.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_of_all_weak_model_type.input
@@ -39,6 +39,7 @@ graphql`fragment PersonComponentFragment on IPerson {
 //- schema.graphql
 
 //- schema-extensions/extension.graphql
-interface IPerson {
-  id: ID!
-}
+type Query { me: IPerson }
+
+# Fields to be added later by resolvers
+interface IPerson

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_non_nullable.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_non_nullable.expected
@@ -29,6 +29,7 @@ graphql`fragment UserFooFragment on User {
 }
 
 //- schema.graphql
+type Query { me: User }
 type User { name: String }
 ==================================== OUTPUT ===================================
 //- __generated__/ResolversSchemaModule.js

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_non_nullable.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_non_nullable.input
@@ -28,4 +28,5 @@ graphql`fragment UserFooFragment on User {
 }
 
 //- schema.graphql
+type Query { me: User }
 type User { name: String }

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_schema_module.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_schema_module.expected
@@ -28,6 +28,7 @@ graphql`fragment UserFooFragment on User {
 }
 
 //- schema.graphql
+type Query { me: User }
 type User { name: String }
 ==================================== OUTPUT ===================================
 //- __generated__/ResolversSchemaModule.js

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_schema_module.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_schema_module.input
@@ -27,4 +27,5 @@ graphql`fragment UserFooFragment on User {
 }
 
 //- schema.graphql
+type Query { me: User }
 type User { name: String }

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_schema_module_apply_to_normalization_ast.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_schema_module_apply_to_normalization_ast.expected
@@ -29,6 +29,7 @@ graphql`fragment UserFooFragment on User {
 }
 
 //- schema.graphql
+type Query { me: User }
 type User { name: String }
 ==================================== OUTPUT ===================================
 //- __generated__/ResolversSchemaModule.js

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_schema_module_apply_to_normalization_ast.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolvers_schema_module_apply_to_normalization_ast.input
@@ -28,4 +28,5 @@ graphql`fragment UserFooFragment on User {
 }
 
 //- schema.graphql
+type Query { me: User }
 type User { name: String }

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/simple_fragment.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/simple_fragment.expected
@@ -12,6 +12,7 @@ graphql`
 }
 
 //- schema.graphql
+type Query { me: User }
 type User { name: String }
 ==================================== OUTPUT ===================================
 //- __generated__/foo.graphql.ts

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/simple_fragment.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/simple_fragment.input
@@ -11,4 +11,5 @@ graphql`
 }
 
 //- schema.graphql
+type Query { me: User }
 type User { name: String }

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/spread_interface_fragment_on_concrete_type.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/spread_interface_fragment_on_concrete_type.expected
@@ -45,6 +45,9 @@ graphql`fragment SpreadInterfaceFragmentOnConcreteTypeComponentFragment on User 
 //- schema.graphql
 
 //- schema-extensions/extension.graphql
+type Query {
+  me: IPerson
+}
 interface IPerson {
   id: ID!
   name: String

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/spread_interface_fragment_on_concrete_type.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/spread_interface_fragment_on_concrete_type.input
@@ -44,6 +44,9 @@ graphql`fragment SpreadInterfaceFragmentOnConcreteTypeComponentFragment on User 
 //- schema.graphql
 
 //- schema-extensions/extension.graphql
+type Query {
+  me: IPerson
+}
 interface IPerson {
   id: ID!
   name: String

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/typescript_resolver_type_import.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/typescript_resolver_type_import.expected
@@ -20,6 +20,7 @@ graphql`fragment barFragment on User {
 }
 
 //- schema.graphql
+type Query { user: User }
 type User { name: String }
 ==================================== OUTPUT ===================================
 //- __generated__/barFragment.graphql.ts

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/typescript_resolver_type_import.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/typescript_resolver_type_import.input
@@ -19,4 +19,5 @@ graphql`fragment barFragment on User {
 }
 
 //- schema.graphql
+type Query { user: User }
 type User { name: String }

--- a/compiler/crates/schema-validate/src/main.rs
+++ b/compiler/crates/schema-validate/src/main.rs
@@ -13,6 +13,7 @@ use common::DiagnosticsResult;
 use schema::build_schema;
 use schema::SDLSchema;
 use schema_validate_lib::validate;
+use schema_validate_lib::SchemaValidationOptions;
 
 #[derive(Parser)]
 #[clap(name = "schema-validate", about = "Binary to Validate GraphQL Schema.")]
@@ -26,7 +27,12 @@ pub fn main() {
     let opt = Opt::parse();
     match build_schema_from_file(&opt.schema_path) {
         Ok(schema) => {
-            let validation_context = validate(&schema);
+            let validation_context = validate(
+                &schema,
+                SchemaValidationOptions {
+                    allow_introspection_names: false,
+                },
+            );
             if !validation_context.errors.is_empty() {
                 eprintln!(
                     "Schema failed validation with below errors:\n{}",

--- a/compiler/crates/schema-validate/tests/validate_schema.rs
+++ b/compiler/crates/schema-validate/tests/validate_schema.rs
@@ -7,9 +7,15 @@
 
 use fixture_tests::Fixture;
 use schema::build_schema;
-use schema_validate_lib::validate;
+use schema_validate_lib::{validate, SchemaValidationOptions};
 
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
     let schema = build_schema(fixture.content).unwrap();
-    Ok(validate(&schema).print_errors())
+    Ok(validate(
+        &schema,
+        SchemaValidationOptions {
+            allow_introspection_names: false,
+        },
+    )
+    .print_errors())
 }


### PR DESCRIPTION
Currently we do not validate the schema. We assume the schema has been pre-validated. This has been fine historically but with Client Schema Extensions and Relay Resolvers, Relay itself is increasingly contributing GraphQL schema in ways that need to be validated.

This change adds experimental support for validating the schema after it's created. It relies on a pre-existing module generally used for standalone schema validation and has its own scheme for error reporting. Specifically, it does not use Diagnostics which are located at a specific position, but rather derives textual error output itself.

This likely won't play well with out LSP. For now I've added it behind a flag without a real error location. This should let us experiment with the feature and explore how we might update the validation to use Diagnostics directly, or at least be able to.

In some cases the server schema may not actually be persisted to disk, in which case the error reporting approach currently used is likely preferable.

This PR also updates all integration tests with invalid schemas to be valid.