### PR TITLE
Integrate with Sapling or Git if they exist

### DIFF
--- a/compiler/crates/relay-compiler/src/build_project.rs
+++ b/compiler/crates/relay-compiler/src/build_project.rs
@@ -67,7 +67,7 @@ use rustc_hash::FxHashSet;
 use schema::SDLSchema;
 use schema_diff::check::IncrementalBuildSchemaChange;
 use schema_diff::check::SchemaChangeSafety;
-pub use source_control::add_to_mercurial;
+pub use source_control::source_control_for_root;
 pub use validate::validate;
 pub use validate::AdditionalValidations;
 

--- a/compiler/crates/relay-compiler/src/build_project/source_control.rs
+++ b/compiler/crates/relay-compiler/src/build_project/source_control.rs
@@ -5,25 +5,41 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Stdio;
 use std::sync::Mutex;
 
+use log::debug;
 use log::info;
 
-pub fn add_to_mercurial(
-    root_dir: &PathBuf,
-    added: &Mutex<Vec<PathBuf>>,
-    removed: &Mutex<Vec<PathBuf>>,
-) -> crate::errors::Result<()> {
-    {
+pub trait SourceControl {
+    fn add_files(&self, root_dir: &Path, added: &Mutex<Vec<PathBuf>>) -> crate::errors::Result<()>;
+
+    fn remove_files(
+        &self,
+        root_dir: &Path,
+        removed: &Mutex<Vec<PathBuf>>,
+    ) -> crate::errors::Result<()>;
+}
+
+trait SourceControlStartAndStopCommands {
+    fn start_tracking_command() -> Command;
+
+    fn stop_tracking_command() -> Command;
+}
+
+impl<T> SourceControl for T
+where
+    T: SourceControlStartAndStopCommands,
+{
+    fn add_files(&self, root_dir: &Path, added: &Mutex<Vec<PathBuf>>) -> crate::errors::Result<()> {
         let mut added = added.lock().unwrap();
         if !added.is_empty() {
             for added_files in added.chunks(100) {
-                if Command::new("hg")
+                if Self::start_tracking_command()
                     .current_dir(root_dir)
-                    .arg("add")
                     .args(added_files)
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())
@@ -31,19 +47,24 @@ pub fn add_to_mercurial(
                     .spawn()
                     .is_err()
                 {
-                    info!("Failed to run `hg add`.");
+                    info!("Failed to run source control 'add' operation.");
                 }
             }
             added.clear();
         }
+        Ok(())
     }
-    {
+
+    fn remove_files(
+        &self,
+        root_dir: &Path,
+        removed: &Mutex<Vec<PathBuf>>,
+    ) -> crate::errors::Result<()> {
         let mut removed = removed.lock().unwrap();
         if !removed.is_empty() {
             for removed_files in removed.chunks(100) {
-                if Command::new("hg")
+                if Self::stop_tracking_command()
                     .current_dir(root_dir)
-                    .arg("forget")
                     .args(removed_files)
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())
@@ -51,11 +72,88 @@ pub fn add_to_mercurial(
                     .spawn()
                     .is_err()
                 {
-                    info!("Failed to run `hg forget`.");
+                    info!("Failed to run source control 'remove' operation.");
                 }
             }
             removed.clear();
         }
+        Ok(())
     }
-    Ok(())
+}
+
+/// Sapling is Meta's fork of Mercurial.
+/// Inside Meta, it is available as both
+/// `sl`, and `hg`.
+struct Sapling;
+
+impl SourceControlStartAndStopCommands for Sapling {
+    fn start_tracking_command() -> Command {
+        let mut command = Command::new("sl");
+        command.arg("add");
+        command
+    }
+
+    fn stop_tracking_command() -> Command {
+        let mut command = Command::new("sl");
+        command.arg("forget");
+        command
+    }
+}
+
+struct Git;
+
+impl SourceControlStartAndStopCommands for Git {
+    fn start_tracking_command() -> Command {
+        let mut command = Command::new("git");
+        command.arg("add");
+        command
+    }
+
+    fn stop_tracking_command() -> Command {
+        let mut command = Command::new("git");
+        command.arg("rm").arg("--cached");
+        command
+    }
+}
+
+pub fn source_control_for_root(root_dir: &PathBuf) -> Option<Box<dyn SourceControl + Send + Sync>> {
+    let check_git = Command::new("git")
+        .arg("status")
+        .current_dir(root_dir)
+        .output();
+
+    if check_git.is_ok() {
+        debug!("Enabling git source control integration");
+        return Some(Box::new(Git));
+    }
+
+    // Warning: `sl` can support git repos, so it's important that we
+    // check the native `git` command first due to differences in
+    // staging behavior between the two.
+    let check_sapling = Command::new("sl")
+        .arg("root")
+        .current_dir(root_dir)
+        .output();
+
+    if check_sapling.is_ok() {
+        let possible_steam_locomotive_check = Command::new("sl").arg("--version").output();
+
+        // The "Steam Locomotive" command also uses `sl` and doesn't have an easy way to detect
+        // if it is actually the `sl` command (it exits with code 0 if run as `sl root`), so we
+        // need to do some additional checking to make sure we can enable Sapling integration:
+        if let Ok(output) = possible_steam_locomotive_check {
+            if output.status.success()
+                && String::from_utf8_lossy(&output.stdout).contains("Sapling")
+            {
+                debug!("Enabling Sapling source control integration");
+                return Some(Box::new(Sapling));
+            } else {
+                debug!(
+                    "The `sl` command is not Sapling, so Sapling source control integration is disabled"
+                );
+            }
+        }
+    }
+
+    None
 }

--- a/compiler/crates/relay-compiler/src/build_project/source_control.rs
+++ b/compiler/crates/relay-compiler/src/build_project/source_control.rs
@@ -122,9 +122,11 @@ pub fn source_control_for_root(root_dir: &PathBuf) -> Option<Box<dyn SourceContr
         .current_dir(root_dir)
         .output();
 
-    if check_git.is_ok() {
-        debug!("Enabling git source control integration");
-        return Some(Box::new(Git));
+    if let Ok(check_git) = check_git {
+        if check_git.status.success() {
+            debug!("Enabling git source control integration");
+            return Some(Box::new(Git));
+        }
     }
 
     // Warning: `sl` can support git repos, so it's important that we
@@ -135,22 +137,24 @@ pub fn source_control_for_root(root_dir: &PathBuf) -> Option<Box<dyn SourceContr
         .current_dir(root_dir)
         .output();
 
-    if check_sapling.is_ok() {
-        let possible_steam_locomotive_check = Command::new("sl").arg("--version").output();
+    if let Ok(check_sapling) = check_sapling {
+        if check_sapling.status.success() {
+            let possible_steam_locomotive_check = Command::new("sl").arg("--version").output();
 
-        // The "Steam Locomotive" command also uses `sl` and doesn't have an easy way to detect
-        // if it is actually the `sl` command (it exits with code 0 if run as `sl root`), so we
-        // need to do some additional checking to make sure we can enable Sapling integration:
-        if let Ok(output) = possible_steam_locomotive_check {
-            if output.status.success()
-                && String::from_utf8_lossy(&output.stdout).contains("Sapling")
-            {
-                debug!("Enabling Sapling source control integration");
-                return Some(Box::new(Sapling));
-            } else {
-                debug!(
-                    "The `sl` command is not Sapling, so Sapling source control integration is disabled"
-                );
+            // The "Steam Locomotive" command also uses `sl` and doesn't have an easy way to detect
+            // if it is actually the `sl` command (it exits with code 0 if run as `sl root`), so we
+            // need to do some additional checking to make sure we can enable Sapling integration:
+            if let Ok(output) = possible_steam_locomotive_check {
+                if output.status.success()
+                    && String::from_utf8_lossy(&output.stdout).contains("Sapling")
+                {
+                    debug!("Enabling Sapling source control integration");
+                    return Some(Box::new(Sapling));
+                } else {
+                    debug!(
+                        "The `sl` command is not Sapling, so Sapling source control integration is disabled"
+                    );
+                }
             }
         }
     }

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -65,6 +65,7 @@ use crate::errors::ConfigValidationError;
 use crate::errors::Error;
 use crate::errors::Result;
 use crate::saved_state::SavedStateLoader;
+use crate::source_control_for_root;
 use crate::status_reporter::ConsoleStatusReporter;
 use crate::status_reporter::StatusReporter;
 
@@ -418,7 +419,10 @@ impl Config {
 
         let config = Self {
             name: config_file.name,
-            artifact_writer: Box::new(ArtifactFileWriter::new(None, root_dir.clone())),
+            artifact_writer: Box::new(ArtifactFileWriter::new(
+                source_control_for_root(&root_dir),
+                root_dir.clone(),
+            )),
             status_reporter: Box::new(ConsoleStatusReporter::new(
                 root_dir.clone(),
                 is_multi_project,

--- a/compiler/crates/relay-compiler/src/lib.rs
+++ b/compiler/crates/relay-compiler/src/lib.rs
@@ -26,7 +26,6 @@ pub mod status_reporter;
 mod utils;
 
 pub use artifact_map::ArtifactSourceKey;
-pub use build_project::add_to_mercurial;
 pub use build_project::artifact_writer::ArtifactDifferenceShardedWriter;
 pub use build_project::artifact_writer::ArtifactDifferenceWriter;
 pub use build_project::artifact_writer::ArtifactFileWriter;
@@ -40,6 +39,7 @@ pub use build_project::find_duplicates;
 pub use build_project::generate_artifacts;
 pub use build_project::generate_extra_artifacts::GenerateExtraArtifactsFn;
 pub use build_project::get_artifacts_file_hash_map::GetArtifactsFileHashMapFn;
+pub use build_project::source_control_for_root;
 pub use build_project::transform_program;
 pub use build_project::validate;
 pub use build_project::validate_program;


### PR DESCRIPTION
There is some basic code here that is AFAICT only used in Meta's private version of the compiler. We can take that code, spruce it up a bit, and integrate it into the public version of the compiler!

Test plan:

I built the compiler locally and tested against a local Sapling repo. It worked as expected. I didn't have a chance to try it on a git repo though :/ 