### PR TITLE
Add code action to create missing fragment argument

### DIFF
--- a/compiler/crates/graphql-ir/src/build.rs
+++ b/compiler/crates/graphql-ir/src/build.rs
@@ -49,6 +49,7 @@ use schema::Type;
 use schema::TypeReference;
 
 use crate::constants::ARGUMENT_DEFINITION;
+use crate::errors::ValidationDiagnosticCode;
 use crate::errors::ValidationMessage;
 use crate::errors::ValidationMessageWithData;
 use crate::ir::*;
@@ -423,10 +424,12 @@ impl<'schema, 'signatures, 'options> Builder<'schema, 'signatures, 'options> {
                 .used_variables
                 .iter()
                 .map(|(undefined_variable, usage)| {
-                    Diagnostic::error(
-                        ValidationMessage::ExpectedOperationVariableToBeDefined(
-                            *undefined_variable,
-                        ),
+                    Diagnostic::error_with_data_and_code(
+                        ValidationDiagnosticCode::EXPECTED_OPERATION_VARIABLE_TO_BE_DEFINED,
+                        ValidationMessageWithData::ExpectedOperationVariableToBeDefined {
+                            variable_name: *undefined_variable,
+                            variable_type: self.schema.get_type_string(&usage.type_),
+                        },
                         self.location.with_span(usage.span),
                     )
                 })

--- a/compiler/crates/graphql-ir/src/errors.rs
+++ b/compiler/crates/graphql-ir/src/errors.rs
@@ -149,9 +149,6 @@ pub enum ValidationMessage {
         next_type: String,
     },
 
-    #[error("Expected variable `${0}` to be defined on the operation")]
-    ExpectedOperationVariableToBeDefined(VariableName),
-
     #[error(
         "Expected argument definition to have an input type (scalar, enum, or input object), found type '{0}'"
     )]
@@ -539,6 +536,13 @@ pub enum ValidationMessage {
     ResolverInMutation,
 }
 
+#[derive(Clone, Debug)]
+pub struct ValidationDiagnosticCode;
+
+impl ValidationDiagnosticCode {
+    pub const EXPECTED_OPERATION_VARIABLE_TO_BE_DEFINED: i32 = 1;
+}
+
 #[derive(
     Clone,
     Debug,
@@ -584,6 +588,12 @@ pub enum ValidationMessageWithData {
         argument_name: StringKey,
         suggestions: Vec<StringKey>,
     },
+
+    #[error("Expected variable `${variable_name}` to be defined on the operation")]
+    ExpectedOperationVariableToBeDefined {
+        variable_name: VariableName,
+        variable_type: String,
+    },
 }
 
 impl WithDiagnosticData for ValidationMessageWithData {
@@ -599,6 +609,13 @@ impl WithDiagnosticData for ValidationMessageWithData {
             ValidationMessageWithData::ExpectedSelectionsOnObjectField { field_name, .. } => {
                 vec![Box::new(format!("{} {{ }}", field_name))]
             }
+            ValidationMessageWithData::ExpectedOperationVariableToBeDefined {
+                variable_name,
+                variable_type,
+            } => vec![
+                Box::new(variable_name.to_owned()),
+                Box::new(variable_type.to_owned()),
+            ],
         }
     }
 }

--- a/compiler/crates/graphql-ir/src/errors.rs
+++ b/compiler/crates/graphql-ir/src/errors.rs
@@ -420,12 +420,6 @@ pub enum ValidationMessage {
     )]
     UnusedIgnoreUnusedVariablesDirective { operation_name: StringKey },
 
-    #[error("Operation '{operation_name}' references undefined variable{variables_string}.")]
-    GlobalVariables {
-        operation_name: StringKey,
-        variables_string: String,
-    },
-
     #[error("Subscription '{subscription_name}' must have a single selection")]
     GenerateSubscriptionNameSingleSelectionItem { subscription_name: StringKey },
 
@@ -541,6 +535,7 @@ pub struct ValidationDiagnosticCode;
 
 impl ValidationDiagnosticCode {
     pub const EXPECTED_OPERATION_VARIABLE_TO_BE_DEFINED: i32 = 1;
+    pub const UNDEFINED_VARIABLE_REFERENCED: i32 = 2;
 }
 
 #[derive(
@@ -594,6 +589,13 @@ pub enum ValidationMessageWithData {
         variable_name: VariableName,
         variable_type: String,
     },
