### PR TITLE
Make schema validation report using diagnostics

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -771,6 +771,7 @@ dependencies = [
  "graphql-test-helpers",
  "graphql-text-printer",
  "intern",
+ "relay-config",
  "relay-test-schema",
  "schema",
  "serde",
@@ -2034,12 +2035,14 @@ dependencies = [
  "common",
  "fixture-tests",
  "fnv",
+ "graphql-cli",
  "intern",
  "lazy_static",
  "log",
  "regex",
  "schema",
  "schema-print",
+ "serde",
  "thiserror",
  "tokio",
 ]
@@ -2438,9 +2441,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes 1.5.0",

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_does_not_pass_schema_validation.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_does_not_pass_schema_validation.invalid.expected
@@ -1,0 +1,64 @@
+==================================== INPUT ====================================
+//- PersonComponent.js
+graphql`fragment PersonComponentFragment on IPerson {
+  name
+}`
+
+//- UserTypeResolvers.js
+/**
+ * @RelayResolver User implements IPerson
+ */
+
+ /**
+  * @RelayResolver User.name: String
+  */
+
+//- AdminTypeResolvers.js
+/**
+ * @RelayResolver Admin implements IPerson
+ */
+
+# Admin should implement name, but does not!
+
+//- relay.config.json
+{
+  "language": "flow",
+  "jsModuleFormat": "haste",
+  "schema": "schema.graphql",
+  "schemaExtensions": [
+    "schema-extensions"
+  ],
+  "featureFlags": {
+    "enable_relay_resolver_transform": true,
+    "enable_resolver_normalization_ast": true,
+    "relay_resolver_enable_interface_output_type": { "kind": "enabled" },
+    "enable_experimental_schema_validation": true
+  }
+}
+
+//- schema.graphql
+type Query {
+  some_field: Boolean
+}
+
+//- schema-extensions/extension.graphql
+interface IPerson {
+  id: ID!
+  name: String
+}
+==================================== OUTPUT ===================================
+✖︎ Interface field 'IPerson.name' expected but 'Admin' does not provide it.
+
+  AdminTypeResolvers.js:2:19
+    1 │ *
+    2 │  * @RelayResolver Admin implements IPerson
+      │                   ^^^^^
+    3 │  
+
+  ℹ︎ The interface field is defined here:
+
+  schema-extensions/extension.graphql:3:3
+    2 │   id: ID!
+    3 │   name: String
+      │   ^^^^
+    4 │ }

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_does_not_pass_schema_validation.invalid.input
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration/fixtures/resolver_on_interface_does_not_pass_schema_validation.invalid.input
@@ -1,0 +1,47 @@
+//- PersonComponent.js
+graphql`fragment PersonComponentFragment on IPerson {
+  name
+}`
+
+//- UserTypeResolvers.js
+/**
+ * @RelayResolver User implements IPerson
+ */
+
+ /**
+  * @RelayResolver User.name: String
+  */
+
+//- AdminTypeResolvers.js
+/**
+ * @RelayResolver Admin implements IPerson
+ */
+
+# Admin should implement name, but does not!
+
+//- relay.config.json
+{
+  "language": "flow",
+  "jsModuleFormat": "haste",
+  "schema": "schema.graphql",
+  "schemaExtensions": [
+    "schema-extensions"
+  ],
+  "featureFlags": {
+    "enable_relay_resolver_transform": true,
+    "enable_resolver_normalization_ast": true,
+    "relay_resolver_enable_interface_output_type": { "kind": "enabled" },
+    "enable_experimental_schema_validation": true
+  }
+}
+
+//- schema.graphql
+type Query {
+  some_field: Boolean
+}
+
+//- schema-extensions/extension.graphql
+interface IPerson {
+  id: ID!
+  name: String
+}

--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration_test.rs
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f5708275a9732c3842b1df840547eac9>>
+ * @generated SignedSource<<acfea8824e445c77070b52df2044f420>>
  */
 
 mod relay_compiler_integration;
