### PR TITLE
Add copy operation command

### DIFF
--- a/compiler/crates/relay-lsp/src/graphql_tools.rs
+++ b/compiler/crates/relay-lsp/src/graphql_tools.rs
@@ -79,7 +79,7 @@ impl Request for GraphQLExecuteQuery {
 /// This function will return the program that contains only operation
 /// and all referenced fragments.
 /// We can use it to print the full query text
-fn get_operation_only_program(
+pub fn get_operation_only_program(
     operation: Arc<OperationDefinition>,
     fragments: Vec<Arc<FragmentDefinition>>,
     program: &Program,

--- a/compiler/crates/relay-lsp/src/lib.rs
+++ b/compiler/crates/relay-lsp/src/lib.rs
@@ -23,6 +23,7 @@ mod lsp_extra_data_provider;
 pub mod lsp_process_error;
 pub mod lsp_runtime_error;
 pub mod node_resolution_info;
+pub mod print_operation;
 pub mod references;
 pub mod rename;
 mod resolved_types_at_location;

--- a/compiler/crates/relay-lsp/src/print_operation.rs
+++ b/compiler/crates/relay-lsp/src/print_operation.rs
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use graphql_ir::OperationDefinitionName;
+use lsp_types::request::Request;
+use lsp_types::TextDocumentPositionParams;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::GlobalState;
+use crate::LSPRuntimeError;
+use crate::LSPRuntimeResult;
+
+pub(crate) fn on_print_operation(
+    state: &impl GlobalState,
+    params: <PrintOperation as Request>::Params,
+) -> LSPRuntimeResult<<PrintOperation as Request>::Result> {
+    let text_document_uri = params
+        .text_document_position_params
+        .text_document
+        .uri
+        .clone();
+
+    let project_name = state.extract_project_name_from_url(&text_document_uri)?;
+    let executable_document_under_cursor =
+        state.extract_executable_document_from_text(&params.text_document_position_params, 1);
+
+    let operation_name = match executable_document_under_cursor {
+        Ok((document, _)) => {
+            get_first_operation_name(&document.definitions).ok_or(LSPRuntimeError::ExpectedError)
+        }
+        Err(_) => {
+            let executable_definitions =
+                state.resolve_executable_definitions(&text_document_uri)?;
+
+            if executable_definitions.is_empty() {
+                return Err(LSPRuntimeError::ExpectedError);
+            }
+
+            get_first_operation_name(&executable_definitions).ok_or(LSPRuntimeError::ExpectedError)
+        }
+    }?;
+
+    state
+        .get_operation_text(operation_name, &project_name)
+        .map(|operation_text| PrintOperationResponse {
+            operation_name: operation_name.0.to_string(),
+            operation_text,
+        })
+}
+
+fn get_first_operation_name(
+    executable_definitions: &[graphql_syntax::ExecutableDefinition],
+) -> Option<OperationDefinitionName> {
+    executable_definitions.iter().find_map(|definition| {
+        if let graphql_syntax::ExecutableDefinition::Operation(operation) = definition {
+            if let Some(name) = &operation.name {
+                return Some(OperationDefinitionName(name.value.clone()));
+            }
+
+            None
+        } else {
+            None
+        }
+    })
+}
+
+pub(crate) enum PrintOperation {}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrintOperationParams {
+    #[serde(flatten)]
+    pub text_document_position_params: TextDocumentPositionParams,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PrintOperationResponse {
+    pub operation_name: String,
+    pub operation_text: String,
+}
+
+impl Request for PrintOperation {
+    type Params = PrintOperationParams;
+    type Result = PrintOperationResponse;
+    const METHOD: &'static str = "relay/printOperation";
+}

--- a/compiler/crates/relay-lsp/src/server.rs
+++ b/compiler/crates/relay-lsp/src/server.rs
@@ -80,6 +80,8 @@ use crate::hover::on_hover;
 use crate::inlay_hints::on_inlay_hint_request;
 use crate::lsp_process_error::LSPProcessResult;
 use crate::lsp_runtime_error::LSPRuntimeError;
+use crate::print_operation::on_print_operation;
+use crate::print_operation::PrintOperation;
 use crate::references::on_references;
 use crate::rename::on_prepare_rename;
 use crate::rename::on_rename;
@@ -258,6 +260,7 @@ fn dispatch_request(request: lsp_server::Request, lsp_state: &impl GlobalState) 
             .on_request_sync::<GetSourceLocationOfTypeDefinition>(
                 on_get_source_location_of_type_definition,
             )?
+            .on_request_sync::<PrintOperation>(on_print_operation)?
             .on_request_sync::<HoverRequest>(on_hover)?
             .on_request_sync::<GotoDefinition>(on_goto_definition)?
             .on_request_sync::<References>(on_references)?

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -39,6 +39,10 @@
       {
         "command": "relay.stopCompiler",
         "title": "Relay: Stop Compiler"
+      },
+      {
+        "command": "relay.copyOperation",
+        "title": "Relay: Copy Operation"
       }
     ],
     "configuration": {

--- a/vscode-extension/src/commands/copyOperation.ts
+++ b/vscode-extension/src/commands/copyOperation.ts
@@ -19,6 +19,9 @@ export function handleCopyOperation(context: RelayExtensionContext): void {
       semver.prerelease(binaryVersion) != null;
 
     if (!isSupportedCompilerVersion) {
+      window.showWarningMessage(
+        'Unsupported relay-compiler version. Requires >17.0.0',
+      );
       return;
     }
   }

--- a/vscode-extension/src/commands/copyOperation.ts
+++ b/vscode-extension/src/commands/copyOperation.ts
@@ -46,11 +46,9 @@ export function handleCopyOperation(context: RelayExtensionContext): void {
 
   context.client.sendRequest(request, params).then(response => {
     env.clipboard.writeText(response.operationText).then(() => {
-      const message = response.operationName
-        ? `Copied operation "${response.operationName}" to clipboard`
-        : 'Copied operation to clipboard';
-
-      window.showInformationMessage(message);
+      window.showInformationMessage(
+        `Copied operation "${response.operationName}" to clipboard`,
+      );
     });
   });
 }

--- a/vscode-extension/src/commands/copyOperation.ts
+++ b/vscode-extension/src/commands/copyOperation.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as semver from 'semver';
+import {window, env} from 'vscode';
+import {RequestType, TextDocumentPositionParams} from 'vscode-languageclient';
+import {RelayExtensionContext} from '../context';
+
+export function handleCopyOperation(context: RelayExtensionContext): void {
+  const {binaryVersion} = context.relayBinaryExecutionOptions;
+
+  if (binaryVersion) {
+    const isSupportedCompilerVersion =
+      semver.satisfies(binaryVersion, '>17.0') ||
+      semver.prerelease(binaryVersion) != null;
+
+    if (!isSupportedCompilerVersion) {
+      return;
+    }
+  }
+
+  if (!context.client || !context.client.isRunning()) {
+    return;
+  }
+
+  const activeEditor = window.activeTextEditor;
+
+  if (!activeEditor) {
+    return;
+  }
+
+  const request = new RequestType<
+    TextDocumentPositionParams,
+    PrintOperationResponse,
+    void
+  >('relay/printOperation');
+
+  const params: TextDocumentPositionParams = {
+    textDocument: {uri: activeEditor.document.uri.toString()},
+    position: activeEditor.selection.active,
+  };
+
+  context.client.sendRequest(request, params).then(response => {
+    env.clipboard.writeText(response.operationText).then(() => {
+      const message = response.operationName
+        ? `Copied operation "${response.operationName}" to clipboard`
+        : 'Copied operation to clipboard';
+
+      window.showInformationMessage(message);
+    });
+  });
+}
+
+type PrintOperationResponse = {
+  operationName: string;
+  operationText: string;
+};

--- a/vscode-extension/src/commands/copyOperation.ts
+++ b/vscode-extension/src/commands/copyOperation.ts
@@ -15,12 +15,12 @@ export function handleCopyOperation(context: RelayExtensionContext): void {
 
   if (binaryVersion) {
     const isSupportedCompilerVersion =
-      semver.satisfies(binaryVersion, '>17.0') ||
+      semver.satisfies(binaryVersion, '>18.0') ||
       semver.prerelease(binaryVersion) != null;
 
     if (!isSupportedCompilerVersion) {
       window.showWarningMessage(
-        'Unsupported relay-compiler version. Requires >17.0.0',
+        'Unsupported relay-compiler version. Requires >18.0.0',
       );
       return;
     }

--- a/vscode-extension/src/commands/register.ts
+++ b/vscode-extension/src/commands/register.ts
@@ -11,6 +11,7 @@ import {handleRestartLanguageServerCommand} from './restart';
 import {handleShowOutputCommand} from './showOutput';
 import {handleStartCompilerCommand} from './startCompiler';
 import {handleStopCompilerCommand} from './stopCompiler';
+import {handleCopyOperation} from './copyOperation';
 
 export function registerCommands(context: RelayExtensionContext) {
   context.extensionContext.subscriptions.push(
@@ -29,6 +30,10 @@ export function registerCommands(context: RelayExtensionContext) {
     commands.registerCommand(
       'relay.showOutput',
       handleShowOutputCommand.bind(null, context),
+    ),
+    commands.registerCommand(
+      'relay.copyOperation',
+      handleCopyOperation.bind(null, context),
     ),
   );
 }


### PR DESCRIPTION
I often find myself in a situation where I want to quickly run a Relay query outside of the configured Relay environment, i.e. a GraphQL IDE or another tool. When not using persisted operations, I need to go to the artifact, copy out the value of the `text` property and get rid of all the `\n` line breaks in the text. For persisted operations it's less tedious, I just grab the `id` from the artifact and look up the operation in the operation store, but it's still more cumbersome than it has to be.

This implements a new `relay/printOperation` request in the LSP that returns the transformed operation text of the operation under the cursor or the first operation inside the document. The VS Code Extension is also updated with a `relay.copyOperation` command that invokes that LSP request and copies the operation text to the clipboard.

<img src="https://github.com/user-attachments/assets/52cdff85-dad2-4236-b4d8-c155c02c2c97" width="500" alt="Example of the command in action" />
