### PR TITLE
Update download-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,27 +230,27 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
       - name: Download artifact relay-bin-linux-x64
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: relay-bin-linux-x64
           path: artifacts/linux-x64
       - name: Download artifact relay-bin-linux-arm64
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: relay-bin-linux-arm64
           path: artifacts/linux-arm64
       - name: Download artifact relay-bin-macos-x64
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: relay-bin-macos-x64
           path: artifacts/macos-x64
       - name: Download artifact relay-bin-macos-arm64
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: relay-bin-macos-arm64
           path: artifacts/macos-arm64
       - name: Download artifact relay-bin-win-x64
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: relay-bin-win-x64
           path: artifacts/win-x64


### PR DESCRIPTION
NPM publish is failing with 
<img width="1341" alt="Screenshot 2024-09-06 at 10 05 09 AM" src="https://github.com/user-attachments/assets/39685c55-e740-45d6-a10d-e35fa71a763e">

Looks like this is symmetrical to @tobias-tengler's https://github.com/facebook/relay/pull/4781