### PR TITLE
Update Rust toolchain to 1.76.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.72.0
+          toolchain: 1.76.0
           override: true
       - name: "Run tests"
         run: cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.72.0
+          toolchain: 1.76.0
           override: true
       - name: "Update fixture tests"
         run: ./scripts/update-fixtures.sh
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.72.0
+          toolchain: 1.76.0
           override: true
           target: ${{ matrix.target.target }}
       - uses: actions/setup-node@v2

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.73.0 # We hit an LLVM error building Wasm on 1.72
+          toolchain: 1.76.0
           override: true
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.72.0
+          toolchain: 1.76.0
           override: true
       - name: cargo check
         run: cargo check --features vendored --manifest-path=compiler/Cargo.toml

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -2079,10 +2079,12 @@ dependencies = [
 name = "schema-print"
 version = "0.0.0"
 dependencies = [
+ "diff",
  "fixture-tests",
  "fnv",
  "intern",
  "itertools 0.11.0",
+ "rayon",
  "schema",
  "tokio",
 ]
@@ -2710,9 +2712,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",


### PR DESCRIPTION
Since https://github.com/facebook/relay/commit/176f96fd637e3879efc2dad0b7867b6703fe023c the compiler can no longer be built in the GitHub CI. 
It seems there's a mismatch between Facebook's internal Rust toolchain version and the one used in OSS (1.72.0).
Through manual testing I found out that the compiler can be built using the 1.76.0 Rust toolchain.