### PR TITLE
Fix argument Inlay Hints on nested fields

### DIFF
--- a/compiler/crates/relay-lsp/src/inlay_hints.rs
+++ b/compiler/crates/relay-lsp/src/inlay_hints.rs
@@ -143,7 +143,9 @@ impl Visitor for InlayHintVisitor<'_> {
 
     fn visit_linked_field(&mut self, field: &graphql_ir::LinkedField) {
         let field_def = self.schema.field(field.definition.item);
-        self.add_field_argument_hints(field_def, &field.arguments)
+        self.add_field_argument_hints(field_def, &field.arguments);
+
+        self.default_visit_linked_field(field);
     }
 
     fn visit_fragment_spread(&mut self, spread: &FragmentSpread) {
@@ -163,7 +165,9 @@ impl Visitor for InlayHintVisitor<'_> {
 
     fn visit_inline_fragment(&mut self, fragment: &InlineFragment) {
         if let Ok(Some(alias)) = fragment.alias(self.schema) {
-            self.add_alias_hint(alias.item, fragment.spread_location)
+            self.add_alias_hint(alias.item, fragment.spread_location);
         }
+
+        self.default_visit_inline_fragment(fragment)
     }
 }


### PR DESCRIPTION
Previously the selections of linked fields weren't visited, so arguments on those selections didn't have inlay hints.

|Before|After|
|---|---|
|![CleanShot 2024-07-13 at 16 25 16@2x](https://github.com/user-attachments/assets/9afc9fc3-9af5-4da2-8dfb-5383c0f8956d)|![CleanShot 2024-07-13 at 16 24 29@2x](https://github.com/user-attachments/assets/ef9358b7-9f68-4ef3-aa99-0dd180a12fd9)|