+
+    #[error("Operation '{operation_name}' references undefined variable '${variable_name}'.")]
+    UndefinedVariableReferenced {
+        operation_name: StringKey,
+        variable_name: VariableName,
+        variable_type: String,
+    },
 }
 
 impl WithDiagnosticData for ValidationMessageWithData {
@@ -612,6 +614,14 @@ impl WithDiagnosticData for ValidationMessageWithData {
             ValidationMessageWithData::ExpectedOperationVariableToBeDefined {
                 variable_name,
                 variable_type,
+            } => vec![
+                Box::new(variable_name.to_owned()),
+                Box::new(variable_type.to_owned()),
+            ],
+            ValidationMessageWithData::UndefinedVariableReferenced {
+                variable_name,
+                variable_type,
+                ..
             } => vec![
                 Box::new(variable_name.to_owned()),
                 Box::new(variable_type.to_owned()),

--- a/compiler/crates/graphql-ir/src/lib.rs
+++ b/compiler/crates/graphql-ir/src/lib.rs
@@ -47,6 +47,7 @@ pub use transform::Transformer;
 pub use validator::Validator;
 pub use visitor::Visitor;
 
+pub use crate::errors::ValidationDiagnosticCode;
 pub use crate::errors::ValidationMessage;
 
 /// Re-exported values to be used by the `associated_data_impl!` macro.

--- a/compiler/crates/graphql-ir/src/lib.rs
+++ b/compiler/crates/graphql-ir/src/lib.rs
@@ -49,6 +49,7 @@ pub use visitor::Visitor;
 
 pub use crate::errors::ValidationDiagnosticCode;
 pub use crate::errors::ValidationMessage;
+pub use crate::errors::ValidationMessageWithData;
 
 /// Re-exported values to be used by the `associated_data_impl!` macro.
 pub mod reexport {

--- a/compiler/crates/relay-lsp/src/code_action.rs
+++ b/compiler/crates/relay-lsp/src/code_action.rs
@@ -64,10 +64,10 @@ pub(crate) fn on_code_action(
         text_document: params.text_document,
         position: params.range.start,
     };
-    let (document, position_span) =
+    let (document, location) =
         state.extract_executable_document_from_text(&text_document_position_params, 1)?;
 
-    let path = document.resolve((), position_span);
+    let path = document.resolve((), location.span());
 
     let used_definition_names = get_definition_names(&definitions);
     let result = get_code_actions(path, used_definition_names, uri, params.range)

--- a/compiler/crates/relay-lsp/src/code_action/create_fragment_argument.rs
+++ b/compiler/crates/relay-lsp/src/code_action/create_fragment_argument.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use common::Location;
+use common::Span;
+use docblock_shared::ARGUMENT_DEFINITIONS;
+use lsp_types::CodeAction;
+use lsp_types::CodeActionOrCommand;
+use lsp_types::TextEdit;
+use lsp_types::Url;
+use lsp_types::WorkspaceEdit;
+
+use crate::GlobalState;
+
+pub fn create_fragment_argument_code_action(
+    fragment: &graphql_syntax::FragmentDefinition,
+    variable_name: &str,
+    variable_type: &str,
+    location: &Location,
+    state: &impl GlobalState,
+    url: &Url,
+) -> Option<CodeActionOrCommand> {
+    create_fragment_argument_text_edit(fragment, variable_name, variable_type, location, state).map(
+        |text_edit| {
+            let mut changes = HashMap::new();
+            changes.insert(url.to_owned(), vec![text_edit]);
+
+            CodeActionOrCommand::CodeAction(CodeAction {
+                title: format!("Create fragment argument '${}'", variable_name),
+                kind: Some(lsp_types::CodeActionKind::QUICKFIX),
+                diagnostics: None,
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    document_changes: None,
+                    ..Default::default()
+                }),
+                command: None,
+                is_preferred: Some(true),
+                ..Default::default()
+            })
+        },
+    )
+}
+
+fn create_fragment_argument_text_edit(
+    fragment: &graphql_syntax::FragmentDefinition,
+    variable_name: &str,
+    variable_type: &str,
+    location: &Location,
+    state: &impl GlobalState,
+) -> Option<TextEdit> {
+    if let Some(argument_definitions_directive) = fragment
+        .directives
+        .iter()
+        .find(|directive| directive.name.value == ARGUMENT_DEFINITIONS.0)
+    {
+        argument_definitions_directive
+            .arguments
+            .as_ref()
+            .and_then(|arguments| arguments.items.last())
+            .and_then(|argument| {
+                state
+                    .get_lsp_location(location.with_span(Span {
+                        start: argument.span.end,
+                        end: argument.span.end,
+                    }))
+                    .ok()
+            })
+            .map(|lsp_location| TextEdit {
+                range: lsp_location.range,
+                new_text: format!(
+                    ", {name}: {{ type: \"{type}\" }}",
+                    name = variable_name,
+                    type = variable_type
+                ),
+            })
+    } else {
+        state
+            .get_lsp_location(location.with_span(Span {
+                start: fragment.type_condition.span.end,
+                end: fragment.type_condition.span.end,
+            }))
+            .ok()
+            .map(|lsp_location| TextEdit {
+                range: lsp_location.range,
+                new_text: format!(
+                    " @{directive_name}({name}: {{ type: \"{type}\" }})",
+                    directive_name = ARGUMENT_DEFINITIONS.0,
+                    name = variable_name,
+                    type = variable_type
+                ),
+            })
+    }
+}

--- a/compiler/crates/relay-lsp/src/code_action/create_operation_variable.rs
+++ b/compiler/crates/relay-lsp/src/code_action/create_operation_variable.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+use common::Location;
+use common::Span;
+use lsp_types::CodeAction;
+use lsp_types::CodeActionOrCommand;
+use lsp_types::TextEdit;
+use lsp_types::Url;
+use lsp_types::WorkspaceEdit;
+
+use crate::GlobalState;
+
+pub fn create_operation_variable_code_action(
+    operation: &graphql_syntax::OperationDefinition,
+    variable_name: &str,
+    variable_type: &str,
+    location: &Location,
+    state: &impl GlobalState,
+    url: &Url,
+) -> Option<CodeActionOrCommand> {
+    create_operation_variable_text_edit(operation, variable_name, variable_type, location, state)
+        .map(|text_edit| {
+            let mut changes = HashMap::new();
+            changes.insert(url.to_owned(), vec![text_edit]);
+
+            CodeActionOrCommand::CodeAction(CodeAction {
+                title: format!("Create operation variable '${}'", variable_name),
+                kind: Some(lsp_types::CodeActionKind::QUICKFIX),
+                diagnostics: None,
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    document_changes: None,
+                    ..Default::default()
+                }),
+                command: None,
+                is_preferred: Some(true),
+                ..Default::default()
+            })
+        })
+}
+
+fn create_operation_variable_text_edit(
+    operation: &graphql_syntax::OperationDefinition,
+    variable_name: &str,
+    variable_type: &str,
+    location: &Location,
+    state: &impl GlobalState,
+) -> Option<TextEdit> {
+    if operation.variable_definitions.is_none() {
+        operation
+            .name
+            .and_then(|operation_name| {
+                state
+                    .get_lsp_location(location.with_span(Span {
+                        start: operation_name.span.end,
+                        end: operation_name.span.end,
+                    }))
+                    .ok()
+            })
+            .map(|lsp_location| TextEdit {
+                range: lsp_location.range,
+                new_text: format!(
+                    "(${name}: {type})",
+                    name = variable_name,
+                    type = variable_type
+                ),
+            })
+    } else {
+        operation
+            .variable_definitions
+            .as_ref()
+            .and_then(|variable_definitions| variable_definitions.items.last())
+            .and_then(|last_variable| {
+                state
+                    .get_lsp_location(location.with_span(Span {
+                        start: last_variable.span.end,
+                        end: last_variable.span.end,
+                    }))
+                    .ok()
+            })
+            .map(|lsp_location| TextEdit {
+                range: lsp_location.range,
+                new_text: format!(
+                    ", ${name}: {type}",
+                    name = variable_name,
+                    type = variable_type
+                ),
+            })
+    }
+}

