### PR TITLE
Improve website build+deploy

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -42,6 +42,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: website/yarn.lock
+
+      - name: Set up Docusaurus Build Cache
+        id: cache-docusaurus
+        uses: actions/cache@v4
+        with:
+          path: |
+            website/node_modules/.cache
+            website/.docusaurus
+          key: "docusaurus-build-${{ hashFiles('website/yarn.lock') }}"
+
       - name: Download Compiler Explorer
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -10,12 +10,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build-compiler-explorer:
     name: Build Compiler Explorer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.73.0 # We hit an LLVM error building Wasm on 1.72
@@ -25,7 +28,7 @@ jobs:
       - name: "Build Compiler Playground Wasm NPM package"
         run: RUST_LOG=debug wasm-pack build --target web
         working-directory: ./compiler/crates/relay-compiler-playground
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: compiler-playground-package
           path: compiler/crates/relay-compiler-playground/pkg/
@@ -35,12 +38,12 @@ jobs:
     needs: [build-compiler-explorer]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Download Compiler Explorer
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: compiler-playground-package
           path: tmp/compiler-playground-package
@@ -57,9 +60,8 @@ jobs:
         working-directory: website/
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: website/build
-          CLEAN: true
+          branch: gh-pages
+          folder: website/build
+          clean: true

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -208,14 +208,8 @@ module.exports = {
       require.resolve('docusaurus-plugin-internaldocs-fb/docusaurus-preset'),
       {
         docs: {
-          showLastUpdateAuthor: fbContent({
-            internal: false,
-            external: true,
-          }),
-          showLastUpdateTime: fbContent({
-            internal: false,
-            external: true,
-          }),
+          showLastUpdateAuthor: false,
+          showLastUpdateTime: false,
           editUrl: fbContent({
             internal:
               'https://www.internalfb.com/intern/diffusion/FBS/browse/master/xplat/js/RKJSModules/Libraries/Relay/oss/__github__/website/',


### PR DESCRIPTION
I got distracted looking at something else for Relay and noticed the repo itself is several GB. This is almost certainly primarily from the `gh-pages` branch. It currently gets rebuilt on every commit to `main` and since the content of the pages include the last modified by & time using that commit data, every single generated page gets rebuilt as well. For example, https://github.com/facebook/relay/commit/79a357573cfc5fc2ce8de15ba133630f3edac8d1 updated 4672 files. That build job took almost 30 minutes (https://github.com/facebook/relay/actions/runs/9067652200)

So I did a few things
1. Removed the modified by stuff. It's not useful and honestly potentially misleading.
2. Updated actions to latest versions. This alone shaved off a bunch of time
3. Persisted the docusaurus cache.

Warm build (typical) time is now 6 minutes. https://github.com/zpao/relay/actions/runs/9052335508