@@ -115,6 +115,13 @@ async fn resolver_on_interface() {
     let input = include_str!("relay_compiler_integration/fixtures/resolver_on_interface.input");
     let expected = include_str!("relay_compiler_integration/fixtures/resolver_on_interface.expected");
     test_fixture(transform_fixture, file!(), "resolver_on_interface.input", "relay_compiler_integration/fixtures/resolver_on_interface.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn resolver_on_interface_does_not_pass_schema_validation_invalid() {
+    let input = include_str!("relay_compiler_integration/fixtures/resolver_on_interface_does_not_pass_schema_validation.invalid.input");
+    let expected = include_str!("relay_compiler_integration/fixtures/resolver_on_interface_does_not_pass_schema_validation.invalid.expected");
+    test_fixture(transform_fixture, file!(), "resolver_on_interface_does_not_pass_schema_validation.invalid.input", "relay_compiler_integration/fixtures/resolver_on_interface_does_not_pass_schema_validation.invalid.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/schema-validate/Cargo.toml
+++ b/compiler/crates/schema-validate/Cargo.toml
@@ -17,7 +17,13 @@ name = "schema_validate_test"
 path = "tests/validate_schema_test.rs"
 
 [dependencies]
-clap = { version = "3.2.25", features = ["derive", "env", "regex", "unicode", "wrap_help"] }
+clap = { version = "3.2.25", features = [
+    "derive",
+    "env",
+    "regex",
+    "unicode",
+    "wrap_help",
+] }
 common = { path = "../common" }
 fnv = "1.0"
 intern = { path = "../intern" }
@@ -25,7 +31,9 @@ lazy_static = "1.4"
 log = { version = "0.4.17", features = ["kv_unstable", "kv_unstable_std"] }
 regex = "1.9.2"
 schema = { path = "../schema" }
+graphql-cli = { path = "../graphql-cli" }
 schema-print = { path = "../schema-print" }
+serde = { version = "1.0.185", features = ["derive", "rc"] }
 thiserror = "1.0.49"
 
 [dev-dependencies]

--- a/compiler/crates/schema-validate/src/errors.rs
+++ b/compiler/crates/schema-validate/src/errors.rs
@@ -10,17 +10,15 @@ use common::InterfaceName;
 use common::ObjectName;
 use common::UnionName;
 use intern::string_key::StringKey;
-use schema::Type;
-use schema::TypeReference;
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error, serde::Serialize)]
 pub enum SchemaValidationError {
     #[error("'{0}' root type must be provided.")]
     MissingRootType(StringKey),
 
-    #[error("'{0}' root type must be Object type. Found '{1:?}'")]
-    InvalidRootType(StringKey, Type),
+    #[error("'{0}' root type must be Object type. Found {1}")]
+    InvalidRootType(StringKey, String),
 
     #[error("Name '{0}' must not begin with '__', which is reserved by GraphQL introspection.")]
     InvalidNamePrefix(String),
@@ -37,11 +35,11 @@ pub enum SchemaValidationError {
     #[error("Type must define one or more fields.")]
     TypeWithNoFields,
 
-    #[error("The type of '{0}.{1}' must be Output Type but got: '{2:?}'.")]
-    InvalidFieldType(StringKey, StringKey, TypeReference<Type>),
+    #[error("The type of '{0}.{1}' must be Output Type but got {2}.")]
+    InvalidFieldType(StringKey, StringKey, String),
 
-    #[error("The type of '{0}.{1}({2}:)' must be InputType but got: '{3:?}'.")]
-    InvalidArgumentType(StringKey, StringKey, ArgumentName, TypeReference<Type>),
+    #[error("The type of '{0}.{1}({2}:)' must be InputType but got: {3}.")]
+    InvalidArgumentType(StringKey, StringKey, ArgumentName, String),
 
     #[error("Type '{0}' can only implement '{1}' once.")]
     DuplicateInterfaceImplementation(StringKey, InterfaceName),

--- a/compiler/crates/schema-validate/src/lib.rs
+++ b/compiler/crates/schema-validate/src/lib.rs
@@ -7,12 +7,15 @@
 
 mod errors;
 
-use std::fmt::Write;
 use std::time::Instant;
 
-use common::DirectiveName;
+use common::ArgumentName;
+use common::Diagnostic;
+use common::DiagnosticsResult;
 use common::InterfaceName;
+use common::Location;
 use common::Named;
+use common::WithLocation;
 use errors::*;
 use fnv::FnvHashMap;
 use fnv::FnvHashSet;
@@ -33,8 +36,6 @@ use schema::Type;
 use schema::TypeReference;
 use schema::TypeWithFields;
 use schema::UnionID;
-use schema_print::print_directive;
-use schema_print::print_type;
 
 lazy_static! {
     static ref INTROSPECTION_TYPES: FnvHashSet<StringKey> = vec![
@@ -59,41 +60,41 @@ pub struct SchemaValidationOptions {
     pub allow_introspection_names: bool,
 }
 
-pub fn validate(schema: &SDLSchema, options: SchemaValidationOptions) -> ValidationContext<'_> {
-    let mut validation_context = ValidationContext::new(schema, options);
+pub fn validate(
+    schema: &SDLSchema,
+    default_location: Location,
+    options: SchemaValidationOptions,
+) -> DiagnosticsResult<()> {
+    let mut validation_context = ValidationContext::new(schema, default_location, options);
     validation_context.validate();
-    validation_context
-}
-
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum ValidationContextType {
-    TypeNode(StringKey),
-    DirectiveNode(StringKey),
-    None,
-}
-
-impl ValidationContextType {
-    pub fn type_name(self) -> String {
-        match self {
-            ValidationContextType::DirectiveNode(type_name)
-            | ValidationContextType::TypeNode(type_name) => type_name.lookup().to_string(),
-            _ => "None".to_string(),
-        }
+    if validation_context.diagnostics.is_empty() {
+        Ok(())
+    } else {
+        validation_context
+            .diagnostics
+            .sort_by_key(|diagnostic| diagnostic.location());
+        Err(validation_context.diagnostics)
     }
 }
 
 pub struct ValidationContext<'schema> {
-    pub schema: &'schema SDLSchema,
-    pub options: SchemaValidationOptions,
-    pub errors: FnvHashMap<ValidationContextType, Vec<SchemaValidationError>>,
+    schema: &'schema SDLSchema,
+    default_location: Location,
+    options: SchemaValidationOptions,
+    diagnostics: Vec<Diagnostic>,
 }
 
 impl<'schema> ValidationContext<'schema> {
-    pub fn new(schema: &'schema SDLSchema, options: SchemaValidationOptions) -> Self {
+    pub fn new(
+        schema: &'schema SDLSchema,
+        default_location: Location,
+        options: SchemaValidationOptions,
+    ) -> Self {
         Self {
             schema,
+            default_location,
             options,
-            errors: FnvHashMap::default(),
+            diagnostics: Default::default(),
         }
     }
 
@@ -102,8 +103,9 @@ impl<'schema> ValidationContext<'schema> {
         self.validate_root_types();
         self.validate_directives();
         self.validate_types();
+        // FIXME: Don't print here
         info!("Validated Schema in {}ms", now.elapsed().as_millis());
-        info!("Found {} validation errors", self.errors.len())
+        info!("Found {} validation errors", self.diagnostics.len())
     }
 
     fn validate_root_types(&mut self) {
@@ -115,36 +117,44 @@ impl<'schema> ValidationContext<'schema> {
     fn validate_root_type(&mut self, root_type: Option<Type>, type_name: StringKey) {
         if let Some(type_) = root_type {
             if !type_.is_object() {
-                self.report_error(
-                    SchemaValidationError::InvalidRootType(type_name, type_),
-                    ValidationContextType::TypeNode(type_name),
-                );
+                self.report_diagnostic(Diagnostic::error(
+                    SchemaValidationError::InvalidRootType(
+                        type_name,
+                        type_.get_variant_name().to_string(),
+                    ),
+                    self.get_type_definition_location(type_),
+                ));
             }
         } else if type_name == *QUERY {
-            self.add_error(SchemaValidationError::MissingRootType(type_name));
+            self.diagnostics.push(Diagnostic::error(
+                SchemaValidationError::MissingRootType(type_name),
+                self.default_location,
+            ));
         }
     }
 
     fn validate_directives(&mut self) {
         for directive in self.schema.get_directives() {
-            let context = ValidationContextType::DirectiveNode(directive.name.item.0);
-            self.validate_name(directive.name.item.0, context);
-            let mut arg_names = FnvHashSet::default();
+            self.validate_name(directive.name.item.0, directive.name.location);
+            let mut arg_names: FnvHashMap<ArgumentName, Location> = FnvHashMap::default();
             for argument in directive.arguments.iter() {
-                self.validate_name(argument.name.item.0, context);
+                self.validate_name(argument.name.item.0, argument.name.location);
 
                 // Ensure unique arguments per directive.
-                if arg_names.contains(&argument.name.item) {
-                    self.report_error(
-                        SchemaValidationError::DuplicateArgument(
-                            argument.name.item,
-                            directive.name.item.0,
-                        ),
-                        context,
+                if let Some(prev_loc) = arg_names.get(&argument.name.item) {
+                    self.report_diagnostic(
+                        Diagnostic::error(
+                            SchemaValidationError::DuplicateArgument(
+                                argument.name.item,
+                                directive.name.item.0,
+                            ),
+                            argument.name.location,
+                        )
+                        .annotate("Previously defined here:", *prev_loc),
                     );
                     continue;
                 }
-                arg_names.insert(argument.name.item);
+                arg_names.insert(argument.name.item, argument.name.location);
             }
         }
     }
@@ -154,7 +164,7 @@ impl<'schema> ValidationContext<'schema> {
         for (type_name, type_) in types {
             // Ensure it is named correctly (excluding introspection types).
             if !is_introspection_type(type_, *type_name) {
-                self.validate_name(*type_name, ValidationContextType::TypeNode(*type_name));
+                self.validate_name(*type_name, self.get_type_definition_location(*type_));
             }
             match type_ {
                 Type::Enum(id) => {
@@ -194,69 +204,77 @@ impl<'schema> ValidationContext<'schema> {
     }
 
     fn validate_fields(&mut self, type_name: StringKey, fields: &[FieldID]) {
-        let context = ValidationContextType::TypeNode(type_name);
         // Must define one or more fields.
         if fields.is_empty() {
-            self.report_error(SchemaValidationError::TypeWithNoFields, context)
+            self.report_diagnostic(Diagnostic::error(
+                SchemaValidationError::TypeWithNoFields,
+                self.get_type_definition_location(self.schema.get_type(type_name).unwrap()),
+            ));
         }
 
-        let mut field_names = FnvHashSet::default();
+        let mut field_names: FnvHashMap<StringKey, Location> = FnvHashMap::default();
         for field_id in fields {
             let field = self.schema.field(*field_id);
-            if field_names.contains(&field.name.item) {
-                self.report_error(
-                    SchemaValidationError::DuplicateField(field.name.item),
-                    context,
+            if let Some(field_loc) = field_names.get(&field.name.item) {
+                self.report_diagnostic(
+                    Diagnostic::error(
+                        SchemaValidationError::DuplicateField(field.name.item),
+                        field.name.location,
+                    )
+                    .annotate("Previously defined here:", field_loc.clone()),
                 );
                 continue;
             }
-            field_names.insert(field.name.item);
+            field_names.insert(field.name.item, field.name.location);
 
             // Ensure they are named correctly.
-            self.validate_name(field.name.item, context);
+            self.validate_name(field.name.item, field.name.location);
 
             // Ensure the type is an output type
             if !is_output_type(&field.type_) {
-                self.report_error(
+                self.report_diagnostic(Diagnostic::error(
                     SchemaValidationError::InvalidFieldType(
                         type_name,
                         field.name.item,
-                        field.type_.clone(),
+                        field.type_.inner().get_variant_name().to_string(),
                     ),
-                    context,
-                )
+                    field.name.location,
+                ))
             }
 
-            let mut arg_names = FnvHashSet::default();
+            let mut arg_names: FnvHashMap<ArgumentName, Location> = FnvHashMap::default();
             for argument in field.arguments.iter() {
                 // Ensure they are named correctly.
-                self.validate_name(argument.name.item.0, context);
+                self.validate_name(argument.name.item.0, argument.name.location);
 
                 // Ensure they are unique per field.
                 // Ensure unique arguments per directive.
-                if arg_names.contains(&argument.name.item) {
-                    self.report_error(
-                        SchemaValidationError::DuplicateArgument(
-                            argument.name.item,
-                            field.name.item,
-                        ),
-                        context,
+                if let Some(previous_loc) = arg_names.get(&argument.name.item) {
+                    self.report_diagnostic(
+                        Diagnostic::error(
+                            SchemaValidationError::DuplicateArgument(
+                                argument.name.item,
+                                field.name.item,
+                            ),
+                            field.name.location,
+                        )
+                        .annotate("Previously defined here:", *previous_loc),
                     );
                     continue;
                 }
-                arg_names.insert(argument.name.item);
+                arg_names.insert(argument.name.item, argument.name.location);
 
                 // Ensure the type is an input type
                 if !is_input_type(&argument.type_) {
-                    self.report_error(
+                    self.report_diagnostic(Diagnostic::error(
                         SchemaValidationError::InvalidArgumentType(
                             type_name,
                             field.name.item,
                             argument.name.item,
-                            argument.type_.clone(),
+                            argument.type_.inner().get_variant_name().to_string(),
                         ),
-                        context,
-                    );
+                        argument.name.location, // Note: Schema does not retain location information for argument type reference
+                    ));
                 }
             }
         }
@@ -264,88 +282,97 @@ impl<'schema> ValidationContext<'schema> {
 
     fn validate_union_members(&mut self, id: UnionID) {
         let union = self.schema.union(id);
-        let context = ValidationContextType::TypeNode(union.name.item.0);
         if union.members.is_empty() {
-            self.report_error(
+            self.report_diagnostic(Diagnostic::error(
                 SchemaValidationError::UnionWithNoMembers(union.name.item),
-                context,
-            );
+                union.name.location,
+            ));
         }
 
         let mut member_names = FnvHashSet::default();
         for member in union.members.iter() {
-            let member_name = self.schema.object(*member).name.item;
-            if member_names.contains(&member_name) {
-                self.report_error(SchemaValidationError::DuplicateMember(member_name), context);
+            let member_name = self.schema.object(*member).name;
+            if member_names.contains(&member_name.item) {
+                self.report_diagnostic(Diagnostic::error(
+                    SchemaValidationError::DuplicateMember(member_name.item),
+                    union.name.location, // Schema does not track location of union members
+                ));
                 continue;
             }
-            member_names.insert(member_name);
+            member_names.insert(member_name.item);
         }
     }
 
     fn validate_enum_type(&mut self, id: EnumID) {
         let enum_ = self.schema.enum_(id);
-        let context = ValidationContextType::TypeNode(enum_.name.item.0);
         if enum_.values.is_empty() {
-            self.report_error(SchemaValidationError::EnumWithNoValues, context);
+            self.report_diagnostic(Diagnostic::error(
+                SchemaValidationError::EnumWithNoValues,
+                enum_.name.location,
+            ))
         }
 
         for value in enum_.values.iter() {
             // Ensure valid name.
-            self.validate_name(value.value, context);
+            self.validate_name(value.value, enum_.name.location); // Note: Schema does not have location for enum value
             let value_name = value.value.lookup();
             if value_name == "true" || value_name == "false" || value_name == "null" {
-                self.report_error(
+                self.report_diagnostic(Diagnostic::error(
                     SchemaValidationError::InvalidEnumValue(value.value),
-                    context,
-                );
+                    enum_.name.location, // Schema does not track location information for individual enum values
+                ));
             }
         }
     }
 
     fn validate_input_object_fields(&mut self, id: InputObjectID) {
         let input_object = self.schema.input_object(id);
-        let context = ValidationContextType::TypeNode(input_object.name.item.0);
         if input_object.fields.is_empty() {
-            self.report_error(SchemaValidationError::TypeWithNoFields, context);
+            self.report_diagnostic(Diagnostic::error(
+                SchemaValidationError::TypeWithNoFields,
+                input_object.name.location,
+            ));
         }
 
         // Ensure the arguments are valid
         for field in input_object.fields.iter() {
             // Ensure they are named correctly.
-            self.validate_name(field.name.item.0, context);
+            self.validate_name(field.name.item.0, field.name.location);
 
             // Ensure the type is an input type
             if !is_input_type(&field.type_) {
-                self.report_error(
+                self.report_diagnostic(Diagnostic::error(
                     SchemaValidationError::InvalidArgumentType(
                         input_object.name.item.0,
                         field.name.item.0,
                         field.name.item,
-                        field.type_.clone(),
+                        field.type_.inner().get_variant_name().to_string(),
                     ),
-                    context,
-                );
+                    field.name.location,
+                ));
             }
         }
     }
 
     fn validate_type_with_interfaces<T: TypeWithFields + Named>(&mut self, type_: &T) {
         let typename = type_.name().lookup().intern();
-        let mut interface_names = FnvHashSet::default();
+        let mut interface_names: FnvHashMap<InterfaceName, Location> = FnvHashMap::default();
         for interface_id in type_.interfaces().iter() {
             let interface = self.schema.interface(*interface_id);
-            if interface_names.contains(&interface.name) {
-                self.report_error(
-                    SchemaValidationError::DuplicateInterfaceImplementation(
-                        typename,
-                        interface.name.item,
-                    ),
-                    ValidationContextType::TypeNode(typename),
+            if let Some(prev_loc) = interface_names.get(&interface.name.item) {
+                self.report_diagnostic(
+                    Diagnostic::error(
+                        SchemaValidationError::DuplicateInterfaceImplementation(
+                            typename,
+                            interface.name.item,
+                        ),
+                        interface.name.location,
+                    )
+                    .annotate("Previously defined here:", *prev_loc),
                 );
                 continue;
             }
-            interface_names.insert(interface.name);
+            interface_names.insert(interface.name.item, interface.name.location);
             self.validate_type_implements_interface(type_, interface);
         }
     }
@@ -358,19 +385,24 @@ impl<'schema> ValidationContext<'schema> {
         let typename = type_.name().lookup().intern();
         let object_field_map = self.field_map(type_.fields());
         let interface_field_map = self.field_map(&interface.fields);
-        let context = ValidationContextType::TypeNode(typename);
 
         // Assert each interface field is implemented.
         for (field_name, interface_field) in interface_field_map {
             // Assert interface field exists on object.
             if !object_field_map.contains_key(&field_name) {
-                self.report_error(
-                    SchemaValidationError::InterfaceFieldNotProvided(
-                        interface.name.item,
-                        field_name,
-                        typename,
+                self.report_diagnostic(
+                    Diagnostic::error(
+                        SchemaValidationError::InterfaceFieldNotProvided(
+                            interface.name.item,
+                            field_name,
+                            typename,
+                        ),
+                        *type_.location(),
+                    )
+                    .annotate(
+                        "The interface field is defined here:",
+                        interface_field.name.location,
                     ),
-                    context,
                 );
                 continue;
             }
@@ -382,15 +414,21 @@ impl<'schema> ValidationContext<'schema> {
                 .schema
                 .is_type_subtype_of(&object_field.type_, &interface_field.type_)
             {
-                self.report_error(
-                    SchemaValidationError::NotASubType(
-                        interface.name.item,
-                        field_name,
-                        self.schema.get_type_name(interface_field.type_.inner()),
-                        typename,
-                        self.schema.get_type_name(object_field.type_.inner()),
+                self.report_diagnostic(
+                    Diagnostic::error(
+                        SchemaValidationError::NotASubType(
+                            interface.name.item,
+                            field_name,
+                            self.schema.get_type_name(interface_field.type_.inner()),
+                            typename,
+                            self.schema.get_type_name(object_field.type_.inner()),
+                        ),
+                        object_field.name.location,
+                    )
+                    .annotate(
+                        "The interface field is defined here:",
+                        interface_field.name.location,
                     ),
-                    context,
                 );
             }
 
@@ -403,14 +441,20 @@ impl<'schema> ValidationContext<'schema> {
 
                 // Assert interface field arg exists on object field.
                 if object_argument.is_none() {
-                    self.report_error(
-                        SchemaValidationError::InterfaceFieldArgumentNotProvided(
-                            interface.name.item,
-                            field_name,
-                            interface_argument.name.item,
-                            typename,
+                    self.report_diagnostic(
+                        Diagnostic::error(
+                            SchemaValidationError::InterfaceFieldArgumentNotProvided(
+                                interface.name.item,
+                                field_name,
+                                interface_argument.name.item,
+                                typename,
+                            ),
+                            object_field.name.location,
+                        )
+                        .annotate(
+                            "The interface field argument is defined here:",
+                            interface_argument.name.location,
                         ),
-                        context,
                     );
                     continue;
                 }
@@ -420,16 +464,22 @@ impl<'schema> ValidationContext<'schema> {
                 // (invariant)
                 // TODO: change to contravariant?
                 if interface_argument.type_ != object_argument.type_ {
-                    self.report_error(
-                        SchemaValidationError::NotEqualType(
-                            interface.name.item,
-                            field_name,
-                            interface_argument.name.item,
-                            self.schema.get_type_name(interface_argument.type_.inner()),
-                            typename,
-                            self.schema.get_type_name(object_argument.type_.inner()),
+                    self.report_diagnostic(
+                        Diagnostic::error(
+                            SchemaValidationError::NotEqualType(
+                                interface.name.item,
+                                field_name,
+                                interface_argument.name.item,
+                                self.schema.get_type_name(interface_argument.type_.inner()),
+                                typename,
+                                self.schema.get_type_name(object_argument.type_.inner()),
+                            ),
+                            object_argument.name.location,
+                        )
+                        .annotate(
+                            "The interface field argument is defined here:",
+                            interface_argument.name.location,
                         ),
-                        context,
                     );
                 }
                 // TODO: validate default values?
@@ -442,14 +492,20 @@ impl<'schema> ValidationContext<'schema> {
                     .contains(object_argument.name.item.0)
                     && object_argument.type_.is_non_null()
                 {
-                    self.report_error(
-                        SchemaValidationError::MissingRequiredArgument(
-                            typename,
-                            field_name,
-                            object_argument.name.item,
-                            interface.name.item,
+                    self.report_diagnostic(
+                        Diagnostic::error(
+                            SchemaValidationError::MissingRequiredArgument(
+                                typename,
+                                field_name,
+                                object_argument.name.item,
+                                interface.name.item,
+                            ),
+                            object_argument.name.location,
+                        )
+                        .annotate(
+                            "The interface field is define here:",
+                            interface_field.name.location,
                         ),
-                        context,
                     );
                 }
             }
@@ -466,17 +522,22 @@ impl<'schema> ValidationContext<'schema> {
                 &mut path,
                 &mut visited,
             ) {
-                self.report_error(
+                let mut diagnostic = Diagnostic::error(
                     SchemaValidationError::CyclicInterfaceInheritance(format!(
                         "{}->{}",
                         path.iter()
-                            .map(|name| name.lookup())
+                            .map(|name| name.item.lookup())
                             .collect::<Vec<_>>()
                             .join("->"),
                         interface.name.item
                     )),
-                    ValidationContextType::TypeNode(interface.name.item.0),
+                    interface.name.location,
                 );
+
+                for name in path.iter().rev() {
+                    diagnostic = diagnostic.annotate("->", name.location);
+                }
+                self.report_diagnostic(diagnostic);
                 return true;
             }
         }
@@ -487,7 +548,7 @@ impl<'schema> ValidationContext<'schema> {
         &self,
         root: &Interface,
         target: InterfaceName,
-        path: &mut Vec<StringKey>,
+        path: &mut Vec<WithLocation<InterfaceName>>,
         visited: &mut FnvHashSet<StringKey>,
     ) -> bool {
         if visited.contains(&root.name.item.0) {
@@ -498,7 +559,7 @@ impl<'schema> ValidationContext<'schema> {
             return true;
         }
 
-        path.push(root.name.item.0);
+        path.push(root.name);
         visited.insert(root.name.item.0);
         for id in root.interfaces() {
             if self.has_path(self.schema.interface(*id), target, path, visited) {
@@ -509,24 +570,24 @@ impl<'schema> ValidationContext<'schema> {
         false
     }
 
-    fn validate_name(&mut self, name: StringKey, context: ValidationContextType) {
+    fn validate_name(&mut self, name: StringKey, location: Location) {
         let name = name.lookup();
 
         if !self.options.allow_introspection_names {
             let mut chars = name.chars();
             if name.len() > 1 && chars.next() == Some('_') && chars.next() == Some('_') {
-                self.report_error(
+                self.report_diagnostic(Diagnostic::error(
                     SchemaValidationError::InvalidNamePrefix(name.to_string()),
-                    context,
-                );
+                    location,
+                ));
             }
         }
 
         if !TYPE_NAME_REGEX.is_match(name) {
-            self.report_error(
+            self.report_diagnostic(Diagnostic::error(
                 SchemaValidationError::InvalidName(name.to_string()),
-                context,
-            );
+                location,
+            ));
         }
     }
 
@@ -538,57 +599,19 @@ impl<'schema> ValidationContext<'schema> {
             .collect::<FnvHashMap<_, _>>()
     }
 
-    fn report_error(&mut self, error: SchemaValidationError, context: ValidationContextType) {
-        self.errors
-            .entry(context)
-            .or_insert_with(Vec::new)
-            .push(error);
+    fn report_diagnostic(&mut self, diagnostic: Diagnostic) {
+        self.diagnostics.push(diagnostic);
     }
 
-    fn add_error(&mut self, error: SchemaValidationError) {
-        self.report_error(error, ValidationContextType::None);
-    }
-
-    pub fn print_errors(&self) -> String {
-        let mut builder: String = String::new();
-        let mut contexts: Vec<_> = self.errors.keys().collect();
-        contexts.sort_by_key(|context| context.type_name());
-        for context in contexts {
-            match context {
-                ValidationContextType::None => writeln!(builder, "Errors:").unwrap(),
-                ValidationContextType::TypeNode(type_name) => writeln!(
-                    builder,
-                    "Type {} with definition:\n\t{}\nhad errors:",
-                    type_name,
-                    print_type(self.schema, self.schema.get_type(*type_name).unwrap()).trim_end()
-                )
-                .unwrap(),
-                ValidationContextType::DirectiveNode(directive_name) => writeln!(
-                    builder,
-                    "Directive {} with definition:\n\t{}\nhad errors:",
-                    directive_name,
-                    print_directive(
-                        self.schema,
-                        self.schema
-                            .get_directive(DirectiveName(*directive_name))
-                            .unwrap()
-                    )
-                    .trim_end()
-                )
-                .unwrap(),
-            }
-            let mut error_strings = self
-                .errors
-                .get(context)
-                .unwrap()
-                .iter()
-                .map(|error| format!("\t* {}", error))
-                .collect::<Vec<_>>();
-            error_strings.sort();
-            writeln!(builder, "{}", error_strings.join("\n")).unwrap();
-            writeln!(builder).unwrap();
+    fn get_type_definition_location(&self, type_: Type) -> Location {
+        match type_ {
+            Type::Enum(id) => self.schema.enum_(id).name.location,
+            Type::InputObject(id) => self.schema.input_object(id).name.location,
+            Type::Interface(id) => self.schema.interface(id).name.location,
+            Type::Object(id) => self.schema.object(id).name.location,
+            Type::Scalar(id) => self.schema.scalar(id).name.location,
+            Type::Union(id) => self.schema.union(id).name.location,
         }
-        builder
     }
 }
 

--- a/compiler/crates/schema-validate/test_schema.graphql
+++ b/compiler/crates/schema-validate/test_schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+    oops
+}

--- a/compiler/crates/schema-validate/tests/validate_schema.rs
+++ b/compiler/crates/schema-validate/tests/validate_schema.rs
@@ -5,18 +5,44 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use common::Location;
+use common::SourceLocationKey;
+use common::Span;
+use common::TextSource;
 use fixture_tests::Fixture;
-use schema::build_schema;
+use graphql_cli::DiagnosticPrinter;
+use schema::build_schema_with_extensions;
 use schema_validate_lib::validate;
 use schema_validate_lib::SchemaValidationOptions;
 
 pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> {
-    let schema = build_schema(fixture.content).unwrap();
-    Ok(validate(
-        &schema,
-        SchemaValidationOptions {
-            allow_introspection_names: false,
-        },
+    let result = build_schema_with_extensions::<&str, &str>(
+        &[(
+            fixture.content,
+            SourceLocationKey::standalone(fixture.file_name),
+        )],
+        &[],
     )
-    .print_errors())
+    .and_then(|schema| {
+        let default_location = Location::new(
+            SourceLocationKey::standalone(fixture.file_name),
+            Span::empty(),
+        );
+        validate(
+            &schema,
+            default_location,
+            SchemaValidationOptions {
+                allow_introspection_names: false,
+            },
+        )
+    });
+    match result {
+        Ok(_) => Ok("OK".to_string()),
+        Err(diagnostics) => {
+            let printer = DiagnosticPrinter::new(|_| {
+                Some(TextSource::from_whole_document(fixture.content.to_string()))
+            });
+            Ok(printer.diagnostics_to_string(&diagnostics))
+        }
+    }
 }

--- a/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_directives.expected
+++ b/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_directives.expected
@@ -30,23 +30,57 @@ type Query {
   user: Human
 }
 ==================================== OUTPUT ===================================
-Directive __fetchable with definition:
-	directive @__fetchable(field_name: String) on OBJECT
-had errors:
-	* Name '__fetchable' must not begin with '__', which is reserved by GraphQL introspection.
+✖︎ Name '__fetchable' must not begin with '__', which is reserved by GraphQL introspection.
 
-Directive __fetchableOther with definition:
-	directive @__fetchableOther(field_name: String, field_name: Int) on OBJECT
-had errors:
-	* Duplicate argument 'field_name' found on field/directive '__fetchableOther'.
-	* Name '__fetchableOther' must not begin with '__', which is reserved by GraphQL introspection.
+  validate_directives.graphql:1:12
+    1 │ directive @__fetchable(field_name: String) on OBJECT
+      │            ^^^^^^^^^^^
+    2 │ 
 
-Directive fetchable with definition:
-	directive @fetchable(__field_name: String) on OBJECT
-had errors:
-	* Name '__field_name' must not begin with '__', which is reserved by GraphQL introspection.
+✖︎ Name '__field_name' must not begin with '__', which is reserved by GraphQL introspection.
 
-Directive fetchableOther with definition:
-	directive @fetchableOther(field_name: String, field_name: Int) on OBJECT
-had errors:
-	* Duplicate argument 'field_name' found on field/directive 'fetchableOther'.
+  validate_directives.graphql:3:22
+    2 │ 
+    3 │ directive @fetchable(__field_name: String) on OBJECT
+      │                      ^^^^^^^^^^^^
+    4 │ 
+
+✖︎ Duplicate argument 'field_name' found on field/directive 'fetchableOther'.
+
+  validate_directives.graphql:5:47
+    4 │ 
+    5 │ directive @fetchableOther(field_name: String, field_name: Int) on OBJECT
+      │                                               ^^^^^^^^^^
+    6 │ 
+
+  ℹ︎ Previously defined here:
+
+  validate_directives.graphql:5:27
+    4 │ 
+    5 │ directive @fetchableOther(field_name: String, field_name: Int) on OBJECT
+      │                           ^^^^^^^^^^
+    6 │ 
+
+✖︎ Name '__fetchableOther' must not begin with '__', which is reserved by GraphQL introspection.
+
+  validate_directives.graphql:7:12
+    6 │ 
+    7 │ directive @__fetchableOther(field_name: String, field_name: Int) on OBJECT
+      │            ^^^^^^^^^^^^^^^^
+    8 │ 
+
+✖︎ Duplicate argument 'field_name' found on field/directive '__fetchableOther'.
+
+  validate_directives.graphql:7:49
+    6 │ 
+    7 │ directive @__fetchableOther(field_name: String, field_name: Int) on OBJECT
+      │                                                 ^^^^^^^^^^
+    8 │ 
+
+  ℹ︎ Previously defined here:
+
+  validate_directives.graphql:7:29
+    6 │ 
+    7 │ directive @__fetchableOther(field_name: String, field_name: Int) on OBJECT
+      │                             ^^^^^^^^^^
+    8 │

--- a/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_enum.expected
+++ b/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_enum.expected
@@ -38,18 +38,34 @@ enum InvlidPetType {
   null
 }
 ==================================== OUTPUT ===================================
-Type EmptyPetType with definition:
-	enum EmptyPetType
-had errors:
-	* Enum must define one or more values.
+✖︎ Enum must define one or more values.
 
-Type InvlidPetType with definition:
-	enum InvlidPetType {
-  true
-  false
-  null
-}
-had errors:
-	* Enum cannot include value: false.
-	* Enum cannot include value: null.
-	* Enum cannot include value: true.
+  validate_enum.graphql:32:6
+   31 │ 
+   32 │ enum EmptyPetType
+      │      ^^^^^^^^^^^^
+   33 │ 
+
+✖︎ Enum cannot include value: true.
+
+  validate_enum.graphql:34:6
+   33 │ 
+   34 │ enum InvlidPetType {
+      │      ^^^^^^^^^^^^^
+   35 │   true
+
+✖︎ Enum cannot include value: false.
+
+  validate_enum.graphql:34:6
+   33 │ 
+   34 │ enum InvlidPetType {
+      │      ^^^^^^^^^^^^^
+   35 │   true
+
+✖︎ Enum cannot include value: null.
+
+  validate_enum.graphql:34:6
+   33 │ 
+   34 │ enum InvlidPetType {
+      │      ^^^^^^^^^^^^^
+   35 │   true

--- a/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_interface_implements_interface_cyclic.expected
+++ b/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_interface_implements_interface_cyclic.expected
@@ -32,39 +32,149 @@ type Query {
   image: Image
 }
 ==================================== OUTPUT ===================================
-Type BaseNode with definition:
-	interface BaseNode implements BaseNode2 {
-  id: ID!
-}
-had errors:
-	* Cyclic reference found for interface inheritance: BaseNode2->BaseNode1->Resource->Node->BaseNode.
+✖︎ Cyclic reference found for interface inheritance: BaseNode2->BaseNode1.
 
-Type BaseNode1 with definition:
-	interface BaseNode1 implements BaseNode2 & Resource {
-  id: ID!
-}
-had errors:
-	* Cyclic reference found for interface inheritance: BaseNode2->BaseNode1.
+  validate_interface_implements_interface_cyclic.graphql:1:11
+    1 │ interface BaseNode1 implements BaseNode2 & Resource {
+      │           ^^^^^^^^^
+    2 │   id: ID!
 
-Type BaseNode2 with definition:
-	interface BaseNode2 implements BaseNode1 {
-  id: ID!
-}
-had errors:
-	* Cyclic reference found for interface inheritance: BaseNode1->BaseNode2.
+  ℹ︎ ->
 
-Type Node with definition:
-	interface Node implements BaseNode & BaseNode1 {
-  name: String!
-}
-had errors:
-	* Cyclic reference found for interface inheritance: BaseNode->BaseNode2->BaseNode1->Resource->Node.
+  validate_interface_implements_interface_cyclic.graphql:5:11
+    4 │ 
+    5 │ interface BaseNode2 implements BaseNode1 {
+      │           ^^^^^^^^^
+    6 │   id: ID!
 
-Type Resource with definition:
-	interface Resource implements Node {
-  id: ID!
-  name: String!
-  url: String
-}
-had errors:
-	* Cyclic reference found for interface inheritance: Node->BaseNode->BaseNode2->BaseNode1->Resource.
+✖︎ Cyclic reference found for interface inheritance: BaseNode1->BaseNode2.
+
+  validate_interface_implements_interface_cyclic.graphql:5:11
+    4 │ 
+    5 │ interface BaseNode2 implements BaseNode1 {
+      │           ^^^^^^^^^
+    6 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:1:11
+    1 │ interface BaseNode1 implements BaseNode2 & Resource {
+      │           ^^^^^^^^^
+    2 │   id: ID!
+
+✖︎ Cyclic reference found for interface inheritance: BaseNode2->BaseNode1->Resource->Node->BaseNode.
+
+  validate_interface_implements_interface_cyclic.graphql:9:11
+    8 │ 
+    9 │ interface BaseNode implements BaseNode2 {
+      │           ^^^^^^^^
+   10 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:13:11
+   12 │ 
+   13 │ interface Node implements BaseNode & BaseNode1 {
+      │           ^^^^
+   14 │   name: String!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:17:11
+   16 │ 
+   17 │ interface Resource implements Node {
+      │           ^^^^^^^^
+   18 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:1:11
+    1 │ interface BaseNode1 implements BaseNode2 & Resource {
+      │           ^^^^^^^^^
+    2 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:5:11
+    4 │ 
+    5 │ interface BaseNode2 implements BaseNode1 {
+      │           ^^^^^^^^^
+    6 │   id: ID!
+
+✖︎ Cyclic reference found for interface inheritance: BaseNode->BaseNode2->BaseNode1->Resource->Node.
+
+  validate_interface_implements_interface_cyclic.graphql:13:11
+   12 │ 
+   13 │ interface Node implements BaseNode & BaseNode1 {
+      │           ^^^^
+   14 │   name: String!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:17:11
+   16 │ 
+   17 │ interface Resource implements Node {
+      │           ^^^^^^^^
+   18 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:1:11
+    1 │ interface BaseNode1 implements BaseNode2 & Resource {
+      │           ^^^^^^^^^
+    2 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:5:11
+    4 │ 
+    5 │ interface BaseNode2 implements BaseNode1 {
+      │           ^^^^^^^^^
+    6 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:9:11
+    8 │ 
+    9 │ interface BaseNode implements BaseNode2 {
+      │           ^^^^^^^^
+   10 │   id: ID!
+
+✖︎ Cyclic reference found for interface inheritance: Node->BaseNode->BaseNode2->BaseNode1->Resource.
+
+  validate_interface_implements_interface_cyclic.graphql:17:11
+   16 │ 
+   17 │ interface Resource implements Node {
+      │           ^^^^^^^^
+   18 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:1:11
+    1 │ interface BaseNode1 implements BaseNode2 & Resource {
+      │           ^^^^^^^^^
+    2 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:5:11
+    4 │ 
+    5 │ interface BaseNode2 implements BaseNode1 {
+      │           ^^^^^^^^^
+    6 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:9:11
+    8 │ 
+    9 │ interface BaseNode implements BaseNode2 {
+      │           ^^^^^^^^
+   10 │   id: ID!
+
+  ℹ︎ ->
+
+  validate_interface_implements_interface_cyclic.graphql:13:11
+   12 │ 
+   13 │ interface Node implements BaseNode & BaseNode1 {
+      │           ^^^^
+   14 │   name: String!

--- a/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_object.expected
+++ b/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_object.expected
@@ -34,6 +34,22 @@ type Human implements Hominid @fetchable(field_name: "id") {
   other_friends(location: Location, location: Location): [Human]
 }
 
+type Ape implements Hominid {
+  pet: Canine
+  friends: [Hominid] # Missing argument
+}
+
+type Chimp implements Hominid {
+  pet: Canine
+  friends(location: String): [Hominid] # Missing argument
+}
+
+# Implement Hominid twice
+type Bonobo implements Hominid & Hominid {
+  pet: Canine
+  friends(location: Location): [Hominid]
+}
+
 type Query {
   fetch__Human(id: ID!): Human
   user: Human
@@ -63,33 +79,146 @@ type Fur {
   color: String
 }
 ==================================== OUTPUT ===================================
-Type EmptyFurType with definition:
-	union EmptyFurType
-had errors:
-	* Union type EmptyFurType must define one or more member types.
+✖︎ Type 'Bonobo' can only implement 'Hominid' once.
 
-Type Human with definition:
-	type Human implements Hominid @fetchable(field_name: "id") {
-  id: ID
-  pet: OtherPet
-  friends(location: Location, radius: Int!, Country: String): [Human]
-  location: Location
-  location: ID
-  other_friends(location: Location, location: Location): [Human]
-}
-had errors:
-	* Duplicate argument 'location' found on field/directive 'other_friends'.
-	* Duplicate field 'location' found.
-	* Interface field 'Hominid.pet' expects type 'Canine' but 'Human.pet' is of type 'OtherPet'.
-	* Object field 'Human.friends' includes required argument 'radius' that is missing from the Interface field 'Hominid.friends'.
-	* The type of 'Human.location' must be Output Type but got: 'Named(InputObject(0))'.
+  validate_object.graphql:3:11
+    2 │ 
+    3 │ interface Hominid {
+      │           ^^^^^^^
+    4 │   pet: Canine
 
-Type Pet with definition:
-	type Pet implements Canine @fetchable(field_name: "id") {
-  id: ID
-  owner: Human
-  type: PetType
-  fur: FurType
-}
-had errors:
-	* Interface field 'Canine.name' expected but 'Pet' does not provide it.
+  ℹ︎ Previously defined here:
+
+  validate_object.graphql:3:11
+    2 │ 
+    3 │ interface Hominid {
+      │           ^^^^^^^
+    4 │   pet: Canine
+
+✖︎ Interface field 'Canine.name' expected but 'Pet' does not provide it.
+
+  validate_object.graphql:13:6
+   12 │ 
+   13 │ type Pet implements Canine @fetchable(field_name: "id") {
+      │      ^^^
+   14 │   id: ID
+
+  ℹ︎ The interface field is defined here:
+
+  validate_object.graphql:10:3
+    9 │   owner: Human
+   10 │   name: String
+      │   ^^^^
+   11 │ }
+
+✖︎ Interface field 'Hominid.pet' expects type 'Canine' but 'Human.pet' is of type 'OtherPet'.
+
+  validate_object.graphql:29:3
+   28 │   id: ID
+   29 │   pet: OtherPet
+      │   ^^^
+   30 │   friends(location: Location, radius: Int!, Country: String): [Human]
+
+  ℹ︎ The interface field is defined here:
+
+  validate_object.graphql:4:3
+    3 │ interface Hominid {
+    4 │   pet: Canine
+      │   ^^^
+    5 │   friends(location: Location): [Hominid]
+
+✖︎ Object field 'Human.friends' includes required argument 'radius' that is missing from the Interface field 'Hominid.friends'.
+
+  validate_object.graphql:30:31
+   29 │   pet: OtherPet
+   30 │   friends(location: Location, radius: Int!, Country: String): [Human]
+      │                               ^^^^^^
+   31 │   location: Location
+
+  ℹ︎ The interface field is define here:
+
+  validate_object.graphql:5:3
+    4 │   pet: Canine
+    5 │   friends(location: Location): [Hominid]
+      │   ^^^^^^^
+    6 │ }
+
+✖︎ The type of 'Human.location' must be Output Type but got an input object.
+
+  validate_object.graphql:31:3
+   30 │   friends(location: Location, radius: Int!, Country: String): [Human]
+   31 │   location: Location
+      │   ^^^^^^^^
+   32 │   location: ID
+
+✖︎ Duplicate field 'location' found.
+
+  validate_object.graphql:32:3
+   31 │   location: Location
+   32 │   location: ID
+      │   ^^^^^^^^
+   33 │   other_friends(location: Location, location: Location): [Human]
+
+  ℹ︎ Previously defined here:
+
+  validate_object.graphql:31:3
+   30 │   friends(location: Location, radius: Int!, Country: String): [Human]
+   31 │   location: Location
+      │   ^^^^^^^^
+   32 │   location: ID
+
+✖︎ Duplicate argument 'location' found on field/directive 'other_friends'.
+
+  validate_object.graphql:33:3
+   32 │   location: ID
+   33 │   other_friends(location: Location, location: Location): [Human]
+      │   ^^^^^^^^^^^^^
+   34 │ }
+
+  ℹ︎ Previously defined here:
+
+  validate_object.graphql:33:17
+   32 │   location: ID
+   33 │   other_friends(location: Location, location: Location): [Human]
+      │                 ^^^^^^^^
+   34 │ }
+
+✖︎ Interface field argument 'Hominid.friends(location:)' expected but 'Ape.friends' does not provide it.
+
+  validate_object.graphql:38:3
+   37 │   pet: Canine
+   38 │   friends: [Hominid] # Missing argument
+      │   ^^^^^^^
+   39 │ }
+
+  ℹ︎ The interface field argument is defined here:
+
+  validate_object.graphql:5:11
+    4 │   pet: Canine
+    5 │   friends(location: Location): [Hominid]
+      │           ^^^^^^^^
+    6 │ }
+
+✖︎ Interface field argument 'Hominid.friends(location:)' expects type 'Location' but 'Chimp.friends(location:)' is type 'String'.
+
+  validate_object.graphql:43:11
+   42 │   pet: Canine
+   43 │   friends(location: String): [Hominid] # Missing argument
+      │           ^^^^^^^^
+   44 │ }
+
+  ℹ︎ The interface field argument is defined here:
+
+  validate_object.graphql:5:11
+    4 │   pet: Canine
+    5 │   friends(location: Location): [Hominid]
+      │           ^^^^^^^^
+    6 │ }
+
+✖︎ Union type EmptyFurType must define one or more member types.
+
+  validate_object.graphql:69:7
+   68 │ 
+   69 │ union EmptyFurType
+      │       ^^^^^^^^^^^^
+   70 │

--- a/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_object.graphql
+++ b/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_object.graphql
@@ -33,6 +33,22 @@ type Human implements Hominid @fetchable(field_name: "id") {
   other_friends(location: Location, location: Location): [Human]
 }
 
+type Ape implements Hominid {
+  pet: Canine
+  friends: [Hominid] # Missing argument
+}
+
+type Chimp implements Hominid {
+  pet: Canine
+  friends(location: String): [Hominid] # Missing argument
+}
+
+# Implement Hominid twice
+type Bonobo implements Hominid & Hominid {
+  pet: Canine
+  friends(location: Location): [Hominid]
+}
+
 type Query {
   fetch__Human(id: ID!): Human
   user: Human

--- a/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_root_types.expected
+++ b/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_root_types.expected
@@ -19,5 +19,9 @@ type Human implements Hominid @fetchable(field_name: "id") {
   pet: Pet
 }
 ==================================== OUTPUT ===================================
-Errors:
-	* 'Query' root type must be provided.
+✖︎ 'Query' root type must be provided.
+
+  validate_root_types.graphql:1:1
+    1 │ directive @fetchable(field_name: String) on OBJECT
+      │ ^
+    2 │

--- a/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_root_types_kind.expected
+++ b/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_root_types_kind.expected
@@ -1,0 +1,26 @@
+==================================== INPUT ====================================
+scalar Query
+
+enum Mutation {
+  CREATE
+  UPDATE
+  DELETE
+}
+
+input Subscription {
+  id: ID!
+  name: String!
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+==================================== OUTPUT ===================================
+✖︎ Expected an object type for name 'Query', got a scalar.
+
+  <generated>:1:1
+    1 │ scalar Query
+      │ ^
+    2 │

--- a/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_root_types_kind.graphql
+++ b/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_root_types_kind.graphql
@@ -1,0 +1,18 @@
+scalar Query
+
+enum Mutation {
+  CREATE
+  UPDATE
+  DELETE
+}
+
+input Subscription {
+  id: ID!
+  name: String!
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}

--- a/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_union.expected
+++ b/compiler/crates/schema-validate/tests/validate_schema/fixtures/validate_union.expected
@@ -51,12 +51,18 @@ type Fur {
   color: String
 }
 ==================================== OUTPUT ===================================
-Type EmptyFurType with definition:
-	union EmptyFurType
-had errors:
-	* Union type EmptyFurType must define one or more member types.
+✖︎ Union type EmptyFurType must define one or more member types.
 
-Type InvalidFurType with definition:
-	union InvalidFurType = Hair | Fur | Hair
-had errors:
-	* Union can only include member Hair once.
+  validate_union.graphql:41:7
+   40 │ 
+   41 │ union EmptyFurType
+      │       ^^^^^^^^^^^^
+   42 │ 
+
+✖︎ Union can only include member Hair once.
+
+  validate_union.graphql:43:7
+   42 │ 
+   43 │ union InvalidFurType = Hair | Fur | Hair
+      │       ^^^^^^^^^^^^^^
+   44 │

--- a/compiler/crates/schema-validate/tests/validate_schema_test.rs
+++ b/compiler/crates/schema-validate/tests/validate_schema_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5eb916d4ea81c5d7dd1c342770b1389e>>
+ * @generated SignedSource<<1199c76ea90111f17b3d287e313d627c>>
  */
 
 mod validate_schema;
@@ -45,6 +45,13 @@ async fn validate_root_types() {
     let input = include_str!("validate_schema/fixtures/validate_root_types.graphql");
     let expected = include_str!("validate_schema/fixtures/validate_root_types.expected");
     test_fixture(transform_fixture, file!(), "validate_root_types.graphql", "validate_schema/fixtures/validate_root_types.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn validate_root_types_kind() {
+    let input = include_str!("validate_schema/fixtures/validate_root_types_kind.graphql");
+    let expected = include_str!("validate_schema/fixtures/validate_root_types_kind.expected");
+    test_fixture(transform_fixture, file!(), "validate_root_types_kind.graphql", "validate_schema/fixtures/validate_root_types_kind.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/schema/src/definitions.rs
+++ b/compiler/crates/schema/src/definitions.rs
@@ -17,6 +17,7 @@ use common::DirectiveName;
 use common::EnumName;
 use common::InputObjectName;
 use common::InterfaceName;
+use common::Location;
 use common::Named;
 use common::NamedItem;
 use common::ObjectName;
@@ -618,6 +619,7 @@ impl IntoIterator for ArgumentDefinitions {
 pub trait TypeWithFields {
     fn fields(&self) -> &Vec<FieldID>;
     fn interfaces(&self) -> &Vec<InterfaceID>;
+    fn location(&self) -> &Location;
 }
 
 impl TypeWithFields for Interface {
@@ -628,6 +630,10 @@ impl TypeWithFields for Interface {
     fn interfaces(&self) -> &Vec<InterfaceID> {
         &self.interfaces
     }
+
+    fn location(&self) -> &Location {
+        &self.name.location
+    }
 }
 
 impl TypeWithFields for Object {
@@ -637,6 +643,10 @@ impl TypeWithFields for Object {
 
     fn interfaces(&self) -> &Vec<InterfaceID> {
         &self.interfaces
+    }
+
+    fn location(&self) -> &Location {
+        &self.name.location
     }
 }
 

--- a/compiler/crates/schema/src/errors.rs
+++ b/compiler/crates/schema/src/errors.rs
@@ -9,8 +9,6 @@ use graphql_syntax::OperationType;
 use intern::string_key::StringKey;
 use thiserror::Error;
 
-use crate::definitions::Type;
-
 pub type Result<T> = std::result::Result<T, SchemaError>;
 
 #[derive(Debug, Error, serde::Serialize)]
@@ -25,11 +23,11 @@ pub enum SchemaError {
     #[error("Cannot extend type '{0}', the type is not defined on the server schema.")]
     ExtendUndefinedType(StringKey),
 
-    #[error("Expected an object type for name '{0}', got '{1:?}'.")]
-    ExpectedObjectReference(StringKey, Type),
+    #[error("Expected an object type for name '{0}', got {1}.")]
+    ExpectedObjectReference(StringKey, String),
 
-    #[error("Expected an interface type for name '{0}', got '{1:?}'.")]
-    ExpectedInterfaceReference(StringKey, Type),
+    #[error("Expected an interface type for name '{0}', got {1}.")]
+    ExpectedInterfaceReference(StringKey, String),
 
     #[error("Reference to undefined type '{0}'.")]
     UndefinedType(StringKey),

--- a/compiler/crates/schema/src/in_memory.rs
+++ b/compiler/crates/schema/src/in_memory.rs
@@ -1576,9 +1576,10 @@ impl InMemorySchema {
     fn build_object_id(&mut self, name: StringKey) -> DiagnosticsResult<ObjectID> {
         match self.type_map.get(&name) {
             Some(Type::Object(id)) => Ok(*id),
-            Some(non_object_type) => {
-                todo_add_location(SchemaError::ExpectedObjectReference(name, *non_object_type))
-            }
+            Some(non_object_type) => todo_add_location(SchemaError::ExpectedObjectReference(
+                name,
+                non_object_type.get_variant_name().to_string(),
+            )),
             None => todo_add_location(SchemaError::UndefinedType(name)),
         }
     }
@@ -1591,7 +1592,10 @@ impl InMemorySchema {
         match self.type_map.get(&name.value) {
             Some(Type::Interface(id)) => Ok(*id),
             Some(non_interface_type) => Err(vec![Diagnostic::error(
-                SchemaError::ExpectedInterfaceReference(name.value, *non_interface_type),
+                SchemaError::ExpectedInterfaceReference(
+                    name.value,
+                    non_interface_type.get_variant_name().to_string(),
+                ),
                 Location::new(*location_key, name.span),
             )]),
             None => Err(vec![Diagnostic::error(

--- a/compiler/crates/schema/tests/build_schema/fixtures/invalid-extension-implements-noninterface.expected
+++ b/compiler/crates/schema/tests/build_schema/fixtures/invalid-extension-implements-noninterface.expected
@@ -17,7 +17,7 @@ extend type User implements Foo {
   client: String
 }
 ==================================== ERROR ====================================
-✖︎ Expected an interface type for name 'Foo', got 'Object(1)'.
+✖︎ Expected an interface type for name 'Foo', got an object.
 
   <generated>:14:29
    13 │ }

--- a/compiler/crates/schema/tests/build_schema/fixtures/invalid-implements-non-interface.expected
+++ b/compiler/crates/schema/tests/build_schema/fixtures/invalid-implements-non-interface.expected
@@ -9,7 +9,7 @@ type Page implements User {
   id: ID
 }
 ==================================== ERROR ====================================
-✖︎ Expected an interface type for name 'User', got 'Object(0)'.
+✖︎ Expected an interface type for name 'User', got an object.
 
   <generated>:7:22
     6 │ 

--- a/compiler/crates/schema/tests/build_schema/fixtures/invalid-interface-implements-noninterface.expected
+++ b/compiler/crates/schema/tests/build_schema/fixtures/invalid-interface-implements-noninterface.expected
@@ -9,7 +9,7 @@ interface Page implements User {
   id: ID
 }
 ==================================== ERROR ====================================
-✖︎ Expected an interface type for name 'User', got 'Object(0)'.
+✖︎ Expected an interface type for name 'User', got an object.
 
   <generated>:7:27
     6 │ 


### PR DESCRIPTION
This PR updates our schema validation crate (which was previously not actually used directly by Relay) to report errors using Diagnostics rather than using its bespoke error reporting approach. This has a few effects:

1. Error reporting is improved for CLI output for the existing validation tool, with file locations and inline context, and related locations all being reported
2. As we look to adopt schema validation in Relay proper the errors will be compatible with the LSP meaning they will surface as red underlines in the correct locations.