### PR TITLE
Log disk usage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
         run: cargo fetch --manifest-path=compiler/Cargo.toml
       - name: "Check free disk space"
         run: df -h
+      - name: "pwd"
+        run: pwd
       - name: "Run tests"
         run: CARGO_TARGET_DIR=/cargo-test-artifacts cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: "pwd"
         run: pwd
       - name: "Run tests"
-        run: CARGO_TARGET_DIR=/cargo-test-artifacts cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
+        run: CARGO_TARGET_DIR=~/cargo-test-artifacts cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 
   build-test-projects:
     name: Compiler output check (${{ matrix.target.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: "Check disk usage (including . files)"
         run: du -sh .[^.]* *
       - name: "Fetch cargo dependencies"
-        run: cargo fetch
+        run: cargo fetch --manifest-path=compiler/Cargo.toml
       - name: "Check free disk space"
         run: df -h
       - name: "Run tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
         with:
           toolchain: 1.72.0
           override: true
+      - name: "Check free disk space"
+        run: df -h
+      - name: "Check disk usage (including . files)"
+        run: du -sh .[^.]* *
       - name: "Run tests"
         run: cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: "Check free disk space"
         run: df -h
       - name: "Run tests"
-        run: cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
+        run: CARGO_TARGET_DIR=/cargo-test-artifacts cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 
   build-test-projects:
     name: Compiler output check (${{ matrix.target.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
         run: df -h
       - name: "Check disk usage (including . files)"
         run: du -sh .[^.]* *
+      - name: "Fetch cargo dependencies"
+        run: cargo fetch
+      - name: "Check free disk space"
+        run: df -h
       - name: "Run tests"
         run: cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 


### PR DESCRIPTION
Trying to debug CI failures caused by running out of disk.

Running Rust tests on Ubuntu is what's failing reliability. Specifically, it fails when compiling the tests. Right before I run tests (which compiles tests as a side effect). The disk usage reported is:

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   55G   18G  76% /
tmpfs           7.9G  172K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

So we should still have 18BG to play with on the main disk, assuming that's where compiler artifacts will be written?

If I run `CARGO_TARGET_DIR=~/tmp/cargo-test cargo test --features vendored` on my local machine (mac). Only 4.2 G of stuff is written to `~/tmp/cargo-test`, which seems like it shouldn't be a problem given we have 18G free...
