### PR TITLE
Improve release notes tool

### DIFF
--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -101,7 +101,7 @@ function getData() {
   const commits = listOfCommits.split('\n').map((commitMessage, index) => {
     const [hash, date, name, _email] = commitMessage.split('|');
     return {
-      hash,
+      hash: hash.slice(0, 6),
       summary: summary[index],
       message: body[index],
       author: name,

--- a/scripts/release-notes/App.js
+++ b/scripts/release-notes/App.js
@@ -38,40 +38,22 @@ const CATEGORIES_NAMES = {
 
 const REPO_URL = 'https://github.com/facebook/relay';
 
-const CommitCard = ({
+function CommitCard({
   message,
   summary,
   author,
   date,
   selectedCategory,
   onCategoryChange,
-}) => {
-  const handleClick = event => {
-    const category = CATEGORIES.findIndex(cat => cat[0] === selectedCategory);
-    let nextCategory;
-    if (event.type === 'contextmenu') {
-      event.preventDefault();
-      nextCategory = -1;
-    } else {
-      nextCategory = category + 1;
-      if (nextCategory == CATEGORIES.length) {
-        nextCategory = -1; // Reset selected category
-      }
-    }
-    onCategoryChange(nextCategory > -1 ? CATEGORIES[nextCategory][0] : null);
-  };
-
+}) {
   return (
-    <button
-      className={`commit ${selectedCategory}`}
-      onClick={handleClick}
-      onContextMenu={handleClick}
-      title={message}>
+    <div className={`commit ${selectedCategory}`} title={message}>
       <p className="summary">{summary}</p>
       <p className="author">{author}</p>
-    </button>
+      <CategoryPicker onPick={category => onCategoryChange(category)} />
+    </div>
   );
-};
+}
 
 // eslint-disable-next-line no-unused-vars
 function App({commits, lastRelease}) {
@@ -121,6 +103,9 @@ function App({commits, lastRelease}) {
           })}
         </section>
         <section className="release_notes">
+          <div className="copy_prompt">
+            (Copy paste the below Markdown into the release notes)
+          </div>
           <GeneratedReleaseNotes
             lastRelease={lastRelease}
             commits={commits}
@@ -139,6 +124,20 @@ function Categories() {
         return (
           <li className={`category ${category}`} key={category}>
             {category}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function CategoryPicker({onPick}) {
+  return (
+    <ul className="categories-picker">
+      {CATEGORIES.map(([category]) => {
+        return (
+          <li className="category" key={category}>
+            <button onClick={() => onPick(category)}>{category}</button>
           </li>
         );
       })}
@@ -180,16 +179,13 @@ function GeneratedReleaseNotes({commits, selectedCategories, lastRelease}) {
 
   return (
     <div className="release_notes_content">
-      <h1>
-        Version {nextReleaseVersion(lastRelease, hasBreakingChanges, hasNewApi)}{' '}
-        Release Notes
-      </h1>
+      {`# Version ${nextReleaseVersion(lastRelease, hasBreakingChanges, hasNewApi)} Release Notes\n`}
       <div>
         {Array.from(categorizedCommits).map(([category, commits]) => {
           if (commits.length) {
             return (
               <div key={category}>
-                <h2>{CATEGORIES_NAMES[category]}</h2>
+                {`## ${CATEGORIES_NAMES[category]}`}
                 <CommitList commits={commits} />
               </div>
             );
@@ -197,8 +193,10 @@ function GeneratedReleaseNotes({commits, selectedCategories, lastRelease}) {
             return null;
           }
         })}
-        <h3>Non-categorized commits</h3>
-        <CommitList commits={nonCategorizedCommits} />
+        <div>
+          {`## Non-categorized commits\n`}
+          <CommitList commits={nonCategorizedCommits} />
+        </div>
       </div>
     </div>
   );
@@ -210,7 +208,7 @@ function CommitList({commits}) {
       {commits.map(commit => {
         return (
           <li key={commit.hash}>
-            [
+            {'- '}[
             <a href={`${REPO_URL}/commit/${commit.hash}`} target="_blank">
               {commit.hash}
             </a>

--- a/scripts/release-notes/style.css
+++ b/scripts/release-notes/style.css
@@ -56,6 +56,11 @@ h2 {
   padding: 0;
 }
 
+.categories-picker {
+  margin: 0;
+  padding: 0;
+}
+
 .category {
   margin: 0;
   padding: 0;
@@ -112,9 +117,24 @@ h2 {
   position: relative;
 }
 
+.copy_prompt {
+  font-style: italic;
+  font-size: 1em;
+  color: gray;
+  margin-bottom: 20px;
+}
+
 .release_notes_content {
   position: sticky;
   top: 0;
   overflow-y: scroll;
   font-family: monospace;
+}
+
+.release_notes_content ul {
+  padding: 0;
+  margin: 0;
+}
+.release_notes_content li {
+  list-style-type: none;
 }


### PR DESCRIPTION
Some minor improvements to our little tool for building release notes:

1. Show results in a format that can be copied as markdown
2. Add buttons to each card so you can just click the category without needing to cycle through