### PR TITLE
Fix act warnings in useQueryLoader-live-query-test, useQueryLoader-test, useStaticFragmentNodeWarning-test

### DIFF
--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
@@ -631,7 +631,7 @@ it('should release and cancel queries on unmount if the callback is called, the 
   expect(renderCount).toEqual(2);
   expect(outerInstance?.toJSON()).toEqual('fallback');
   expect(dispose).not.toHaveBeenCalled();
-  ReactTestRenderer.act(() => outerInstance.unmount());
+  ReactTestRenderer.act(() => outerInstance?.unmount());
   expect(dispose).toHaveBeenCalledTimes(1);
 });
 
@@ -686,7 +686,7 @@ it('releases and cancels all queries if a the callback is called, the component 
   expect(outerInstance?.toJSON()).toEqual('fallback');
   expect(firstDispose).toHaveBeenCalledTimes(1);
   expect(secondDispose).not.toHaveBeenCalled();
-  ReactTestRenderer.act(() => outerInstance.unmount());
+  ReactTestRenderer.act(() => outerInstance?.unmount());
   expect(secondDispose).toHaveBeenCalledTimes(1);
 });
 
@@ -731,7 +731,7 @@ it('releases and cancels all queries if the component suspends, another query is
   expect(renderCount).toEqual(2);
   expect(outerInstance?.toJSON()).toEqual('fallback');
   expect(dispose).not.toHaveBeenCalled();
-  ReactTestRenderer.act(() => outerInstance.unmount());
+  ReactTestRenderer.act(() => outerInstance?.unmount());
   expect(dispose).toHaveBeenCalledTimes(1);
 });
 

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
@@ -614,7 +614,10 @@ it('should release and cancel queries on unmount if the callback is called, the 
     );
   }
 
-  const outerInstance = ReactTestRenderer.create(<Outer />);
+  let outerInstance;
+  ReactTestRenderer.act(() => {
+    outerInstance = ReactTestRenderer.create(<Outer />);
+  });
   expect(renderCount).toEqual(1);
   ReactTestRenderer.act(() => {
     /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
@@ -626,7 +629,7 @@ it('should release and cancel queries on unmount if the callback is called, the 
     setShouldSuspend(true);
   });
   expect(renderCount).toEqual(2);
-  expect(outerInstance.toJSON()).toEqual('fallback');
+  expect(outerInstance?.toJSON()).toEqual('fallback');
   expect(dispose).not.toHaveBeenCalled();
   ReactTestRenderer.act(() => outerInstance.unmount());
   expect(dispose).toHaveBeenCalledTimes(1);
@@ -654,7 +657,10 @@ it('releases and cancels all queries if a the callback is called, the component 
     );
   }
 
