### PR TITLE
Prepare for variable refactorings

### DIFF
--- a/compiler/crates/relay-lsp/src/code_action.rs
+++ b/compiler/crates/relay-lsp/src/code_action.rs
@@ -64,10 +64,10 @@ pub(crate) fn on_code_action(
         text_document: params.text_document,
         position: params.range.start,
     };
-    let (document, position_span) =
+    let (document, location) =
         state.extract_executable_document_from_text(&text_document_position_params, 1)?;
 
-    let path = document.resolve((), position_span);
+    let path = document.resolve((), location.span());
 
     let used_definition_names = get_definition_names(&definitions);
     let result = get_code_actions(path, used_definition_names, uri, params.range)

--- a/compiler/crates/relay-lsp/src/completion.rs
+++ b/compiler/crates/relay-lsp/src/completion.rs
@@ -1312,13 +1312,13 @@ pub fn on_completion(
     params: <Completion as Request>::Params,
 ) -> LSPRuntimeResult<<Completion as Request>::Result> {
     match state.extract_executable_document_from_text(&params.text_document_position, 0) {
-        Ok((document, position_span)) => {
+        Ok((document, location)) => {
             let project_name = state
                 .extract_project_name_from_url(&params.text_document_position.text_document.uri)?;
             let schema = &state.get_schema(&project_name)?;
             let items = resolve_completion_items(
                 document,
-                position_span,
+                location.span(),
                 project_name,
                 schema,
                 state.get_schema_documentation(project_name.lookup()),

--- a/compiler/crates/relay-lsp/src/diagnostic_reporter.rs
+++ b/compiler/crates/relay-lsp/src/diagnostic_reporter.rs
@@ -210,7 +210,7 @@ impl DiagnosticReporter {
             .collect::<Vec<_>>();
 
         Diagnostic {
-            code: None,
+            code: diagnostic.code(),
             data: get_diagnostics_data(diagnostic),
             message: diagnostic.message().to_string(),
             range: text_source.to_span_range(diagnostic.location().span()),

--- a/compiler/crates/relay-lsp/src/find_field_usages.rs
+++ b/compiler/crates/relay-lsp/src/find_field_usages.rs
@@ -31,7 +31,6 @@ use schema::Type;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::location::transform_relay_location_to_lsp_location;
 use crate::server::GlobalState;
 use crate::LSPRuntimeError;
 use crate::LSPRuntimeResult;
@@ -80,13 +79,12 @@ pub fn on_find_field_usages(
 
     let schema = state.get_schema(&schema_name)?;
     let program = state.get_program(&schema_name)?;
-    let root_dir = &state.root_dir();
 
     let ir_locations = get_usages(&program, &schema, type_name, field_name)?;
     let lsp_locations = ir_locations
         .into_iter()
         .map(|(label, ir_location)| {
-            let lsp_location = transform_relay_location_to_lsp_location(root_dir, ir_location)?;
+            let lsp_location = state.get_lsp_location(ir_location)?;
             Ok(FindFieldUsageResultItem {
                 location_uri: lsp_location.uri.to_string(),
                 location_range: lsp_location.range,

--- a/compiler/crates/relay-lsp/src/goto_definition.rs
+++ b/compiler/crates/relay-lsp/src/goto_definition.rs
@@ -69,7 +69,7 @@ pub fn on_goto_definition(
     state: &impl GlobalState,
     params: <GotoDefinition as Request>::Params,
 ) -> LSPRuntimeResult<<GotoDefinition as Request>::Result> {
-    let (feature, position_span) =
+    let (feature, location) =
         state.extract_feature_from_text(&params.text_document_position_params, 1)?;
 
     let project_name = state
@@ -79,10 +79,10 @@ pub fn on_goto_definition(
 
     let definition_description = match feature {
         crate::Feature::GraphQLDocument(document) => {
-            get_graphql_definition_description(document, position_span, &schema)?
+            get_graphql_definition_description(document, location.span(), &schema)?
         }
         crate::Feature::DocblockIr(docblock_ir) => {
-            get_docblock_definition_description(&docblock_ir, position_span)?
+            get_docblock_definition_description(&docblock_ir, location.span())?
         }
     };
 

--- a/compiler/crates/relay-lsp/src/hover.rs
+++ b/compiler/crates/relay-lsp/src/hover.rs
@@ -67,10 +67,10 @@ pub fn on_hover(
     state: &impl GlobalState,
     params: <HoverRequest as Request>::Params,
 ) -> LSPRuntimeResult<<HoverRequest as Request>::Result> {
-    let (document, position_span) =
+    let (document, location) =
         state.extract_executable_document_from_text(&params.text_document_position_params, 1)?;
 
-    let resolution_path = document.resolve((), position_span);
+    let resolution_path = document.resolve((), location.span());
 
     let project_name = state
         .extract_project_name_from_url(&params.text_document_position_params.text_document.uri)?;


### PR DESCRIPTION
Depends on #4509

At the moment all diagnostic fixes are simply replacing what's under the cursor with suggestions from the diagnostic data. In order to support more complex refactorings we need to be able to identify the kind of diagnostic we're dealing with when creating a code action.
This adds `code` to the diagnostic as a way to identify a specific diagnostic we want to act upon. Also when resolving a document you now get access to the full `Location` and not just the position span. This is necessary to later map from modifications done to a document (which consists of relative spans) to a full LSP location.