### PR TITLE
Add instructions to run relay compiler after query update

### DIFF
--- a/website/docs/tutorial/fragments-1.md
+++ b/website/docs/tutorial/fragments-1.md
@@ -33,7 +33,9 @@ const NewsfeedQuery = graphql`
 `;
 ```
 
-Now go to `Story.tsx` and modify it to display the date:
+Now we've updated the query, we need to run the relay compiler so that it knows about the updated Graphql query by running `npm run relay`.
+
+Next, go to `Story.tsx` and modify it to display the date:
 
 ```
 // change-line


### PR DESCRIPTION
I've been following along with the tutorial and it wasn't immediately clear to me that I needed to re-run the relay compiler for the `createdAt` field to pull through. 

Mirrored language used here - https://github.com/facebook/relay/blob/main/website/docs/tutorial/queries-1.md?plain=1#L83