### PR TITLE
Report require_custom_scalar_types as a diagnostic instead of panicking

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1812,6 +1812,7 @@ dependencies = [
  "docblock-shared",
  "intern",
  "lazy_static",
+ "relay-config",
  "schema",
 ]
 

--- a/compiler/crates/relay-compiler-playground/src/lib.rs
+++ b/compiler/crates/relay-compiler-playground/src/lib.rs
@@ -96,6 +96,7 @@ pub fn parse_to_ir_impl(schema_text: &str, document_text: &str) -> PlaygroundRes
         build_schema_with_extensions(
             &[(schema_text, SourceLocationKey::generated())],
             &Vec::<(&str, SourceLocationKey)>::new(),
+            &Default::default(),
         )
         .map_err(|diagnostics| map_diagnostics(diagnostics, &InputType::Schema(schema_text)))?,
     );
@@ -132,6 +133,7 @@ pub fn parse_to_reader_ast_impl(
         build_schema_with_extensions(
             &[(schema_text, SourceLocationKey::Generated)],
             &Vec::<(&str, SourceLocationKey)>::new(),
+            &Default::default(),
         )
         .map_err(|diagnostics| map_diagnostics(diagnostics, &InputType::Schema(schema_text)))?,
     );
@@ -179,6 +181,7 @@ pub fn parse_to_normalization_ast_impl(
         build_schema_with_extensions(
             &[(schema_text, SourceLocationKey::Generated)],
             &Vec::<(&str, SourceLocationKey)>::new(),
+            &Default::default(),
         )
         .map_err(|diagnostics| map_diagnostics(diagnostics, &InputType::Schema(schema_text)))?,
     );
@@ -225,6 +228,7 @@ pub fn parse_to_types_impl(
         build_schema_with_extensions(
             &[(schema_text, SourceLocationKey::Generated)],
             &Vec::<(&str, SourceLocationKey)>::new(),
+            &Default::default(),
         )
         .map_err(|diagnostics| map_diagnostics(diagnostics, &InputType::Schema(schema_text)))?,
     );
@@ -282,6 +286,7 @@ fn transform_impl(
         build_schema_with_extensions(
             &[(schema_text, SourceLocationKey::Generated)],
             &Vec::<(&str, SourceLocationKey)>::new(),
+            &Default::default(),
         )
         .map_err(|diagnostics| map_diagnostics(diagnostics, &InputType::Schema(schema_text)))?,
     );