-  const outerInstance = ReactTestRenderer.create(<Outer />);
+  let outerInstance;
+  ReactTestRenderer.act(() => {
+    outerInstance = ReactTestRenderer.create(<Outer />);
+  });
   expect(renderCount).toEqual(1);
   ReactTestRenderer.act(() => {
     /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
@@ -668,7 +674,7 @@ it('releases and cancels all queries if a the callback is called, the component 
   });
   expect(renderCount).toEqual(2);
   expect(firstDispose).not.toHaveBeenCalled();
-  expect(outerInstance.toJSON()).toEqual('fallback');
+  expect(outerInstance?.toJSON()).toEqual('fallback');
 
   ReactTestRenderer.act(() => {
     /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
@@ -677,7 +683,7 @@ it('releases and cancels all queries if a the callback is called, the component 
   });
   const secondDispose = dispose;
   expect(renderCount).toEqual(3);
-  expect(outerInstance.toJSON()).toEqual('fallback');
+  expect(outerInstance?.toJSON()).toEqual('fallback');
   expect(firstDispose).toHaveBeenCalledTimes(1);
   expect(secondDispose).not.toHaveBeenCalled();
   ReactTestRenderer.act(() => outerInstance.unmount());
@@ -706,13 +712,16 @@ it('releases and cancels all queries if the component suspends, another query is
     );
   }
 
-  const outerInstance = ReactTestRenderer.create(<Outer />);
+  let outerInstance;
+  ReactTestRenderer.act(() => {
+    outerInstance = ReactTestRenderer.create(<Outer />);
+  });
   expect(renderCount).toEqual(1);
   ReactTestRenderer.act(() => {
     setShouldSuspend(true);
   });
   expect(renderCount).toEqual(1);
-  expect(outerInstance.toJSON()).toEqual('fallback');
+  expect(outerInstance?.toJSON()).toEqual('fallback');
   ReactTestRenderer.act(() => {
     /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
      * useQueryLoader */
@@ -720,7 +729,7 @@ it('releases and cancels all queries if the component suspends, another query is
   });
 
   expect(renderCount).toEqual(2);
-  expect(outerInstance.toJSON()).toEqual('fallback');
+  expect(outerInstance?.toJSON()).toEqual('fallback');
   expect(dispose).not.toHaveBeenCalled();
   ReactTestRenderer.act(() => outerInstance.unmount());
   expect(dispose).toHaveBeenCalledTimes(1);

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
@@ -681,7 +681,7 @@ describe('useQueryLoader', () => {
     expect(renderCount).toEqual(2);
     expect(outerInstance?.toJSON()).toEqual('fallback');
     expect(releaseQuery).not.toHaveBeenCalled();
-    ReactTestRenderer.act(() => outerInstance.unmount());
+    ReactTestRenderer.act(() => outerInstance?.unmount());
     expect(releaseQuery).toHaveBeenCalledTimes(1);
   });
 
@@ -781,7 +781,7 @@ describe('useQueryLoader', () => {
     expect(renderCount).toEqual(2);
     expect(outerInstance?.toJSON()).toEqual('fallback');
     expect(releaseQuery).not.toHaveBeenCalled();
-    ReactTestRenderer.act(() => outerInstance.unmount());
+    ReactTestRenderer.act(() => outerInstance?.unmount());
     expect(releaseQuery).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
@@ -664,7 +664,10 @@ describe('useQueryLoader', () => {
       );
     }
 
-    const outerInstance = ReactTestRenderer.create(<Outer />);
+    let outerInstance;
+    ReactTestRenderer.act(() => {
+      outerInstance = ReactTestRenderer.create(<Outer />);
+    });
     expect(renderCount).toEqual(1);
     ReactTestRenderer.act(() => {
       /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
@@ -676,7 +679,7 @@ describe('useQueryLoader', () => {
       setShouldSuspend(true);
     });
     expect(renderCount).toEqual(2);
-    expect(outerInstance.toJSON()).toEqual('fallback');
+    expect(outerInstance?.toJSON()).toEqual('fallback');
     expect(releaseQuery).not.toHaveBeenCalled();
     ReactTestRenderer.act(() => outerInstance.unmount());
     expect(releaseQuery).toHaveBeenCalledTimes(1);
@@ -704,7 +707,10 @@ describe('useQueryLoader', () => {
       );
     }
 
-    const outerInstance = ReactTestRenderer.create(<Outer />);
+    let outerInstance;
+    ReactTestRenderer.act(() => {
+      outerInstance = ReactTestRenderer.create(<Outer />);
+    });
     expect(renderCount).toEqual(1);
     ReactTestRenderer.act(() => {
       /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
@@ -718,7 +724,7 @@ describe('useQueryLoader', () => {
     });
     expect(renderCount).toEqual(2);
     expect(firstDispose).not.toHaveBeenCalled();
-    expect(outerInstance.toJSON()).toEqual('fallback');
+    expect(outerInstance?.toJSON()).toEqual('fallback');
 
     ReactTestRenderer.act(() => {
       /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
@@ -726,11 +732,11 @@ describe('useQueryLoader', () => {
       queryLoaderCallback({});
     });
     const secondDispose = releaseQuery;
-    expect(renderCount).toEqual(3);
-    expect(outerInstance.toJSON()).toEqual('fallback');
+    expect(renderCount).toEqual(2);
+    expect(outerInstance?.toJSON()).toEqual('fallback');
     expect(firstDispose).toHaveBeenCalledTimes(1);
     expect(secondDispose).not.toHaveBeenCalled();
-    ReactTestRenderer.act(() => outerInstance.unmount());
+    ReactTestRenderer.act(() => outerInstance?.unmount());
     expect(secondDispose).toHaveBeenCalledTimes(1);
   });
 
@@ -756,13 +762,16 @@ describe('useQueryLoader', () => {
       );
     }
 
-    const outerInstance = ReactTestRenderer.create(<Outer />);
+    let outerInstance;
+    ReactTestRenderer.act(() => {
+      outerInstance = ReactTestRenderer.create(<Outer />);
+    });
     expect(renderCount).toEqual(1);
     ReactTestRenderer.act(() => {
       setShouldSuspend(true);
     });
     expect(renderCount).toEqual(1);
-    expect(outerInstance.toJSON()).toEqual('fallback');
+    expect(outerInstance?.toJSON()).toEqual('fallback');
     ReactTestRenderer.act(() => {
       /* $FlowFixMe[prop-missing] error exposed when improving flow typing of
        * useQueryLoader */
@@ -770,7 +779,7 @@ describe('useQueryLoader', () => {
     });
 
     expect(renderCount).toEqual(2);
-    expect(outerInstance.toJSON()).toEqual('fallback');
+    expect(outerInstance?.toJSON()).toEqual('fallback');
     expect(releaseQuery).not.toHaveBeenCalled();
     ReactTestRenderer.act(() => outerInstance.unmount());
     expect(releaseQuery).toHaveBeenCalledTimes(1);

--- a/packages/react-relay/relay-hooks/__tests__/useStaticFragmentNodeWarning-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useStaticFragmentNodeWarning-test.js
@@ -34,29 +34,42 @@ test('warn when a static prop changes', () => {
   const fragmentNode = {name: 'Fragment_foo'};
 
   // initial render doesn't warn
-  const testRenderer = TestRenderer.create(
-    <Example foo={fragmentNode} bar="bar1" />,
-  );
+  let testRenderer;
+  TestRenderer.act(() => {
+    testRenderer = TestRenderer.create(
+      <Example foo={fragmentNode} bar="bar1" />,
+    );
+  });
   expect(mockWarning.mock.calls.length).toBe(1);
   expect(mockWarning.mock.calls[0]).toEqual(notWarned);
 
   // not updating props doesnt warn
-  testRenderer.update(<Example foo={fragmentNode} bar="bar1" />);
+  TestRenderer.act(() => {
+    testRenderer?.update(<Example foo={fragmentNode} bar="bar1" />);
+  });
   expect(mockWarning.mock.calls.length).toBe(2);
   expect(mockWarning.mock.calls[1]).toEqual(notWarned);
 
   // updating a non-checked prop doesn't warn
-  testRenderer.update(<Example foo={fragmentNode} bar="bar2" />);
+  TestRenderer.act(() => {
+    testRenderer?.update(<Example foo={fragmentNode} bar="bar2" />);
+  });
   expect(mockWarning.mock.calls.length).toBe(3);
   expect(mockWarning.mock.calls[2]).toEqual(notWarned);
 
   // different fragment node with same name doesn't warn
-  testRenderer.update(<Example foo={{...fragmentNode}} bar="bar1" />);
+  TestRenderer.act(() => {
+    testRenderer?.update(<Example foo={{...fragmentNode}} bar="bar1" />);
+  });
   expect(mockWarning.mock.calls.length).toBe(4);
   expect(mockWarning.mock.calls[3]).toEqual(notWarned);
 
   // updating a expected static prop warns
-  testRenderer.update(<Example foo={{name: 'OtherFragment_foo'}} bar="bar1" />);
+  TestRenderer.act(() => {
+    testRenderer?.update(
+      <Example foo={{name: 'OtherFragment_foo'}} bar="bar1" />,
+    );
+  });
   expect(mockWarning.mock.calls.length).toBe(5);
   expect(mockWarning.mock.calls[4]).toEqual(warned);
 });


### PR DESCRIPTION

Summary:

Not all tests are passing 100%. But this diff fixes the following errors that showed up after migrating them to React 19 in OSS:

```
    An update to Root inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act
```

Test Plan:

`yarn run jest //path/to/test` in OSS repo

Reviewers:

Subscribers:

Tasks:

Tags: