### PR TITLE
Normalize paths in diagnostics CLI output

### DIFF
--- a/compiler/crates/graphql-cli/src/diagnostic_printer.rs
+++ b/compiler/crates/graphql-cli/src/diagnostic_printer.rs
@@ -85,7 +85,7 @@ impl<TSources: Sources> DiagnosticPrinter<TSources> {
             writeln!(
                 writer,
                 "  {}{}",
-                location.source_location().path().underline(),
+                normalize_path(location.source_location().path()).underline(),
                 format!(":{}:{}", range.start.line + 1, range.start.character + 1).dimmed()
             )?;
             source_printer.write_span_with_highlight_style(
@@ -99,7 +99,7 @@ impl<TSources: Sources> DiagnosticPrinter<TSources> {
             writeln!(
                 writer,
                 "{}: <missing source>",
-                location.source_location().path()
+                normalize_path(location.source_location().path())
             )?;
         }
         Ok(())
@@ -117,4 +117,10 @@ where
     fn get(&self, source_location: SourceLocationKey) -> Option<TextSource> {
         self(source_location)
     }
+}
+
+/// Normalize Windows paths to Unix style. This is important for stable test
+/// output across Mac/Windows/Linux.
+fn normalize_path(path: &str) -> String {
+    path.replace("\\", "/")
 }


### PR DESCRIPTION
This should fix the current breakage of our windows tests. One thing I'm not sure about is if this will cause any problems with things like clickable file paths in the terminal on Windows.