--- a/compiler/crates/relay-compiler/src/build_project.rs
+++ b/compiler/crates/relay-compiler/src/build_project.rs
@@ -208,20 +208,13 @@ pub fn build_programs(
     let mut build_mode = if !compiler_state.has_processed_changes() {
         BuildMode::Full
     } else {
-        let project_schema_change = compiler_state.schema_change_safety(
-            log_event,
-            project_name,
-            &project_config.schema_config,
-        );
+        let project_schema_change =
+            compiler_state.schema_change_safety(log_event, project_name, &project_config);
         match project_schema_change {
             SchemaChangeSafety::Unsafe => BuildMode::Full,
             SchemaChangeSafety::Safe | SchemaChangeSafety::SafeWithIncrementalBuild(_) => {
                 let base_schema_change = if let Some(base) = project_config.base {
-                    compiler_state.schema_change_safety(
-                        log_event,
-                        base,
-                        &project_config.schema_config,
-                    )
+                    compiler_state.schema_change_safety(log_event, base, &project_config)
                 } else {
                     SchemaChangeSafety::Safe
                 };

--- a/compiler/crates/relay-compiler/src/build_project/build_schema.rs
+++ b/compiler/crates/relay-compiler/src/build_project/build_schema.rs
@@ -48,8 +48,11 @@ pub fn build_schema(
                     .into_iter()
                     .map(|(schema, location_key)| (schema.as_str(), location_key)),
             );
-            let mut schema =
-                relay_schema::build_schema_with_extensions(&schema_sources, &extensions)?;
+            let mut schema = relay_schema::build_schema_with_extensions(
+                &schema_sources,
+                &extensions,
+                project_config,
+            )?;
 
             if project_config.feature_flags.enable_relay_resolver_transform {
                 extend_schema_with_resolvers(

--- a/compiler/crates/relay-compiler/src/compiler.rs
+++ b/compiler/crates/relay-compiler/src/compiler.rs
@@ -370,8 +370,8 @@ async fn build_projects<TPerfLogger: PerfLogger + 'static>(
             .unwrap_or_else(|| Arc::new(ArtifactMapKind::Unconnected(Default::default())));
         let mut removed_artifact_sources = graphql_asts
             .remove(&project_name)
-            .expect("Expect GraphQLAsts to exist.")
-            .removed_definition_names;
+            .map(|ast| ast.removed_definition_names)
+            .unwrap_or_else(|| Vec::new()); // We may have no js files in this project yet
 
         let removed_docblock_artifact_sources =
             get_removed_docblock_artifact_source_keys(compiler_state.docblocks.get(&project_name));

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/custom_scalar_not_defined_in_config.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/custom_scalar_not_defined_in_config.invalid.expected
@@ -1,0 +1,26 @@
+==================================== INPUT ====================================
+==================================== INPUT ====================================
+//- foo.js
+graphql`
+  fragment foo on Query {
+     greeting
+  }`;
+
+//- relay.config.json
+{
+   "language": "typescript",
+   "schema": "./schema.graphql",
+   "requireCustomScalarTypes": true
+}
+
+//- schema.graphql
+type Query { greeting: MyScalar }
+
+scalar MyScalar # Not present in config
+==================================== OUTPUT ===================================
+✖︎ Expected the JS type for 'MyScalar' to be defined, please update 'customScalarTypes' in your compiler config.
+
+  schema.graphql:3:8
+    2 │ 
+    3 │ scalar MyScalar # Not present in config
+      │        ^^^^^^^^

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/custom_scalar_not_defined_in_config.invalid.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/custom_scalar_not_defined_in_config.invalid.input
@@ -1,0 +1,18 @@
+==================================== INPUT ====================================
+//- foo.js
+graphql`
+  fragment foo on Query {
+     greeting
+  }`;
+
+//- relay.config.json
+{
+   "language": "typescript",
+   "schema": "./schema.graphql",
+   "requireCustomScalarTypes": true
+}
+
+//- schema.graphql
+type Query { greeting: MyScalar }
+
+scalar MyScalar # Not present in config

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/project_with_no_js.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/project_with_no_js.expected
@@ -1,0 +1,10 @@
+==================================== INPUT ====================================
+//- relay.config.json
+{
+   "language": "typescript",
+   "schema": "./schema.graphql"
+}
+
+//- schema.graphql
+type Query { greeting: String }
+==================================== OUTPUT ===================================

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/project_with_no_js.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/project_with_no_js.input
@@ -1,0 +1,8 @@
+//- relay.config.json
+{
+   "language": "typescript",
+   "schema": "./schema.graphql"
+}
+
+//- schema.graphql
+type Query { greeting: String }

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration_test.rs
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f79ec1771e29102c917c2acdb8bdb98d>>
+ * @generated SignedSource<<adeb8226ad6a02ceb0968abce186b942>>
  */
 
 mod relay_compiler_integration;
@@ -45,6 +45,13 @@ async fn client_mutation_resolver_invalid_nonscalar() {
     let input = include_str!("relay_compiler_integration/fixtures/client_mutation_resolver_invalid_nonscalar.input");
     let expected = include_str!("relay_compiler_integration/fixtures/client_mutation_resolver_invalid_nonscalar.expected");
     test_fixture(transform_fixture, file!(), "client_mutation_resolver_invalid_nonscalar.input", "relay_compiler_integration/fixtures/client_mutation_resolver_invalid_nonscalar.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn custom_scalar_not_defined_in_config_invalid() {
+    let input = include_str!("relay_compiler_integration/fixtures/custom_scalar_not_defined_in_config.invalid.input");
+    let expected = include_str!("relay_compiler_integration/fixtures/custom_scalar_not_defined_in_config.invalid.expected");
+    test_fixture(transform_fixture, file!(), "custom_scalar_not_defined_in_config.invalid.input", "relay_compiler_integration/fixtures/custom_scalar_not_defined_in_config.invalid.expected", input, expected).await;
 }
 
 #[tokio::test]
@@ -94,6 +101,13 @@ async fn preloadable_query_typescript() {
     let input = include_str!("relay_compiler_integration/fixtures/preloadable_query_typescript.input");
     let expected = include_str!("relay_compiler_integration/fixtures/preloadable_query_typescript.expected");
     test_fixture(transform_fixture, file!(), "preloadable_query_typescript.input", "relay_compiler_integration/fixtures/preloadable_query_typescript.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn project_with_no_js() {
+    let input = include_str!("relay_compiler_integration/fixtures/project_with_no_js.input");
+    let expected = include_str!("relay_compiler_integration/fixtures/project_with_no_js.expected");
+    test_fixture(transform_fixture, file!(), "project_with_no_js.input", "relay_compiler_integration/fixtures/project_with_no_js.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/relay-lsp/src/server/lsp_state_resources.rs
+++ b/compiler/crates/relay-lsp/src/server/lsp_state_resources.rs
@@ -408,17 +408,13 @@ impl<TPerfLogger: PerfLogger + 'static, TSchemaDocumentation: SchemaDocumentatio
             let project_schema_change = compiler_state.schema_change_safety(
                 log_event,
                 project_config.name,
-                &project_config.schema_config,
+                &project_config,
             );
             match project_schema_change {
                 SchemaChangeSafety::Unsafe => BuildMode::Full,
                 SchemaChangeSafety::Safe | SchemaChangeSafety::SafeWithIncrementalBuild(_) => {
                     let base_schema_change = if let Some(base) = project_config.base {
-                        compiler_state.schema_change_safety(
-                            log_event,
-                            base,
-                            &project_config.schema_config,
-                        )
+                        compiler_state.schema_change_safety(log_event, base, &project_config)
                     } else {
                         SchemaChangeSafety::Safe
                     };

--- a/compiler/crates/relay-schema/Cargo.toml
+++ b/compiler/crates/relay-schema/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 [dependencies]
 common = { path = "../common" }
 docblock-shared = { path = "../docblock-shared" }
+relay-config = { path = "../relay-config" }
 intern = { path = "../intern" }
 lazy_static = "1.4"
 schema = { path = "../schema" }

--- a/compiler/crates/relay-test-schema/src/lib.rs
+++ b/compiler/crates/relay-test-schema/src/lib.rs
@@ -23,7 +23,8 @@ lazy_static! {
     pub static ref TEST_SCHEMA: Arc<SDLSchema> = Arc::new(
         build_schema_with_extensions::<_, &str>(
             &[(TEST_SCHEMA_DATA, SourceLocationKey::generated())],
-            &[]
+            &[],
+            &Default::default(),
         )
         .expect("Expected test schema to be valid")
     );
@@ -33,7 +34,8 @@ lazy_static! {
                 TEST_SCHEMA_WITH_CUSTOM_ID_DATA,
                 SourceLocationKey::generated()
             )],
-            &[]
+            &[],
+            &Default::default(),
         )
         .expect("Expected test schema to be valid")
     );
@@ -55,6 +57,7 @@ pub fn get_test_schema_with_located_extensions(
         build_schema_with_extensions(
             &[(TEST_SCHEMA_DATA, SourceLocationKey::generated())],
             &[(extensions_sdl, source_location)],
+            &Default::default(),
         )
         .expect("Expected test schema (and extensions) to be valid"),
     )
@@ -72,6 +75,7 @@ pub fn get_test_schema_with_custom_id_with_extensions(extensions_sdl: &str) -> A
                 SourceLocationKey::generated(),
             )],
             &[(extensions_sdl, SourceLocationKey::generated())],
+            &Default::default(),
         )
         .expect("Expected test schema (and extensions) to be valid"),
     )

--- a/compiler/crates/relay-typegen/src/visit.rs
+++ b/compiler/crates/relay-typegen/src/visit.rs
@@ -1960,6 +1960,8 @@ fn transform_graphql_scalar_type(
             .typegen_config
             .require_custom_scalar_types
         {
+            // There is a diagnostic in relay-schema which checks this when the schema is built. We should never hit this
+            // condition in practice.
             panic!(
                 "Expected the JS type for '{}' to be defined, please update 'customScalarTypes' in your compiler config.",
                 scalar_name.item

--- a/compiler/crates/schema/src/definitions.rs
+++ b/compiler/crates/schema/src/definitions.rs
@@ -12,6 +12,9 @@ use std::fmt;
 use std::hash::Hash;
 use std::slice::Iter;
 
+use ::intern::intern;
+use ::intern::string_key::Intern;
+use ::intern::string_key::StringKey;
 use common::ArgumentName;
 use common::DirectiveName;
 use common::EnumName;
@@ -26,8 +29,6 @@ use common::WithLocation;
 use graphql_syntax::ConstantValue;
 use graphql_syntax::DirectiveLocation;
 pub use interface::*;
-use intern::string_key::Intern;
-use intern::string_key::StringKey;
 use lazy_static::lazy_static;
 
 use crate::Schema;
@@ -384,6 +385,17 @@ pub struct Scalar {
     pub directives: Vec<DirectiveValue>,
     pub description: Option<StringKey>,
     pub hack_source: Option<StringKey>,
+}
+
+impl Scalar {
+    pub fn is_builtin_type(&self) -> bool {
+        let name = self.name.item.0;
+        name == intern!("String")
+            || name == intern!("Int")
+            || name == intern!("Float")
+            || name == intern!("Boolean")
+            || name == intern!("ID")
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]


### PR DESCRIPTION
Without this change we might panic and crash the compiler/LSP