### PR TITLE
Don't skip ActorChangeWithStream in OSS, it already passes

### DIFF
--- a/packages/react-relay/multi-actor/__tests__/ActorChangeWithStream-test.js
+++ b/packages/react-relay/multi-actor/__tests__/ActorChangeWithStream-test.js
@@ -37,7 +37,7 @@ const {
   MultiActorEnvironment,
   getActorIdentifier,
 } = require('relay-runtime/multi-actor-environment');
-const {disallowWarnings, skipIf} = require('relay-test-utils-internal');
+const {disallowWarnings} = require('relay-test-utils-internal');
 
 function ComponentWrapper(
   props: $ReadOnly<{
@@ -148,7 +148,7 @@ describe('ActorChange with @stream', () => {
     );
   });
 
-  skipIf(process.env.OSS, 'should render a fragment for actor', () => {
+  test('should render a fragment for actor', () => {
     fetchFnForActor = (
       ...args: Array<?(
         | LogRequestInfoFunction


### PR DESCRIPTION
This test does not play well with skipIf because it generates a snapshot and Jest sees the skipped snapshot test as out of date and thus failing. But when I tried to run it locally without skipping it, it seems to pass on my machine.
<img width="471" alt="Screenshot 2024-08-05 at 1 17 10 PM" src="https://github.com/user-attachments/assets/2275916e-21a1-4f42-9b34-e09199dbd3ae">
