### PR TITLE
Fix render and dispose checks in useQueryLoader tests

### DIFF
--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-live-query-test.js
@@ -681,13 +681,11 @@ it('releases and cancels all queries if a the callback is called, the component 
      * useQueryLoader */
     queryLoaderCallback({});
   });
-  const secondDispose = dispose;
-  expect(renderCount).toEqual(3);
+  expect(renderCount).toEqual(2);
   expect(outerInstance?.toJSON()).toEqual('fallback');
-  expect(firstDispose).toHaveBeenCalledTimes(1);
-  expect(secondDispose).not.toHaveBeenCalled();
+  expect(firstDispose).not.toHaveBeenCalled();
   ReactTestRenderer.act(() => outerInstance?.unmount());
-  expect(secondDispose).toHaveBeenCalledTimes(1);
+  expect(firstDispose).toHaveBeenCalledTimes(1);
 });
 
 it('releases and cancels all queries if the component suspends, another query is loaded and then the component unmounts', () => {
@@ -728,7 +726,7 @@ it('releases and cancels all queries if the component suspends, another query is
     queryLoaderCallback({});
   });
 
-  expect(renderCount).toEqual(2);
+  expect(renderCount).toEqual(1);
   expect(outerInstance?.toJSON()).toEqual('fallback');
   expect(dispose).not.toHaveBeenCalled();
   ReactTestRenderer.act(() => outerInstance?.unmount());

--- a/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useQueryLoader-test.js
@@ -731,13 +731,11 @@ describe('useQueryLoader', () => {
        * useQueryLoader */
       queryLoaderCallback({});
     });
-    const secondDispose = releaseQuery;
     expect(renderCount).toEqual(2);
     expect(outerInstance?.toJSON()).toEqual('fallback');
-    expect(firstDispose).toHaveBeenCalledTimes(1);
-    expect(secondDispose).not.toHaveBeenCalled();
+    expect(firstDispose).not.toHaveBeenCalled();
     ReactTestRenderer.act(() => outerInstance?.unmount());
-    expect(secondDispose).toHaveBeenCalledTimes(1);
+    expect(firstDispose).toHaveBeenCalledTimes(1);
   });
 
   it('releases all queries if the component suspends, another query is loaded and then the component unmounts', () => {
@@ -778,7 +776,7 @@ describe('useQueryLoader', () => {
       queryLoaderCallback({});
     });
 
-    expect(renderCount).toEqual(2);
+    expect(renderCount).toEqual(1);
     expect(outerInstance?.toJSON()).toEqual('fallback');
     expect(releaseQuery).not.toHaveBeenCalled();
     ReactTestRenderer.act(() => outerInstance?.unmount());


### PR DESCRIPTION
Tests on `renderCount` would be testing React internals, which is unadvised since the tests may fail depending on the React version, and are probably ok to remove. But, these tests are testing Relay behavior -- whether queries are disposed upon re-render -- so I kept the React `renderCount` checks to clarify the expected render behavior that is triggering these query disposals.

I updated the `renderCount` to the correct number for React 19.