### PR TITLE
Fix conditional sub-selections in raw response type

### DIFF
--- a/compiler/crates/relay-typegen/src/visit.rs
+++ b/compiler/crates/relay-typegen/src/visit.rs
@@ -1296,6 +1296,38 @@ fn visit_scalar_field(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn raw_response_visit_condition(
+    typegen_context: &'_ TypegenContext<'_>,
+    type_selections: &mut Vec<TypeSelection>,
+    condition: &Condition,
+    encountered_enums: &mut EncounteredEnums,
+    match_fields: &mut MatchFields,
+    encountered_fragments: &mut EncounteredFragments,
+    imported_raw_response_types: &mut ImportedRawResponseTypes,
+    runtime_imports: &mut RuntimeImports,
+    custom_scalars: &mut CustomScalarsImports,
+    enclosing_linked_field_concrete_type: Option<Type>,
+    emit_semantic_types: bool,
+) {
+    let mut selections = raw_response_visit_selections(
+        typegen_context,
+        &condition.selections,
+        encountered_enums,
+        match_fields,
+        encountered_fragments,
+        imported_raw_response_types,
+        runtime_imports,
+        custom_scalars,
+        enclosing_linked_field_concrete_type,
+        emit_semantic_types,
+    );
+    for selection in selections.iter_mut() {
+        selection.set_conditional(true);
+    }
+    type_selections.append(&mut selections);
+}
+
+#[allow(clippy::too_many_arguments)]
 fn visit_condition(
     typegen_context: &'_ TypegenContext<'_>,
     type_selections: &mut Vec<TypeSelection>,
@@ -2338,20 +2370,19 @@ pub(crate) fn raw_response_visit_selections(
                 enclosing_linked_field_concrete_type,
                 emit_semantic_types,
             ),
-            Selection::Condition(condition) => {
-                type_selections.extend(raw_response_visit_selections(
-                    typegen_context,
-                    &condition.selections,
-                    encountered_enums,
-                    match_fields,
-                    encountered_fragments,
-                    imported_raw_response_types,
-                    runtime_imports,
-                    custom_scalars,
-                    enclosing_linked_field_concrete_type,
-                    emit_semantic_types,
-                ));
-            }
+            Selection::Condition(condition) => raw_response_visit_condition(
+                typegen_context,
+                &mut type_selections,
+                condition,
+                encountered_enums,
+                match_fields,
+                encountered_fragments,
+                imported_raw_response_types,
+                runtime_imports,
+                custom_scalars,
+                enclosing_linked_field_concrete_type,
+                emit_semantic_types,
+            ),
         }
     }
     type_selections

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-raw-response-on-conditional.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/query-with-raw-response-on-conditional.expected
@@ -29,13 +29,13 @@ export type ExampleQuery$data = {|
 export type ExampleQuery$rawResponse = {|
   +node: ?({|
     +__typename: "User",
-    +feedback: ?{|
+    +feedback?: ?{|
       +id: string,
       +name: ?string,
     |},
     +id: string,
-    +lastName: ?string,
-    +name: ?string,
+    +lastName?: ?string,
+    +name?: ?string,
   |} | {|
     +__typename: string,
     +id: string,

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-conditional.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/query-with-raw-response-on-conditional.expected
@@ -29,13 +29,13 @@ export type ExampleQuery$data = {
 export type ExampleQuery$rawResponse = {
   readonly node: {
     readonly __typename: "User";
-    readonly feedback: {
+    readonly feedback?: {
       readonly id: string;
       readonly name: string | null | undefined;
     } | null | undefined;
     readonly id: string;
-    readonly lastName: string | null | undefined;
-    readonly name: string | null | undefined;
+    readonly lastName?: string | null | undefined;
+    readonly name?: string | null | undefined;
   } | {
     readonly __typename: string;
     readonly id: string;

--- a/packages/relay-test-utils/__tests__/__generated__/RelayMockPayloadGeneratorTest_fragment59$normalization.graphql.js
+++ b/packages/relay-test-utils/__tests__/__generated__/RelayMockPayloadGeneratorTest_fragment59$normalization.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<e611708b926d554b0ade476854044390>>
+ * @generated SignedSource<<4cdda03c548724371f4b5575c7ac4495>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -21,7 +21,7 @@ import type { NormalizationSplitOperation } from 'relay-runtime';
 
 export type RelayMockPayloadGeneratorTest_fragment59$normalization = {|
   +id: string,
-  +name: ?string,
+  +name?: ?string,
 |};
 
 */

--- a/packages/relay-test-utils/__tests__/__generated__/RelayMockPayloadGeneratorTest_fragment61$normalization.graphql.js
+++ b/packages/relay-test-utils/__tests__/__generated__/RelayMockPayloadGeneratorTest_fragment61$normalization.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<eceadb8efbc75aa6f4d980309b354fb0>>
+ * @generated SignedSource<<10d99aad572cf708781d6a2425fc893e>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -21,7 +21,7 @@ import type { NormalizationSplitOperation } from 'relay-runtime';
 
 export type RelayMockPayloadGeneratorTest_fragment61$normalization = {|
   +id: string,
-  +name: ?string,
+  +name?: ?string,
 |};
 
 */


### PR DESCRIPTION
Previously conditional selections were always generated as required properties on the raw response type.
This is inconvenient if your component code checks for the presence of a field and you can't model the skipped state in a test using `@raw_response_type` without partially disabling type checking.

This PR makes all conditional selections optional in the raw response type.