### PR TITLE
Fix GitHub CI (again)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Build project
         working-directory: compiler
         run: ${{ matrix.target.cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target.target }} ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target.artifact-name }}
           path: compiler/target/${{ matrix.target.target }}/release/${{ matrix.target.build-name }}


### PR DESCRIPTION
The builds are failing because of the usage of the deprecated `actions/upload-artifact@v2`: https://github.com/facebook/relay/actions/runs/10705945142/job/29682504657

This PR switches to the latest `actions/upload-artifact@v4`