### PR TITLE
Remove loadQuery during render warning

### DIFF
--- a/packages/react-relay/relay-hooks/__tests__/loadQuery-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/loadQuery-test.js
@@ -25,11 +25,10 @@ import type {
   Variables,
 } from 'relay-runtime';
 
-const {loadQuery, useTrackLoadQueryInRender} = require('../loadQuery');
+const {loadQuery} = require('../loadQuery');
 // Need React require for OSS build
 // eslint-disable-next-line no-unused-vars
 const React = require('react');
-const ReactTestRenderer = require('react-test-renderer');
 const {
   Network,
   Observable,
@@ -40,7 +39,6 @@ const {
   createMockEnvironment,
   disallowConsoleErrors,
   disallowWarnings,
-  expectWarningWillFire,
 } = require('relay-test-utils-internal');
 
 disallowWarnings();
@@ -890,54 +888,6 @@ describe('loadQuery', () => {
         );
         preloadedQuery.dispose();
         expect(disposeEnvironmentRetain).toHaveBeenCalledTimes(1);
-      });
-    });
-  });
-
-  describe('warnings', () => {
-    let Container;
-    let LoadDuringRender;
-
-    beforeEach(() => {
-      Container = (props: {children: React.Node}) => {
-        // $FlowFixMe[react-rule-hook]
-        useTrackLoadQueryInRender();
-        return props.children;
-      };
-      LoadDuringRender = (props: {name?: ?string}) => {
-        loadQuery(environment, preloadableConcreteRequest, variables, {
-          fetchPolicy: 'store-or-network',
-          __nameForWarning: props.name,
-        });
-        return null;
-      };
-    });
-
-    it('warns if called during render', () => {
-      expectWarningWillFire(
-        'Relay: `loadQuery` should not be called inside a React render function.',
-      );
-
-      ReactTestRenderer.act(() => {
-        ReactTestRenderer.create(
-          <Container>
-            <LoadDuringRender />
-          </Container>,
-        );
-      });
-    });
-
-    it('uses provided name for warning', () => {
-      expectWarningWillFire(
-        'Relay: `refetch` should not be called inside a React render function.',
-      );
-
-      ReactTestRenderer.act(() => {
-        ReactTestRenderer.create(
-          <Container>
-            <LoadDuringRender name="refetch" />
-          </Container>,
-        );
       });
     });
   });

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
@@ -51,7 +51,6 @@ const loadQuery = jest.fn().mockImplementation(() => {
 
 jest.mock('../loadQuery', () => ({
   loadQuery,
-  useTrackLoadQueryInRender: () => {},
 }));
 
 beforeEach(() => {

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
@@ -52,7 +52,6 @@ const loadQuery = jest.fn().mockImplementation(() => {
 
 jest.mock('../loadQuery', () => ({
   loadQuery,
-  useTrackLoadQueryInRender: () => {},
 }));
 
 describe('useQueryLoader', () => {

--- a/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useRefetchableFragmentNode-test.js
@@ -38,7 +38,6 @@ import type {
 import type {OperationDescriptor, Variables} from 'relay-runtime';
 import type {Query} from 'relay-runtime/util/RelayRuntimeTypes';
 
-const {useTrackLoadQueryInRender} = require('../loadQuery');
 const RelayEnvironmentProvider = require('../RelayEnvironmentProvider');
 const useRefetchableFragmentInternal = require('../useRefetchableFragmentInternal');
 const invariant = require('invariant');
@@ -362,7 +361,6 @@ describe.each([['New', useRefetchableFragmentInternal]])(
       };
 
       const ContextProvider = ({children}: {children: React.Node}) => {
-        useTrackLoadQueryInRender();
         const [env, _setEnv] = useState(environment);
         const relayContext = useMemo(() => ({environment: env}), [env]);
 

--- a/packages/react-relay/relay-hooks/loadQuery.js
+++ b/packages/react-relay/relay-hooks/loadQuery.js
@@ -30,7 +30,6 @@ import type {
 } from 'relay-runtime';
 
 const invariant = require('invariant');
-const React = require('react');
 const {
   __internal: {fetchQueryDeduped},
   Observable,
@@ -41,21 +40,8 @@ const {
   getRequest,
   getRequestIdentifier,
 } = require('relay-runtime');
-const warning = require('warning');
 
-let RenderDispatcher = null;
 let fetchKey = 100001;
-
-hook useTrackLoadQueryInRender() {
-  if (RenderDispatcher === null) {
-    // Flow does not know of React internals (rightly so), but we need to
-    // ensure here that this function isn't called inside render.
-    RenderDispatcher =
-      // $FlowFixMe[prop-missing]
-      React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
-        ?.ReactCurrentDispatcher?.current;
-  }
-}
 
 type QueryType<T> =
   T extends Query<infer V, infer D, infer RR>
@@ -87,17 +73,6 @@ function loadQuery<
   options?: ?LoadQueryOptions,
   environmentProviderOptions?: ?TEnvironmentProviderOptions,
 ): PreloadedQueryInner<TQuery, TEnvironmentProviderOptions> {
-  // This code ensures that we don't call loadQuery during render.
-  const CurrentDispatcher =
-    // $FlowFixMe[prop-missing]
-    React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
-      ?.ReactCurrentDispatcher?.current;
-  warning(
-    RenderDispatcher == null || CurrentDispatcher !== RenderDispatcher,
-    'Relay: `%s` should not be called inside a React render function.',
-    options?.__nameForWarning ?? 'loadQuery',
-  );
-
   // Every time you call loadQuery, we will generate a new fetchKey.
   // This will ensure that every query reference that is created and
   // passed to usePreloadedQuery is independently evaluated,
@@ -407,5 +382,4 @@ function loadQuery<
 
 module.exports = {
   loadQuery,
-  useTrackLoadQueryInRender,
 };

--- a/packages/react-relay/relay-hooks/useEntryPointLoader.js
+++ b/packages/react-relay/relay-hooks/useEntryPointLoader.js
@@ -20,7 +20,6 @@ import type {
 } from './EntryPointTypes.flow';
 
 const loadEntryPoint = require('./loadEntryPoint');
-const {useTrackLoadQueryInRender} = require('./loadQuery');
 const useIsMountedRef = require('./useIsMountedRef');
 const {useCallback, useEffect, useRef, useState} = require('react');
 
@@ -101,8 +100,6 @@ hook useLoadEntryPoint<
    * Finally, when the hook unmounts, we also dispose of all remaining uncommitted
    * entry point references.
    */
-
-  useTrackLoadQueryInRender();
 
   const initialEntryPointReferenceInternal =
     options?.TEST_ONLY__initialEntryPointData?.entryPointReference ??

--- a/packages/react-relay/relay-hooks/useFragment.js
+++ b/packages/react-relay/relay-hooks/useFragment.js
@@ -13,7 +13,6 @@
 
 import type {Fragment, FragmentType, GraphQLTaggedNode} from 'relay-runtime';
 
-const {useTrackLoadQueryInRender} = require('./loadQuery');
 const useFragmentInternal = require('./useFragmentInternal');
 const useStaticFragmentNodeWarning = require('./useStaticFragmentNodeWarning');
 const {useDebugValue} = require('react');
@@ -49,10 +48,6 @@ declare hook useFragment<TFragmentType: FragmentType, TData>(
 ): ?TData;
 
 hook useFragment(fragment: GraphQLTaggedNode, key: mixed): mixed {
-  // We need to use this hook in order to be able to track if
-  // loadQuery was called during render
-  useTrackLoadQueryInRender();
-
   const fragmentNode = getFragment(fragment);
   useStaticFragmentNodeWarning(fragmentNode, 'first argument of useFragment()');
   const data = useFragmentInternal(fragmentNode, key, 'useFragment()');

--- a/packages/react-relay/relay-hooks/useLazyLoadQuery.js
+++ b/packages/react-relay/relay-hooks/useLazyLoadQuery.js
@@ -19,7 +19,6 @@ import type {
   Variables,
 } from 'relay-runtime';
 
-const {useTrackLoadQueryInRender} = require('./loadQuery');
 const useLazyLoadQueryNode = require('./useLazyLoadQueryNode');
 const useMemoOperationDescriptor = require('./useMemoOperationDescriptor');
 const useRelayEnvironment = require('./useRelayEnvironment');
@@ -51,10 +50,6 @@ hook useLazyLoadQuery<TVariables: Variables, TData>(
     UNSTABLE_renderPolicy?: RenderPolicy,
   },
 ): TData {
-  // We need to use this hook in order to be able to track if
-  // loadQuery was called during render
-  useTrackLoadQueryInRender();
-
   const environment = useRelayEnvironment();
 
   const query = useMemoOperationDescriptor(

--- a/packages/react-relay/relay-hooks/usePreloadedQuery.js
+++ b/packages/react-relay/relay-hooks/usePreloadedQuery.js
@@ -18,7 +18,6 @@ import type {
 } from './EntryPointTypes.flow';
 import type {Query, RenderPolicy, Variables} from 'relay-runtime';
 
-const {useTrackLoadQueryInRender} = require('./loadQuery');
 const useLazyLoadQueryNode = require('./useLazyLoadQueryNode');
 const useMemoOperationDescriptor = require('./useMemoOperationDescriptor');
 const useRelayEnvironment = require('./useRelayEnvironment');
@@ -67,10 +66,6 @@ hook usePreloadedQuery<
     UNSTABLE_renderPolicy?: RenderPolicy,
   },
 ): TData {
-  // We need to use this hook in order to be able to track if
-  // loadQuery was called during render
-  useTrackLoadQueryInRender();
-
   const environment = useRelayEnvironment();
   const {fetchKey, fetchPolicy, source, variables, networkCacheConfig} =
     preloadedQuery;

--- a/packages/react-relay/relay-hooks/useQueryLoader.js
+++ b/packages/react-relay/relay-hooks/useQueryLoader.js
@@ -23,7 +23,7 @@ import type {
   Variables,
 } from 'relay-runtime';
 
-const {loadQuery, useTrackLoadQueryInRender} = require('./loadQuery');
+const {loadQuery} = require('./loadQuery');
 const useIsMountedRef = require('./useIsMountedRef');
 const useRelayEnvironment = require('./useRelayEnvironment');
 const {useCallback, useEffect, useRef, useState} = require('react');
@@ -146,7 +146,6 @@ hook useQueryLoader<TVariables: Variables, TData, TRawResponse: ?{...} = void>(
     initialQueryReference ?? initialNullQueryReferenceState;
 
   const environment = useRelayEnvironment();
-  useTrackLoadQueryInRender();
 
   const isMountedRef = useIsMountedRef();
   const undisposedQueryReferencesRef = useRef<


### PR DESCRIPTION
As part of our push to get runtime tests running on React 19, I uncovered that this internal flag has been removed in React 19 and no reliable alternative currently exists. As such, I think we just have to say goodbye to this warning.