### PR TITLE
[POC] Support multiple @module fragments in the same selection if they have @alias

### DIFF
--- a/packages/relay-runtime/store/__tests__/RelayReader-AliasedFragments-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-AliasedFragments-test.js
@@ -173,9 +173,9 @@ describe('Fragment Spreads', () => {
       '1': {
         __id: '1',
         id: '1',
-        __module_component_RelayReaderAliasedFragmentsTestModuleMatchesQuery:
+        __module_component_RelayReaderAliasedFragmentsTestModuleMatchesQuery_aliased_fragment:
           'PlainUserNameRenderer.react',
-        __module_operation_RelayReaderAliasedFragmentsTestModuleMatchesQuery:
+        __module_operation_RelayReaderAliasedFragmentsTestModuleMatchesQuery_aliased_fragment:
           'RelayReaderAliasedFragmentsTestModuleMatches_user$normalization.graphql',
         __typename: 'User',
       },
@@ -1114,6 +1114,131 @@ describe('Inline Fragments', () => {
     });
   });
 
+  it('Multiple aliased fragments with @module on the same type', () => {
+    const userTypeID = generateTypeID('User');
+    const source = RelayRecordSource.create({
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        'node(id:"1")': {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __module_component_RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_a:
+          'PlainUserNameRenderer.react',
+        __module_operation_RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_a:
+          'RelayReaderAliasedFragmentsTestModuleA_user$normalization.graphql',
+        __module_component_RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_b:
+          'PlainUserNameRenderer.react',
+        __module_operation_RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_b:
+          'RelayReaderAliasedFragmentsTestModuleB_user$normalization.graphql',
+        __typename: 'User',
+      },
+      [userTypeID]: {
+        __id: userTypeID,
+        __typename: TYPE_SCHEMA_TYPE,
+      },
+    });
+
+    graphql`
+      fragment RelayReaderAliasedFragmentsTestModuleA_user on User {
+        name
+      }
+    `;
+    graphql`
+      fragment RelayReaderAliasedFragmentsTestModuleB_user on User {
+        name
+      }
+    `;
+
+    const FooQuery = graphql`
+      query RelayReaderAliasedFragmentsTestMultipleModulesQuery(
+        $id: ID!
+        $conditionA: Boolean!
+        $conditionB: Boolean!
+      ) {
+        node(id: $id) {
+          ...RelayReaderAliasedFragmentsTestModuleA_user
+            @alias(as: "alias_a")
+            @module(name: "PlainUserNameRenderer.react")
+            @include(if: $conditionA)
+          ...RelayReaderAliasedFragmentsTestModuleB_user
+            @alias(as: "alias_b")
+            @module(name: "PlainUserNameRenderer.react")
+            @include(if: $conditionB)
+        }
+      }
+    `;
+
+    function aliasA(operation) {
+      return {
+        __id: '1',
+        __fragments: {
+          RelayReaderAliasedFragmentsTestModuleA_user: {},
+        },
+        __fragmentOwner: operation.request,
+        __fragmentPropName: 'user',
+        __module_component: 'PlainUserNameRenderer.react',
+      };
+    }
+
+    function aliasB(operation) {
+      return {
+        __id: '1',
+        __fragments: {
+          RelayReaderAliasedFragmentsTestModuleB_user: {},
+        },
+        __fragmentOwner: operation.request,
+        __fragmentPropName: 'user',
+        __module_component: 'PlainUserNameRenderer.react',
+      };
+    }
+
+    // Both
+    const both = createOperationDescriptor(FooQuery, {
+      id: '1',
+      conditionA: true,
+      conditionB: true,
+    });
+    expect(read(source, both.fragment).data).toEqual({
+      node: {alias_a: aliasA(both), alias_b: aliasB(both)},
+    });
+
+    // Only A
+    const onlyA = createOperationDescriptor(FooQuery, {
+      id: '1',
+      conditionA: true,
+      conditionB: false,
+    });
+    expect(read(source, onlyA.fragment).data).toEqual({
+      node: {alias_a: aliasA(onlyA), alias_b: undefined},
+    });
+
+    // Only B
+    const onlyB = createOperationDescriptor(FooQuery, {
+      id: '1',
+      conditionA: false,
+      conditionB: true,
+    });
+    expect(read(source, onlyB.fragment).data).toEqual({
+      node: {
+        alias_a: undefined,
+        alias_b: aliasB(onlyB),
+      },
+    });
+
+    // Neither A nor B
+    const neither = createOperationDescriptor(FooQuery, {
+      id: '1',
+      conditionA: false,
+      conditionB: false,
+    });
+    expect(read(source, neither.fragment).data).toEqual({
+      node: {alias_a: undefined, alias_b: undefined},
+    });
+  });
+
   it('Kitchen sink (compose all the directives!)', () => {
     const userTypeID = generateTypeID('User');
     const source = RelayRecordSource.create({
@@ -1125,9 +1250,9 @@ describe('Inline Fragments', () => {
       '1': {
         __id: '1',
         id: '1',
-        __module_component_RelayReaderAliasedFragmentsTestKitchenSinkQuery:
+        __module_component_RelayReaderAliasedFragmentsTestKitchenSinkQuery_aliased_fragment:
           'PlainUserNameRenderer.react',
-        __module_operation_RelayReaderAliasedFragmentsTestKitchenSinkQuery:
+        __module_operation_RelayReaderAliasedFragmentsTestKitchenSinkQuery_aliased_fragment:
           'RelayReaderAliasedFragmentsTestKitchenSink_user$normalization.graphql',
         __typename: 'User',
       },

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestKitchenSinkQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestKitchenSinkQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<69ce567c6fdcad15ae3f85b493df8f16>>
+ * @generated SignedSource<<0f635e1223ce0a75546d8f1bcf5f6c43>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -16,7 +16,7 @@
 
 'use strict';
 
-// @dataDrivenDependency RelayReaderAliasedFragmentsTestKitchenSinkQuery.node {"branches":{"User":{"component":"PlainUserNameRenderer.react","fragment":"RelayReaderAliasedFragmentsTestKitchenSink_user$normalization.graphql"}},"plural":false}
+// @dataDrivenDependency RelayReaderAliasedFragmentsTestKitchenSinkQuery.node.aliased_fragment {"branches":{"User":{"component":"PlainUserNameRenderer.react","fragment":"RelayReaderAliasedFragmentsTestKitchenSink_user$normalization.graphql"}},"plural":false}
 
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
@@ -67,7 +67,7 @@ v3 = [
 v4 = [
   {
     "args": null,
-    "documentName": "RelayReaderAliasedFragmentsTestKitchenSinkQuery",
+    "documentName": "RelayReaderAliasedFragmentsTestKitchenSinkQuery_aliased_fragment",
     "fragmentName": "RelayReaderAliasedFragmentsTestKitchenSink_user",
     "fragmentPropName": "user",
     "kind": "ModuleImport"
@@ -179,12 +179,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f3d045f03aa63d13ef58ad191df1355b",
+    "cacheID": "4f41799dae79fea7b1dd6890150a707c",
     "id": null,
     "metadata": {},
     "name": "RelayReaderAliasedFragmentsTestKitchenSinkQuery",
     "operationKind": "query",
-    "text": "query RelayReaderAliasedFragmentsTestKitchenSinkQuery(\n  $id: ID!\n  $shouldSkip: Boolean!\n  $shouldDefer: Boolean!\n) {\n  node(id: $id) {\n    __typename\n    ... @skip(if: $shouldSkip) @defer(label: \"RelayReaderAliasedFragmentsTestKitchenSinkQuery$defer$RelayReaderAliasedFragmentsTestKitchenSink_user\", if: $shouldDefer) {\n      ... on User {\n        ...RelayReaderAliasedFragmentsTestKitchenSink_user\n        __module_operation_RelayReaderAliasedFragmentsTestKitchenSinkQuery: js(module: \"RelayReaderAliasedFragmentsTestKitchenSink_user$normalization.graphql\", id: \"RelayReaderAliasedFragmentsTestKitchenSinkQuery.node\")\n        __module_component_RelayReaderAliasedFragmentsTestKitchenSinkQuery: js(module: \"PlainUserNameRenderer.react\", id: \"RelayReaderAliasedFragmentsTestKitchenSinkQuery.node\")\n      }\n    }\n    id\n  }\n}\n\nfragment RelayReaderAliasedFragmentsTestKitchenSink_user on User {\n  name\n}\n"
+    "text": "query RelayReaderAliasedFragmentsTestKitchenSinkQuery(\n  $id: ID!\n  $shouldSkip: Boolean!\n  $shouldDefer: Boolean!\n) {\n  node(id: $id) {\n    __typename\n    ... @skip(if: $shouldSkip) @defer(label: \"RelayReaderAliasedFragmentsTestKitchenSinkQuery$defer$RelayReaderAliasedFragmentsTestKitchenSink_user\", if: $shouldDefer) {\n      ... on User {\n        ...RelayReaderAliasedFragmentsTestKitchenSink_user\n        __module_operation_RelayReaderAliasedFragmentsTestKitchenSinkQuery_aliased_fragment: js(module: \"RelayReaderAliasedFragmentsTestKitchenSink_user$normalization.graphql\", id: \"RelayReaderAliasedFragmentsTestKitchenSinkQuery.node.aliased_fragment\")\n        __module_component_RelayReaderAliasedFragmentsTestKitchenSinkQuery_aliased_fragment: js(module: \"PlainUserNameRenderer.react\", id: \"RelayReaderAliasedFragmentsTestKitchenSinkQuery.node.aliased_fragment\")\n      }\n    }\n    id\n  }\n}\n\nfragment RelayReaderAliasedFragmentsTestKitchenSink_user on User {\n  name\n}\n"
   }
 };
 })();

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleA_user$normalization.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleA_user$normalization.graphql.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<a543ee4cce1b1f9d5153c5028b3d2316>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { NormalizationSplitOperation } from 'relay-runtime';
+
+*/
+
+var node/*: NormalizationSplitOperation*/ = {
+  "kind": "SplitOperation",
+  "metadata": {},
+  "name": "RelayReaderAliasedFragmentsTestModuleA_user$normalization",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ]
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "2208c38dc786830dd9c31b09e48dafec";
+}
+
+module.exports = node;

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleA_user.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleA_user.graphql.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<6eb62a5c4057af2db8b775c4fa1a42c2>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RelayReaderAliasedFragmentsTestModuleA_user$fragmentType: FragmentType;
+export type RelayReaderAliasedFragmentsTestModuleA_user$data = {|
+  +name: ?string,
+  +$fragmentType: RelayReaderAliasedFragmentsTestModuleA_user$fragmentType,
+|};
+export type RelayReaderAliasedFragmentsTestModuleA_user$key = {
+  +$data?: RelayReaderAliasedFragmentsTestModuleA_user$data,
+  +$fragmentSpreads: RelayReaderAliasedFragmentsTestModuleA_user$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayReaderAliasedFragmentsTestModuleA_user",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "2208c38dc786830dd9c31b09e48dafec";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  RelayReaderAliasedFragmentsTestModuleA_user$fragmentType,
+  RelayReaderAliasedFragmentsTestModuleA_user$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleB_user$normalization.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleB_user$normalization.graphql.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<f3d53140b6e0c5a184d7f86152690118>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { NormalizationSplitOperation } from 'relay-runtime';
+
+*/
+
+var node/*: NormalizationSplitOperation*/ = {
+  "kind": "SplitOperation",
+  "metadata": {},
+  "name": "RelayReaderAliasedFragmentsTestModuleB_user$normalization",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ]
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "81e045c46e00a4b0594cd79e672bdc3a";
+}
+
+module.exports = node;

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleB_user.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleB_user.graphql.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<bd28c39881893152799abdeadcbb4d5e>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RelayReaderAliasedFragmentsTestModuleB_user$fragmentType: FragmentType;
+export type RelayReaderAliasedFragmentsTestModuleB_user$data = {|
+  +name: ?string,
+  +$fragmentType: RelayReaderAliasedFragmentsTestModuleB_user$fragmentType,
+|};
+export type RelayReaderAliasedFragmentsTestModuleB_user$key = {
+  +$data?: RelayReaderAliasedFragmentsTestModuleB_user$data,
+  +$fragmentSpreads: RelayReaderAliasedFragmentsTestModuleB_user$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayReaderAliasedFragmentsTestModuleB_user",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "81e045c46e00a4b0594cd79e672bdc3a";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  RelayReaderAliasedFragmentsTestModuleB_user$fragmentType,
+  RelayReaderAliasedFragmentsTestModuleB_user$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleMatchesQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleMatchesQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<e4433a962e951f5172582d97d2bce930>>
+ * @generated SignedSource<<a6ed51be71b0339dad7c5301c2c90dc8>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -16,7 +16,7 @@
 
 'use strict';
 
-// @dataDrivenDependency RelayReaderAliasedFragmentsTestModuleMatchesQuery.node {"branches":{"User":{"component":"PlainUserNameRenderer.react","fragment":"RelayReaderAliasedFragmentsTestModuleMatches_user$normalization.graphql"}},"plural":false}
+// @dataDrivenDependency RelayReaderAliasedFragmentsTestModuleMatchesQuery.node.aliased_fragment {"branches":{"User":{"component":"PlainUserNameRenderer.react","fragment":"RelayReaderAliasedFragmentsTestModuleMatches_user$normalization.graphql"}},"plural":false}
 
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
@@ -59,7 +59,7 @@ v2 = {
   "selections": [
     {
       "args": null,
-      "documentName": "RelayReaderAliasedFragmentsTestModuleMatchesQuery",
+      "documentName": "RelayReaderAliasedFragmentsTestModuleMatchesQuery_aliased_fragment",
       "fragmentName": "RelayReaderAliasedFragmentsTestModuleMatches_user",
       "fragmentPropName": "user",
       "kind": "ModuleImport"
@@ -130,12 +130,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4a7639cd62769895c4173c07bc244220",
+    "cacheID": "a94a76ec6b0f3725e7fc6b6b14c4f188",
     "id": null,
     "metadata": {},
     "name": "RelayReaderAliasedFragmentsTestModuleMatchesQuery",
     "operationKind": "query",
-    "text": "query RelayReaderAliasedFragmentsTestModuleMatchesQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on User {\n      ...RelayReaderAliasedFragmentsTestModuleMatches_user\n      __module_operation_RelayReaderAliasedFragmentsTestModuleMatchesQuery: js(module: \"RelayReaderAliasedFragmentsTestModuleMatches_user$normalization.graphql\", id: \"RelayReaderAliasedFragmentsTestModuleMatchesQuery.node\")\n      __module_component_RelayReaderAliasedFragmentsTestModuleMatchesQuery: js(module: \"PlainUserNameRenderer.react\", id: \"RelayReaderAliasedFragmentsTestModuleMatchesQuery.node\")\n    }\n    id\n  }\n}\n\nfragment RelayReaderAliasedFragmentsTestModuleMatches_user on User {\n  name\n}\n"
+    "text": "query RelayReaderAliasedFragmentsTestModuleMatchesQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on User {\n      ...RelayReaderAliasedFragmentsTestModuleMatches_user\n      __module_operation_RelayReaderAliasedFragmentsTestModuleMatchesQuery_aliased_fragment: js(module: \"RelayReaderAliasedFragmentsTestModuleMatches_user$normalization.graphql\", id: \"RelayReaderAliasedFragmentsTestModuleMatchesQuery.node.aliased_fragment\")\n      __module_component_RelayReaderAliasedFragmentsTestModuleMatchesQuery_aliased_fragment: js(module: \"PlainUserNameRenderer.react\", id: \"RelayReaderAliasedFragmentsTestModuleMatchesQuery.node.aliased_fragment\")\n    }\n    id\n  }\n}\n\nfragment RelayReaderAliasedFragmentsTestModuleMatches_user on User {\n  name\n}\n"
   }
 };
 })();

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestModuleQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<8b62361e8f91cc9a7b8f369c8fcadc07>>
+ * @generated SignedSource<<e601ab9ce3e4b6af164e20ce3b64f3e1>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -16,7 +16,7 @@
 
 'use strict';
 
-// @dataDrivenDependency RelayReaderAliasedFragmentsTestModuleQuery.node {"branches":{"User":{"component":"SomeModuleName","fragment":"RelayReaderAliasedFragmentsTestModule_user$normalization.graphql"}},"plural":false}
+// @dataDrivenDependency RelayReaderAliasedFragmentsTestModuleQuery.node.aliased_fragment {"branches":{"User":{"component":"SomeModuleName","fragment":"RelayReaderAliasedFragmentsTestModule_user$normalization.graphql"}},"plural":false}
 
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
@@ -59,7 +59,7 @@ v2 = {
   "selections": [
     {
       "args": null,
-      "documentName": "RelayReaderAliasedFragmentsTestModuleQuery",
+      "documentName": "RelayReaderAliasedFragmentsTestModuleQuery_aliased_fragment",
       "fragmentName": "RelayReaderAliasedFragmentsTestModule_user",
       "fragmentPropName": "user",
       "kind": "ModuleImport"
@@ -130,12 +130,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "747f1fdb5be4d1a2a3bfdef5dffe06da",
+    "cacheID": "590e37c92dcd029eda6bb7ffcc3920e9",
     "id": null,
     "metadata": {},
     "name": "RelayReaderAliasedFragmentsTestModuleQuery",
     "operationKind": "query",
-    "text": "query RelayReaderAliasedFragmentsTestModuleQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on User {\n      ...RelayReaderAliasedFragmentsTestModule_user\n      __module_operation_RelayReaderAliasedFragmentsTestModuleQuery: js(module: \"RelayReaderAliasedFragmentsTestModule_user$normalization.graphql\", id: \"RelayReaderAliasedFragmentsTestModuleQuery.node\")\n      __module_component_RelayReaderAliasedFragmentsTestModuleQuery: js(module: \"SomeModuleName\", id: \"RelayReaderAliasedFragmentsTestModuleQuery.node\")\n    }\n    id\n  }\n}\n\nfragment RelayReaderAliasedFragmentsTestModule_user on User {\n  name\n}\n"
+    "text": "query RelayReaderAliasedFragmentsTestModuleQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ... on User {\n      ...RelayReaderAliasedFragmentsTestModule_user\n      __module_operation_RelayReaderAliasedFragmentsTestModuleQuery_aliased_fragment: js(module: \"RelayReaderAliasedFragmentsTestModule_user$normalization.graphql\", id: \"RelayReaderAliasedFragmentsTestModuleQuery.node.aliased_fragment\")\n      __module_component_RelayReaderAliasedFragmentsTestModuleQuery_aliased_fragment: js(module: \"SomeModuleName\", id: \"RelayReaderAliasedFragmentsTestModuleQuery.node.aliased_fragment\")\n    }\n    id\n  }\n}\n\nfragment RelayReaderAliasedFragmentsTestModule_user on User {\n  name\n}\n"
   }
 };
 })();

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestMultipleModulesQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderAliasedFragmentsTestMultipleModulesQuery.graphql.js
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<fd1d541a67ef0ff1db5b0d842aae690c>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+// @dataDrivenDependency RelayReaderAliasedFragmentsTestMultipleModulesQuery.node.alias_a {"branches":{"User":{"component":"PlainUserNameRenderer.react","fragment":"RelayReaderAliasedFragmentsTestModuleA_user$normalization.graphql"}},"plural":false}
+// @dataDrivenDependency RelayReaderAliasedFragmentsTestMultipleModulesQuery.node.alias_b {"branches":{"User":{"component":"PlainUserNameRenderer.react","fragment":"RelayReaderAliasedFragmentsTestModuleB_user$normalization.graphql"}},"plural":false}
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { RelayReaderAliasedFragmentsTestModuleA_user$fragmentType } from "./RelayReaderAliasedFragmentsTestModuleA_user.graphql";
+import type { RelayReaderAliasedFragmentsTestModuleB_user$fragmentType } from "./RelayReaderAliasedFragmentsTestModuleB_user.graphql";
+export type RelayReaderAliasedFragmentsTestMultipleModulesQuery$variables = {|
+  conditionA: boolean,
+  conditionB: boolean,
+  id: string,
+|};
+export type RelayReaderAliasedFragmentsTestMultipleModulesQuery$data = {|
+  +node: ?{|
+    +alias_a?: ?{|
+      +__fragmentPropName: ?string,
+      +__module_component: ?string,
+      +$fragmentSpreads: RelayReaderAliasedFragmentsTestModuleA_user$fragmentType,
+    |},
+    +alias_b?: ?{|
+      +__fragmentPropName: ?string,
+      +__module_component: ?string,
+      +$fragmentSpreads: RelayReaderAliasedFragmentsTestModuleB_user$fragmentType,
+    |},
+  |},
+|};
+export type RelayReaderAliasedFragmentsTestMultipleModulesQuery = {|
+  response: RelayReaderAliasedFragmentsTestMultipleModulesQuery$data,
+  variables: RelayReaderAliasedFragmentsTestMultipleModulesQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "conditionA"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "conditionB"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v4 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "args": null,
+      "documentName": "RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_a",
+      "fragmentName": "RelayReaderAliasedFragmentsTestModuleA_user",
+      "fragmentPropName": "user",
+      "kind": "ModuleImport"
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+},
+v5 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "args": null,
+      "documentName": "RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_b",
+      "fragmentName": "RelayReaderAliasedFragmentsTestModuleB_user",
+      "fragmentPropName": "user",
+      "kind": "ModuleImport"
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayReaderAliasedFragmentsTestMultipleModulesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "condition": "conditionA",
+            "kind": "Condition",
+            "passingValue": true,
+            "selections": [
+              {
+                "fragment": (v4/*: any*/),
+                "kind": "AliasedInlineFragmentSpread",
+                "name": "alias_a"
+              }
+            ]
+          },
+          {
+            "condition": "conditionB",
+            "kind": "Condition",
+            "passingValue": true,
+            "selections": [
+              {
+                "fragment": (v5/*: any*/),
+                "kind": "AliasedInlineFragmentSpread",
+                "name": "alias_b"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v2/*: any*/),
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "RelayReaderAliasedFragmentsTestMultipleModulesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "condition": "conditionA",
+            "kind": "Condition",
+            "passingValue": true,
+            "selections": [
+              (v4/*: any*/)
+            ]
+          },
+          {
+            "condition": "conditionB",
+            "kind": "Condition",
+            "passingValue": true,
+            "selections": [
+              (v5/*: any*/)
+            ]
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d74c686aa3b59ad8e84f1695b25d87e5",
+    "id": null,
+    "metadata": {},
+    "name": "RelayReaderAliasedFragmentsTestMultipleModulesQuery",
+    "operationKind": "query",
+    "text": "query RelayReaderAliasedFragmentsTestMultipleModulesQuery(\n  $id: ID!\n  $conditionA: Boolean!\n  $conditionB: Boolean!\n) {\n  node(id: $id) {\n    __typename\n    ... on User @include(if: $conditionA) {\n      ...RelayReaderAliasedFragmentsTestModuleA_user\n      __module_operation_RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_a: js(module: \"RelayReaderAliasedFragmentsTestModuleA_user$normalization.graphql\", id: \"RelayReaderAliasedFragmentsTestMultipleModulesQuery.node.alias_a\")\n      __module_component_RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_a: js(module: \"PlainUserNameRenderer.react\", id: \"RelayReaderAliasedFragmentsTestMultipleModulesQuery.node.alias_a\")\n    }\n    ... on User @include(if: $conditionB) {\n      ...RelayReaderAliasedFragmentsTestModuleB_user\n      __module_operation_RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_b: js(module: \"RelayReaderAliasedFragmentsTestModuleB_user$normalization.graphql\", id: \"RelayReaderAliasedFragmentsTestMultipleModulesQuery.node.alias_b\")\n      __module_component_RelayReaderAliasedFragmentsTestMultipleModulesQuery_alias_b: js(module: \"PlainUserNameRenderer.react\", id: \"RelayReaderAliasedFragmentsTestMultipleModulesQuery.node.alias_b\")\n    }\n    id\n  }\n}\n\nfragment RelayReaderAliasedFragmentsTestModuleA_user on User {\n  name\n}\n\nfragment RelayReaderAliasedFragmentsTestModuleB_user on User {\n  name\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "63907b10c529badf9ae8d1ca38e8bc4d";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  RelayReaderAliasedFragmentsTestMultipleModulesQuery$variables,
+  RelayReaderAliasedFragmentsTestMultipleModulesQuery$data,
+>*/);


### PR DESCRIPTION
This will allow us to do a simple variable (or [provided variable](https://relay.dev/docs/next/api-reference/graphql-and-directives/#provided-variables)) version of 3D that does not require adding anything to the schema:

```graphql
query srcAppQuery($condition: Boolean!, $otherCondition: Boolean!) {
  me @match(key: "srcAppQuery_foo") {
     ...Foo @module(name: "ComponentA") @alias @skip(if: $condition)
     ...Bar @module(name: "ComponentB") @alias @skip(if: $otherCondition)
  }
}

fragment Foo on User {
  name
}

fragment Bar on User {
  name
}
```

[Compiler Playground](https://relay.dev/compiler-explorer/#enc=1&schemaText=C4TwDgpgBAigrhATiKBvAUFKBbCAuKAVQGclMoArYgCmwHsATOAG3ygGVhEBLAOwHMAhABoo3BgU48BASklc%2B-dAF906PsCQAzAIYBjaAEkACkmJ1eacrx2550pavShIRUojHYwrXL2DEoEzMLKywbOw4FAXIqWkYWNilFETEJSIc5dMUVNRdoAEEGbD5Pbwhff0DTRHNLDDDbRKilLFj6JlZ7ZNFxLtk%2BxzViPQALcp1QqABHBGQCeCQQHPRhnWYdDwApdgARCEheBghePRAgA&documentText=I4VwpgTgngBAzhAxgQQA6oIrmgCgCSID2AdgCYCWALuSQFwwBChhANmAIbECEANDHoUoALSAGESFanUbM2nLgEoYAbwBQMGAFswMAAKb2lREJwBrMFHoAiBCnRZIUAPoAzZlaVqN3gHR%2BAYsx6moSkIGw4xOza1uKaqCRgxJTIHnrsLOTscHpwpuSoOOQu9AQSVDTECureMH4%2BDOwQwaHhYJHRYLGE8YnJDGm6GVk5unkFRSX8giIQ4mQVJNUaAL6qa6ouEOwA5trJMIGEMCQwAKpwkCo1Udrrqpvbe0mUjE0nxOeXzV4wt2DrIA&inputWindow=document&outputType=operation&no_inline=true&enable_3d_branch_arg_generation=true&actor_change_support=true&text_artifacts=true&skip_printing_nulls=true&compact_query_text=true&enable_fragment_aliases=true&enforce_fragment_alias_where_ambiguous=true&enable_catch_directive_transform=true&disallow_required_on_non_null_fields=true&language=typescript) (fails on current playground)

## Todo:

- [ ] Add compiler tests
- [ ] Add tests for nested aliases
- [ ] Add tests when the alias is on an inline fragment
- [ ] See if there are error messages where we could recommend using `@alias`

## Optional:
- [ ] Check if we can remove the need for `@match` key all together (could we derive one from path? is there some value in it being explicit?)
- [ ] I noticed that we can probably remove `fragmentPropName` from module import normalization nodes. Maybe even `fragmentName` (it's only used for runtime error reporting).