### PR TITLE
Make workspace root lazy static to try to avoid cwd race condition

### DIFF
--- a/compiler/crates/fixture-tests/src/lib.rs
+++ b/compiler/crates/fixture-tests/src/lib.rs
@@ -63,6 +63,12 @@ use tokio::sync::Mutex;
 
 lazy_static! {
     static ref LOCK: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+    // It's possible that a test will change the current directory leading to a
+    // race condition where if an async test is running at the same time as
+    // another test is trying to check the workspace root, it will get the wrong
+    // value. To mitigate that risk we compute the workspace root only
+    // once, before any tests run, and reuse that value for all tests.
+    pub static ref WORKSPACE_ROOT: PathBuf = workspace_root();
 }
 
 /// Passed to the `transform_fixture` from the test as the input to transform.
@@ -101,6 +107,11 @@ pub async fn test_fixture<T, U, V>(
     U: std::fmt::Display,
     V: std::fmt::Display,
 {
+    // It's possible that a test will change the current directory leading to a
+    // race condition where if an async test is running at the same time as
+    // another test is trying to check the workspace root, it will get the wrong
+    // value. To mitigate that risk we compute the workspace root early.
+    let workspace_root = &WORKSPACE_ROOT;
     let fixture = Fixture {
         file_name: input_file_name,
         content: input,
@@ -155,7 +166,7 @@ pub async fn test_fixture<T, U, V>(
     };
 
     let actual = format!("{}\n", actual.trim_end());
-    let expected_file_path = workspace_root()
+    let expected_file_path = workspace_root
         .join(source_file_path)
         .with_file_name(expected_file_name);
     assert_file_contains(&actual, expected_file_path, expected)
@@ -187,7 +198,7 @@ pub fn assert_file_contains(actual: &str, expected_file_path: PathBuf, expected:
     }
 }
 
-pub fn workspace_root() -> PathBuf {
+fn workspace_root() -> PathBuf {
     if let Ok(cargo) = std::env::var("CARGO") {
         let output_result = Command::new(cargo)
             .args(["locate-project", "--workspace", "--message-format=plain"])

--- a/compiler/crates/fixture-tests/src/lib.rs
+++ b/compiler/crates/fixture-tests/src/lib.rs
@@ -189,11 +189,19 @@ pub fn assert_file_contains(actual: &str, expected_file_path: PathBuf, expected:
 
 pub fn workspace_root() -> PathBuf {
     if let Ok(cargo) = std::env::var("CARGO") {
-        let stdout = Command::new(cargo)
+        let output_result = Command::new(cargo)
             .args(["locate-project", "--workspace", "--message-format=plain"])
-            .output()
-            .unwrap()
-            .stdout;
+            .output();
+        let stdout = match output_result {
+            Ok(output) => output.stdout,
+            Err(err) => {
+                panic!(
+                    "Failed to locate project from within {:?}: {:?}",
+                    std::env::current_dir(),
+                    err
+                )
+            }
+        };
         let workspace_cargo_toml = PathBuf::from(&std::str::from_utf8(&stdout).unwrap().trim());
         workspace_cargo_toml.parent().unwrap().to_path_buf()
     } else {

--- a/compiler/crates/relay-compiler/tests/relay_config_schema_json_test.rs
+++ b/compiler/crates/relay-compiler/tests/relay_config_schema_json_test.rs
@@ -6,7 +6,7 @@
  */
 
 use fixture_tests::assert_file_contains;
-use fixture_tests::workspace_root;
+use fixture_tests::WORKSPACE_ROOT;
 use relay_compiler::ConfigFile;
 
 #[tokio::test]
@@ -15,7 +15,7 @@ async fn json_schema() {
     let expected = include_str!("../relay-compiler-config-schema.json");
     let source_file_path = file!();
 
-    let expected_file_path = workspace_root()
+    let expected_file_path = WORKSPACE_ROOT
         .join(source_file_path)
         .with_file_name("../relay-compiler-config-schema.json");
     assert_file_contains(&actual, expected_file_path, expected)


### PR DESCRIPTION
Trying to get more info on the failure I see here: https://github.com/facebook/relay/actions/runs/10742885102/job/29796930703