### PR TITLE
Relay: Forward Compatibility in Jest Tests for `enableRefAsProp`

### DIFF
--- a/packages/react-relay/__tests__/ReactRelayFragmentContainer-WithFragmentOwnership-test.js
+++ b/packages/react-relay/__tests__/ReactRelayFragmentContainer-WithFragmentOwnership-test.js
@@ -117,7 +117,10 @@ describe('ReactRelayFragmentContainer with fragment ownership', () => {
       user: UserFragment,
     };
     variables = {rootVariable: 'root'};
-    TestComponent = render;
+    TestComponent = ({ref, ...props}) => {
+      // Omit `ref` for forward-compatibility with `enableRefAsProp`.
+      return render(props);
+    };
     TestComponent.displayName = 'TestComponent';
     TestContainer = ReactRelayFragmentContainer.createContainer(
       TestComponent,

--- a/packages/react-relay/__tests__/ReactRelayFragmentContainer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayFragmentContainer-test.js
@@ -117,7 +117,10 @@ describe('ReactRelayFragmentContainer', () => {
       user: UserFragment,
     };
 
-    TestComponent = render;
+    TestComponent = ({ref, ...props}) => {
+      // Omit `ref` for forward-compatibility with `enableRefAsProp`.
+      return render(props);
+    };
     TestComponent.displayName = 'TestComponent';
     TestContainer = ReactRelayFragmentContainer.createContainer(
       TestComponent,

--- a/packages/react-relay/__tests__/ReactRelayPaginationContainer-WithFragmentOwnership-test.js
+++ b/packages/react-relay/__tests__/ReactRelayPaginationContainer-WithFragmentOwnership-test.js
@@ -183,7 +183,10 @@ describe('ReactRelayPaginationContainer with fragment ownership', () => {
         count,
       };
     });
-    TestComponent = render;
+    TestComponent = ({ref, ...props}) => {
+      // Omit `ref` for forward-compatibility with `enableRefAsProp`.
+      return render(props);
+    };
     TestComponent.displayName = 'TestComponent';
     TestContainer = ReactRelayPaginationContainer.createContainer(
       TestComponent,
@@ -374,7 +377,7 @@ describe('ReactRelayPaginationContainer with fragment ownership', () => {
       loadMore(1, jest.fn());
       expect(render.mock.calls.length).toBe(1);
 
-      TestComponent.mockClear();
+      render.mockClear();
       TestChildComponent.mockClear();
       ReactTestRenderer.act(() => {
         environment.mock.resolve(UserQuery, {
@@ -915,7 +918,7 @@ describe('ReactRelayPaginationContainer with fragment ownership', () => {
       };
       expect(environment.mock.isLoading(UserQuery, variables)).toBe(true);
 
-      TestComponent.mockClear();
+      render.mockClear();
       TestChildComponent.mockClear();
       environment.mock.resolve(UserQuery, {
         data: {

--- a/packages/react-relay/__tests__/ReactRelayPaginationContainer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayPaginationContainer-test.js
@@ -148,7 +148,10 @@ describe('ReactRelayPaginationContainer', () => {
         count,
       };
     });
-    TestComponent = render;
+    TestComponent = ({ref, ...props}) => {
+      // Omit `ref` for forward-compatibility with `enableRefAsProp`.
+      return render(props);
+    };
     TestComponent.displayName = 'TestComponent';
     TestContainer = ReactRelayPaginationContainer.createContainer(
       TestComponent,

--- a/packages/react-relay/__tests__/ReactRelayRefetchContainer-test.js
+++ b/packages/react-relay/__tests__/ReactRelayRefetchContainer-test.js
@@ -126,7 +126,10 @@ describe('ReactRelayRefetchContainer', () => {
       return <ContextGetter />;
     });
     variables = {};
-    TestComponent = render;
+    TestComponent = ({ref, ...props}) => {
+      // Omit `ref` for forward-compatibility with `enableRefAsProp`.
+      return render(props);
+    };
     TestComponent.displayName = 'TestComponent';
     TestContainer = ReactRelayRefetchContainer.createContainer(
       TestComponent,


### PR DESCRIPTION
Summary: Refactors a few Jest unit tests so that they're resilient to upcoming changes in React, when `enableRefAsProp` is enabled.

Differential Revision: D57133519