--- a/compiler/crates/relay-lsp/src/completion.rs
+++ b/compiler/crates/relay-lsp/src/completion.rs
@@ -1312,13 +1312,13 @@ pub fn on_completion(
     params: <Completion as Request>::Params,
 ) -> LSPRuntimeResult<<Completion as Request>::Result> {
     match state.extract_executable_document_from_text(&params.text_document_position, 0) {
-        Ok((document, position_span)) => {
+        Ok((document, location)) => {
             let project_name = state
                 .extract_project_name_from_url(&params.text_document_position.text_document.uri)?;
             let schema = &state.get_schema(&project_name)?;
             let items = resolve_completion_items(
                 document,
-                position_span,
+                location.span(),
                 project_name,
                 schema,
                 state.get_schema_documentation(project_name.lookup()),

--- a/compiler/crates/relay-lsp/src/diagnostic_reporter.rs
+++ b/compiler/crates/relay-lsp/src/diagnostic_reporter.rs
@@ -210,7 +210,7 @@ impl DiagnosticReporter {
             .collect::<Vec<_>>();
 
         Diagnostic {
-            code: None,
+            code: diagnostic.code(),
             data: get_diagnostics_data(diagnostic),
             message: diagnostic.message().to_string(),
             range: text_source.to_span_range(diagnostic.location().span()),

--- a/compiler/crates/relay-lsp/src/find_field_usages.rs
+++ b/compiler/crates/relay-lsp/src/find_field_usages.rs
@@ -31,7 +31,6 @@ use schema::Type;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::location::transform_relay_location_to_lsp_location;
 use crate::server::GlobalState;
 use crate::LSPRuntimeError;
 use crate::LSPRuntimeResult;
@@ -80,13 +79,12 @@ pub fn on_find_field_usages(
 
     let schema = state.get_schema(&schema_name)?;
     let program = state.get_program(&schema_name)?;
-    let root_dir = &state.root_dir();
 
     let ir_locations = get_usages(&program, &schema, type_name, field_name)?;
     let lsp_locations = ir_locations
         .into_iter()
         .map(|(label, ir_location)| {
-            let lsp_location = transform_relay_location_to_lsp_location(root_dir, ir_location)?;
+            let lsp_location = state.get_lsp_location(ir_location)?;
             Ok(FindFieldUsageResultItem {
                 location_uri: lsp_location.uri.to_string(),
                 location_range: lsp_location.range,

--- a/compiler/crates/relay-lsp/src/goto_definition.rs
+++ b/compiler/crates/relay-lsp/src/goto_definition.rs
@@ -69,7 +69,7 @@ pub fn on_goto_definition(
     state: &impl GlobalState,
     params: <GotoDefinition as Request>::Params,
 ) -> LSPRuntimeResult<<GotoDefinition as Request>::Result> {
-    let (feature, position_span) =
+    let (feature, location) =
         state.extract_feature_from_text(&params.text_document_position_params, 1)?;
 
     let project_name = state
@@ -79,10 +79,10 @@ pub fn on_goto_definition(
 
     let definition_description = match feature {
         crate::Feature::GraphQLDocument(document) => {
-            get_graphql_definition_description(document, position_span, &schema)?
+            get_graphql_definition_description(document, location.span(), &schema)?
         }
         crate::Feature::DocblockIr(docblock_ir) => {
-            get_docblock_definition_description(&docblock_ir, position_span)?
+            get_docblock_definition_description(&docblock_ir, location.span())?
         }
     };
 

--- a/compiler/crates/relay-lsp/src/hover.rs
+++ b/compiler/crates/relay-lsp/src/hover.rs
@@ -67,10 +67,10 @@ pub fn on_hover(
     state: &impl GlobalState,
     params: <HoverRequest as Request>::Params,
 ) -> LSPRuntimeResult<<HoverRequest as Request>::Result> {
-    let (document, position_span) =
+    let (document, location) =
         state.extract_executable_document_from_text(&params.text_document_position_params, 1)?;
 
-    let resolution_path = document.resolve((), position_span);
+    let resolution_path = document.resolve((), location.span());
 
     let project_name = state
         .extract_project_name_from_url(&params.text_document_position_params.text_document.uri)?;

--- a/compiler/crates/resolution-path/src/lib.rs
+++ b/compiler/crates/resolution-path/src/lib.rs
@@ -196,6 +196,18 @@ pub trait ResolvePosition<'a>: Sized {
     }
 }
 
+pub trait ResolveDefinition {
+    fn find_definition(&self, position_span: Span) -> Option<&ExecutableDefinition>;
+}
+
+impl ResolveDefinition for ExecutableDocument {
+    fn find_definition(&self, position_span: Span) -> Option<&ExecutableDefinition> {
+        self.definitions
+            .iter()
+            .find(|def| def.contains(position_span))
+    }
+}
+
 pub type ExecutableDocumentPath<'a> = Path<&'a ExecutableDocument, ()>;
 
 // Clippy gets grumpy about us passing around `()`, but we need it for consistency with other implementations of `ResolvePosition`.


### PR DESCRIPTION
Depends on #4680

This renames the `GlobalVariables` error to `ExpectedOperationVariableToBeDefined` and emits the error for each problematic variable identifier, instead of a single error for multiple infringements. Also extends the error to include the variable name and type in the diagnostic data. Using this data we create a code action that appends the missing argument with the correct type to the fragment arguments (only using `@argumentDefinitions` for now).
No diagnostic is emitted for orphan fragments that aren't referenced in an operation. I plan on supporting this case and add a refactor for global variables in a later PR.