### PR TITLE
Attempt to avoid cycled when expanding updated ids to include impacted resolvers

### DIFF
--- a/packages/react-relay/__tests__/LiveResolvers-test.js
+++ b/packages/react-relay/__tests__/LiveResolvers-test.js
@@ -92,1783 +92,1813 @@ test('Can read an external state resolver directly', () => {
   });
 });
 
-test('Environment subscribers see updates pushed from external data source', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-      me: {__ref: '1'},
-    },
-    '1': {
-      __id: '1',
-      __typename: 'User',
-      id: '1',
-    },
-  });
-  const FooQuery = graphql`
-    query LiveResolversTest2Query {
-      counter
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  let observedCounter = null;
-
-  const snapshot = environment.lookup(operation.fragment);
-  // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-  observedCounter = (snapshot.data: any).counter;
-
-  const environmentUpdateHandler = jest.fn(() => {
-    const s = environment.lookup(operation.fragment);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    observedCounter = (s.data: any).counter;
-  });
-  const disposable = environment.subscribe(
-    snapshot,
-    // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
-    environmentUpdateHandler,
-  );
-
-  // SETUP COMPLETE
-
-  // Read the initial value
-  expect(observedCounter).toBe(0);
-  expect(environmentUpdateHandler).not.toHaveBeenCalled();
-
-  // Increment and assert we get notified of the new value
-  GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
-  expect(observedCounter).toBe(1);
-
-  // Unsubscribe then increment and assert don't get notified.
-  disposable.dispose();
-  GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
-  expect(observedCounter).toBe(1);
-
-  // Explicitly read and assert we see the incremented value
-  // missed before due to unsubscribing.
-  const nextSnapshot = environment.lookup(operation.fragment);
-
-  expect(nextSnapshot.data).toEqual({
-    counter: 2,
-  });
-});
-
-test('Relay Resolvers that read Live Resolvers see updates pushed from external data source', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-      me: {__ref: '1'},
-    },
-    '1': {
-      __id: '1',
-      __typename: 'User',
-      id: '1',
-    },
-  });
-  const FooQuery = graphql`
-    query LiveResolversTest3Query {
-      counter_plus_one
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  let observedCounterPlusOne = null;
-
-  const snapshot = environment.lookup(operation.fragment);
-  // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-  observedCounterPlusOne = (snapshot.data: any).counter_plus_one;
-
-  const environmentUpdateHandler = jest.fn(() => {
-    const s = environment.lookup(operation.fragment);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    observedCounterPlusOne = (s.data: any).counter_plus_one;
-  });
-  const disposable = environment.subscribe(
-    snapshot,
-    // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
-    environmentUpdateHandler,
-  );
-
-  // SETUP COMPLETE
-
-  // Read the initial value
-  expect(observedCounterPlusOne).toBe(1);
-  expect(environmentUpdateHandler).not.toHaveBeenCalled();
-
-  // Increment and assert we get notified of the new value
-  GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
-  expect(observedCounterPlusOne).toBe(2);
-
-  // Unsubscribe then increment and assert don't get notified.
-  disposable.dispose();
-  GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
-  expect(observedCounterPlusOne).toBe(2);
-
-  // Explicitly read and assert we see the incremented value
-  // missed before due to unsubscribing.
-  const nextSnapshot = environment.lookup(operation.fragment);
-  expect(nextSnapshot.data).toEqual({
-    counter_plus_one: 3,
-  });
-});
-
-// This triggers a potential edge case where the subscription is created before
-// we create the record where we store the value.
-test('Can handle a Live Resolver that triggers an update immediately on subscribe', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-      me: {__ref: '1'},
-    },
-    '1': {
-      __id: '1',
-      __typename: 'User',
-      id: '1',
-    },
-  });
-  const FooQuery = graphql`
-    query LiveResolversTest4Query {
-      ping
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  const data = environment.lookup(operation.fragment).data;
-  expect(data).toEqual({
-    ping: 'pong',
-  });
-});
-
-test('Subscriptions created while in an optimistic state is in place get cleaned up correctly', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-    '1': {
-      __id: '1',
-      __typename: 'User',
-      id: '1',
-      name: 'Alice',
-    },
-  });
-  const store = new LiveResolverStore(source, {gcReleaseBufferSize: 0});
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  const update = environment.applyUpdate({
-    storeUpdater: store => {
-      const alice = store.get('1');
-      if (alice == null) {
-        throw new Error('Expected to have record "1"');
-      }
-      const storeRoot = store.getRoot();
-      storeRoot.setLinkedRecord(alice, 'me');
-    },
-  });
-
-  const FooQuery = graphql`
-    query LiveResolversTestOptimisticUpdateQuery {
-      counter
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-
-  // Read a live resolver field (Creating a subscription to the live state)
-  const snapshot = environment.lookup(operation.fragment);
-  const disposable = environment.subscribe(snapshot, () => {
-    // Noop. We just need to be subscribed.
-  });
-
-  // Revert the optimisitic update.
-  // This should unsubscribe the subscription created during the optimistic
-  // update, and then reread `counter`. Since `counter` is missing its `me`
-  // dependency, it should leave `counter` in a state with no liveValue and
-  // _no subscription_.
-  update.dispose();
-
-  // Fire the subscription, which should be ignored by Relay.
-  expect(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  }).not.toThrow();
-
-  // Clean up (just good hygiene)
-  disposable.dispose();
-});
-
-test('Outer resolvers do not overwrite subscriptions made by inner resolvers (regression)', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-      me: {__ref: '1'},
-    },
-    '1': {
-      __id: '1',
-      __typename: 'User',
-      id: '1',
-      name: 'Alice',
-    },
-  });
-
-  const FooQuery = graphql`
-    query LiveResolversTestNestedQuery {
-      # Outer consumes inner
-      outer
-      # We include inner again as a subsequent sibling of outer. This ensures
-      # that even if outer overwrites the cached version of inner, we end with
-      # inner in a valid state. This is nessesary to trigger the error.
-      inner
-    }
-  `;
-
-  const store = new LiveResolverStore(source, {gcReleaseBufferSize: 0});
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  function Environment({children}: {children: React.Node}) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">{children}</React.Suspense>
-      </RelayEnvironmentProvider>
-    );
-  }
-
-  function TestComponent() {
-    const queryData = useLazyLoadQuery(FooQuery, {});
-    return queryData.outer ?? null;
-  }
-
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <Environment>
-        <TestComponent />
-      </Environment>,
-    );
-  });
-
-  expect(renderer?.toJSON()).toEqual('0');
-
-  let update;
-  // Delete data putting `inner`'s fragment into a state where it's missing
-  // data. This _should_ unsubscribe us from `inner`'s external state.
-  TestRenderer.act(() => {
-    update = environment.applyUpdate({
-      storeUpdater: store => {
-        const alice = store.get('1');
-        if (alice == null) {
-          throw new Error('Expected to have record "1"');
+describe.each([true, false])(
+  'AVOID_CYCLES_IN_RESOLVER_NOTIFICATION is %p',
+  avoidCycles => {
+    RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION = avoidCycles;
+    test('Environment subscribers see updates pushed from external data source', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          me: {__ref: '1'},
+        },
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+        },
+      });
+      const FooQuery = graphql`
+        query LiveResolversTest2Query {
+          counter
         }
-        alice.setValue(undefined, 'name');
-      },
-    });
-  });
+      `;
 
-  TestRenderer.act(() => jest.runAllImmediates());
-  expect(renderer.toJSON()).toEqual(null);
+      const operation = createOperationDescriptor(FooQuery, {});
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+      });
 
-  // Calling increment here should be ignored by Relay. However, if there are
-  // dangling subscriptions, this will put inner into a dirty state.
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  TestRenderer.act(() => jest.runAllImmediates());
-  expect(renderer.toJSON()).toEqual(null);
-
-  // Revering optimistic update puts inner back into a state where its
-  // fragment is valid. HOWEVER, if a dangling subscription has marked inner
-  // as dirty, we will try to read from a LiveValue that does not exist.
-  TestRenderer.act(() => update.dispose());
-  expect(renderer.toJSON()).toEqual('1');
-
-  // Not part of the repro, but just to confirm: We should now be resubscribed...
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  TestRenderer.act(() => jest.runAllImmediates());
-  expect(renderer.toJSON()).toEqual('2');
-});
-
-test("Resolvers without fragments aren't reevaluated when their parent record updates.", async () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-  });
-
-  const FooQuery = graphql`
-    query LiveResolversTest14Query {
-      counter_no_fragment
-
-      # An additional field on Query which can be updated, invalidating the root record.
-      me {
-        __typename
-      }
-    }
-  `;
-
-  const store = new LiveResolverStore(source, {gcReleaseBufferSize: 0});
-
-  const mockPayload = Promise.resolve({
-    data: {
-      me: {
-        id: '1',
-        __typename: 'User',
-      },
-    },
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(() => mockPayload),
-    store,
-  });
-
-  function Environment({children}: {children: React.Node}) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">{children}</React.Suspense>
-      </RelayEnvironmentProvider>
-    );
-  }
-
-  function TestComponent() {
-    const queryData = useLazyLoadQuery(FooQuery, {});
-    return queryData.counter_no_fragment;
-  }
-
-  const initialCallCount = counterNoFragmentResolver.callCount;
-
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <Environment>
-        <TestComponent />
-      </Environment>,
-    );
-  });
-
-  expect(counterNoFragmentResolver.callCount).toBe(initialCallCount + 1);
-  // Initial render evaluates (and caches) the `counter_no_fragment` resolver.
-  expect(renderer?.toJSON()).toEqual('Loading...');
-
-  // When the network response returns, it updates the query root, which would
-  // invalidate a resolver with a fragment on Query. However,
-  // `counter_no_fragment` has no fragment, so it should not be revaluated.
-  TestRenderer.act(() => jest.runAllImmediates());
-
-  expect(counterNoFragmentResolver.callCount).toBe(initialCallCount + 1);
-  expect(renderer.toJSON()).toEqual('0');
-});
-
-test('Can suspend', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-  });
-
-  const Fragment = graphql`
-    fragment LiveResolversTest5Fragment on Query {
-      counter_suspends_when_odd
-    }
-  `;
-  const FooQuery = graphql`
-    query LiveResolversTest5Query {
-      ...LiveResolversTest5Fragment
-    }
-  `;
-
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-  environment.commitPayload(
-    createOperationDescriptor(getRequest(FooQuery), {}),
-    {
-      me: {id: '1'},
-    },
-  );
-
-  function Environment({children}: {children: React.Node}) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">{children}</React.Suspense>
-      </RelayEnvironmentProvider>
-    );
-  }
-
-  function TestComponent() {
-    const queryData = useLazyLoadQuery(FooQuery, {});
-    const fragmentData = useFragment(Fragment, queryData);
-    return fragmentData.counter_suspends_when_odd;
-  }
-
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <Environment>
-        <TestComponent />
-      </Environment>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('0');
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  // If do not trigger `act` here, the renderer is still `0`. Probably, a React thing...
-  TestRenderer.act(() => jest.runAllImmediates());
-  expect(renderer.toJSON()).toEqual('Loading...');
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  expect(renderer.toJSON()).toEqual('2');
-});
-
-test('Can suspend with resolver that uses live resolver', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-      me: {__ref: '1'},
-    },
-    '1': {
-      __id: '1',
-      __typename: 'User',
-      id: '1',
-      name: 'Alice',
-    },
-  });
-
-  const FooQuery = graphql`
-    query LiveResolversTest6Query {
-      ...LiveResolversTest6Fragment
-    }
-  `;
-
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  function Environment({children}: {children: React.Node}) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">{children}</React.Suspense>
-      </RelayEnvironmentProvider>
-    );
-  }
-
-  function TestComponent() {
-    const queryData = useLazyLoadQuery(FooQuery, {});
-    const fragmentData = useFragment(
-      graphql`
-        fragment LiveResolversTest6Fragment on Query {
-          user_name_and_counter_suspends_when_odd
-        }
-      `,
-      queryData,
-    );
-    return fragmentData.user_name_and_counter_suspends_when_odd;
-  }
-
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <Environment>
-        <TestComponent />
-      </Environment>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('Alice 0');
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  // If do not trigger `act` here, the renderer is still `0`. Probably, a React thing...
-  TestRenderer.act(() => jest.runAllImmediates());
-  expect(renderer.toJSON()).toEqual('Loading...');
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  expect(renderer.toJSON()).toEqual('Alice 2');
-  TestRenderer.act(() => {
-    const operationDescriptor = createOperationDescriptor(
-      getRequest(FooQuery),
-      {},
-    );
-    environment.commitPayload(operationDescriptor, {
-      me: {id: '1', name: 'Bob', __typename: 'User'},
-    });
-  });
-  expect(renderer.toJSON()).toEqual('Bob 2');
-});
-
-describe('Live Resolver with Suspense and Missing Data', () => {
-  let renderer;
-
-  function InnerTestComponent({scale}: {scale: number}) {
-    const data = useLazyLoadQuery(
-      graphql`
-        query LiveResolversTest7Query($id: ID!, $scale: Float!) {
-          node(id: $id) {
-            ... on User {
-              name
-              user_profile_picture_uri_suspends_when_the_counter_is_odd(
-                scale: $scale
-              )
-            }
-          }
-        }
-      `,
-      {id: '1', scale},
-      {fetchPolicy: 'store-only'},
-    );
-    return `${String(data.node?.name)}: ${String(
-      data.node?.user_profile_picture_uri_suspends_when_the_counter_is_odd,
-    )}`;
-  }
-
-  function TestComponent({
-    environment,
-    ...rest
-  }: {
-    environment: RelayModernEnvironment,
-    scale: number,
-  }) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">
-          <InnerTestComponent {...rest} />
-        </React.Suspense>
-      </RelayEnvironmentProvider>
-    );
-  }
-
-  function createEnvironment(source: MutableRecordSource) {
-    return new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store: new LiveResolverStore(source),
-    });
-  }
-
-  it('should renderer the data from the store, after global state resolves the value', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        'node(id:"1")': {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        __typename: 'User',
-        name: 'Alice',
-        id: '1',
-        'profile_picture(scale:1.5)': {
-          __ref: 'client:1:profile_picture(scale:1.5)',
-        },
-      },
-      'client:1:profile_picture(scale:1.5)': {
-        __id: 'client:1:profile_picture(scale:1.5)',
-        uri: 'scale 1.5',
-      },
-    });
-    const environment = createEnvironment(source);
-
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(
-        <TestComponent environment={environment} scale={1.5} />,
-      );
-    });
-    expect(renderer.toJSON()).toEqual('Loading...');
-    TestRenderer.act(() => {
-      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-    });
-    TestRenderer.act(() => jest.runAllImmediates());
-    expect(renderer.toJSON()).toEqual(
-      'Alice: Hello, Alice! Picture Url: scale 1.5',
-    );
-  });
-
-  it('should render undefined value for missing data in live resolver field', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        'node(id:"1")': {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        __typename: 'User',
-        name: 'Alice',
-        id: '1',
-        'profile_picture(scale:1.5)': {
-          __ref: 'client:1:profile_picture(scale:1.5)',
-        },
-        'profile_picture(scale:2)': {
-          __ref: 'client:1:profile_picture(scale:2)',
-        },
-      },
-      'client:1:profile_picture(scale:1.5)': {
-        __id: 'client:1:profile_picture(scale:1.5)',
-        uri: 'scale 1.5',
-      },
-      'client:1:profile_picture(scale:2)': {
-        __id: 'client:1:profile_picture(scale:2)',
-        // missing data for uri
-      },
-    });
-    const environment = createEnvironment(source);
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(
-        <TestComponent environment={environment} scale={1.5} />,
-      );
-    });
-    TestRenderer.act(() => {
-      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-    });
-    TestRenderer.act(() => jest.runAllImmediates());
-    expect(renderer.toJSON()).toEqual(
-      'Alice: Hello, Alice! Picture Url: scale 1.5',
-    );
-    TestRenderer.act(() => {
-      renderer.update(<TestComponent environment={environment} scale={2} />);
-    });
-    // the data for scale 2 is missing in the store
-    expect(renderer.toJSON()).toEqual('Alice: undefined');
-  });
-
-  it('should render undefined value for missing data in live resolver field and trigger different states of suspense ', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        'node(id:"1")': {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        __typename: 'User',
-        name: 'Alice',
-        id: '1',
-        'profile_picture(scale:1.5)': {
-          __ref: 'client:1:profile_picture(scale:1.5)',
-        },
-        'profile_picture(scale:2)': {
-          __ref: 'client:1:profile_picture(scale:2)',
-        },
-        'profile_picture(scale:3)': {
-          __ref: 'client:1:profile_picture(scale:3)',
-        },
-      },
-      'client:1:profile_picture(scale:1.5)': {
-        __id: 'client:1:profile_picture(scale:1.5)',
-        uri: 'scale 1.5',
-      },
-      'client:1:profile_picture(scale:2)': {
-        __id: 'client:1:profile_picture(scale:2)',
-        // missing data for uri
-      },
-      'client:1:profile_picture(scale:3)': {
-        __id: 'client:1:profile_picture(scale:3)',
-        uri: 'scale 3',
-      },
-    });
-    const environment = createEnvironment(source);
-
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(
-        <TestComponent environment={environment} scale={1.5} />,
-      );
-    });
-
-    expect(renderer.toJSON()).toEqual('Loading...');
-    // This should trigger the re-render with the missing data in the fragment
-    TestRenderer.act(() => {
-      renderer.update(<TestComponent environment={environment} scale={2} />);
-    });
-    // Now, the whole live field became undefined, as some of
-    // the data in the live field resolver fragment is missing
-    expect(renderer.toJSON()).toEqual('Alice: undefined');
-    TestRenderer.act(() => {
-      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-    });
-    TestRenderer.act(() => jest.runAllImmediates());
-    expect(renderer.toJSON()).toEqual('Alice: undefined');
-
-    // Next, we're re-rendering with new `scale`, and for this value (3) we have the data in
-    // the store (no missing data)
-    TestRenderer.act(() => {
-      renderer.update(<TestComponent environment={environment} scale={3} />);
-    });
-    // And we are rendering the data with the new scale
-    expect(renderer.toJSON()).toEqual(
-      'Alice: Hello, Alice! Picture Url: scale 3',
-    );
-
-    // Re-render fragment with missing data, to make sure we correctly use cached value
-    TestRenderer.act(() => {
-      renderer.update(<TestComponent environment={environment} scale={2} />);
-    });
-    expect(renderer.toJSON()).toEqual('Alice: undefined');
-
-    TestRenderer.act(() => {
-      renderer.update(<TestComponent environment={environment} scale={3} />);
-    });
-    // And we are rendering the data with the new scale
-    expect(renderer.toJSON()).toEqual(
-      'Alice: Hello, Alice! Picture Url: scale 3',
-    );
-
-    // Now, the global store should have the data
-    TestRenderer.act(() => {
-      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-    });
-    TestRenderer.act(() => jest.runAllImmediates());
-
-    // Now, again we are suspending, because the global state is still not ready
-    expect(renderer.toJSON()).toEqual('Loading...');
-  });
-});
-
-skipIf(
-  process.env.OSS,
-  'Live Resolver with Missing Data and @required',
-  async () => {
-    function InnerTestComponent({id}: {id: string}) {
-      const data = useLazyLoadQuery(
-        graphql`
-          query LiveResolversTest8Query($id: ID!) {
-            node(id: $id) {
-              ... on User {
-                name
-                resolver_that_throws
-              }
-            }
-          }
-        `,
-        {id},
-        {fetchPolicy: 'store-only'},
-      );
-      return `${data.node?.name ?? 'Unknown name'}: ${
-        data.node?.resolver_that_throws ?? 'Unknown resolver_that_throws value'
-      }`;
-    }
-
-    function TestComponent({
-      environment,
-      ...rest
-    }: {
-      environment: RelayModernEnvironment,
-      id: string,
-    }) {
-      return (
-        <RelayEnvironmentProvider environment={environment}>
-          <React.Suspense fallback="Loading...">
-            <InnerTestComponent {...rest} />
-          </React.Suspense>
-        </RelayEnvironmentProvider>
-      );
-    }
-    const relayFieldLogger = jest.fn<
-      $FlowFixMe | [RelayFieldLoggerEvent],
-      void,
-    >();
-    function createEnvironment(source: MutableRecordSource) {
-      return new RelayModernEnvironment({
+      const environment = new RelayModernEnvironment({
         network: RelayNetwork.create(jest.fn()),
-        store: new LiveResolverStore(source),
-        relayFieldLogger,
+        store,
       });
-    }
 
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        'node(id:"1")': {__ref: '1'},
-        'node(id:"2")': {__ref: '2'},
-      },
-      '1': {
-        __id: '1',
-        __typename: 'User',
-        name: 'Alice',
-        // username is missing
-        id: '1',
-      },
-      '2': {
-        __id: '2',
-        __typename: 'User',
-        name: 'Bob',
-        username: 'bob',
-        id: '2',
-      },
-    });
-    const environment = createEnvironment(source);
+      let observedCounter = null;
 
-    // First, render with missing data
-    await expect(async () => {
-      await TestRenderer.act(() => {
-        TestRenderer.create(<TestComponent environment={environment} id="1" />);
+      const snapshot = environment.lookup(operation.fragment);
+      // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+      observedCounter = (snapshot.data: any).counter;
+
+      const environmentUpdateHandler = jest.fn(() => {
+        const s = environment.lookup(operation.fragment);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        observedCounter = (s.data: any).counter;
       });
-    }).rejects.toThrow(
-      "Relay: Missing @required value at path 'username' in 'ResolverThatThrows'.",
-    );
-    expect(relayFieldLogger.mock.calls).toEqual([
-      [
-        {
-          kind: 'missing_field.throw',
-          owner: 'ResolverThatThrows',
-          fieldPath: 'username',
-        },
-      ],
-    ]);
-    relayFieldLogger.mockReset();
-
-    // Render with complete data
-    let renderer;
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(
-        <TestComponent environment={environment} id="2" />,
+      const disposable = environment.subscribe(
+        snapshot,
+        // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
+        environmentUpdateHandler,
       );
+
+      // SETUP COMPLETE
+
+      // Read the initial value
+      expect(observedCounter).toBe(0);
+      expect(environmentUpdateHandler).not.toHaveBeenCalled();
+
+      // Increment and assert we get notified of the new value
+      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
+      expect(observedCounter).toBe(1);
+
+      // Unsubscribe then increment and assert don't get notified.
+      disposable.dispose();
+      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
+      expect(observedCounter).toBe(1);
+
+      // Explicitly read and assert we see the incremented value
+      // missed before due to unsubscribing.
+      const nextSnapshot = environment.lookup(operation.fragment);
+
+      expect(nextSnapshot.data).toEqual({
+        counter: 2,
+      });
     });
 
-    if (renderer == null) {
-      throw new Error('Renderer is expected to be defined.');
-    }
-
-    expect(relayFieldLogger.mock.calls).toEqual([
-      [
-        {
-          error: new Error(
-            'The resolver should throw earlier. It should have missing data.',
-          ),
-          fieldPath: 'node.resolver_that_throws',
-          kind: 'relay_resolver.error',
-          owner: 'LiveResolversTest8Query',
+    test('Relay Resolvers that read Live Resolvers see updates pushed from external data source', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          me: {__ref: '1'},
         },
-      ],
-    ]);
-
-    expect(renderer.toJSON()).toEqual(
-      'Bob: Unknown resolver_that_throws value',
-    );
-  },
-);
-
-test('apply optimistic updates to live resolver field', () => {
-  let renderer;
-
-  function InnerTestComponent({scale}: {scale: number}) {
-    const data = useLazyLoadQuery(
-      graphql`
-        query LiveResolversTest9Query($id: ID!, $scale: Float!) {
-          node(id: $id) {
-            ... on User {
-              profile_picture_uri: user_profile_picture_uri_suspends_when_the_counter_is_odd(
-                scale: $scale
-              )
-            }
-          }
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+        },
+      });
+      const FooQuery = graphql`
+        query LiveResolversTest3Query {
+          counter_plus_one
         }
-      `,
-      {id: '1', scale},
-      {fetchPolicy: 'store-only'},
-    );
-    return data.node?.profile_picture_uri;
-  }
+      `;
 
-  function TestComponent({
-    environment,
-    ...rest
-  }: {
-    environment: RelayModernEnvironment,
-    scale: number,
-  }) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">
-          <InnerTestComponent {...rest} />
-        </React.Suspense>
-      </RelayEnvironmentProvider>
-    );
-  }
+      const operation = createOperationDescriptor(FooQuery, {});
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+      });
 
-  function createEnvironment(source: MutableRecordSource) {
-    return new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store: new LiveResolverStore(source),
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+
+      let observedCounterPlusOne = null;
+
+      const snapshot = environment.lookup(operation.fragment);
+      // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+      observedCounterPlusOne = (snapshot.data: any).counter_plus_one;
+
+      const environmentUpdateHandler = jest.fn(() => {
+        const s = environment.lookup(operation.fragment);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        observedCounterPlusOne = (s.data: any).counter_plus_one;
+      });
+      const disposable = environment.subscribe(
+        snapshot,
+        // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
+        environmentUpdateHandler,
+      );
+
+      // SETUP COMPLETE
+
+      // Read the initial value
+      expect(observedCounterPlusOne).toBe(1);
+      expect(environmentUpdateHandler).not.toHaveBeenCalled();
+
+      // Increment and assert we get notified of the new value
+      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
+      expect(observedCounterPlusOne).toBe(2);
+
+      // Unsubscribe then increment and assert don't get notified.
+      disposable.dispose();
+      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
+      expect(observedCounterPlusOne).toBe(2);
+
+      // Explicitly read and assert we see the incremented value
+      // missed before due to unsubscribing.
+      const nextSnapshot = environment.lookup(operation.fragment);
+      expect(nextSnapshot.data).toEqual({
+        counter_plus_one: 3,
+      });
     });
-  }
 
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-      'node(id:"1")': {__ref: '1'},
-    },
-    '1': {
-      __id: '1',
-      __typename: 'User',
-      name: 'Alice',
-      id: '1',
-      'profile_picture(scale:1.5)': {
-        __ref: 'client:1:profile_picture(scale:1.5)',
-      },
-    },
-    'client:1:profile_picture(scale:1.5)': {
-      __id: 'client:1:profile_picture(scale:1.5)',
-      uri: 'scale 1.5',
-    },
-  });
-  const environment = createEnvironment(source);
-
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <TestComponent environment={environment} scale={1.5} />,
-    );
-  });
-
-  if (renderer == null) {
-    throw new Error('Renderer is expected to be defined.');
-  }
-
-  expect(renderer.toJSON()).toEqual('Loading...');
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  TestRenderer.act(() => jest.runAllImmediates());
-  expect(renderer.toJSON()).toEqual('Hello, Alice! Picture Url: scale 1.5');
-
-  let update;
-  TestRenderer.act(() => {
-    update = environment.applyUpdate({
-      storeUpdater: store => {
-        const alice = store.get('1');
-        if (alice == null) {
-          throw new Error('Expected to have record "1"');
+    // This triggers a potential edge case where the subscription is created before
+    // we create the record where we store the value.
+    test('Can handle a Live Resolver that triggers an update immediately on subscribe', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          me: {__ref: '1'},
+        },
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+        },
+      });
+      const FooQuery = graphql`
+        query LiveResolversTest4Query {
+          ping
         }
-        alice.setValue('Alicia', 'name');
-      },
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+      });
+
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+
+      const data = environment.lookup(operation.fragment).data;
+      expect(data).toEqual({
+        ping: 'pong',
+      });
     });
-  });
-  expect(renderer.toJSON()).toEqual('Hello, Alicia! Picture Url: scale 1.5');
 
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  TestRenderer.act(() => jest.runAllImmediates());
-  expect(renderer.toJSON()).toEqual('Loading...');
-
-  // Revering optimistic update
-  TestRenderer.act(() => update.dispose());
-  // Reverting optimistic update should
-  // not change suspense state of the live-resolver
-  // this should still be `Loading...`
-  expect(renderer.toJSON()).toEqual('Loading...');
-
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  expect(renderer.toJSON()).toEqual('Hello, Alice! Picture Url: scale 1.5');
-});
-
-// Regression test for a case where we were resetting the parent snapshot's
-// `isMissingData` to false when reading a live resolver field.
-test('Missing data is not clobbered by non-null empty missingLiveResolverFields on snapshot', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-      me: {__ref: '1'},
-    },
-    '1': {
-      __id: '1',
-      __typename: 'User',
-      id: '1',
-    },
-  });
-  const FooQuery = graphql`
-    query LiveResolversTest10Query {
-      me {
-        # Should be tracked as missing data
-        name
-      }
-      counter
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  const snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.missingLiveResolverFields).toEqual([]);
-  expect(snapshot.isMissingData).toBe(true);
-});
-
-test('with client-only field', () => {
-  let renderer;
-
-  function InnerTestComponent() {
-    const data = useClientQuery(
-      graphql`
-        query LiveResolversTest11Query {
-          counter_no_fragment
-        }
-      `,
-      {},
-    );
-    return data.counter_no_fragment;
-  }
-
-  function TestComponent({environment}: {environment: IEnvironment}) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">
-          <InnerTestComponent />
-        </React.Suspense>
-      </RelayEnvironmentProvider>
-    );
-  }
-
-  function createEnvironment(source: MutableRecordSource) {
-    return new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store: new LiveResolverStore(source),
-    });
-  }
-
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-  });
-  const environment = createEnvironment(source);
-
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(<TestComponent environment={environment} />);
-  });
-
-  if (renderer == null) {
-    throw new Error('Renderer is expected to be defined.');
-  }
-
-  expect(renderer.toJSON()).toEqual('0');
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  expect(renderer.toJSON()).toEqual('1');
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  expect(renderer.toJSON()).toEqual('2');
-});
-
-test('with client-only field and args', () => {
-  let renderer;
-
-  function InnerTestComponent({prefix}: {prefix: string}) {
-    const data = useClientQuery(
-      graphql`
-        query LiveResolversTest12Query($prefix: String!) {
-          counter_no_fragment_with_arg(prefix: $prefix)
-        }
-      `,
-      {prefix},
-    );
-    return data.counter_no_fragment_with_arg;
-  }
-
-  function TestComponent({
-    environment,
-    ...rest
-  }: {
-    environment: IEnvironment,
-    prefix: string,
-  }) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">
-          <InnerTestComponent {...rest} />
-        </React.Suspense>
-      </RelayEnvironmentProvider>
-    );
-  }
-
-  function createEnvironment(source: MutableRecordSource) {
-    return new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store: new LiveResolverStore(source),
-    });
-  }
-
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-  });
-  const environment = createEnvironment(source);
-
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <TestComponent prefix="Counter is" environment={environment} />,
-    );
-  });
-
-  if (renderer == null) {
-    throw new Error('Renderer is expected to be defined.');
-  }
-
-  expect(renderer.toJSON()).toEqual('Counter is 0');
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  expect(renderer.toJSON()).toEqual('Counter is 1');
-  TestRenderer.act(() => {
-    GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-  });
-  expect(renderer.toJSON()).toEqual('Counter is 2');
-});
-
-test('Can read a live client edge without a fragment', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-    '1338': {
-      __id: '1338',
-      id: '1338',
-      __typename: 'User',
-      name: 'Elizabeth',
-    },
-  });
-
-  const FooQuery = graphql`
-    query LiveResolversTest13Query {
-      live_constant_client_edge @waterfall {
-        name
-      }
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  const data = environment.lookup(operation.fragment).data;
-  expect(data).toEqual({
-    live_constant_client_edge: {
-      name: 'Elizabeth',
-    },
-  });
-});
-
-test('live resolver with the edge that always suspend', () => {
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store: new LiveResolverStore(
-      RelayRecordSource.create({
+    test('Subscriptions created while in an optimistic state is in place get cleaned up correctly', () => {
+      const source = RelayRecordSource.create({
         'client:root': {
           __id: 'client:root',
           __typename: '__Root',
         },
-      }),
-    ),
-  });
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+        },
+      });
+      const store = new LiveResolverStore(source, {gcReleaseBufferSize: 0});
 
-  function Environment({children}: {children: React.Node}) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">{children}</React.Suspense>
-      </RelayEnvironmentProvider>
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+
+      const update = environment.applyUpdate({
+        storeUpdater: store => {
+          const alice = store.get('1');
+          if (alice == null) {
+            throw new Error('Expected to have record "1"');
+          }
+          const storeRoot = store.getRoot();
+          storeRoot.setLinkedRecord(alice, 'me');
+        },
+      });
+
+      const FooQuery = graphql`
+        query LiveResolversTestOptimisticUpdateQuery {
+          counter
+        }
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+
+      // Read a live resolver field (Creating a subscription to the live state)
+      const snapshot = environment.lookup(operation.fragment);
+      const disposable = environment.subscribe(snapshot, () => {
+        // Noop. We just need to be subscribed.
+      });
+
+      // Revert the optimisitic update.
+      // This should unsubscribe the subscription created during the optimistic
+      // update, and then reread `counter`. Since `counter` is missing its `me`
+      // dependency, it should leave `counter` in a state with no liveValue and
+      // _no subscription_.
+      update.dispose();
+
+      // Fire the subscription, which should be ignored by Relay.
+      expect(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      }).not.toThrow();
+
+      // Clean up (just good hygiene)
+      disposable.dispose();
+    });
+
+    test('Outer resolvers do not overwrite subscriptions made by inner resolvers (regression)', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          me: {__ref: '1'},
+        },
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+        },
+      });
+
+      const FooQuery = graphql`
+        query LiveResolversTestNestedQuery {
+          # Outer consumes inner
+          outer
+          # We include inner again as a subsequent sibling of outer. This ensures
+          # that even if outer overwrites the cached version of inner, we end with
+          # inner in a valid state. This is nessesary to trigger the error.
+          inner
+        }
+      `;
+
+      const store = new LiveResolverStore(source, {gcReleaseBufferSize: 0});
+
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+
+      function Environment({children}: {children: React.Node}) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">{children}</React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      function TestComponent() {
+        const queryData = useLazyLoadQuery(FooQuery, {});
+        return queryData.outer ?? null;
+      }
+
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <Environment>
+            <TestComponent />
+          </Environment>,
+        );
+      });
+
+      expect(renderer?.toJSON()).toEqual('0');
+
+      let update;
+      // Delete data putting `inner`'s fragment into a state where it's missing
+      // data. This _should_ unsubscribe us from `inner`'s external state.
+      TestRenderer.act(() => {
+        update = environment.applyUpdate({
+          storeUpdater: store => {
+            const alice = store.get('1');
+            if (alice == null) {
+              throw new Error('Expected to have record "1"');
+            }
+            alice.setValue(undefined, 'name');
+          },
+        });
+      });
+
+      TestRenderer.act(() => jest.runAllImmediates());
+      expect(renderer.toJSON()).toEqual(null);
+
+      // Calling increment here should be ignored by Relay. However, if there are
+      // dangling subscriptions, this will put inner into a dirty state.
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      TestRenderer.act(() => jest.runAllImmediates());
+      expect(renderer.toJSON()).toEqual(null);
+
+      // Revering optimistic update puts inner back into a state where its
+      // fragment is valid. HOWEVER, if a dangling subscription has marked inner
+      // as dirty, we will try to read from a LiveValue that does not exist.
+      TestRenderer.act(() => update.dispose());
+      expect(renderer.toJSON()).toEqual('1');
+
+      // Not part of the repro, but just to confirm: We should now be resubscribed...
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      TestRenderer.act(() => jest.runAllImmediates());
+      expect(renderer.toJSON()).toEqual('2');
+    });
+
+    test("Resolvers without fragments aren't reevaluated when their parent record updates.", async () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+        },
+      });
+
+      const FooQuery = graphql`
+        query LiveResolversTest14Query {
+          counter_no_fragment
+
+          # An additional field on Query which can be updated, invalidating the root record.
+          me {
+            __typename
+          }
+        }
+      `;
+
+      const store = new LiveResolverStore(source, {gcReleaseBufferSize: 0});
+
+      const mockPayload = Promise.resolve({
+        data: {
+          me: {
+            id: '1',
+            __typename: 'User',
+          },
+        },
+      });
+
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(() => mockPayload),
+        store,
+      });
+
+      function Environment({children}: {children: React.Node}) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">{children}</React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      function TestComponent() {
+        const queryData = useLazyLoadQuery(FooQuery, {});
+        return queryData.counter_no_fragment;
+      }
+
+      const initialCallCount = counterNoFragmentResolver.callCount;
+
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <Environment>
+            <TestComponent />
+          </Environment>,
+        );
+      });
+
+      expect(counterNoFragmentResolver.callCount).toBe(initialCallCount + 1);
+      // Initial render evaluates (and caches) the `counter_no_fragment` resolver.
+      expect(renderer?.toJSON()).toEqual('Loading...');
+
+      // When the network response returns, it updates the query root, which would
+      // invalidate a resolver with a fragment on Query. However,
+      // `counter_no_fragment` has no fragment, so it should not be revaluated.
+      TestRenderer.act(() => jest.runAllImmediates());
+
+      expect(counterNoFragmentResolver.callCount).toBe(initialCallCount + 1);
+      expect(renderer.toJSON()).toEqual('0');
+    });
+
+    test('Can suspend', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+        },
+      });
+
+      const Fragment = graphql`
+        fragment LiveResolversTest5Fragment on Query {
+          counter_suspends_when_odd
+        }
+      `;
+      const FooQuery = graphql`
+        query LiveResolversTest5Query {
+          ...LiveResolversTest5Fragment
+        }
+      `;
+
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+      });
+
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+      environment.commitPayload(
+        createOperationDescriptor(getRequest(FooQuery), {}),
+        {
+          me: {id: '1'},
+        },
+      );
+
+      function Environment({children}: {children: React.Node}) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">{children}</React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      function TestComponent() {
+        const queryData = useLazyLoadQuery(FooQuery, {});
+        const fragmentData = useFragment(Fragment, queryData);
+        return fragmentData.counter_suspends_when_odd;
+      }
+
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <Environment>
+            <TestComponent />
+          </Environment>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('0');
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      // If do not trigger `act` here, the renderer is still `0`. Probably, a React thing...
+      TestRenderer.act(() => jest.runAllImmediates());
+      expect(renderer.toJSON()).toEqual('Loading...');
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      expect(renderer.toJSON()).toEqual('2');
+    });
+
+    test('Can suspend with resolver that uses live resolver', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          me: {__ref: '1'},
+        },
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+        },
+      });
+
+      const FooQuery = graphql`
+        query LiveResolversTest6Query {
+          ...LiveResolversTest6Fragment
+        }
+      `;
+
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+      });
+
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+
+      function Environment({children}: {children: React.Node}) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">{children}</React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      function TestComponent() {
+        const queryData = useLazyLoadQuery(FooQuery, {});
+        const fragmentData = useFragment(
+          graphql`
+            fragment LiveResolversTest6Fragment on Query {
+              user_name_and_counter_suspends_when_odd
+            }
+          `,
+          queryData,
+        );
+        return fragmentData.user_name_and_counter_suspends_when_odd;
+      }
+
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <Environment>
+            <TestComponent />
+          </Environment>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('Alice 0');
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      // If do not trigger `act` here, the renderer is still `0`. Probably, a React thing...
+      TestRenderer.act(() => jest.runAllImmediates());
+      expect(renderer.toJSON()).toEqual('Loading...');
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      expect(renderer.toJSON()).toEqual('Alice 2');
+      TestRenderer.act(() => {
+        const operationDescriptor = createOperationDescriptor(
+          getRequest(FooQuery),
+          {},
+        );
+        environment.commitPayload(operationDescriptor, {
+          me: {id: '1', name: 'Bob', __typename: 'User'},
+        });
+      });
+      expect(renderer.toJSON()).toEqual('Bob 2');
+    });
+
+    describe('Live Resolver with Suspense and Missing Data', () => {
+      let renderer;
+
+      function InnerTestComponent({scale}: {scale: number}) {
+        const data = useLazyLoadQuery(
+          graphql`
+            query LiveResolversTest7Query($id: ID!, $scale: Float!) {
+              node(id: $id) {
+                ... on User {
+                  name
+                  user_profile_picture_uri_suspends_when_the_counter_is_odd(
+                    scale: $scale
+                  )
+                }
+              }
+            }
+          `,
+          {id: '1', scale},
+          {fetchPolicy: 'store-only'},
+        );
+        return `${String(data.node?.name)}: ${String(
+          data.node?.user_profile_picture_uri_suspends_when_the_counter_is_odd,
+        )}`;
+      }
+
+      function TestComponent({
+        environment,
+        ...rest
+      }: {
+        environment: RelayModernEnvironment,
+        scale: number,
+      }) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">
+              <InnerTestComponent {...rest} />
+            </React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      function createEnvironment(source: MutableRecordSource) {
+        return new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store: new LiveResolverStore(source),
+        });
+      }
+
+      it('should renderer the data from the store, after global state resolves the value', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            'node(id:"1")': {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            __typename: 'User',
+            name: 'Alice',
+            id: '1',
+            'profile_picture(scale:1.5)': {
+              __ref: 'client:1:profile_picture(scale:1.5)',
+            },
+          },
+          'client:1:profile_picture(scale:1.5)': {
+            __id: 'client:1:profile_picture(scale:1.5)',
+            uri: 'scale 1.5',
+          },
+        });
+        const environment = createEnvironment(source);
+
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <TestComponent environment={environment} scale={1.5} />,
+          );
+        });
+        expect(renderer.toJSON()).toEqual('Loading...');
+        TestRenderer.act(() => {
+          GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+        });
+        TestRenderer.act(() => jest.runAllImmediates());
+        expect(renderer.toJSON()).toEqual(
+          'Alice: Hello, Alice! Picture Url: scale 1.5',
+        );
+      });
+
+      it('should render undefined value for missing data in live resolver field', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            'node(id:"1")': {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            __typename: 'User',
+            name: 'Alice',
+            id: '1',
+            'profile_picture(scale:1.5)': {
+              __ref: 'client:1:profile_picture(scale:1.5)',
+            },
+            'profile_picture(scale:2)': {
+              __ref: 'client:1:profile_picture(scale:2)',
+            },
+          },
+          'client:1:profile_picture(scale:1.5)': {
+            __id: 'client:1:profile_picture(scale:1.5)',
+            uri: 'scale 1.5',
+          },
+          'client:1:profile_picture(scale:2)': {
+            __id: 'client:1:profile_picture(scale:2)',
+            // missing data for uri
+          },
+        });
+        const environment = createEnvironment(source);
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <TestComponent environment={environment} scale={1.5} />,
+          );
+        });
+        TestRenderer.act(() => {
+          GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+        });
+        TestRenderer.act(() => jest.runAllImmediates());
+        expect(renderer.toJSON()).toEqual(
+          'Alice: Hello, Alice! Picture Url: scale 1.5',
+        );
+        TestRenderer.act(() => {
+          renderer.update(
+            <TestComponent environment={environment} scale={2} />,
+          );
+        });
+        // the data for scale 2 is missing in the store
+        expect(renderer.toJSON()).toEqual('Alice: undefined');
+      });
+
+      it('should render undefined value for missing data in live resolver field and trigger different states of suspense ', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            'node(id:"1")': {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            __typename: 'User',
+            name: 'Alice',
+            id: '1',
+            'profile_picture(scale:1.5)': {
+              __ref: 'client:1:profile_picture(scale:1.5)',
+            },
+            'profile_picture(scale:2)': {
+              __ref: 'client:1:profile_picture(scale:2)',
+            },
+            'profile_picture(scale:3)': {
+              __ref: 'client:1:profile_picture(scale:3)',
+            },
+          },
+          'client:1:profile_picture(scale:1.5)': {
+            __id: 'client:1:profile_picture(scale:1.5)',
+            uri: 'scale 1.5',
+          },
+          'client:1:profile_picture(scale:2)': {
+            __id: 'client:1:profile_picture(scale:2)',
+            // missing data for uri
+          },
+          'client:1:profile_picture(scale:3)': {
+            __id: 'client:1:profile_picture(scale:3)',
+            uri: 'scale 3',
+          },
+        });
+        const environment = createEnvironment(source);
+
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <TestComponent environment={environment} scale={1.5} />,
+          );
+        });
+
+        expect(renderer.toJSON()).toEqual('Loading...');
+        // This should trigger the re-render with the missing data in the fragment
+        TestRenderer.act(() => {
+          renderer.update(
+            <TestComponent environment={environment} scale={2} />,
+          );
+        });
+        // Now, the whole live field became undefined, as some of
+        // the data in the live field resolver fragment is missing
+        expect(renderer.toJSON()).toEqual('Alice: undefined');
+        TestRenderer.act(() => {
+          GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+        });
+        TestRenderer.act(() => jest.runAllImmediates());
+        expect(renderer.toJSON()).toEqual('Alice: undefined');
+
+        // Next, we're re-rendering with new `scale`, and for this value (3) we have the data in
+        // the store (no missing data)
+        TestRenderer.act(() => {
+          renderer.update(
+            <TestComponent environment={environment} scale={3} />,
+          );
+        });
+        // And we are rendering the data with the new scale
+        expect(renderer.toJSON()).toEqual(
+          'Alice: Hello, Alice! Picture Url: scale 3',
+        );
+
+        // Re-render fragment with missing data, to make sure we correctly use cached value
+        TestRenderer.act(() => {
+          renderer.update(
+            <TestComponent environment={environment} scale={2} />,
+          );
+        });
+        expect(renderer.toJSON()).toEqual('Alice: undefined');
+
+        TestRenderer.act(() => {
+          renderer.update(
+            <TestComponent environment={environment} scale={3} />,
+          );
+        });
+        // And we are rendering the data with the new scale
+        expect(renderer.toJSON()).toEqual(
+          'Alice: Hello, Alice! Picture Url: scale 3',
+        );
+
+        // Now, the global store should have the data
+        TestRenderer.act(() => {
+          GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+        });
+        TestRenderer.act(() => jest.runAllImmediates());
+
+        // Now, again we are suspending, because the global state is still not ready
+        expect(renderer.toJSON()).toEqual('Loading...');
+      });
+    });
+
+    skipIf(
+      process.env.OSS,
+      'Live Resolver with Missing Data and @required',
+      async () => {
+        function InnerTestComponent({id}: {id: string}) {
+          const data = useLazyLoadQuery(
+            graphql`
+              query LiveResolversTest8Query($id: ID!) {
+                node(id: $id) {
+                  ... on User {
+                    name
+                    resolver_that_throws
+                  }
+                }
+              }
+            `,
+            {id},
+            {fetchPolicy: 'store-only'},
+          );
+          return `${data.node?.name ?? 'Unknown name'}: ${
+            data.node?.resolver_that_throws ??
+            'Unknown resolver_that_throws value'
+          }`;
+        }
+
+        function TestComponent({
+          environment,
+          ...rest
+        }: {
+          environment: RelayModernEnvironment,
+          id: string,
+        }) {
+          return (
+            <RelayEnvironmentProvider environment={environment}>
+              <React.Suspense fallback="Loading...">
+                <InnerTestComponent {...rest} />
+              </React.Suspense>
+            </RelayEnvironmentProvider>
+          );
+        }
+        const relayFieldLogger = jest.fn<
+          $FlowFixMe | [RelayFieldLoggerEvent],
+          void,
+        >();
+        function createEnvironment(source: MutableRecordSource) {
+          return new RelayModernEnvironment({
+            network: RelayNetwork.create(jest.fn()),
+            store: new LiveResolverStore(source),
+            relayFieldLogger,
+          });
+        }
+
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            'node(id:"1")': {__ref: '1'},
+            'node(id:"2")': {__ref: '2'},
+          },
+          '1': {
+            __id: '1',
+            __typename: 'User',
+            name: 'Alice',
+            // username is missing
+            id: '1',
+          },
+          '2': {
+            __id: '2',
+            __typename: 'User',
+            name: 'Bob',
+            username: 'bob',
+            id: '2',
+          },
+        });
+        const environment = createEnvironment(source);
+
+        // First, render with missing data
+        await expect(async () => {
+          await TestRenderer.act(() => {
+            TestRenderer.create(
+              <TestComponent environment={environment} id="1" />,
+            );
+          });
+        }).rejects.toThrow(
+          "Relay: Missing @required value at path 'username' in 'ResolverThatThrows'.",
+        );
+        expect(relayFieldLogger.mock.calls).toEqual([
+          [
+            {
+              kind: 'missing_field.throw',
+              owner: 'ResolverThatThrows',
+              fieldPath: 'username',
+            },
+          ],
+        ]);
+        relayFieldLogger.mockReset();
+
+        // Render with complete data
+        let renderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <TestComponent environment={environment} id="2" />,
+          );
+        });
+
+        if (renderer == null) {
+          throw new Error('Renderer is expected to be defined.');
+        }
+
+        expect(relayFieldLogger.mock.calls).toEqual([
+          [
+            {
+              error: new Error(
+                'The resolver should throw earlier. It should have missing data.',
+              ),
+              fieldPath: 'node.resolver_that_throws',
+              kind: 'relay_resolver.error',
+              owner: 'LiveResolversTest8Query',
+            },
+          ],
+        ]);
+
+        expect(renderer.toJSON()).toEqual(
+          'Bob: Unknown resolver_that_throws value',
+        );
+      },
     );
-  }
 
-  function TestComponent() {
-    const data = useClientQuery(
-      graphql`
-        query LiveResolversTest15Query {
-          live_user_resolver_always_suspend @waterfall {
+    test('apply optimistic updates to live resolver field', () => {
+      let renderer;
+
+      function InnerTestComponent({scale}: {scale: number}) {
+        const data = useLazyLoadQuery(
+          graphql`
+            query LiveResolversTest9Query($id: ID!, $scale: Float!) {
+              node(id: $id) {
+                ... on User {
+                  profile_picture_uri: user_profile_picture_uri_suspends_when_the_counter_is_odd(
+                    scale: $scale
+                  )
+                }
+              }
+            }
+          `,
+          {id: '1', scale},
+          {fetchPolicy: 'store-only'},
+        );
+        return data.node?.profile_picture_uri;
+      }
+
+      function TestComponent({
+        environment,
+        ...rest
+      }: {
+        environment: RelayModernEnvironment,
+        scale: number,
+      }) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">
+              <InnerTestComponent {...rest} />
+            </React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      function createEnvironment(source: MutableRecordSource) {
+        return new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store: new LiveResolverStore(source),
+        });
+      }
+
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'node(id:"1")': {__ref: '1'},
+        },
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          name: 'Alice',
+          id: '1',
+          'profile_picture(scale:1.5)': {
+            __ref: 'client:1:profile_picture(scale:1.5)',
+          },
+        },
+        'client:1:profile_picture(scale:1.5)': {
+          __id: 'client:1:profile_picture(scale:1.5)',
+          uri: 'scale 1.5',
+        },
+      });
+      const environment = createEnvironment(source);
+
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <TestComponent environment={environment} scale={1.5} />,
+        );
+      });
+
+      if (renderer == null) {
+        throw new Error('Renderer is expected to be defined.');
+      }
+
+      expect(renderer.toJSON()).toEqual('Loading...');
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      TestRenderer.act(() => jest.runAllImmediates());
+      expect(renderer.toJSON()).toEqual('Hello, Alice! Picture Url: scale 1.5');
+
+      let update;
+      TestRenderer.act(() => {
+        update = environment.applyUpdate({
+          storeUpdater: store => {
+            const alice = store.get('1');
+            if (alice == null) {
+              throw new Error('Expected to have record "1"');
+            }
+            alice.setValue('Alicia', 'name');
+          },
+        });
+      });
+      expect(renderer.toJSON()).toEqual(
+        'Hello, Alicia! Picture Url: scale 1.5',
+      );
+
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      TestRenderer.act(() => jest.runAllImmediates());
+      expect(renderer.toJSON()).toEqual('Loading...');
+
+      // Revering optimistic update
+      TestRenderer.act(() => update.dispose());
+      // Reverting optimistic update should
+      // not change suspense state of the live-resolver
+      // this should still be `Loading...`
+      expect(renderer.toJSON()).toEqual('Loading...');
+
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      expect(renderer.toJSON()).toEqual('Hello, Alice! Picture Url: scale 1.5');
+    });
+
+    // Regression test for a case where we were resetting the parent snapshot's
+    // `isMissingData` to false when reading a live resolver field.
+    test('Missing data is not clobbered by non-null empty missingLiveResolverFields on snapshot', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          me: {__ref: '1'},
+        },
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+        },
+      });
+      const FooQuery = graphql`
+        query LiveResolversTest10Query {
+          me {
+            # Should be tracked as missing data
+            name
+          }
+          counter
+        }
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+      });
+
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+
+      const snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.missingLiveResolverFields).toEqual([]);
+      expect(snapshot.isMissingData).toBe(true);
+    });
+
+    test('with client-only field', () => {
+      let renderer;
+
+      function InnerTestComponent() {
+        const data = useClientQuery(
+          graphql`
+            query LiveResolversTest11Query {
+              counter_no_fragment
+            }
+          `,
+          {},
+        );
+        return data.counter_no_fragment;
+      }
+
+      function TestComponent({environment}: {environment: IEnvironment}) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">
+              <InnerTestComponent />
+            </React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      function createEnvironment(source: MutableRecordSource) {
+        return new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store: new LiveResolverStore(source),
+        });
+      }
+
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+        },
+      });
+      const environment = createEnvironment(source);
+
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <TestComponent environment={environment} />,
+        );
+      });
+
+      if (renderer == null) {
+        throw new Error('Renderer is expected to be defined.');
+      }
+
+      expect(renderer.toJSON()).toEqual('0');
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      expect(renderer.toJSON()).toEqual('1');
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      expect(renderer.toJSON()).toEqual('2');
+    });
+
+    test('with client-only field and args', () => {
+      let renderer;
+
+      function InnerTestComponent({prefix}: {prefix: string}) {
+        const data = useClientQuery(
+          graphql`
+            query LiveResolversTest12Query($prefix: String!) {
+              counter_no_fragment_with_arg(prefix: $prefix)
+            }
+          `,
+          {prefix},
+        );
+        return data.counter_no_fragment_with_arg;
+      }
+
+      function TestComponent({
+        environment,
+        ...rest
+      }: {
+        environment: IEnvironment,
+        prefix: string,
+      }) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">
+              <InnerTestComponent {...rest} />
+            </React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      function createEnvironment(source: MutableRecordSource) {
+        return new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store: new LiveResolverStore(source),
+        });
+      }
+
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+        },
+      });
+      const environment = createEnvironment(source);
+
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <TestComponent prefix="Counter is" environment={environment} />,
+        );
+      });
+
+      if (renderer == null) {
+        throw new Error('Renderer is expected to be defined.');
+      }
+
+      expect(renderer.toJSON()).toEqual('Counter is 0');
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      expect(renderer.toJSON()).toEqual('Counter is 1');
+      TestRenderer.act(() => {
+        GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+      });
+      expect(renderer.toJSON()).toEqual('Counter is 2');
+    });
+
+    test('Can read a live client edge without a fragment', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+        },
+        '1338': {
+          __id: '1338',
+          id: '1338',
+          __typename: 'User',
+          name: 'Elizabeth',
+        },
+      });
+
+      const FooQuery = graphql`
+        query LiveResolversTest13Query {
+          live_constant_client_edge @waterfall {
             name
           }
         }
-      `,
-      {},
-    );
-    return data.live_user_resolver_always_suspend?.name;
-  }
+      `;
 
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <Environment>
-        <TestComponent />
-      </Environment>,
-    );
-  });
+      const operation = createOperationDescriptor(FooQuery, {});
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+      });
 
-  expect(renderer?.toJSON()).toBe('Loading...');
-});
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
 
-describe('client-only fragments', () => {
-  const LiveResolversTestCounterUserFragment = graphql`
-    fragment LiveResolversTestCounterUserFragment on User {
-      counter_suspends_when_odd
-    }
-  `;
+      const data = environment.lookup(operation.fragment).data;
+      expect(data).toEqual({
+        live_constant_client_edge: {
+          name: 'Elizabeth',
+        },
+      });
+    });
 
-  const LiveResolversTestLiveResolverSuspenseQuery = graphql`
-    query LiveResolversTestLiveResolverSuspenseQuery($id: ID!) {
-      node(id: $id) {
-        ...LiveResolversTestCounterUserFragment
+    test('live resolver with the edge that always suspend', () => {
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store: new LiveResolverStore(
+          RelayRecordSource.create({
+            'client:root': {
+              __id: 'client:root',
+              __typename: '__Root',
+            },
+          }),
+        ),
+      });
+
+      function Environment({children}: {children: React.Node}) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">{children}</React.Suspense>
+          </RelayEnvironmentProvider>
+        );
       }
-    }
-  `;
 
-  function Environment({
-    children,
-    environment,
-  }: {
-    children: React.Node,
-    environment: RelayModernEnvironment,
-  }) {
-    return (
-      <RelayEnvironmentProvider environment={environment}>
-        <React.Suspense fallback="Loading...">{children}</React.Suspense>
-      </RelayEnvironmentProvider>
-    );
-  }
-
-  function TestComponent(props: {id: string}) {
-    const queryData = useLazyLoadQuery(
-      LiveResolversTestLiveResolverSuspenseQuery,
-      {id: props.id},
-    );
-    const fragmentData = useFragment(
-      LiveResolversTestCounterUserFragment,
-      queryData.node,
-    );
-    return fragmentData?.counter_suspends_when_odd;
-  }
-
-  test('correctly suspend on fragments with client-only data', () => {
-    const environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store: new LiveResolverStore(RelayRecordSource.create()),
-    });
-    environment.commitPayload(
-      createOperationDescriptor(LiveResolversTestLiveResolverSuspenseQuery, {
-        id: '1',
-      }),
-      {
-        node: {id: '1', __typename: 'User'},
-      },
-    );
-    let renderer;
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(
-        <Environment environment={environment}>
-          <TestComponent id="1" />
-        </Environment>,
-      );
-    });
-    expect(renderer?.toJSON()).toEqual('0');
-    TestRenderer.act(() => {
-      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-    });
-    TestRenderer.act(() => jest.runAllImmediates());
-    expect(renderer.toJSON()).toEqual('Loading...');
-    TestRenderer.act(() => {
-      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-    });
-    expect(renderer.toJSON()).toEqual('2');
-  });
-
-  test('invariant for invalid liveState value in the Relay store.', () => {
-    const environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store: new LiveResolverStore(RelayRecordSource.create()),
-    });
-    environment.commitPayload(
-      createOperationDescriptor(LiveResolversTestLiveResolverSuspenseQuery, {
-        id: '1',
-      }),
-      {
-        node: {id: '1', __typename: 'User'},
-      },
-    );
-    let renderer;
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(
-        <Environment environment={environment}>
-          <TestComponent id="1" />
-        </Environment>,
-      );
-    });
-    expect(renderer?.toJSON()).toEqual('0');
-    TestRenderer.act(() => {
-      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-    });
-    TestRenderer.act(() => jest.runAllImmediates());
-    expect(renderer.toJSON()).toEqual('Loading...');
-    environment.applyUpdate({
-      storeUpdater: store => {
-        const record = store.get('client:1:counter_suspends_when_odd');
-        // this will force the invalid `liveState` value` in the resolver record
-        record?.setValue(undefined, '__resolverLiveStateValue');
-      },
-    });
-    expect(() => {
-      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-    }).toThrowError(
-      'Unexpected LiveState value returned from Relay Resolver internal field `RELAY_RESOLVER_LIVE_STATE_VALUE`. It is likely a bug in Relay, or a corrupt state of the relay store state Field Path `counter_suspends_when_odd`. Record `{"__id":"client:1:counter_suspends_when_odd","__typename":"__RELAY_RESOLVER__","__resolverError":null,"__resolverValue":{"__LIVE_RESOLVER_SUSPENSE_SENTINEL":true},"__resolverLiveStateDirty":true}`.',
-    );
-    expect(renderer.toJSON()).toEqual('Loading...');
-  });
-});
-
-test('Subscriptions cleaned up correctly after GC', () => {
-  const store = new LiveResolverStore(RelayRecordSource.create(), {
-    gcReleaseBufferSize: 0,
-  });
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  // We're adding some data for `me { id } ` query so the initial read for
-  // `live_counter_with_possible_missing_fragment_data` won't have any missing data
-  //  and we will be able to create a valid live resolver record for it.
-  function publishMeData() {
-    environment.commitPayload(
-      createOperationDescriptor(
-        graphql`
-          query LiveResolversTestWithGCUserQuery {
-            me {
-              id
+      function TestComponent() {
+        const data = useClientQuery(
+          graphql`
+            query LiveResolversTest15Query {
+              live_user_resolver_always_suspend @waterfall {
+                name
+              }
             }
+          `,
+          {},
+        );
+        return data.live_user_resolver_always_suspend?.name;
+      }
+
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <Environment>
+            <TestComponent />
+          </Environment>,
+        );
+      });
+
+      expect(renderer?.toJSON()).toBe('Loading...');
+    });
+
+    describe('client-only fragments', () => {
+      const LiveResolversTestCounterUserFragment = graphql`
+        fragment LiveResolversTestCounterUserFragment on User {
+          counter_suspends_when_odd
+        }
+      `;
+
+      const LiveResolversTestLiveResolverSuspenseQuery = graphql`
+        query LiveResolversTestLiveResolverSuspenseQuery($id: ID!) {
+          node(id: $id) {
+            ...LiveResolversTestCounterUserFragment
+          }
+        }
+      `;
+
+      function Environment({
+        children,
+        environment,
+      }: {
+        children: React.Node,
+        environment: RelayModernEnvironment,
+      }) {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading...">{children}</React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      function TestComponent(props: {id: string}) {
+        const queryData = useLazyLoadQuery(
+          LiveResolversTestLiveResolverSuspenseQuery,
+          {id: props.id},
+        );
+        const fragmentData = useFragment(
+          LiveResolversTestCounterUserFragment,
+          queryData.node,
+        );
+        return fragmentData?.counter_suspends_when_odd;
+      }
+
+      test('correctly suspend on fragments with client-only data', () => {
+        const environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store: new LiveResolverStore(RelayRecordSource.create()),
+        });
+        environment.commitPayload(
+          createOperationDescriptor(
+            LiveResolversTestLiveResolverSuspenseQuery,
+            {
+              id: '1',
+            },
+          ),
+          {
+            node: {id: '1', __typename: 'User'},
+          },
+        );
+        let renderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <Environment environment={environment}>
+              <TestComponent id="1" />
+            </Environment>,
+          );
+        });
+        expect(renderer?.toJSON()).toEqual('0');
+        TestRenderer.act(() => {
+          GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+        });
+        TestRenderer.act(() => jest.runAllImmediates());
+        expect(renderer.toJSON()).toEqual('Loading...');
+        TestRenderer.act(() => {
+          GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+        });
+        expect(renderer.toJSON()).toEqual('2');
+      });
+
+      test('invariant for invalid liveState value in the Relay store.', () => {
+        const environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store: new LiveResolverStore(RelayRecordSource.create()),
+        });
+        environment.commitPayload(
+          createOperationDescriptor(
+            LiveResolversTestLiveResolverSuspenseQuery,
+            {
+              id: '1',
+            },
+          ),
+          {
+            node: {id: '1', __typename: 'User'},
+          },
+        );
+        let renderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <Environment environment={environment}>
+              <TestComponent id="1" />
+            </Environment>,
+          );
+        });
+        expect(renderer?.toJSON()).toEqual('0');
+        TestRenderer.act(() => {
+          GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+        });
+        TestRenderer.act(() => jest.runAllImmediates());
+        expect(renderer.toJSON()).toEqual('Loading...');
+        environment.applyUpdate({
+          storeUpdater: store => {
+            const record = store.get('client:1:counter_suspends_when_odd');
+            // this will force the invalid `liveState` value` in the resolver record
+            record?.setValue(undefined, '__resolverLiveStateValue');
+          },
+        });
+        expect(() => {
+          GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+        }).toThrowError(
+          'Unexpected LiveState value returned from Relay Resolver internal field `RELAY_RESOLVER_LIVE_STATE_VALUE`. It is likely a bug in Relay, or a corrupt state of the relay store state Field Path `counter_suspends_when_odd`. Record `{"__id":"client:1:counter_suspends_when_odd","__typename":"__RELAY_RESOLVER__","__resolverError":null,"__resolverValue":{"__LIVE_RESOLVER_SUSPENSE_SENTINEL":true},"__resolverLiveStateDirty":true}`.',
+        );
+        expect(renderer.toJSON()).toEqual('Loading...');
+      });
+    });
+
+    test('Subscriptions cleaned up correctly after GC', () => {
+      const store = new LiveResolverStore(RelayRecordSource.create(), {
+        gcReleaseBufferSize: 0,
+      });
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+
+      // We're adding some data for `me { id } ` query so the initial read for
+      // `live_counter_with_possible_missing_fragment_data` won't have any missing data
+      //  and we will be able to create a valid live resolver record for it.
+      function publishMeData() {
+        environment.commitPayload(
+          createOperationDescriptor(
+            graphql`
+              query LiveResolversTestWithGCUserQuery {
+                me {
+                  id
+                }
+              }
+            `,
+            {},
+          ),
+          {
+            me: {
+              id: '1',
+            },
+          },
+        );
+      }
+      publishMeData();
+
+      const operation = createOperationDescriptor(
+        graphql`
+          query LiveResolversTestWithGCQuery {
+            live_counter_with_possible_missing_fragment_data
           }
         `,
         {},
-      ),
-      {
-        me: {
+      );
+
+      // The first time we read `live_counter_with_possible_missing_fragment_data` we will
+      // create live resolver record and subscribe to the external store for updates
+      let snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.data).toEqual({
+        live_counter_with_possible_missing_fragment_data: 0,
+      });
+      expect(snapshot.isMissingData).toBe(false);
+
+      // Note: this is another issue with GC here.
+      // Our GC will remove **all** records from the store(including __ROOT__) if they are not retained.
+      //
+      // So in this test we need to retain some unrelevant records in the store to keep the __ROOT__
+      // record arount after GC run.
+      environment.retain(
+        createOperationDescriptor(
+          graphql`
+            query LiveResolversTestWithGCCounterQuery {
+              counter_no_fragment
+            }
+          `,
+          {},
+        ),
+      );
+
+      const subscriptionsCountBeforeGCRun =
+        GLOBAL_STORE.getSubscriptionsCount();
+
+      // Go-go-go! Clean the store!
+      store.scheduleGC();
+      jest.runAllImmediates();
+      // This will clean the store, and unsubscribe from the external states
+
+      const subscriptionsCountAfterGCRun = GLOBAL_STORE.getSubscriptionsCount();
+
+      // this will verify that we unsubscribed from the external store
+      expect(subscriptionsCountAfterGCRun).toEqual(
+        subscriptionsCountBeforeGCRun - 1,
+      );
+
+      // Re-reading resolvers will create new records for them (but) the
+      // `live_counter_with_possible_missing_fragment_data` will have missing required data at this
+      // point so we won't be able to create a fully-valid live-resolver record for it (and subscribe/read)
+      // from the external state.
+      environment.lookup(operation.fragment);
+
+      // this will dispatch an action from the external store and the callback that was created before GC
+      GLOBAL_STORE.dispatch({type: 'INCREMENT'});
+
+      // The data for the live resolver is missing (it has missing dependecies)
+      snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.data).toEqual({
+        live_counter_with_possible_missing_fragment_data: undefined,
+      });
+      expect(snapshot.isMissingData).toBe(true);
+
+      // We should be able to re-read the data once the missing data in avaialbe again
+      publishMeData();
+
+      snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.data).toEqual({
+        live_counter_with_possible_missing_fragment_data: 1,
+      });
+      expect(snapshot.isMissingData).toBe(false);
+    });
+
+    test('Errors when reading a @live resolver that does not return a LiveState object', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+        },
+      });
+      const FooQuery = graphql`
+        query LiveResolversTest16Query {
+          live_resolver_with_bad_return_value
+        }
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+      });
+
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+
+      expect(() => {
+        environment.lookup(operation.fragment);
+      }).toThrow(
+        'Expected the @live Relay Resolver backing the field "live_resolver_with_bad_return_value" to return a value that implements LiveState. Did you mean to remove the @live annotation on this resolver?',
+      );
+    });
+
+    test('Errors when reading a non-@live resolver that returns a LiveState object', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+        },
+      });
+      const FooQuery = graphql`
+        query LiveResolversTest17Query {
+          non_live_resolver_with_live_return_value
+        }
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+      });
+
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
+
+      expect(() => {
+        environment.lookup(operation.fragment);
+      }).toThrow(
+        'Unexpected LiveState value returned from the non-@live Relay Resolver backing the field "non_live_resolver_with_live_return_value". Did you intend to add @live to this resolver?',
+      );
+    });
+
+    test('Errors when reading a @live resolver that does not return a LiveState object and throws instead.', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+        },
+      });
+      const FooQuery = graphql`
+        query LiveResolversTest18Query {
+          live_resolver_throws
+        }
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store: new LiveResolverStore(source, {
+          gcReleaseBufferSize: 0,
+        }),
+      });
+
+      const data = environment.lookup(operation.fragment);
+      expect(data.relayResolverErrors).toEqual([
+        {
+          field: {
+            owner: 'LiveResolversTest18Query',
+            path: 'live_resolver_throws',
+          },
+          error: new Error('What?'),
+        },
+      ]);
+    });
+
+    test('Errors when reading a @live resolver that does not return a LiveState object and returns `undefined`.', () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+        },
+      });
+      const FooQuery = graphql`
+        query LiveResolversTest19Query {
+          live_resolver_return_undefined
+        }
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store: new LiveResolverStore(source, {
+          gcReleaseBufferSize: 0,
+        }),
+      });
+
+      expect(() => {
+        environment.lookup(operation.fragment);
+      }).toThrow(
+        'Expected the @live Relay Resolver backing the field "live_resolver_return_undefined" to return a value that implements LiveState interface. The result for this field is `undefined`, we also did not detect any errors, or missing data during resolver execution. Did you mean to remove the @live annotation on this resolver, or was there unexpected early return in the function?',
+      );
+    });
+
+    test('provided variables and resolvers', () => {
+      const FooQuery = graphql`
+        query LiveResolversTestWithProvidedVariablesQuery {
+          hello_world_with_provided_variable
+        }
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store: new LiveResolverStore(RelayRecordSource.create(), {
+          gcReleaseBufferSize: 0,
+        }),
+      });
+
+      const snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.relayResolverErrors).toEqual([]);
+      expect(snapshot.data).toEqual({
+        hello_world_with_provided_variable: 'Hello, Hello, World!!',
+      });
+    });
+
+    test('allows dependencies to be provided through the store', () => {
+      const FooQuery = graphql`
+        query LiveResolversTestWithContextQuery {
+          hello_world_with_context
+        }
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store: new LiveResolverStore(RelayRecordSource.create(), {
+          gcReleaseBufferSize: 0,
+          resolverContext: {
+            greeting: {myHello: 'Hello Allemaal!'},
+          },
+        }),
+      });
+
+      const snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.relayResolverErrors).toEqual([]);
+      expect(snapshot.data).toEqual({
+        hello_world_with_context: 'Hello Hello Allemaal!!',
+      });
+    });
+
+    test('allows objects to be provided to be provided through the store', () => {
+      const FooQuery = graphql`
+        query LiveResolversTestWithContextObjectQuery {
+          hello_world_with_context_object
+        }
+      `;
+
+      const operation = createOperationDescriptor(FooQuery, {});
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store: new LiveResolverStore(RelayRecordSource.create(), {
+          gcReleaseBufferSize: 0,
+          resolverContext: {
+            greeting: {
+              myHello: 'Hello Allemaal!',
+            },
+          },
+        }),
+      });
+
+      const snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.relayResolverErrors).toEqual([]);
+      expect(snapshot.data).toEqual({
+        hello_world_with_context_object: 'Hello Hello Allemaal!!',
+      });
+    });
+
+    test('ResolverContext can contain observable values', async () => {
+      const source = RelayRecordSource.create({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          me: {__ref: '1'},
+        },
+        '1': {
+          __id: '1',
+          __typename: 'User',
           id: '1',
         },
-      },
-    );
-  }
-  publishMeData();
-
-  const operation = createOperationDescriptor(
-    graphql`
-      query LiveResolversTestWithGCQuery {
-        live_counter_with_possible_missing_fragment_data
-      }
-    `,
-    {},
-  );
-
-  // The first time we read `live_counter_with_possible_missing_fragment_data` we will
-  // create live resolver record and subscribe to the external store for updates
-  let snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.data).toEqual({
-    live_counter_with_possible_missing_fragment_data: 0,
-  });
-  expect(snapshot.isMissingData).toBe(false);
-
-  // Note: this is another issue with GC here.
-  // Our GC will remove **all** records from the store(including __ROOT__) if they are not retained.
-  //
-  // So in this test we need to retain some unrelevant records in the store to keep the __ROOT__
-  // record arount after GC run.
-  environment.retain(
-    createOperationDescriptor(
-      graphql`
-        query LiveResolversTestWithGCCounterQuery {
-          counter_no_fragment
+      });
+      const FooQuery = graphql`
+        query LiveResolversTestCounterContextQuery {
+          counter_context
         }
-      `,
-      {},
-    ),
-  );
+      `;
 
-  const subscriptionsCountBeforeGCRun = GLOBAL_STORE.getSubscriptionsCount();
+      let next: (v: number) => void = () => {
+        throw new Error('next() not initialized');
+      };
 
-  // Go-go-go! Clean the store!
-  store.scheduleGC();
-  jest.runAllImmediates();
-  // This will clean the store, and unsubscribe from the external states
-
-  const subscriptionsCountAfterGCRun = GLOBAL_STORE.getSubscriptionsCount();
-
-  // this will verify that we unsubscribed from the external store
-  expect(subscriptionsCountAfterGCRun).toEqual(
-    subscriptionsCountBeforeGCRun - 1,
-  );
-
-  // Re-reading resolvers will create new records for them (but) the
-  // `live_counter_with_possible_missing_fragment_data` will have missing required data at this
-  // point so we won't be able to create a fully-valid live-resolver record for it (and subscribe/read)
-  // from the external state.
-  environment.lookup(operation.fragment);
-
-  // this will dispatch an action from the external store and the callback that was created before GC
-  GLOBAL_STORE.dispatch({type: 'INCREMENT'});
-
-  // The data for the live resolver is missing (it has missing dependecies)
-  snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.data).toEqual({
-    live_counter_with_possible_missing_fragment_data: undefined,
-  });
-  expect(snapshot.isMissingData).toBe(true);
-
-  // We should be able to re-read the data once the missing data in avaialbe again
-  publishMeData();
-
-  snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.data).toEqual({
-    live_counter_with_possible_missing_fragment_data: 1,
-  });
-  expect(snapshot.isMissingData).toBe(false);
-});
-
-test('Errors when reading a @live resolver that does not return a LiveState object', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-  });
-  const FooQuery = graphql`
-    query LiveResolversTest16Query {
-      live_resolver_with_bad_return_value
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  expect(() => {
-    environment.lookup(operation.fragment);
-  }).toThrow(
-    'Expected the @live Relay Resolver backing the field "live_resolver_with_bad_return_value" to return a value that implements LiveState. Did you mean to remove the @live annotation on this resolver?',
-  );
-});
-
-test('Errors when reading a non-@live resolver that returns a LiveState object', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-  });
-  const FooQuery = graphql`
-    query LiveResolversTest17Query {
-      non_live_resolver_with_live_return_value
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-  });
-
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
-
-  expect(() => {
-    environment.lookup(operation.fragment);
-  }).toThrow(
-    'Unexpected LiveState value returned from the non-@live Relay Resolver backing the field "non_live_resolver_with_live_return_value". Did you intend to add @live to this resolver?',
-  );
-});
-
-test('Errors when reading a @live resolver that does not return a LiveState object and throws instead.', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-  });
-  const FooQuery = graphql`
-    query LiveResolversTest18Query {
-      live_resolver_throws
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store: new LiveResolverStore(source, {
-      gcReleaseBufferSize: 0,
-    }),
-  });
-
-  const data = environment.lookup(operation.fragment);
-  expect(data.relayResolverErrors).toEqual([
-    {
-      field: {
-        owner: 'LiveResolversTest18Query',
-        path: 'live_resolver_throws',
-      },
-      error: new Error('What?'),
-    },
-  ]);
-});
-
-test('Errors when reading a @live resolver that does not return a LiveState object and returns `undefined`.', () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-    },
-  });
-  const FooQuery = graphql`
-    query LiveResolversTest19Query {
-      live_resolver_return_undefined
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store: new LiveResolverStore(source, {
-      gcReleaseBufferSize: 0,
-    }),
-  });
-
-  expect(() => {
-    environment.lookup(operation.fragment);
-  }).toThrow(
-    'Expected the @live Relay Resolver backing the field "live_resolver_return_undefined" to return a value that implements LiveState interface. The result for this field is `undefined`, we also did not detect any errors, or missing data during resolver execution. Did you mean to remove the @live annotation on this resolver, or was there unexpected early return in the function?',
-  );
-});
-
-test('provided variables and resolvers', () => {
-  const FooQuery = graphql`
-    query LiveResolversTestWithProvidedVariablesQuery {
-      hello_world_with_provided_variable
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store: new LiveResolverStore(RelayRecordSource.create(), {
-      gcReleaseBufferSize: 0,
-    }),
-  });
-
-  const snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.relayResolverErrors).toEqual([]);
-  expect(snapshot.data).toEqual({
-    hello_world_with_provided_variable: 'Hello, Hello, World!!',
-  });
-});
-
-test('allows dependencies to be provided through the store', () => {
-  const FooQuery = graphql`
-    query LiveResolversTestWithContextQuery {
-      hello_world_with_context
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store: new LiveResolverStore(RelayRecordSource.create(), {
-      gcReleaseBufferSize: 0,
-      resolverContext: {
-        greeting: {myHello: 'Hello Allemaal!'},
-      },
-    }),
-  });
-
-  const snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.relayResolverErrors).toEqual([]);
-  expect(snapshot.data).toEqual({
-    hello_world_with_context: 'Hello Hello Allemaal!!',
-  });
-});
-
-test('allows objects to be provided to be provided through the store', () => {
-  const FooQuery = graphql`
-    query LiveResolversTestWithContextObjectQuery {
-      hello_world_with_context_object
-    }
-  `;
-
-  const operation = createOperationDescriptor(FooQuery, {});
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store: new LiveResolverStore(RelayRecordSource.create(), {
-      gcReleaseBufferSize: 0,
-      resolverContext: {
-        greeting: {
-          myHello: 'Hello Allemaal!',
+      const operation = createOperationDescriptor(FooQuery, {});
+      const store = new LiveResolverStore(source, {
+        gcReleaseBufferSize: 0,
+        resolverContext: {
+          counter: Observable.create<number>(observer => {
+            next = (value: number) => observer.next(value);
+          }),
         },
-      },
-    }),
-  });
+      });
 
-  const snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.relayResolverErrors).toEqual([]);
-  expect(snapshot.data).toEqual({
-    hello_world_with_context_object: 'Hello Hello Allemaal!!',
-  });
-});
+      const environment = new RelayModernEnvironment({
+        network: RelayNetwork.create(jest.fn()),
+        store,
+      });
 
-test('ResolverContext can contain observable values', async () => {
-  const source = RelayRecordSource.create({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-      me: {__ref: '1'},
-    },
-    '1': {
-      __id: '1',
-      __typename: 'User',
-      id: '1',
-    },
-  });
-  const FooQuery = graphql`
-    query LiveResolversTestCounterContextQuery {
-      counter_context
-    }
-  `;
+      let observedCounter = null;
 
-  let next: (v: number) => void = () => {
-    throw new Error('next() not initialized');
-  };
+      const snapshot = environment.lookup(operation.fragment);
+      // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+      observedCounter = (snapshot.data: any).counter_context;
 
-  const operation = createOperationDescriptor(FooQuery, {});
-  const store = new LiveResolverStore(source, {
-    gcReleaseBufferSize: 0,
-    resolverContext: {
-      counter: Observable.create<number>(observer => {
-        next = (value: number) => observer.next(value);
-      }),
-    },
-  });
+      const environmentUpdateHandler = jest.fn(() => {
+        const s = environment.lookup(operation.fragment);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        observedCounter = (s.data: any).counter_context;
+      });
+      const disposable = environment.subscribe(
+        snapshot,
+        // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
+        environmentUpdateHandler,
+      );
 
-  const environment = new RelayModernEnvironment({
-    network: RelayNetwork.create(jest.fn()),
-    store,
-  });
+      // SETUP COMPLETE
 
-  let observedCounter = null;
+      // Read the initial value
+      expect(observedCounter).toBe(0);
+      expect(environmentUpdateHandler).not.toHaveBeenCalled();
 
-  const snapshot = environment.lookup(operation.fragment);
-  // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-  observedCounter = (snapshot.data: any).counter_context;
+      // Increment and assert we get notified of the new value
+      next(43);
+      expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
+      expect(observedCounter).toBe(43);
 
-  const environmentUpdateHandler = jest.fn(() => {
-    const s = environment.lookup(operation.fragment);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    observedCounter = (s.data: any).counter_context;
-  });
-  const disposable = environment.subscribe(
-    snapshot,
-    // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
-    environmentUpdateHandler,
-  );
+      // Unsubscribe then increment and assert don't get notified.
+      disposable.dispose();
+      next(1);
+      expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
+      expect(observedCounter).toBe(43);
 
-  // SETUP COMPLETE
+      // Explicitly read and assert we see the incremented value
+      // missed before due to unsubscribing.
+      const nextSnapshot = environment.lookup(operation.fragment);
 
-  // Read the initial value
-  expect(observedCounter).toBe(0);
-  expect(environmentUpdateHandler).not.toHaveBeenCalled();
-
-  // Increment and assert we get notified of the new value
-  next(43);
-  expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
-  expect(observedCounter).toBe(43);
-
-  // Unsubscribe then increment and assert don't get notified.
-  disposable.dispose();
-  next(1);
-  expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
-  expect(observedCounter).toBe(43);
-
-  // Explicitly read and assert we see the incremented value
-  // missed before due to unsubscribing.
-  const nextSnapshot = environment.lookup(operation.fragment);
-
-  expect(nextSnapshot.data).toEqual({
-    counter_context: 1,
-  });
-});
+      expect(nextSnapshot.data).toEqual({
+        counter_context: 1,
+      });
+    });
+  },
+);

--- a/packages/react-relay/__tests__/RelayResolverInterface-test.js
+++ b/packages/react-relay/__tests__/RelayResolverInterface-test.js
@@ -93,382 +93,392 @@ function AnimalLegsComponent(props: {
   return animal?.legs;
 }
 
-test('should read the legs of a cat', () => {
-  function CatLegsRootComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverInterfaceTestCatLegsQuery {
-          cat {
-            ...RelayResolverInterfaceTestAnimalLegsFragment
-          }
-        }
-      `,
-      {},
-    );
+describe.each([true, false])(
+  'AVOID_CYCLES_IN_RESOLVER_NOTIFICATION is %p',
+  avoidCycles => {
+    RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION = avoidCycles;
+    test('should read the legs of a cat', () => {
+      function CatLegsRootComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverInterfaceTestCatLegsQuery {
+              cat {
+                ...RelayResolverInterfaceTestAnimalLegsFragment
+              }
+            }
+          `,
+          {},
+        );
 
-    return <AnimalLegsComponent animal={data.cat} />;
-  }
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <CatLegsRootComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('4');
-});
-
-test('should read the legs of a fish', () => {
-  function FishLegsRootComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverInterfaceTestFishLegsQuery {
-          fish {
-            ...RelayResolverInterfaceTestAnimalLegsFragment
-          }
-        }
-      `,
-      {},
-    );
-
-    return <AnimalLegsComponent animal={data.fish} />;
-  }
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <FishLegsRootComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('0');
-});
-
-test('should read the legs of a chicken (client schema extension type)', () => {
-  function ChickenLegsRootComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverInterfaceTestChickenLegsQuery {
-          chicken {
-            ...RelayResolverInterfaceTestAnimalLegsFragment
-          }
-        }
-      `,
-      {},
-    );
-
-    return <AnimalLegsComponent animal={data.chicken} />;
-  }
-
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <ChickenLegsRootComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('2');
-});
-
-function WeakAnimalColorFragmentComponent(props: {
-  animal: ?RelayResolverInterfaceTestWeakAnimalColorFragment$key,
-}) {
-  const animal = useFragment(
-    graphql`
-      fragment RelayResolverInterfaceTestWeakAnimalColorFragment on IWeakAnimal {
-        color
+        return <AnimalLegsComponent animal={data.cat} />;
       }
-    `,
-    props.animal,
-  );
-  return animal?.color;
-}
-
-test('should read the color of a red octopus (weak model type)', () => {
-  function RedOctopusColorRootComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverInterfaceTestRedOctopusColorQuery {
-          red_octopus {
-            ...RelayResolverInterfaceTestWeakAnimalColorFragment
-          }
-        }
-      `,
-      {},
-    );
-
-    return <WeakAnimalColorFragmentComponent animal={data.red_octopus} />;
-  }
-
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <RedOctopusColorRootComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('red');
-});
-
-function AnimalGreetingQueryComponent(props: {
-  request: {ofType: string, returnValidID: boolean},
-}) {
-  const data = useClientQuery(
-    graphql`
-      query RelayResolverInterfaceTestAnimalGreetingQuery(
-        $request: AnimalRequest!
-      ) {
-        animal(request: $request) {
-          greeting
-        }
-      }
-    `,
-    {request: props.request},
-  );
-  if (data.animal == null) {
-    return 'NULL';
-  }
-  return data.animal.greeting;
-}
-
-function WeakAnimalGreetingQueryComponent(props: {request: {ofType: string}}) {
-  const data = useClientQuery(
-    graphql`
-      query RelayResolverInterfaceTestWeakAnimalGreetingQuery(
-        $request: WeakAnimalRequest!
-      ) {
-        weak_animal(request: $request) {
-          greeting
-        }
-      }
-    `,
-    {request: props.request},
-  );
-  if (data.weak_animal == null) {
-    return 'NULL';
-  }
-  return data.weak_animal.greeting;
-}
-
-describe.each([
-  {
-    inputAnimalType: 'Fish',
-    id: '12redblue',
-  },
-  {
-    inputAnimalType: 'Cat',
-    id: '1234567890',
-  },
-])(
-  'resolvers can read resolver on an interface where all implementors are strong model types: %s',
-  ({inputAnimalType, id}) => {
-    test(`should read the greeting of a ${inputAnimalType}`, () => {
-      let animalRenderer;
+      let renderer;
       TestRenderer.act(() => {
-        animalRenderer = TestRenderer.create(
+        renderer = TestRenderer.create(
           <EnvironmentWrapper environment={environment}>
-            <AnimalGreetingQueryComponent
-              request={{ofType: inputAnimalType, returnValidID: true}}
-            />
+            <CatLegsRootComponent />
           </EnvironmentWrapper>,
         );
       });
-      expect(animalRenderer?.toJSON()).toEqual(`Hello, ${id}!`);
+      expect(renderer?.toJSON()).toEqual('4');
     });
 
-    test(`should return null for nonexistent ${inputAnimalType}`, () => {
-      let nullRenderer;
+    test('should read the legs of a fish', () => {
+      function FishLegsRootComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverInterfaceTestFishLegsQuery {
+              fish {
+                ...RelayResolverInterfaceTestAnimalLegsFragment
+              }
+            }
+          `,
+          {},
+        );
+
+        return <AnimalLegsComponent animal={data.fish} />;
+      }
+      let renderer;
       TestRenderer.act(() => {
-        nullRenderer = TestRenderer.create(
+        renderer = TestRenderer.create(
           <EnvironmentWrapper environment={environment}>
-            <AnimalGreetingQueryComponent
-              request={{ofType: inputAnimalType, returnValidID: false}} // This should trigger a `null` value.
-            />
+            <FishLegsRootComponent />
           </EnvironmentWrapper>,
         );
       });
-      expect(nullRenderer?.toJSON()).toEqual('NULL');
+      expect(renderer?.toJSON()).toEqual('0');
     });
-  },
-);
 
-describe.each([
-  {
-    inputAnimalType: 'RedOctopus',
-    name: 'Shiny',
-  },
-  {
-    inputAnimalType: 'PurpleOctopus',
-    name: 'Glowing',
-  },
-])(
-  'resolvers can read resolver on an interface where all implementors are weak model types: %s',
-  ({inputAnimalType, name}) => {
-    test(`should read the greeting of a ${inputAnimalType}`, () => {
-      let animalRenderer;
+    test('should read the legs of a chicken (client schema extension type)', () => {
+      function ChickenLegsRootComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverInterfaceTestChickenLegsQuery {
+              chicken {
+                ...RelayResolverInterfaceTestAnimalLegsFragment
+              }
+            }
+          `,
+          {},
+        );
+
+        return <AnimalLegsComponent animal={data.chicken} />;
+      }
+
+      let renderer;
       TestRenderer.act(() => {
-        animalRenderer = TestRenderer.create(
+        renderer = TestRenderer.create(
           <EnvironmentWrapper environment={environment}>
-            <WeakAnimalGreetingQueryComponent
-              request={{ofType: inputAnimalType}}
-            />
+            <ChickenLegsRootComponent />
           </EnvironmentWrapper>,
         );
       });
-      expect(animalRenderer?.toJSON()).toEqual(`Hello, ${name}!`);
+      expect(renderer?.toJSON()).toEqual('2');
     });
-  },
-);
 
-describe.each([
-  {
-    animalType: 'RedOctopus',
-    color: 'red',
-  },
-  {
-    animalType: 'PurpleOctopus',
-    color: 'purple',
-  },
-])(
-  'resolvers can return an interface where all implementors are weak model types: %s',
-  ({animalType, color}) => {
-    function WeakAnimalColorQueryComponent(props: {request: {ofType: string}}) {
+    function WeakAnimalColorFragmentComponent(props: {
+      animal: ?RelayResolverInterfaceTestWeakAnimalColorFragment$key,
+    }) {
+      const animal = useFragment(
+        graphql`
+          fragment RelayResolverInterfaceTestWeakAnimalColorFragment on IWeakAnimal {
+            color
+          }
+        `,
+        props.animal,
+      );
+      return animal?.color;
+    }
+
+    test('should read the color of a red octopus (weak model type)', () => {
+      function RedOctopusColorRootComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverInterfaceTestRedOctopusColorQuery {
+              red_octopus {
+                ...RelayResolverInterfaceTestWeakAnimalColorFragment
+              }
+            }
+          `,
+          {},
+        );
+
+        return <WeakAnimalColorFragmentComponent animal={data.red_octopus} />;
+      }
+
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <RedOctopusColorRootComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('red');
+    });
+
+    function AnimalGreetingQueryComponent(props: {
+      request: {ofType: string, returnValidID: boolean},
+    }) {
       const data = useClientQuery(
         graphql`
-          query RelayResolverInterfaceTestWeakAnimalColorQuery(
-            $request: WeakAnimalRequest!
+          query RelayResolverInterfaceTestAnimalGreetingQuery(
+            $request: AnimalRequest!
           ) {
-            weak_animal(request: $request) {
-              ...RelayResolverInterfaceTestWeakAnimalColorFragment
+            animal(request: $request) {
+              greeting
             }
           }
         `,
         {request: props.request},
       );
-      return <WeakAnimalColorFragmentComponent animal={data.weak_animal} />;
-    }
-
-    test(`should read the color of a ${animalType}`, () => {
-      let animalRenderer;
-      TestRenderer.act(() => {
-        animalRenderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <WeakAnimalColorQueryComponent request={{ofType: animalType}} />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(animalRenderer?.toJSON()).toEqual(color);
-    });
-  },
-);
-
-test('resolvers can return a list of interfaces where all implementors are strong model types', () => {
-  function AnimalsLegsQueryComponent(props: {
-    requests: Array<{ofType: string, returnValidID: boolean}>,
-  }) {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverInterfaceTestAnimalsLegsQuery(
-          $requests: [AnimalRequest!]!
-        ) {
-          animals(requests: $requests) {
-            id
-            ...RelayResolverInterfaceTestAnimalLegsFragment
-          }
-        }
-      `,
-      {requests: props.requests},
-    );
-
-    return data.animals?.map((animal, index) => {
-      if (animal == null) {
+      if (data.animal == null) {
         return 'NULL';
       }
-      return <AnimalLegsComponent key={animal.id} animal={animal} />;
-    });
-  }
+      return data.animal.greeting;
+    }
 
-  let animalRenderer;
-  TestRenderer.act(() => {
-    animalRenderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <AnimalsLegsQueryComponent
-          requests={[
-            {ofType: 'Fish', returnValidID: true},
-            {ofType: 'Fish', returnValidID: false}, // This should trigger a `null` value.
-            {ofType: 'Cat', returnValidID: true},
-            {ofType: 'Cat', returnValidID: false}, // This should trigger a `null` value.
-          ]}
-        />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(animalRenderer?.toJSON()).toEqual(['0', 'NULL', '4', 'NULL']);
-});
-
-function AnimalLegsQueryComponent(props: {
-  request: {ofType: string, returnValidID: boolean},
-}) {
-  const data = useClientQuery(
-    graphql`
-      query RelayResolverInterfaceTestAnimalLegsQuery(
-        $request: AnimalRequest!
-      ) {
-        animal(request: $request) {
-          ...RelayResolverInterfaceTestAnimalLegsFragment
-        }
+    function WeakAnimalGreetingQueryComponent(props: {
+      request: {ofType: string},
+    }) {
+      const data = useClientQuery(
+        graphql`
+          query RelayResolverInterfaceTestWeakAnimalGreetingQuery(
+            $request: WeakAnimalRequest!
+          ) {
+            weak_animal(request: $request) {
+              greeting
+            }
+          }
+        `,
+        {request: props.request},
+      );
+      if (data.weak_animal == null) {
+        return 'NULL';
       }
-    `,
-    {request: props.request},
-  );
-  if (data.animal == null) {
-    return 'NULL';
-  }
+      return data.weak_animal.greeting;
+    }
 
-  return <AnimalLegsComponent animal={data.animal} />;
-}
+    describe.each([
+      {
+        inputAnimalType: 'Fish',
+        id: '12redblue',
+      },
+      {
+        inputAnimalType: 'Cat',
+        id: '1234567890',
+      },
+    ])(
+      'resolvers can read resolver on an interface where all implementors are strong model types: %s',
+      ({inputAnimalType, id}) => {
+        test(`should read the greeting of a ${inputAnimalType}`, () => {
+          let animalRenderer;
+          TestRenderer.act(() => {
+            animalRenderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <AnimalGreetingQueryComponent
+                  request={{ofType: inputAnimalType, returnValidID: true}}
+                />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(animalRenderer?.toJSON()).toEqual(`Hello, ${id}!`);
+        });
 
-describe.each([
-  {
-    inputAnimalType: 'Fish',
-    expectedLegs: '0',
-  },
-  {
-    inputAnimalType: 'Cat',
-    expectedLegs: '4',
-  },
-])(
-  'resolvers can return an interface where all implementors are strong model types: %s',
-  ({inputAnimalType, expectedLegs}) => {
-    test(`should read the legs of a ${inputAnimalType}`, () => {
+        test(`should return null for nonexistent ${inputAnimalType}`, () => {
+          let nullRenderer;
+          TestRenderer.act(() => {
+            nullRenderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <AnimalGreetingQueryComponent
+                  request={{ofType: inputAnimalType, returnValidID: false}} // This should trigger a `null` value.
+                />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(nullRenderer?.toJSON()).toEqual('NULL');
+        });
+      },
+    );
+
+    describe.each([
+      {
+        inputAnimalType: 'RedOctopus',
+        name: 'Shiny',
+      },
+      {
+        inputAnimalType: 'PurpleOctopus',
+        name: 'Glowing',
+      },
+    ])(
+      'resolvers can read resolver on an interface where all implementors are weak model types: %s',
+      ({inputAnimalType, name}) => {
+        test(`should read the greeting of a ${inputAnimalType}`, () => {
+          let animalRenderer;
+          TestRenderer.act(() => {
+            animalRenderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <WeakAnimalGreetingQueryComponent
+                  request={{ofType: inputAnimalType}}
+                />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(animalRenderer?.toJSON()).toEqual(`Hello, ${name}!`);
+        });
+      },
+    );
+
+    describe.each([
+      {
+        animalType: 'RedOctopus',
+        color: 'red',
+      },
+      {
+        animalType: 'PurpleOctopus',
+        color: 'purple',
+      },
+    ])(
+      'resolvers can return an interface where all implementors are weak model types: %s',
+      ({animalType, color}) => {
+        function WeakAnimalColorQueryComponent(props: {
+          request: {ofType: string},
+        }) {
+          const data = useClientQuery(
+            graphql`
+              query RelayResolverInterfaceTestWeakAnimalColorQuery(
+                $request: WeakAnimalRequest!
+              ) {
+                weak_animal(request: $request) {
+                  ...RelayResolverInterfaceTestWeakAnimalColorFragment
+                }
+              }
+            `,
+            {request: props.request},
+          );
+          return <WeakAnimalColorFragmentComponent animal={data.weak_animal} />;
+        }
+
+        test(`should read the color of a ${animalType}`, () => {
+          let animalRenderer;
+          TestRenderer.act(() => {
+            animalRenderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <WeakAnimalColorQueryComponent request={{ofType: animalType}} />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(animalRenderer?.toJSON()).toEqual(color);
+        });
+      },
+    );
+
+    test('resolvers can return a list of interfaces where all implementors are strong model types', () => {
+      function AnimalsLegsQueryComponent(props: {
+        requests: Array<{ofType: string, returnValidID: boolean}>,
+      }) {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverInterfaceTestAnimalsLegsQuery(
+              $requests: [AnimalRequest!]!
+            ) {
+              animals(requests: $requests) {
+                id
+                ...RelayResolverInterfaceTestAnimalLegsFragment
+              }
+            }
+          `,
+          {requests: props.requests},
+        );
+
+        return data.animals?.map((animal, index) => {
+          if (animal == null) {
+            return 'NULL';
+          }
+          return <AnimalLegsComponent key={animal.id} animal={animal} />;
+        });
+      }
+
       let animalRenderer;
       TestRenderer.act(() => {
         animalRenderer = TestRenderer.create(
           <EnvironmentWrapper environment={environment}>
-            <AnimalLegsQueryComponent
-              request={{ofType: inputAnimalType, returnValidID: true}}
+            <AnimalsLegsQueryComponent
+              requests={[
+                {ofType: 'Fish', returnValidID: true},
+                {ofType: 'Fish', returnValidID: false}, // This should trigger a `null` value.
+                {ofType: 'Cat', returnValidID: true},
+                {ofType: 'Cat', returnValidID: false}, // This should trigger a `null` value.
+              ]}
             />
           </EnvironmentWrapper>,
         );
       });
-      expect(animalRenderer?.toJSON()).toEqual(expectedLegs);
+      expect(animalRenderer?.toJSON()).toEqual(['0', 'NULL', '4', 'NULL']);
     });
 
-    test(`should return null for nonexistent ${inputAnimalType}`, () => {
-      let nullRenderer;
-      TestRenderer.act(() => {
-        nullRenderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <AnimalLegsQueryComponent
-              request={{ofType: inputAnimalType, returnValidID: false}} // This should trigger a `null` value.
-            />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(nullRenderer?.toJSON()).toEqual('NULL');
-    });
+    function AnimalLegsQueryComponent(props: {
+      request: {ofType: string, returnValidID: boolean},
+    }) {
+      const data = useClientQuery(
+        graphql`
+          query RelayResolverInterfaceTestAnimalLegsQuery(
+            $request: AnimalRequest!
+          ) {
+            animal(request: $request) {
+              ...RelayResolverInterfaceTestAnimalLegsFragment
+            }
+          }
+        `,
+        {request: props.request},
+      );
+      if (data.animal == null) {
+        return 'NULL';
+      }
+
+      return <AnimalLegsComponent animal={data.animal} />;
+    }
+
+    describe.each([
+      {
+        inputAnimalType: 'Fish',
+        expectedLegs: '0',
+      },
+      {
+        inputAnimalType: 'Cat',
+        expectedLegs: '4',
+      },
+    ])(
+      'resolvers can return an interface where all implementors are strong model types: %s',
+      ({inputAnimalType, expectedLegs}) => {
+        test(`should read the legs of a ${inputAnimalType}`, () => {
+          let animalRenderer;
+          TestRenderer.act(() => {
+            animalRenderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <AnimalLegsQueryComponent
+                  request={{ofType: inputAnimalType, returnValidID: true}}
+                />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(animalRenderer?.toJSON()).toEqual(expectedLegs);
+        });
+
+        test(`should return null for nonexistent ${inputAnimalType}`, () => {
+          let nullRenderer;
+          TestRenderer.act(() => {
+            nullRenderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <AnimalLegsQueryComponent
+                  request={{ofType: inputAnimalType, returnValidID: false}} // This should trigger a `null` value.
+                />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(nullRenderer?.toJSON()).toEqual('NULL');
+        });
+      },
+    );
   },
 );

--- a/packages/react-relay/__tests__/RelayResolverModel-test.js
+++ b/packages/react-relay/__tests__/RelayResolverModel-test.js
@@ -82,644 +82,665 @@ function EnvironmentWrapper({
   );
 }
 
-describe.each([['New', useFragment]])(
-  'Hook implementation: %s',
-  (_hookName, useFragment) => {
-    let environment;
-    let store;
-    beforeEach(() => {
-      store = new LiveResolverStore(RelayRecordSource.create(), {
-        log: logFn,
-      });
-      environment = new RelayModernEnvironment({
-        network: RelayNetwork.create(jest.fn()),
-        store,
-        log: logFn,
-      });
-    });
+describe.each([true, false])(
+  'AVOID_CYCLES_IN_RESOLVER_NOTIFICATION is %p',
+  avoidCycles => {
+    RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION = avoidCycles;
+    describe.each([['New', useFragment]])(
+      'Hook implementation: %s',
+      (_hookName, useFragment) => {
+        let environment;
+        let store;
+        beforeEach(() => {
+          store = new LiveResolverStore(RelayRecordSource.create(), {
+            log: logFn,
+          });
+          environment = new RelayModernEnvironment({
+            network: RelayNetwork.create(jest.fn()),
+            store,
+            log: logFn,
+          });
+        });
 
-    function TodoComponent(props: {
-      fragmentKey: ?RelayResolverModelTestFragment$key,
-    }) {
-      const data = useFragment(
-        graphql`
-          fragment RelayResolverModelTestFragment on TodoModel {
-            id
-            fancy_description {
-              text
-              color
-            }
-          }
-        `,
-        props.fragmentKey,
-      );
-      if (data == null) {
-        return null;
-      }
-
-      // TODO: The `__relay_model_instance` will be hidden from the
-      // users and impossible to select.
-      return `${data.fancy_description?.text ?? 'unknown'} - ${
-        data.fancy_description?.color ?? 'unknown'
-      }`;
-    }
-
-    function TodoRootComponent(props: {todoID: string}) {
-      const data = useClientQuery(
-        graphql`
-          query RelayResolverModelTestTodoQuery($id: ID!) {
-            todo_model(todoID: $id) {
-              ...RelayResolverModelTestFragment
-            }
-          }
-        `,
-        {id: props.todoID},
-      );
-      if (data?.todo_model == null) {
-        return null;
-      }
-
-      return <TodoComponent fragmentKey={data?.todo_model} />;
-    }
-
-    test('should read title of the model', () => {
-      addTodo('Test todo');
-
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoRootComponent todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('Test todo - red');
-    });
-
-    test('should render `null` model.', () => {
-      function TodoNullComponent() {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestTodoNullQuery {
-              todo_model_null {
+        function TodoComponent(props: {
+          fragmentKey: ?RelayResolverModelTestFragment$key,
+        }) {
+          const data = useFragment(
+            graphql`
+              fragment RelayResolverModelTestFragment on TodoModel {
                 id
-              }
-            }
-          `,
-          {},
-        );
-        if (data?.todo_model_null == null) {
-          return null;
-        }
-
-        return data?.todo_model_null.id;
-      }
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoNullComponent />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual(null);
-    });
-
-    test('read plural resolver field', () => {
-      function TodoComponentWithPluralResolverComponent(props: {
-        todoID: string,
-      }) {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestTodoWithPluralFieldQuery($id: ID!) {
-              todo_model(todoID: $id) {
-                ...RelayResolverModelTestWithPluralFragment
-              }
-            }
-          `,
-          {id: props.todoID},
-        );
-        if (data?.todo_model == null) {
-          return null;
-        }
-
-        return (
-          <TodoComponentWithPluralDescription fragmentKey={data.todo_model} />
-        );
-      }
-
-      function TodoComponentWithPluralDescription(props: {
-        fragmentKey: ?RelayResolverModelTestWithPluralFragment$key,
-      }) {
-        const data = useFragment(
-          graphql`
-            fragment RelayResolverModelTestWithPluralFragment on TodoModel {
-              many_fancy_descriptions {
-                text
-                color
-              }
-            }
-          `,
-          props.fragmentKey,
-        );
-        if (data == null) {
-          return null;
-        }
-
-        return data.many_fancy_descriptions
-          ?.map(
-            item => `${item?.text ?? 'unknown'} - ${item?.color ?? 'unknown'}`,
-          )
-          .join(',');
-      }
-
-      addTodo('Test todo');
-
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithPluralResolverComponent todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('Test todo - red');
-    });
-
-    test('read live @weak resolver field', () => {
-      function TodoComponentWithPluralResolverComponent(props: {
-        todoID: string,
-      }) {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestWeakLiveFieldQuery($id: ID!) {
-              live_todo_description(todoID: $id) {
-                text
-                color
-              }
-            }
-          `,
-          {id: props.todoID},
-        );
-        if (data?.live_todo_description == null) {
-          return null;
-        }
-
-        return `${data.live_todo_description?.text ?? 'unknown'} - ${
-          data.live_todo_description?.color ?? 'unknown'
-        }`;
-      }
-
-      addTodo('Test todo');
-
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithPluralResolverComponent todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('Test todo - red');
-
-      TestRenderer.act(() => {
-        completeTodo('todo-1');
-        jest.runAllImmediates();
-      });
-      expect(renderer.toJSON()).toEqual('Test todo - green');
-    });
-
-    test('should correctly invalidate subscriptions on live fields when updating @weak models', () => {
-      LiveColorSubscriptions.activeSubscriptions = [];
-      function TodoComponentWithPluralResolverComponent(props: {
-        todoID: string,
-      }) {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestWeakLiveColorFieldQuery($id: ID!) {
-              live_todo_description(todoID: $id) {
-                text
-                live_color
-              }
-            }
-          `,
-          {id: props.todoID},
-        );
-        if (data?.live_todo_description == null) {
-          return null;
-        }
-
-        return `${data.live_todo_description?.text ?? 'unknown'} - ${
-          data.live_todo_description?.live_color ?? 'unknown'
-        }`;
-      }
-      addTodo('Test todo');
-      expect(LiveColorSubscriptions.activeSubscriptions.length).toBe(0);
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithPluralResolverComponent todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('Test todo - red');
-      expect(LiveColorSubscriptions.activeSubscriptions.length).toBe(1);
-
-      TestRenderer.act(() => {
-        completeTodo('todo-1');
-        jest.runAllImmediates();
-      });
-      expect(LiveColorSubscriptions.activeSubscriptions.length).toBe(1);
-
-      expect(renderer.toJSON()).toEqual('Test todo - green');
-
-      TestRenderer.act(() => {
-        removeTodo('todo-1');
-        jest.runAllImmediates();
-      });
-
-      expect(renderer.toJSON()).toEqual(null);
-      // Run GC to will remove "orphan" records and unsubscribe if they have live resolver subscriptions
-      store.scheduleGC();
-      jest.runAllImmediates();
-
-      expect(LiveColorSubscriptions.activeSubscriptions.length).toBe(0);
-    });
-
-    test('read a field with arguments', () => {
-      function TodoComponentWithFieldWithArgumentsComponent(props: {
-        todoID: string,
-      }) {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestFieldWithArgumentsQuery($id: ID!) {
-              todo_model(todoID: $id) {
                 fancy_description {
-                  text_with_prefix(prefix: "[x]")
-                }
-              }
-            }
-          `,
-          {id: props.todoID},
-        );
-        return data?.todo_model?.fancy_description?.text_with_prefix;
-      }
-
-      addTodo('Test todo');
-
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithFieldWithArgumentsComponent todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('[x] Test todo');
-
-      TestRenderer.act(() => {
-        changeDescription('todo-1', 'Changed todo description text');
-        jest.runAllImmediates();
-      });
-      expect(renderer.toJSON()).toEqual('[x] Changed todo description text');
-    });
-
-    // If a resolver that returns a weak model returns null, that should result in
-    // the edge beign null, not just the model field.
-    test('@weak model client edge returns null', () => {
-      function TodoComponentWithNullWeakClientEdge(props: {todoID: string}) {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestNullWeakClientEdgeQuery($id: ID!) {
-              todo_model(todoID: $id) {
-                fancy_description_null {
-                  text_with_prefix(prefix: "[x]")
-                }
-              }
-            }
-          `,
-          {id: props.todoID},
-        );
-        invariant(
-          data.todo_model != null,
-          'Expected todo model to be defiend.',
-        );
-        return data.todo_model.fancy_description_null == null
-          ? 'NULL!'
-          : 'NOT NULL!';
-      }
-      addTodo('Test todo');
-
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithNullWeakClientEdge todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('NULL!');
-    });
-
-    // Ensure we don't:
-    // 1. Wrap a suspense value coming from a @weak model resolver
-    // 2. Don't try to normalize a suspense sentinel as a model value
-    test('@weak model client edge suspends', () => {
-      function TodoComponentWithNullWeakClientEdge(props: {todoID: string}) {
-        useClientQuery(
-          graphql`
-            query RelayResolverModelTestSuspendedWeakClientEdgeQuery($id: ID!) {
-              todo_model(todoID: $id) {
-                fancy_description_suspends {
-                  text_with_prefix(prefix: "[x]")
-                }
-              }
-            }
-          `,
-          {id: props.todoID},
-        );
-        invariant(false, 'Expected to suspend.');
-      }
-
-      addTodo('Test todo');
-
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithNullWeakClientEdge todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('Loading...');
-    });
-
-    test('null items in list of @weak models', () => {
-      function TodoComponentWithNullablePluralResolverComponent(props: {
-        todoID: string,
-      }) {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestTodoWithNullablePluralFieldQuery(
-              $id: ID!
-            ) {
-              todo_model(todoID: $id) {
-                many_fancy_descriptions_but_some_are_null {
                   text
+                  color
                 }
               }
-            }
-          `,
-          {id: props.todoID},
-        );
+            `,
+            props.fragmentKey,
+          );
+          if (data == null) {
+            return null;
+          }
 
-        const fancyDescriptions =
-          data?.todo_model?.many_fancy_descriptions_but_some_are_null;
-        if (fancyDescriptions == null) {
-          return null;
+          // TODO: The `__relay_model_instance` will be hidden from the
+          // users and impossible to select.
+          return `${data.fancy_description?.text ?? 'unknown'} - ${
+            data.fancy_description?.color ?? 'unknown'
+          }`;
         }
 
-        return fancyDescriptions
-          .map(item =>
-            item == null ? 'ITEM IS NULL' : item.text ?? 'TEXT IS NULL',
-          )
-          .join(', ');
-      }
-      addTodo('Test todo');
-
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithNullablePluralResolverComponent todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-
-      // TODO: T184433715 We currently break with the GraphQL spec and filter out null items in lists.
-      expect(renderer?.toJSON()).toEqual('Test todo');
-    });
-
-    test('read a field with its own root fragment', () => {
-      function TodoComponentWithFieldWithRootFragmentComponent(props: {
-        todoID: string,
-      }) {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestFieldWithRootFragmentQuery($id: ID!) {
-              todo_model(todoID: $id) {
-                capitalized_id
-              }
-            }
-          `,
-          {id: props.todoID},
-        );
-        return data?.todo_model?.capitalized_id;
-      }
-
-      addTodo('Test todo');
-
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithFieldWithRootFragmentComponent todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('TODO-1');
-    });
-
-    test('read a field with its own root fragment defined using legacy non-terse syntax', () => {
-      function TodoComponentWithFieldWithRootFragmentComponent(props: {
-        todoID: string,
-      }) {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestFieldWithRootFragmentLegacyQuery(
-              $id: ID!
-            ) {
-              todo_model(todoID: $id) {
-                capitalized_id_legacy
-              }
-            }
-          `,
-          {id: props.todoID},
-        );
-        return data?.todo_model?.capitalized_id_legacy;
-      }
-
-      addTodo('Test todo');
-
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithFieldWithRootFragmentComponent todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('TODO-1');
-    });
-
-    test('read interface field', () => {
-      function TodoComponentWithInterfaceComponent(props: {todoID: string}) {
-        const data = useClientQuery(
-          graphql`
-            query RelayResolverModelTestTodoWithInterfaceQuery($id: ID!) {
-              todo_model(todoID: $id) {
-                ...RelayResolverModelTestInterfaceFragment
-              }
-            }
-          `,
-          {id: props.todoID},
-        );
-        if (data?.todo_model == null) {
-          return null;
-        }
-
-        return <TodoComponentWithInterface fragmentKey={data.todo_model} />;
-      }
-
-      function TodoComponentWithInterface(props: {
-        fragmentKey: ?RelayResolverModelTestInterfaceFragment$key,
-      }) {
-        const data = useFragment(
-          graphql`
-            fragment RelayResolverModelTestInterfaceFragment on TodoModel {
-              fancy_description {
-                some_interface {
-                  __typename
-                  description
+        function TodoRootComponent(props: {todoID: string}) {
+          const data = useClientQuery(
+            graphql`
+              query RelayResolverModelTestTodoQuery($id: ID!) {
+                todo_model(todoID: $id) {
+                  ...RelayResolverModelTestFragment
                 }
-                some_client_type_with_interface {
-                  client_interface {
-                    __typename
-                    description
+              }
+            `,
+            {id: props.todoID},
+          );
+          if (data?.todo_model == null) {
+            return null;
+          }
+
+          return <TodoComponent fragmentKey={data?.todo_model} />;
+        }
+
+        test('should read title of the model', () => {
+          addTodo('Test todo');
+
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoRootComponent todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('Test todo - red');
+        });
+
+        test('should render `null` model.', () => {
+          function TodoNullComponent() {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestTodoNullQuery {
+                  todo_model_null {
+                    id
                   }
                 }
-              }
+              `,
+              {},
+            );
+            if (data?.todo_model_null == null) {
+              return null;
             }
-          `,
-          props.fragmentKey,
-        );
-        return JSON.stringify(data);
-      }
 
-      addTodo('Test todo');
+            return data?.todo_model_null.id;
+          }
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoNullComponent />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual(null);
+        });
 
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <TodoComponentWithInterfaceComponent todoID="todo-1" />
-          </EnvironmentWrapper>,
-        );
-      });
-      // $FlowFixMe[incompatible-call] Yes, it is compatible...
-      const response = JSON.parse(renderer?.toJSON() ?? '{}');
-      jest.runAllImmediates();
+        test('read plural resolver field', () => {
+          function TodoComponentWithPluralResolverComponent(props: {
+            todoID: string,
+          }) {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestTodoWithPluralFieldQuery($id: ID!) {
+                  todo_model(todoID: $id) {
+                    ...RelayResolverModelTestWithPluralFragment
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+            if (data?.todo_model == null) {
+              return null;
+            }
 
-      // This incorrectly currently reads out just the typename from resolvers which
-      // return interface fields
-      expect(response.fancy_description?.some_interface).toEqual({
-        __typename: 'ClientTypeImplementingClientInterface',
-        description: 'It was a magical place',
-      });
+            return (
+              <TodoComponentWithPluralDescription
+                fragmentKey={data.todo_model}
+              />
+            );
+          }
 
-      // However, for resolvers which return objects that contain interface fields,
-      // we correctly read out the data.
-      expect(
-        response?.fancy_description?.some_client_type_with_interface,
-      ).toEqual({
-        client_interface: {
-          __typename: 'ClientTypeImplementingClientInterface',
-          description: 'It was a magical place',
-        },
-      });
-    });
+          function TodoComponentWithPluralDescription(props: {
+            fragmentKey: ?RelayResolverModelTestWithPluralFragment$key,
+          }) {
+            const data = useFragment(
+              graphql`
+                fragment RelayResolverModelTestWithPluralFragment on TodoModel {
+                  many_fancy_descriptions {
+                    text
+                    color
+                  }
+                }
+              `,
+              props.fragmentKey,
+            );
+            if (data == null) {
+              return null;
+            }
 
-    const getMutableEntityQuery = graphql`
-      query RelayResolverModelTestGetMutableEntityQuery {
-        mutable_entity
-      }
-    `;
-    test('should not mutate complex resolver values', () => {
-      resetModels();
-      // Do not deep freeze
-      jest.mock('relay-runtime/util/deepFreeze');
+            return data.many_fancy_descriptions
+              ?.map(
+                item =>
+                  `${item?.text ?? 'unknown'} - ${item?.color ?? 'unknown'}`,
+              )
+              .join(',');
+          }
 
-      TestRenderer.act(() => {
-        setIsHuman(true);
-      });
+          addTodo('Test todo');
 
-      function GetMutableEntity() {
-        const data = useClientQuery(getMutableEntityQuery, {});
-        if (data.mutable_entity == null) {
-          return null;
-        }
-        return `${data.mutable_entity.type}:${data.mutable_entity.props.battery}`;
-      }
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <GetMutableEntity />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('human:0');
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithPluralResolverComponent todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('Test todo - red');
+        });
 
-      TestRenderer.act(() => {
-        setIsHuman(false);
-        jest.runAllImmediates();
-      });
-      expect(renderer.toJSON()).toEqual('robot:0');
+        test('read live @weak resolver field', () => {
+          function TodoComponentWithPluralResolverComponent(props: {
+            todoID: string,
+          }) {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestWeakLiveFieldQuery($id: ID!) {
+                  live_todo_description(todoID: $id) {
+                    text
+                    color
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+            if (data?.live_todo_description == null) {
+              return null;
+            }
 
-      TestRenderer.act(() => {
-        chargeBattery();
-        setIsHuman(true);
-        jest.runAllImmediates();
-      });
-      expect(renderer.toJSON()).toEqual('human:0');
+            return `${data.live_todo_description?.text ?? 'unknown'} - ${
+              data.live_todo_description?.color ?? 'unknown'
+            }`;
+          }
 
-      TestRenderer.act(() => {
-        renderer.unmount();
-      });
-      jest.unmock('relay-runtime/util/deepFreeze');
-    });
+          addTodo('Test todo');
 
-    test('should not freeze complex resolver values', () => {
-      resetModels();
-      TestRenderer.act(() => {
-        setIsHuman(false);
-      });
-      function GetMutableEntity() {
-        const data = useClientQuery(getMutableEntityQuery, {});
-        if (data.mutable_entity == null) {
-          return null;
-        }
-        return `${data.mutable_entity.type}:${data.mutable_entity.props.battery}`;
-      }
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithPluralResolverComponent todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('Test todo - red');
 
-      let renderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <EnvironmentWrapper environment={environment}>
-            <GetMutableEntity />
-          </EnvironmentWrapper>,
-        );
-      });
-      expect(renderer?.toJSON()).toEqual('robot:0');
+          TestRenderer.act(() => {
+            completeTodo('todo-1');
+            jest.runAllImmediates();
+          });
+          expect(renderer.toJSON()).toEqual('Test todo - green');
+        });
 
-      expect(() => {
-        chargeBattery();
-      }).not.toThrow();
+        test('should correctly invalidate subscriptions on live fields when updating @weak models', () => {
+          LiveColorSubscriptions.activeSubscriptions = [];
+          function TodoComponentWithPluralResolverComponent(props: {
+            todoID: string,
+          }) {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestWeakLiveColorFieldQuery($id: ID!) {
+                  live_todo_description(todoID: $id) {
+                    text
+                    live_color
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+            if (data?.live_todo_description == null) {
+              return null;
+            }
 
-      TestRenderer.act(() => {
-        renderer.unmount();
-      });
-    });
+            return `${data.live_todo_description?.text ?? 'unknown'} - ${
+              data.live_todo_description?.live_color ?? 'unknown'
+            }`;
+          }
+          addTodo('Test todo');
+          expect(LiveColorSubscriptions.activeSubscriptions.length).toBe(0);
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithPluralResolverComponent todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('Test todo - red');
+          expect(LiveColorSubscriptions.activeSubscriptions.length).toBe(1);
+
+          TestRenderer.act(() => {
+            completeTodo('todo-1');
+            jest.runAllImmediates();
+          });
+          expect(LiveColorSubscriptions.activeSubscriptions.length).toBe(1);
+
+          expect(renderer.toJSON()).toEqual('Test todo - green');
+
+          TestRenderer.act(() => {
+            removeTodo('todo-1');
+            jest.runAllImmediates();
+          });
+
+          expect(renderer.toJSON()).toEqual(null);
+          // Run GC to will remove "orphan" records and unsubscribe if they have live resolver subscriptions
+          store.scheduleGC();
+          jest.runAllImmediates();
+
+          expect(LiveColorSubscriptions.activeSubscriptions.length).toBe(0);
+        });
+
+        test('read a field with arguments', () => {
+          function TodoComponentWithFieldWithArgumentsComponent(props: {
+            todoID: string,
+          }) {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestFieldWithArgumentsQuery($id: ID!) {
+                  todo_model(todoID: $id) {
+                    fancy_description {
+                      text_with_prefix(prefix: "[x]")
+                    }
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+            return data?.todo_model?.fancy_description?.text_with_prefix;
+          }
+
+          addTodo('Test todo');
+
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithFieldWithArgumentsComponent todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('[x] Test todo');
+
+          TestRenderer.act(() => {
+            changeDescription('todo-1', 'Changed todo description text');
+            jest.runAllImmediates();
+          });
+          expect(renderer.toJSON()).toEqual(
+            '[x] Changed todo description text',
+          );
+        });
+
+        // If a resolver that returns a weak model returns null, that should result in
+        // the edge beign null, not just the model field.
+        test('@weak model client edge returns null', () => {
+          function TodoComponentWithNullWeakClientEdge(props: {
+            todoID: string,
+          }) {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestNullWeakClientEdgeQuery($id: ID!) {
+                  todo_model(todoID: $id) {
+                    fancy_description_null {
+                      text_with_prefix(prefix: "[x]")
+                    }
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+            invariant(
+              data.todo_model != null,
+              'Expected todo model to be defiend.',
+            );
+            return data.todo_model.fancy_description_null == null
+              ? 'NULL!'
+              : 'NOT NULL!';
+          }
+          addTodo('Test todo');
+
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithNullWeakClientEdge todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('NULL!');
+        });
+
+        // Ensure we don't:
+        // 1. Wrap a suspense value coming from a @weak model resolver
+        // 2. Don't try to normalize a suspense sentinel as a model value
+        test('@weak model client edge suspends', () => {
+          function TodoComponentWithNullWeakClientEdge(props: {
+            todoID: string,
+          }) {
+            useClientQuery(
+              graphql`
+                query RelayResolverModelTestSuspendedWeakClientEdgeQuery(
+                  $id: ID!
+                ) {
+                  todo_model(todoID: $id) {
+                    fancy_description_suspends {
+                      text_with_prefix(prefix: "[x]")
+                    }
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+            invariant(false, 'Expected to suspend.');
+          }
+
+          addTodo('Test todo');
+
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithNullWeakClientEdge todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('Loading...');
+        });
+
+        test('null items in list of @weak models', () => {
+          function TodoComponentWithNullablePluralResolverComponent(props: {
+            todoID: string,
+          }) {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestTodoWithNullablePluralFieldQuery(
+                  $id: ID!
+                ) {
+                  todo_model(todoID: $id) {
+                    many_fancy_descriptions_but_some_are_null {
+                      text
+                    }
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+
+            const fancyDescriptions =
+              data?.todo_model?.many_fancy_descriptions_but_some_are_null;
+            if (fancyDescriptions == null) {
+              return null;
+            }
+
+            return fancyDescriptions
+              .map(item =>
+                item == null ? 'ITEM IS NULL' : item.text ?? 'TEXT IS NULL',
+              )
+              .join(', ');
+          }
+          addTodo('Test todo');
+
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithNullablePluralResolverComponent todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+
+          // TODO: T184433715 We currently break with the GraphQL spec and filter out null items in lists.
+          expect(renderer?.toJSON()).toEqual('Test todo');
+        });
+
+        test('read a field with its own root fragment', () => {
+          function TodoComponentWithFieldWithRootFragmentComponent(props: {
+            todoID: string,
+          }) {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestFieldWithRootFragmentQuery(
+                  $id: ID!
+                ) {
+                  todo_model(todoID: $id) {
+                    capitalized_id
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+            return data?.todo_model?.capitalized_id;
+          }
+
+          addTodo('Test todo');
+
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithFieldWithRootFragmentComponent todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('TODO-1');
+        });
+
+        test('read a field with its own root fragment defined using legacy non-terse syntax', () => {
+          function TodoComponentWithFieldWithRootFragmentComponent(props: {
+            todoID: string,
+          }) {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestFieldWithRootFragmentLegacyQuery(
+                  $id: ID!
+                ) {
+                  todo_model(todoID: $id) {
+                    capitalized_id_legacy
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+            return data?.todo_model?.capitalized_id_legacy;
+          }
+
+          addTodo('Test todo');
+
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithFieldWithRootFragmentComponent todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('TODO-1');
+        });
+
+        test('read interface field', () => {
+          function TodoComponentWithInterfaceComponent(props: {
+            todoID: string,
+          }) {
+            const data = useClientQuery(
+              graphql`
+                query RelayResolverModelTestTodoWithInterfaceQuery($id: ID!) {
+                  todo_model(todoID: $id) {
+                    ...RelayResolverModelTestInterfaceFragment
+                  }
+                }
+              `,
+              {id: props.todoID},
+            );
+            if (data?.todo_model == null) {
+              return null;
+            }
+
+            return <TodoComponentWithInterface fragmentKey={data.todo_model} />;
+          }
+
+          function TodoComponentWithInterface(props: {
+            fragmentKey: ?RelayResolverModelTestInterfaceFragment$key,
+          }) {
+            const data = useFragment(
+              graphql`
+                fragment RelayResolverModelTestInterfaceFragment on TodoModel {
+                  fancy_description {
+                    some_interface {
+                      __typename
+                      description
+                    }
+                    some_client_type_with_interface {
+                      client_interface {
+                        __typename
+                        description
+                      }
+                    }
+                  }
+                }
+              `,
+              props.fragmentKey,
+            );
+            return JSON.stringify(data);
+          }
+
+          addTodo('Test todo');
+
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <TodoComponentWithInterfaceComponent todoID="todo-1" />
+              </EnvironmentWrapper>,
+            );
+          });
+          // $FlowFixMe[incompatible-call] Yes, it is compatible...
+          const response = JSON.parse(renderer?.toJSON() ?? '{}');
+          jest.runAllImmediates();
+
+          // This incorrectly currently reads out just the typename from resolvers which
+          // return interface fields
+          expect(response.fancy_description?.some_interface).toEqual({
+            __typename: 'ClientTypeImplementingClientInterface',
+            description: 'It was a magical place',
+          });
+
+          // However, for resolvers which return objects that contain interface fields,
+          // we correctly read out the data.
+          expect(
+            response?.fancy_description?.some_client_type_with_interface,
+          ).toEqual({
+            client_interface: {
+              __typename: 'ClientTypeImplementingClientInterface',
+              description: 'It was a magical place',
+            },
+          });
+        });
+
+        const getMutableEntityQuery = graphql`
+          query RelayResolverModelTestGetMutableEntityQuery {
+            mutable_entity
+          }
+        `;
+        test('should not mutate complex resolver values', () => {
+          resetModels();
+          // Do not deep freeze
+          jest.mock('relay-runtime/util/deepFreeze');
+
+          TestRenderer.act(() => {
+            setIsHuman(true);
+          });
+
+          function GetMutableEntity() {
+            const data = useClientQuery(getMutableEntityQuery, {});
+            if (data.mutable_entity == null) {
+              return null;
+            }
+            return `${data.mutable_entity.type}:${data.mutable_entity.props.battery}`;
+          }
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <GetMutableEntity />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('human:0');
+
+          TestRenderer.act(() => {
+            setIsHuman(false);
+            jest.runAllImmediates();
+          });
+          expect(renderer.toJSON()).toEqual('robot:0');
+
+          TestRenderer.act(() => {
+            chargeBattery();
+            setIsHuman(true);
+            jest.runAllImmediates();
+          });
+          expect(renderer.toJSON()).toEqual('human:0');
+
+          TestRenderer.act(() => {
+            renderer.unmount();
+          });
+          jest.unmock('relay-runtime/util/deepFreeze');
+        });
+
+        test('should not freeze complex resolver values', () => {
+          resetModels();
+          TestRenderer.act(() => {
+            setIsHuman(false);
+          });
+          function GetMutableEntity() {
+            const data = useClientQuery(getMutableEntityQuery, {});
+            if (data.mutable_entity == null) {
+              return null;
+            }
+            return `${data.mutable_entity.type}:${data.mutable_entity.props.battery}`;
+          }
+
+          let renderer;
+          TestRenderer.act(() => {
+            renderer = TestRenderer.create(
+              <EnvironmentWrapper environment={environment}>
+                <GetMutableEntity />
+              </EnvironmentWrapper>,
+            );
+          });
+          expect(renderer?.toJSON()).toEqual('robot:0');
+
+          expect(() => {
+            chargeBattery();
+          }).not.toThrow();
+
+          TestRenderer.act(() => {
+            renderer.unmount();
+          });
+        });
+      },
+    );
   },
 );

--- a/packages/react-relay/__tests__/RelayResolverNullableModelClientEdge-test.js
+++ b/packages/react-relay/__tests__/RelayResolverNullableModelClientEdge-test.js
@@ -219,355 +219,361 @@ let environment;
 beforeEach(() => {
   environment = createEnvironment();
 });
-test('client edge to plural IDs, none have corresponding live object', () => {
-  function TodoNullComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverNullableModelClientEdgeTest_PluralLiveModelNoneExist_Query {
-          edge_to_plural_live_objects_none_exist {
-            id
-            description
-          }
+describe.each([true, false])(
+  'AVOID_CYCLES_IN_RESOLVER_NOTIFICATION is %p',
+  avoidCycles => {
+    RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION = avoidCycles;
+    test('client edge to plural IDs, none have corresponding live object', () => {
+      function TodoNullComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverNullableModelClientEdgeTest_PluralLiveModelNoneExist_Query {
+              edge_to_plural_live_objects_none_exist {
+                id
+                description
+              }
+            }
+          `,
+          {},
+        );
+
+        invariant(data != null, 'Query response should be nonnull');
+        expect(data.edge_to_plural_live_objects_none_exist).toHaveLength(2);
+        return data.edge_to_plural_live_objects_none_exist
+          ?.map(item =>
+            item
+              ? `${item.id ?? 'unknown'} - ${item.description ?? 'unknown'}`
+              : 'unknown',
+          )
+          .join(',');
+      }
+
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoNullComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('unknown,unknown');
+    });
+
+    test('client edge to plural IDs, some with no corresponding live object', () => {
+      function TodoNullComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverNullableModelClientEdgeTest_PluralLiveModel_Query {
+              edge_to_plural_live_objects_some_exist {
+                id
+                description
+              }
+            }
+          `,
+          {},
+        );
+
+        invariant(data != null, 'Query response should be nonnull');
+        expect(data.edge_to_plural_live_objects_some_exist).toHaveLength(2);
+        return data.edge_to_plural_live_objects_some_exist
+          ?.map(item =>
+            item
+              ? `${item.id ?? 'unknown'} - ${item.description ?? 'unknown'}`
+              : 'unknown',
+          )
+          .join(',');
+      }
+
+      addTodo('Test todo');
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoNullComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('todo-1 - Test todo,unknown');
+    });
+
+    test('client edge to ID with no corresponding live object', () => {
+      function TodoNullComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverNullableModelClientEdgeTest_LiveModel_Query {
+              edge_to_live_object_does_not_exist {
+                id
+                fancy_description {
+                  text
+                }
+              }
+            }
+          `,
+          {},
+        );
+
+        invariant(data != null, 'Query response should be nonnull');
+
+        switch (data.edge_to_live_object_does_not_exist) {
+          case null:
+            return 'Todo was null';
+          case undefined:
+            return 'Todo was undefined';
+          default:
+            return 'Todo was not null or undefined';
         }
-      `,
-      {},
-    );
+      }
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoNullComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('Todo was null');
+    });
 
-    invariant(data != null, 'Query response should be nonnull');
-    expect(data.edge_to_plural_live_objects_none_exist).toHaveLength(2);
-    return data.edge_to_plural_live_objects_none_exist
-      ?.map(item =>
-        item
-          ? `${item.id ?? 'unknown'} - ${item.description ?? 'unknown'}`
-          : 'unknown',
-      )
-      .join(',');
-  }
+    test('client edge to ID with no corresponding weak object', () => {
+      function NullWeakModelComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverNullableModelClientEdgeTest_WeakModel_Query {
+              edge_to_null_weak_model {
+                first_name
+              }
+            }
+          `,
+          {},
+        );
 
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoNullComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('unknown,unknown');
-});
+        invariant(data != null, 'Query response should be nonnull');
 
-test('client edge to plural IDs, some with no corresponding live object', () => {
-  function TodoNullComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverNullableModelClientEdgeTest_PluralLiveModel_Query {
-          edge_to_plural_live_objects_some_exist {
-            id
-            description
-          }
+        switch (data.edge_to_null_weak_model) {
+          case null:
+            return 'Weak model was null';
+          case undefined:
+            return 'Weak model was undefined';
+          default:
+            return 'Weak model was not null or undefined';
         }
-      `,
-      {},
-    );
+      }
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <NullWeakModelComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('Weak model was null');
+    });
 
-    invariant(data != null, 'Query response should be nonnull');
-    expect(data.edge_to_plural_live_objects_some_exist).toHaveLength(2);
-    return data.edge_to_plural_live_objects_some_exist
-      ?.map(item =>
-        item
-          ? `${item.id ?? 'unknown'} - ${item.description ?? 'unknown'}`
-          : 'unknown',
-      )
-      .join(',');
-  }
+    test('client edge to ID with no corresponding strong object', () => {
+      function NullStrongModelComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverNullableModelClientEdgeTest_StrongModel_Query {
+              edge_to_strong_model_does_not_exist {
+                name
+              }
+            }
+          `,
+          {},
+        );
 
-  addTodo('Test todo');
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoNullComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('todo-1 - Test todo,unknown');
-});
+        invariant(data != null, 'Query response should be nonnull');
 
-test('client edge to ID with no corresponding live object', () => {
-  function TodoNullComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverNullableModelClientEdgeTest_LiveModel_Query {
-          edge_to_live_object_does_not_exist {
-            id
-            fancy_description {
-              text
+        switch (data.edge_to_strong_model_does_not_exist) {
+          case null:
+            return 'strong model was null';
+          case undefined:
+            return 'strong model was undefined';
+          default:
+            return 'strong model was not null or undefined';
+        }
+      }
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <NullStrongModelComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('strong model was null');
+    });
+
+    test('client edge to server ID with no corresponding server object', () => {
+      function NullServerObjectComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverNullableModelClientEdgeTest_ServerObject_Query {
+              edge_to_server_object_does_not_exist @waterfall {
+                name
+              }
+            }
+          `,
+          {},
+        );
+
+        invariant(data != null, 'Query response should be nonnull');
+
+        switch (data.edge_to_server_object_does_not_exist) {
+          case null:
+            return 'server object was null';
+          case undefined:
+            return 'server object was undefined';
+          default:
+            return 'server object was not null or undefined';
+        }
+      }
+      const mock_environment = createMockEnvironment();
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={mock_environment}>
+            <NullServerObjectComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('Loading...');
+      TestRenderer.act(() => {
+        mock_environment.mock.resolveMostRecentOperation({data: {node: null}});
+        jest.runAllImmediates();
+      });
+      // TODO T169274655 should this be 'server object was null'?
+      expect(renderer?.toJSON()).toEqual('server object was undefined');
+    });
+
+    test('client edge to server ID with no corresponding server object (read only id)', () => {
+      function NullServerObjectComponent() {
+        const data = useClientQuery(
+          graphql`
+            query RelayResolverNullableModelClientEdgeTest_ServerObjectReadOnlyId_Query {
+              edge_to_server_object_does_not_exist @waterfall {
+                id
+              }
+            }
+          `,
+          {},
+        );
+
+        invariant(data != null, 'Query response should be nonnull');
+
+        switch (data.edge_to_server_object_does_not_exist) {
+          case null:
+            return 'server object was null';
+          case undefined:
+            return 'server object was undefined';
+          default:
+            return 'server object was not null or undefined';
+        }
+      }
+      const mock_environment = createMockEnvironment();
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={mock_environment}>
+            <NullServerObjectComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('Loading...');
+      TestRenderer.act(() => {
+        mock_environment.mock.resolveMostRecentOperation({data: {node: null}});
+        jest.runAllImmediates();
+      });
+      // TODO T169274655 should this be 'server object was null'?
+      expect(renderer?.toJSON()).toEqual('server object was undefined');
+    });
+
+    test('Errors thrown when reading the model a client edge points to are caught as resolver errors', () => {
+      const operation = createOperationDescriptor(
+        graphql`
+          query RelayResolverNullableModelClientEdgeTest_ErrorModel_Query {
+            edge_to_model_that_throws {
+              __typename
             }
           }
-        }
-      `,
-      {},
-    );
+        `,
+        {},
+      );
+      const snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.relayResolverErrors).toEqual([
+        {
+          error: Error(ERROR_MESSAGE),
+          field: {
+            owner: 'RelayResolverNullableModelClientEdgeTest_ErrorModel_Query',
+            path: 'edge_to_model_that_throws.__relay_model_instance',
+          },
+        },
+      ]);
+      const data: $FlowExpectedError = snapshot.data;
+      expect(data.edge_to_model_that_throws).toBe(null);
+    });
 
-    invariant(data != null, 'Query response should be nonnull');
-
-    switch (data.edge_to_live_object_does_not_exist) {
-      case null:
-        return 'Todo was null';
-      case undefined:
-        return 'Todo was undefined';
-      default:
-        return 'Todo was not null or undefined';
-    }
-  }
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoNullComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('Todo was null');
-});
-
-test('client edge to ID with no corresponding weak object', () => {
-  function NullWeakModelComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverNullableModelClientEdgeTest_WeakModel_Query {
-          edge_to_null_weak_model {
-            first_name
+    test('Errors thrown when reading plural client edge are caught as resolver errors', () => {
+      const operation = createOperationDescriptor(
+        graphql`
+          query RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query {
+            edge_to_plural_models_that_throw {
+              __typename
+            }
           }
-        }
-      `,
-      {},
-    );
+        `,
+        {},
+      );
+      const snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.relayResolverErrors).toEqual([
+        {
+          error: Error(ERROR_MESSAGE),
+          field: {
+            owner:
+              'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
+            path: 'edge_to_plural_models_that_throw.__relay_model_instance',
+          },
+        },
+        {
+          error: Error(ERROR_MESSAGE),
+          field: {
+            owner:
+              'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
+            path: 'edge_to_plural_models_that_throw.__relay_model_instance',
+          },
+        },
+      ]);
+      const data: $FlowExpectedError = snapshot.data;
+      expect(data.edge_to_plural_models_that_throw).toStrictEqual([null, null]);
+    });
 
-    invariant(data != null, 'Query response should be nonnull');
-
-    switch (data.edge_to_null_weak_model) {
-      case null:
-        return 'Weak model was null';
-      case undefined:
-        return 'Weak model was undefined';
-      default:
-        return 'Weak model was not null or undefined';
-    }
-  }
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <NullWeakModelComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('Weak model was null');
-});
-
-test('client edge to ID with no corresponding strong object', () => {
-  function NullStrongModelComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverNullableModelClientEdgeTest_StrongModel_Query {
-          edge_to_strong_model_does_not_exist {
-            name
+    test('Errors thrown when reading plural client edge are caught as resolver errors and valid data is returned', () => {
+      const operation = createOperationDescriptor(
+        graphql`
+          query RelayResolverNullableModelClientEdgeTest_PluralSomeErrorModel_Query {
+            edge_to_plural_models_some_throw {
+              id
+            }
           }
-        }
-      `,
-      {},
-    );
-
-    invariant(data != null, 'Query response should be nonnull');
-
-    switch (data.edge_to_strong_model_does_not_exist) {
-      case null:
-        return 'strong model was null';
-      case undefined:
-        return 'strong model was undefined';
-      default:
-        return 'strong model was not null or undefined';
-    }
-  }
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <NullStrongModelComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('strong model was null');
-});
-
-test('client edge to server ID with no corresponding server object', () => {
-  function NullServerObjectComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverNullableModelClientEdgeTest_ServerObject_Query {
-          edge_to_server_object_does_not_exist @waterfall {
-            name
-          }
-        }
-      `,
-      {},
-    );
-
-    invariant(data != null, 'Query response should be nonnull');
-
-    switch (data.edge_to_server_object_does_not_exist) {
-      case null:
-        return 'server object was null';
-      case undefined:
-        return 'server object was undefined';
-      default:
-        return 'server object was not null or undefined';
-    }
-  }
-  const mock_environment = createMockEnvironment();
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={mock_environment}>
-        <NullServerObjectComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('Loading...');
-  TestRenderer.act(() => {
-    mock_environment.mock.resolveMostRecentOperation({data: {node: null}});
-    jest.runAllImmediates();
-  });
-  // TODO T169274655 should this be 'server object was null'?
-  expect(renderer?.toJSON()).toEqual('server object was undefined');
-});
-
-test('client edge to server ID with no corresponding server object (read only id)', () => {
-  function NullServerObjectComponent() {
-    const data = useClientQuery(
-      graphql`
-        query RelayResolverNullableModelClientEdgeTest_ServerObjectReadOnlyId_Query {
-          edge_to_server_object_does_not_exist @waterfall {
-            id
-          }
-        }
-      `,
-      {},
-    );
-
-    invariant(data != null, 'Query response should be nonnull');
-
-    switch (data.edge_to_server_object_does_not_exist) {
-      case null:
-        return 'server object was null';
-      case undefined:
-        return 'server object was undefined';
-      default:
-        return 'server object was not null or undefined';
-    }
-  }
-  const mock_environment = createMockEnvironment();
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={mock_environment}>
-        <NullServerObjectComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('Loading...');
-  TestRenderer.act(() => {
-    mock_environment.mock.resolveMostRecentOperation({data: {node: null}});
-    jest.runAllImmediates();
-  });
-  // TODO T169274655 should this be 'server object was null'?
-  expect(renderer?.toJSON()).toEqual('server object was undefined');
-});
-
-test('Errors thrown when reading the model a client edge points to are caught as resolver errors', () => {
-  const operation = createOperationDescriptor(
-    graphql`
-      query RelayResolverNullableModelClientEdgeTest_ErrorModel_Query {
-        edge_to_model_that_throws {
-          __typename
-        }
-      }
-    `,
-    {},
-  );
-  const snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.relayResolverErrors).toEqual([
-    {
-      error: Error(ERROR_MESSAGE),
-      field: {
-        owner: 'RelayResolverNullableModelClientEdgeTest_ErrorModel_Query',
-        path: 'edge_to_model_that_throws.__relay_model_instance',
-      },
-    },
-  ]);
-  const data: $FlowExpectedError = snapshot.data;
-  expect(data.edge_to_model_that_throws).toBe(null);
-});
-
-test('Errors thrown when reading plural client edge are caught as resolver errors', () => {
-  const operation = createOperationDescriptor(
-    graphql`
-      query RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query {
-        edge_to_plural_models_that_throw {
-          __typename
-        }
-      }
-    `,
-    {},
-  );
-  const snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.relayResolverErrors).toEqual([
-    {
-      error: Error(ERROR_MESSAGE),
-      field: {
-        owner:
-          'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
-        path: 'edge_to_plural_models_that_throw.__relay_model_instance',
-      },
-    },
-    {
-      error: Error(ERROR_MESSAGE),
-      field: {
-        owner:
-          'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
-        path: 'edge_to_plural_models_that_throw.__relay_model_instance',
-      },
-    },
-  ]);
-  const data: $FlowExpectedError = snapshot.data;
-  expect(data.edge_to_plural_models_that_throw).toStrictEqual([null, null]);
-});
-
-test('Errors thrown when reading plural client edge are caught as resolver errors and valid data is returned', () => {
-  const operation = createOperationDescriptor(
-    graphql`
-      query RelayResolverNullableModelClientEdgeTest_PluralSomeErrorModel_Query {
-        edge_to_plural_models_some_throw {
-          id
-        }
-      }
-    `,
-    {},
-  );
-  const snapshot = environment.lookup(operation.fragment);
-  expect(snapshot.relayResolverErrors).toEqual([
-    {
-      error: Error(ERROR_MESSAGE),
-      field: {
-        owner:
-          'RelayResolverNullableModelClientEdgeTest_PluralSomeErrorModel_Query',
-        path: 'edge_to_plural_models_some_throw.__relay_model_instance',
-      },
-    },
-  ]);
-  const data: $FlowExpectedError = snapshot.data;
-  expect(data.edge_to_plural_models_some_throw).toStrictEqual([
-    null,
-    {id: 'a valid id!'},
-  ]);
-});
+        `,
+        {},
+      );
+      const snapshot = environment.lookup(operation.fragment);
+      expect(snapshot.relayResolverErrors).toEqual([
+        {
+          error: Error(ERROR_MESSAGE),
+          field: {
+            owner:
+              'RelayResolverNullableModelClientEdgeTest_PluralSomeErrorModel_Query',
+            path: 'edge_to_plural_models_some_throw.__relay_model_instance',
+          },
+        },
+      ]);
+      const data: $FlowExpectedError = snapshot.data;
+      expect(data.edge_to_plural_models_some_throw).toStrictEqual([
+        null,
+        {id: 'a valid id!'},
+      ]);
+    });
+  },
+);

--- a/packages/react-relay/__tests__/RelayResolvers-withOutputType-test.js
+++ b/packages/react-relay/__tests__/RelayResolvers-withOutputType-test.js
@@ -278,514 +278,523 @@ function ManyLiveTodosComponent() {
   });
 }
 
-test('should render empty state', () => {
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoListComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual('No Items');
-});
-
-test('add new item to the list', () => {
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoListComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-
-  TestRenderer.act(() => {
-    addTodo('My first todo');
-    jest.runAllImmediates();
-  });
-
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-
-  TestRenderer.act(() => {
-    addTodo('My second todo');
-    jest.runAllImmediates();
-  });
-
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My second todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-});
-
-test('complete todo', () => {
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoListComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  TestRenderer.act(() => {
-    addTodo('My first todo');
-    jest.runAllImmediates();
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-
-  TestRenderer.act(() => {
-    completeTodo('todo-1');
-    jest.runAllImmediates();
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is completed',
-    'style: normal',
-    'color: color is green',
-  ]);
-});
-
-test('complete todo and add one more', () => {
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoListComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-  TestRenderer.act(() => {
-    addTodo('My first todo');
-    completeTodo('todo-1');
-    jest.runAllImmediates();
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is completed',
-    'style: normal',
-    'color: color is green',
-  ]);
-  TestRenderer.act(() => {
-    addTodo('My second todo');
-    jest.runAllImmediates();
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is completed',
-    'style: normal',
-    'color: color is green',
-    'My second todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-});
-
-test('query single todo item (item is missing)', () => {
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoRootComponent todoID="todo-1" />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toBe(null);
-});
-
-test('query single todo item (item is present) and complete it', () => {
-  addTodo('My first todo');
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoRootComponent todoID="todo-1" />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-  TestRenderer.act(() => {
-    completeTodo('todo-1');
-    jest.runAllImmediates();
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is completed',
-    'style: normal',
-    'color: color is green',
-  ]);
-});
-
-test('render both list and item component', () => {
-  addTodo('My first todo');
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoListComponent />
-        <TodoRootComponent todoID="todo-1" />
-      </EnvironmentWrapper>,
-    );
-  });
-
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-
-  TestRenderer.act(() => {
-    addTodo('Second todo');
-    jest.runAllImmediates();
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'Second todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-
-  // complete the first item
-  TestRenderer.act(() => {
-    completeTodo('todo-1');
-    jest.runAllImmediates();
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is completed',
-    'style: normal',
-    'color: color is green',
-    'Second todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My first todo',
-    'is completed',
-    'style: normal',
-    'color: color is green',
-  ]);
-});
-
-test('removes item', () => {
-  addTodo('My first todo');
-  addTodo('Second todo');
-  completeTodo('todo-1');
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoListComponent />
-        <TodoRootComponent todoID="todo-1" />
-      </EnvironmentWrapper>,
-    );
-  });
-
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is completed',
-    'style: normal',
-    'color: color is green',
-    'Second todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My first todo',
-    'is completed',
-    'style: normal',
-    'color: color is green',
-  ]);
-
-  TestRenderer.act(() => {
-    removeTodo('todo-1');
-    jest.runAllImmediates();
-  });
-
-  expect(renderer?.toJSON()).toEqual([
-    'Second todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-});
-
-test('renders after GC', () => {
-  addTodo('My first todo');
-
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoListComponent />
-      </EnvironmentWrapper>,
-    );
-  });
-
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-
-  (environment.getStore(): $FlowFixMe).__gc();
-  jest.runAllTimers();
-
-  expect(environment.getStore().getSource().toJSON()).toEqual({
-    'client:root': {
-      __id: 'client:root',
-      __typename: '__Root',
-      'todos(first:10)': {
-        __ref: 'client:root:todos(first:10)',
-      },
-    },
-    'client:root:todos(first:10)': {
-      __id: 'client:root:todos(first:10)',
-      __resolverError: null,
-      __resolverLiveStateDirty: false,
-      __resolverLiveStateSubscription: expect.anything(),
-      __resolverLiveStateValue: {
-        read: expect.anything(),
-        subscribe: expect.anything(),
-      },
-      __resolverOutputTypeRecordIDs: new Set([
-        'client:TodoConnection:client:root:todos(first:10)',
-        'client:TodoConnection:client:root:todos(first:10):edges:0',
-        'client:TodoConnection:client:root:todos(first:10):edges:0:node',
-        'client:TodoConnection:client:root:todos(first:10):pageInfo',
-      ]),
-      __resolverSnapshot: undefined,
-      __resolverValue: 'client:TodoConnection:client:root:todos(first:10)',
-      __typename: '__RELAY_RESOLVER__',
-    },
-    'client:TodoConnection:client:root:todos(first:10)': {
-      __id: 'client:TodoConnection:client:root:todos(first:10)',
-      __typename: 'TodoConnection',
-      count: 1,
-      edges: {
-        __refs: ['client:TodoConnection:client:root:todos(first:10):edges:0'],
-      },
-      pageInfo: {
-        __ref: 'client:TodoConnection:client:root:todos(first:10):pageInfo',
-      },
-    },
-    'client:TodoConnection:client:root:todos(first:10):edges:0': {
-      __id: 'client:TodoConnection:client:root:todos(first:10):edges:0',
-      __typename: 'TodoEdge',
-      cursor: null,
-      node: {
-        __ref: 'client:TodoConnection:client:root:todos(first:10):edges:0:node',
-      },
-    },
-    'client:TodoConnection:client:root:todos(first:10):edges:0:node': {
-      __id: 'client:TodoConnection:client:root:todos(first:10):edges:0:node',
-      __typename: 'Todo',
-      complete: {
-        __ref:
-          'client:TodoConnection:client:root:todos(first:10):edges:0:node:complete',
-      },
-      self: {
-        __ref:
-          'client:TodoConnection:client:root:todos(first:10):edges:0:node:self',
-      },
-      text: {
-        __ref:
-          'client:TodoConnection:client:root:todos(first:10):edges:0:node:text',
-      },
-      todo_id: 'todo-1',
-    },
-    'client:TodoConnection:client:root:todos(first:10):pageInfo': {
-      __id: 'client:TodoConnection:client:root:todos(first:10):pageInfo',
-      __typename: 'TodoConnectionPageInfo',
-      endCursor: null,
-      hasNextPage: false,
-      hasPreviousPage: false,
-      startCursor: null,
-    },
-  });
-
-  expect(() => {
-    TestRenderer.act(() => {
-      renderer.update(
-        <EnvironmentWrapper environment={environment} key="1">
-          <TodoListComponent />
-        </EnvironmentWrapper>,
-      );
+describe.each([true, false])(
+  'AVOID_CYCLES_IN_RESOLVER_NOTIFICATION is %p',
+  avoidCycles => {
+    RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION = avoidCycles;
+    test('should render empty state', () => {
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoListComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual('No Items');
     });
-  }).not.toThrow();
-});
 
-test('render with recursive resolvers (with blocked_by)', () => {
-  addTodo('My first todo');
-  addTodo('My second todo');
-  addTodo('My 3rd todo');
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <TodoListComponent />
-        <TodoRootWithBlockedComponent todoID="todo-1" />
-      </EnvironmentWrapper>,
-    );
-  });
+    test('add new item to the list', () => {
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoListComponent />
+          </EnvironmentWrapper>,
+        );
+      });
 
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My second todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My 3rd todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
+      TestRenderer.act(() => {
+        addTodo('My first todo');
+        jest.runAllImmediates();
+      });
 
-  TestRenderer.act(() => {
-    blockedBy('todo-1', 'todo-2');
-    jest.runAllImmediates();
-  });
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
 
-  expect(renderer?.toJSON()).toEqual([
-    'My first todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My second todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My 3rd todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'My second todo',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-});
+      TestRenderer.act(() => {
+        addTodo('My second todo');
+        jest.runAllImmediates();
+      });
 
-// TODO: T184433715 We currently break with the GraphQL spec here and filter out null values.
-test('rendering lists with nulls', () => {
-  addTodo('Todo 1');
-  addTodo('Todo 2');
-  addTodo('Todo 3');
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <ManyTodosComponent todos={['todo-1', null, 'todo-2']} />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'Todo 1',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'Todo 2',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-  TestRenderer.act(() => {
-    renderer.update(
-      <EnvironmentWrapper environment={environment}>
-        <ManyTodosComponent todos={['todo-1', 'todo-2', 'todo-3']} />
-      </EnvironmentWrapper>,
-    );
-  });
-  expect(renderer?.toJSON()).toEqual([
-    'Todo 1',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'Todo 2',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'Todo 3',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-});
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My second todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+    });
 
-test('rendering live list', () => {
-  addTodo('Todo 1');
-  addTodo('Todo 2');
-  addTodo('Todo 3');
-  let renderer;
-  TestRenderer.act(() => {
-    renderer = TestRenderer.create(
-      <EnvironmentWrapper environment={environment}>
-        <ManyLiveTodosComponent />
-      </EnvironmentWrapper>,
-    );
-  });
+    test('complete todo', () => {
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoListComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      TestRenderer.act(() => {
+        addTodo('My first todo');
+        jest.runAllImmediates();
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
 
-  expect(renderer?.toJSON()).toEqual([
-    'Todo 1',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'Todo 2',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-    'Todo 3',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
+      TestRenderer.act(() => {
+        completeTodo('todo-1');
+        jest.runAllImmediates();
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is completed',
+        'style: normal',
+        'color: color is green',
+      ]);
+    });
 
-  TestRenderer.act(() => {
-    removeTodo('todo-1');
-    removeTodo('todo-2');
-    jest.runAllImmediates();
-  });
+    test('complete todo and add one more', () => {
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoListComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+      TestRenderer.act(() => {
+        addTodo('My first todo');
+        completeTodo('todo-1');
+        jest.runAllImmediates();
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is completed',
+        'style: normal',
+        'color: color is green',
+      ]);
+      TestRenderer.act(() => {
+        addTodo('My second todo');
+        jest.runAllImmediates();
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is completed',
+        'style: normal',
+        'color: color is green',
+        'My second todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+    });
 
-  expect(renderer?.toJSON()).toEqual([
-    'Todo 3',
-    'is not completed',
-    'style: bold',
-    'color: color is red',
-  ]);
-});
+    test('query single todo item (item is missing)', () => {
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoRootComponent todoID="todo-1" />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toBe(null);
+    });
+
+    test('query single todo item (item is present) and complete it', () => {
+      addTodo('My first todo');
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoRootComponent todoID="todo-1" />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+      TestRenderer.act(() => {
+        completeTodo('todo-1');
+        jest.runAllImmediates();
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is completed',
+        'style: normal',
+        'color: color is green',
+      ]);
+    });
+
+    test('render both list and item component', () => {
+      addTodo('My first todo');
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoListComponent />
+            <TodoRootComponent todoID="todo-1" />
+          </EnvironmentWrapper>,
+        );
+      });
+
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+
+      TestRenderer.act(() => {
+        addTodo('Second todo');
+        jest.runAllImmediates();
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'Second todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+
+      // complete the first item
+      TestRenderer.act(() => {
+        completeTodo('todo-1');
+        jest.runAllImmediates();
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is completed',
+        'style: normal',
+        'color: color is green',
+        'Second todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My first todo',
+        'is completed',
+        'style: normal',
+        'color: color is green',
+      ]);
+    });
+
+    test('removes item', () => {
+      addTodo('My first todo');
+      addTodo('Second todo');
+      completeTodo('todo-1');
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoListComponent />
+            <TodoRootComponent todoID="todo-1" />
+          </EnvironmentWrapper>,
+        );
+      });
+
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is completed',
+        'style: normal',
+        'color: color is green',
+        'Second todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My first todo',
+        'is completed',
+        'style: normal',
+        'color: color is green',
+      ]);
+
+      TestRenderer.act(() => {
+        removeTodo('todo-1');
+        jest.runAllImmediates();
+      });
+
+      expect(renderer?.toJSON()).toEqual([
+        'Second todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+    });
+
+    test('renders after GC', () => {
+      addTodo('My first todo');
+
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoListComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+
+      (environment.getStore(): $FlowFixMe).__gc();
+      jest.runAllTimers();
+
+      expect(environment.getStore().getSource().toJSON()).toEqual({
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'todos(first:10)': {
+            __ref: 'client:root:todos(first:10)',
+          },
+        },
+        'client:root:todos(first:10)': {
+          __id: 'client:root:todos(first:10)',
+          __resolverError: null,
+          __resolverLiveStateDirty: false,
+          __resolverLiveStateSubscription: expect.anything(),
+          __resolverLiveStateValue: {
+            read: expect.anything(),
+            subscribe: expect.anything(),
+          },
+          __resolverOutputTypeRecordIDs: new Set([
+            'client:TodoConnection:client:root:todos(first:10)',
+            'client:TodoConnection:client:root:todos(first:10):edges:0',
+            'client:TodoConnection:client:root:todos(first:10):edges:0:node',
+            'client:TodoConnection:client:root:todos(first:10):pageInfo',
+          ]),
+          __resolverSnapshot: undefined,
+          __resolverValue: 'client:TodoConnection:client:root:todos(first:10)',
+          __typename: '__RELAY_RESOLVER__',
+        },
+        'client:TodoConnection:client:root:todos(first:10)': {
+          __id: 'client:TodoConnection:client:root:todos(first:10)',
+          __typename: 'TodoConnection',
+          count: 1,
+          edges: {
+            __refs: [
+              'client:TodoConnection:client:root:todos(first:10):edges:0',
+            ],
+          },
+          pageInfo: {
+            __ref: 'client:TodoConnection:client:root:todos(first:10):pageInfo',
+          },
+        },
+        'client:TodoConnection:client:root:todos(first:10):edges:0': {
+          __id: 'client:TodoConnection:client:root:todos(first:10):edges:0',
+          __typename: 'TodoEdge',
+          cursor: null,
+          node: {
+            __ref:
+              'client:TodoConnection:client:root:todos(first:10):edges:0:node',
+          },
+        },
+        'client:TodoConnection:client:root:todos(first:10):edges:0:node': {
+          __id: 'client:TodoConnection:client:root:todos(first:10):edges:0:node',
+          __typename: 'Todo',
+          complete: {
+            __ref:
+              'client:TodoConnection:client:root:todos(first:10):edges:0:node:complete',
+          },
+          self: {
+            __ref:
+              'client:TodoConnection:client:root:todos(first:10):edges:0:node:self',
+          },
+          text: {
+            __ref:
+              'client:TodoConnection:client:root:todos(first:10):edges:0:node:text',
+          },
+          todo_id: 'todo-1',
+        },
+        'client:TodoConnection:client:root:todos(first:10):pageInfo': {
+          __id: 'client:TodoConnection:client:root:todos(first:10):pageInfo',
+          __typename: 'TodoConnectionPageInfo',
+          endCursor: null,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: null,
+        },
+      });
+
+      expect(() => {
+        TestRenderer.act(() => {
+          renderer.update(
+            <EnvironmentWrapper environment={environment} key="1">
+              <TodoListComponent />
+            </EnvironmentWrapper>,
+          );
+        });
+      }).not.toThrow();
+    });
+
+    test('render with recursive resolvers (with blocked_by)', () => {
+      addTodo('My first todo');
+      addTodo('My second todo');
+      addTodo('My 3rd todo');
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <TodoListComponent />
+            <TodoRootWithBlockedComponent todoID="todo-1" />
+          </EnvironmentWrapper>,
+        );
+      });
+
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My second todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My 3rd todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+
+      TestRenderer.act(() => {
+        blockedBy('todo-1', 'todo-2');
+        jest.runAllImmediates();
+      });
+
+      expect(renderer?.toJSON()).toEqual([
+        'My first todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My second todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My 3rd todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'My second todo',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+    });
+
+    // TODO: T184433715 We currently break with the GraphQL spec here and filter out null values.
+    test('rendering lists with nulls', () => {
+      addTodo('Todo 1');
+      addTodo('Todo 2');
+      addTodo('Todo 3');
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <ManyTodosComponent todos={['todo-1', null, 'todo-2']} />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'Todo 1',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'Todo 2',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+      TestRenderer.act(() => {
+        renderer.update(
+          <EnvironmentWrapper environment={environment}>
+            <ManyTodosComponent todos={['todo-1', 'todo-2', 'todo-3']} />
+          </EnvironmentWrapper>,
+        );
+      });
+      expect(renderer?.toJSON()).toEqual([
+        'Todo 1',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'Todo 2',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'Todo 3',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+    });
+
+    test('rendering live list', () => {
+      addTodo('Todo 1');
+      addTodo('Todo 2');
+      addTodo('Todo 3');
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <EnvironmentWrapper environment={environment}>
+            <ManyLiveTodosComponent />
+          </EnvironmentWrapper>,
+        );
+      });
+
+      expect(renderer?.toJSON()).toEqual([
+        'Todo 1',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'Todo 2',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+        'Todo 3',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+
+      TestRenderer.act(() => {
+        removeTodo('todo-1');
+        removeTodo('todo-2');
+        jest.runAllImmediates();
+      });
+
+      expect(renderer?.toJSON()).toEqual([
+        'Todo 3',
+        'is not completed',
+        'style: bold',
+        'color: color is red',
+      ]);
+    });
+  },
+);

--- a/packages/relay-runtime/store/__tests__/RelayReader-ClientEdges-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-ClientEdges-test.js
@@ -124,451 +124,461 @@ const NULL_EDGE_QUERY = graphql`
   }
 `;
 
-describe('RelayReader Client Edges behavior', () => {
-  it('follows the client edge to an available record', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-      '1337': {
-        __id: '1337',
-        id: '1337',
-        __typename: 'User',
-        name: 'Bob',
-      },
-    });
-    const resolverCache = new RecordResolverCache(() => source);
-    const FooQuery = BASIC_QUERY;
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
-    const {data, seenRecords, missingClientEdges} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me?.client_edge?.name).toEqual('Bob');
-    expect(Array.from(seenRecords).sort()).toEqual([
-      '1',
-      '1337',
-      'client:1:client_edge',
-      'client:root',
-    ]);
-    expect(missingClientEdges?.length ?? 0).toEqual(0);
-  });
-
-  it('returns a missing data request if the destination record is missing', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
-    const resolverCache = new RecordResolverCache(() => source);
-    const FooQuery = BASIC_QUERY;
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
-    const {data, seenRecords, missingClientEdges} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me?.client_edge?.name).toEqual(undefined);
-    expect(Array.from(seenRecords).sort()).toEqual([
-      '1',
-      '1337',
-      'client:1:client_edge',
-      'client:root',
-    ]);
-    expect(missingClientEdges?.length).toEqual(1);
-    expect(missingClientEdges?.[0]).not.toBeFalsy();
-    const edge = missingClientEdges?.[0] ?? {};
-    expect(edge.clientEdgeDestinationID).toBe('1337');
-    expect(edge.request).toMatchObject({
-      kind: 'Request',
-      fragment: {
-        kind: 'Fragment',
-        type: 'Query',
-        name: 'ClientEdgeQuery_RelayReaderClientEdgesTest1Query_me__client_edge',
-        argumentDefinitions: [{name: 'id'}],
-        selections: [
-          {
-            kind: 'LinkedField',
-            name: 'node',
-            selections: [
-              {
-                kind: 'FragmentSpread',
-                name: 'RefetchableClientEdgeQuery_RelayReaderClientEdgesTest1Query_me__client_edge',
-              },
-            ],
+describe.each([true, false])(
+  'AVOID_CYCLES_IN_RESOLVER_NOTIFICATION is %p',
+  avoidCycles => {
+    RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION = avoidCycles;
+    describe('RelayReader Client Edges behavior', () => {
+      it('follows the client edge to an available record', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
           },
-        ],
-      },
-      operation: {
-        kind: 'Operation',
-        name: 'ClientEdgeQuery_RelayReaderClientEdgesTest1Query_me__client_edge',
-        argumentDefinitions: [{name: 'id'}],
-        selections: [
-          {
-            kind: 'LinkedField',
-            name: 'node',
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+          '1337': {
+            __id: '1337',
+            id: '1337',
+            __typename: 'User',
+            name: 'Bob',
+          },
+        });
+        const resolverCache = new RecordResolverCache(() => source);
+        const FooQuery = BASIC_QUERY;
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const {data, seenRecords, missingClientEdges} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me?.client_edge?.name).toEqual('Bob');
+        expect(Array.from(seenRecords).sort()).toEqual([
+          '1',
+          '1337',
+          'client:1:client_edge',
+          'client:root',
+        ]);
+        expect(missingClientEdges?.length ?? 0).toEqual(0);
+      });
+
+      it('returns a missing data request if the destination record is missing', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
+        const resolverCache = new RecordResolverCache(() => source);
+        const FooQuery = BASIC_QUERY;
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const {data, seenRecords, missingClientEdges} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me?.client_edge?.name).toEqual(undefined);
+        expect(Array.from(seenRecords).sort()).toEqual([
+          '1',
+          '1337',
+          'client:1:client_edge',
+          'client:root',
+        ]);
+        expect(missingClientEdges?.length).toEqual(1);
+        expect(missingClientEdges?.[0]).not.toBeFalsy();
+        const edge = missingClientEdges?.[0] ?? {};
+        expect(edge.clientEdgeDestinationID).toBe('1337');
+        expect(edge.request).toMatchObject({
+          kind: 'Request',
+          fragment: {
+            kind: 'Fragment',
+            type: 'Query',
+            name: 'ClientEdgeQuery_RelayReaderClientEdgesTest1Query_me__client_edge',
+            argumentDefinitions: [{name: 'id'}],
             selections: [
               {
-                kind: 'ScalarField',
-                name: '__typename',
-              },
-              {
-                kind: 'ScalarField',
-                name: 'id',
-              },
-              {
-                kind: 'InlineFragment',
-                type: 'User',
+                kind: 'LinkedField',
+                name: 'node',
                 selections: [
                   {
-                    kind: 'ScalarField',
-                    name: 'name',
+                    kind: 'FragmentSpread',
+                    name: 'RefetchableClientEdgeQuery_RelayReaderClientEdgesTest1Query_me__client_edge',
                   },
                 ],
               },
             ],
           },
-        ],
-      },
-      params: {
-        name: 'ClientEdgeQuery_RelayReaderClientEdgesTest1Query_me__client_edge',
-      },
-    });
-  });
+          operation: {
+            kind: 'Operation',
+            name: 'ClientEdgeQuery_RelayReaderClientEdgesTest1Query_me__client_edge',
+            argumentDefinitions: [{name: 'id'}],
+            selections: [
+              {
+                kind: 'LinkedField',
+                name: 'node',
+                selections: [
+                  {
+                    kind: 'ScalarField',
+                    name: '__typename',
+                  },
+                  {
+                    kind: 'ScalarField',
+                    name: 'id',
+                  },
+                  {
+                    kind: 'InlineFragment',
+                    type: 'User',
+                    selections: [
+                      {
+                        kind: 'ScalarField',
+                        name: 'name',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          params: {
+            name: 'ClientEdgeQuery_RelayReaderClientEdgesTest1Query_me__client_edge',
+          },
+        });
+      });
 
-  it('works when the backing field is aliased', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-      '1337': {
-        __id: '1337',
-        id: '1337',
-        __typename: 'User',
-        name: 'Bob',
-      },
-    });
-    const resolverCache = new RecordResolverCache(() => source);
-    const FooQuery = QUERY_WITH_ALIAS;
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
-    const {data, seenRecords, missingClientEdges} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me?.the_alias?.name).toEqual('Bob');
-    expect(me?.client_edge).toBeUndefined();
-    expect(Array.from(seenRecords).sort()).toEqual([
-      '1',
-      '1337',
-      'client:1:client_edge',
-      'client:root',
-    ]);
-    expect(missingClientEdges?.length ?? 0).toEqual(0);
-  });
+      it('works when the backing field is aliased', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+          '1337': {
+            __id: '1337',
+            id: '1337',
+            __typename: 'User',
+            name: 'Bob',
+          },
+        });
+        const resolverCache = new RecordResolverCache(() => source);
+        const FooQuery = QUERY_WITH_ALIAS;
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const {data, seenRecords, missingClientEdges} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me?.the_alias?.name).toEqual('Bob');
+        expect(me?.client_edge).toBeUndefined();
+        expect(Array.from(seenRecords).sort()).toEqual([
+          '1',
+          '1337',
+          'client:1:client_edge',
+          'client:root',
+        ]);
+        expect(missingClientEdges?.length ?? 0).toEqual(0);
+      });
 
-  it('gives a null client edge field when the backing field is null', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
-    const resolverCache = new RecordResolverCache(() => source);
-    const FooQuery = NULL_EDGE_QUERY;
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
-    const {data, seenRecords, missingClientEdges} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me?.null_client_edge).toBe(null);
-    expect(Array.from(seenRecords).sort()).toEqual([
-      '1',
-      'client:1:null_client_edge',
-      'client:root',
-    ]);
-    expect(missingClientEdges?.length ?? 0).toEqual(0);
-  });
+      it('gives a null client edge field when the backing field is null', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
+        const resolverCache = new RecordResolverCache(() => source);
+        const FooQuery = NULL_EDGE_QUERY;
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const {data, seenRecords, missingClientEdges} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me?.null_client_edge).toBe(null);
+        expect(Array.from(seenRecords).sort()).toEqual([
+          '1',
+          'client:1:null_client_edge',
+          'client:root',
+        ]);
+        expect(missingClientEdges?.length ?? 0).toEqual(0);
+      });
 
-  it('returns a missing data request if a record beyond the destination record via a linked field is missing', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-      '1337': {
-        __id: '1337',
-        id: '1337',
-        __typename: 'User',
-        name: 'Bob',
-        author: {__ref: '1338'}, // missing
-      },
-    });
-    const resolverCache = new RecordResolverCache(() => source);
-    const FooQuery = LINKED_FIELD_WITHIN_CLIENT_EDGE_QUERY;
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
-    const {data, seenRecords, missingClientEdges} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me?.client_edge?.author).toEqual(undefined);
-    expect(Array.from(seenRecords).sort()).toEqual([
-      '1',
-      '1337',
-      '1338',
-      'client:1:client_edge',
-      'client:root',
-    ]);
-    expect(missingClientEdges?.length).toEqual(1);
-  });
+      it('returns a missing data request if a record beyond the destination record via a linked field is missing', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+          '1337': {
+            __id: '1337',
+            id: '1337',
+            __typename: 'User',
+            name: 'Bob',
+            author: {__ref: '1338'}, // missing
+          },
+        });
+        const resolverCache = new RecordResolverCache(() => source);
+        const FooQuery = LINKED_FIELD_WITHIN_CLIENT_EDGE_QUERY;
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const {data, seenRecords, missingClientEdges} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me?.client_edge?.author).toEqual(undefined);
+        expect(Array.from(seenRecords).sort()).toEqual([
+          '1',
+          '1337',
+          '1338',
+          'client:1:client_edge',
+          'client:root',
+        ]);
+        expect(missingClientEdges?.length).toEqual(1);
+      });
 
-  it('returns a missing data request if data is missing within a fragment spread in the destination record of a client edge', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-      '1337': {
-        __id: '1337',
-        id: '1337',
-        __typename: 'User',
-        // name is missing
-      },
-    });
-    const resolverCache = new RecordResolverCache(() => source);
-    const FooQuery = FRAGMENT_SPREAD_WITHIN_CLIENT_EDGE_QUERY;
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
-    const {data: parentData} = read(source, operation.fragment, resolverCache);
-    const {data, seenRecords, missingClientEdges} = read(
-      source,
-      nullthrows(
-        getSingularSelector(
-          getFragment(FRAGMENT_ON_USER),
-          // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-          nullthrows((parentData: any).me.client_edge),
-        ),
-      ),
-      resolverCache,
-    );
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me?.client_edge?.name).toEqual(undefined);
-    expect(Array.from(seenRecords).sort()).toEqual(['1337']);
-    expect(missingClientEdges?.length).toEqual(1);
-  });
+      it('returns a missing data request if data is missing within a fragment spread in the destination record of a client edge', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+          '1337': {
+            __id: '1337',
+            id: '1337',
+            __typename: 'User',
+            // name is missing
+          },
+        });
+        const resolverCache = new RecordResolverCache(() => source);
+        const FooQuery = FRAGMENT_SPREAD_WITHIN_CLIENT_EDGE_QUERY;
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const {data: parentData} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        const {data, seenRecords, missingClientEdges} = read(
+          source,
+          nullthrows(
+            getSingularSelector(
+              getFragment(FRAGMENT_ON_USER),
+              // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+              nullthrows((parentData: any).me.client_edge),
+            ),
+          ),
+          resolverCache,
+        );
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me?.client_edge?.name).toEqual(undefined);
+        expect(Array.from(seenRecords).sort()).toEqual(['1337']);
+        expect(missingClientEdges?.length).toEqual(1);
+      });
 
-  it('returns a missing data request if data is missing within a client edge within a client edge', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-      '1337': {
-        __id: '1337',
-        id: '1337',
-        __typename: 'User',
-        // name is missing
-      },
-    });
-    const resolverCache = new RecordResolverCache(() => source);
-    const FooQuery = NESTED_CLIENT_EDGE_QUERY;
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
-    const {data, seenRecords, missingClientEdges} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me?.client_edge?.name).toEqual(undefined);
-    expect(Array.from(seenRecords).sort()).toEqual([
-      '1',
-      '1337',
-      '1338',
-      'client:1337:another_client_edge',
-      'client:1:client_edge',
-      'client:root',
-    ]);
-    expect(missingClientEdges?.length).toEqual(1);
-    // Make sure it's the request for the inner edge and not the outer one:
-    expect(missingClientEdges?.[0].request.fragment.name).toEqual(
-      'ClientEdgeQuery_RelayReaderClientEdgesTest4Query_me__client_edge__another_client_edge',
-    );
-  });
+      it('returns a missing data request if data is missing within a client edge within a client edge', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+          '1337': {
+            __id: '1337',
+            id: '1337',
+            __typename: 'User',
+            // name is missing
+          },
+        });
+        const resolverCache = new RecordResolverCache(() => source);
+        const FooQuery = NESTED_CLIENT_EDGE_QUERY;
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const {data, seenRecords, missingClientEdges} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me?.client_edge?.name).toEqual(undefined);
+        expect(Array.from(seenRecords).sort()).toEqual([
+          '1',
+          '1337',
+          '1338',
+          'client:1337:another_client_edge',
+          'client:1:client_edge',
+          'client:root',
+        ]);
+        expect(missingClientEdges?.length).toEqual(1);
+        // Make sure it's the request for the inner edge and not the outer one:
+        expect(missingClientEdges?.[0].request.fragment.name).toEqual(
+          'ClientEdgeQuery_RelayReaderClientEdgesTest4Query_me__client_edge__another_client_edge',
+        );
+      });
 
-  it('Considers data as missing when a client edge is reached after traversing a client extension', () => {
-    // This tests an exception to the usual rule that isMissingData shouldn't be set
-    // when traversing past a client extension, since the parent query can't help with
-    // client data. But for client edges, we can help using the client edge query, no matter
-    // how that client edge was reached.
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-        client_extension_linked_field: {__ref: '1338'},
-      },
-      '1338': {
-        __id: '1338',
-        id: '1338',
-        __typename: 'User',
-        name: 'Bob',
-      },
-      // 1337 (the client edge destination) is missing.
-    });
-    const resolverCache = new RecordResolverCache(() => source);
-    const FooQuery = CLIENT_EDGE_WITHIN_CLIENT_EXTENSION;
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
-    const {data, seenRecords, missingClientEdges} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me?.client_edge?.author).toEqual(undefined);
-    expect(Array.from(seenRecords).sort()).toEqual([
-      '1',
-      '1337',
-      '1338',
-      'client:1338:client_edge',
-      'client:root',
-    ]);
-    expect(missingClientEdges?.length).toEqual(1);
-  });
+      it('Considers data as missing when a client edge is reached after traversing a client extension', () => {
+        // This tests an exception to the usual rule that isMissingData shouldn't be set
+        // when traversing past a client extension, since the parent query can't help with
+        // client data. But for client edges, we can help using the client edge query, no matter
+        // how that client edge was reached.
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+            client_extension_linked_field: {__ref: '1338'},
+          },
+          '1338': {
+            __id: '1338',
+            id: '1338',
+            __typename: 'User',
+            name: 'Bob',
+          },
+          // 1337 (the client edge destination) is missing.
+        });
+        const resolverCache = new RecordResolverCache(() => source);
+        const FooQuery = CLIENT_EDGE_WITHIN_CLIENT_EXTENSION;
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const {data, seenRecords, missingClientEdges} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me?.client_edge?.author).toEqual(undefined);
+        expect(Array.from(seenRecords).sort()).toEqual([
+          '1',
+          '1337',
+          '1338',
+          'client:1338:client_edge',
+          'client:root',
+        ]);
+        expect(missingClientEdges?.length).toEqual(1);
+      });
 
-  it('propagates missing client edge data errors from the resolver up to the reader', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: null,
-      },
-      '1337': {
-        // `client_edge` points here
-        __id: '1337',
-        id: '1337',
-        __typename: 'User',
-        name: undefined, // The missing data
-      },
-    });
-    const FooQuery = graphql`
-      query RelayReaderClientEdgesTestMissingClientEdgeDataQuery {
-        me {
-          reads_client_edge
-        }
-      }
-    `;
+      it('propagates missing client edge data errors from the resolver up to the reader', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: null,
+          },
+          '1337': {
+            // `client_edge` points here
+            __id: '1337',
+            id: '1337',
+            __typename: 'User',
+            name: undefined, // The missing data
+          },
+        });
+        const FooQuery = graphql`
+          query RelayReaderClientEdgesTestMissingClientEdgeDataQuery {
+            me {
+              reads_client_edge
+            }
+          }
+        `;
 
-    const operation = createOperationDescriptor(FooQuery, {});
-    const resolverCache = new RecordResolverCache(() => source);
-    const {missingClientEdges} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    expect(missingClientEdges).toEqual([
-      expect.objectContaining({
-        request: expect.objectContaining({
-          fragment: expect.objectContaining({
-            name: 'ClientEdgeQuery_UserReadsClientEdgeResolver_client_edge',
+        const operation = createOperationDescriptor(FooQuery, {});
+        const resolverCache = new RecordResolverCache(() => source);
+        const {missingClientEdges} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        expect(missingClientEdges).toEqual([
+          expect.objectContaining({
+            request: expect.objectContaining({
+              fragment: expect.objectContaining({
+                name: 'ClientEdgeQuery_UserReadsClientEdgeResolver_client_edge',
+              }),
+            }),
           }),
-        }),
-      }),
-    ]);
+        ]);
 
-    // Lookup a second time to ensure that we still report the missing client edge data when
-    // reading from the cache.
-    const {missingClientEdges: stillMissingClientEdges} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    expect(stillMissingClientEdges).toEqual([
-      expect.objectContaining({
-        request: expect.objectContaining({
-          fragment: expect.objectContaining({
-            name: 'ClientEdgeQuery_UserReadsClientEdgeResolver_client_edge',
+        // Lookup a second time to ensure that we still report the missing client edge data when
+        // reading from the cache.
+        const {missingClientEdges: stillMissingClientEdges} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        expect(stillMissingClientEdges).toEqual([
+          expect.objectContaining({
+            request: expect.objectContaining({
+              fragment: expect.objectContaining({
+                name: 'ClientEdgeQuery_UserReadsClientEdgeResolver_client_edge',
+              }),
+            }),
           }),
-        }),
-      }),
-    ]);
-  });
-});
+        ]);
+      });
+    });
+  },
+);

--- a/packages/relay-runtime/store/__tests__/RelayReader-Resolver-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-Resolver-test.js
@@ -54,950 +54,956 @@ afterEach(() => {
   UserConstantDependentResolver._relayResolverTestCallCount = undefined;
 });
 
-describe.each([
-  {
-    name: 'RecordResolverCache',
-    ResolverCache: RecordResolverCache,
-    RelayStore: RelayModernStore,
-  },
-  {
-    name: 'LiveResolverCache',
-    ResolverCache: LiveResolverCache,
-    RelayStore: LiveResolverStore,
-  },
-])('Relay Resolver with $name', ({ResolverCache, RelayStore}) => {
-  it('returns the result of the resolver function', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
+describe.each([true, false])(
+  'AVOID_CYCLES_IN_RESOLVER_NOTIFICATION is %p',
+  avoidCycles => {
+    RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION = avoidCycles;
+    describe.each([
+      {
+        name: 'RecordResolverCache',
+        ResolverCache: RecordResolverCache,
+        RelayStore: RelayModernStore,
       },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
+      {
+        name: 'LiveResolverCache',
+        ResolverCache: LiveResolverCache,
+        RelayStore: LiveResolverStore,
       },
-    });
-    const resolverCache = new ResolverCache(() => source);
+    ])('Relay Resolver with $name', ({ResolverCache, RelayStore}) => {
+      it('returns the result of the resolver function', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
+        const resolverCache = new ResolverCache(() => source);
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest1Query {
-        me {
-          greeting
-        }
-      }
-    `;
+        const FooQuery = graphql`
+          query RelayReaderResolverTest1Query {
+            me {
+              greeting
+            }
+          }
+        `;
 
-    const operation = createOperationDescriptor(FooQuery, {});
+        const operation = createOperationDescriptor(FooQuery, {});
 
-    const {data, seenRecords} = read(source, operation.fragment, resolverCache);
+        const {data, seenRecords} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
 
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me.greeting).toEqual('Hello, Alice!'); // Resolver result
-    expect(me.name).toEqual(undefined); // Fields needed by resolver's fragment don't end up in the result
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me.greeting).toEqual('Hello, Alice!'); // Resolver result
+        expect(me.name).toEqual(undefined); // Fields needed by resolver's fragment don't end up in the result
 
-    expect(Array.from(seenRecords).sort()).toEqual([
-      '1',
-      'client:1:greeting',
-      'client:root',
-    ]);
-  });
+        expect(Array.from(seenRecords).sort()).toEqual([
+          '1',
+          'client:1:greeting',
+          'client:root',
+        ]);
+      });
 
-  it('are passed field arguments', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
-    const resolverCache = new ResolverCache(() => source);
+      it('are passed field arguments', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
+        const resolverCache = new ResolverCache(() => source);
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTestCustomGreetingDynamicQuery(
-        $salutation: String!
-      ) {
-        me {
-          dynamic_greeting: custom_greeting(salutation: $salutation)
-          greetz: custom_greeting(salutation: "Greetz")
-          willkommen: custom_greeting(salutation: "Willkommen")
-        }
-      }
-    `;
+        const FooQuery = graphql`
+          query RelayReaderResolverTestCustomGreetingDynamicQuery(
+            $salutation: String!
+          ) {
+            me {
+              dynamic_greeting: custom_greeting(salutation: $salutation)
+              greetz: custom_greeting(salutation: "Greetz")
+              willkommen: custom_greeting(salutation: "Willkommen")
+            }
+          }
+        `;
 
-    const operation = createOperationDescriptor(FooQuery, {
-      salutation: 'Dynamic Greeting',
-    });
+        const operation = createOperationDescriptor(FooQuery, {
+          salutation: 'Dynamic Greeting',
+        });
 
-    const {data} = read(source, operation.fragment, resolverCache);
+        const {data} = read(source, operation.fragment, resolverCache);
 
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me.dynamic_greeting).toEqual('Dynamic Greeting, Alice!');
-    expect(me.greetz).toEqual('Greetz, Alice!');
-    expect(me.willkommen).toEqual('Willkommen, Alice!');
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me.dynamic_greeting).toEqual('Dynamic Greeting, Alice!');
+        expect(me.greetz).toEqual('Greetz, Alice!');
+        expect(me.willkommen).toEqual('Willkommen, Alice!');
 
-    // If variables change and we reread, we should observe the new value.
-    const operationWithNewVariables = createOperationDescriptor(FooQuery, {
-      salutation: 'New Dynamic Greeting',
-    });
-    const {data: dataWithNewVariables} = read(
-      source,
-      operationWithNewVariables.fragment,
-      resolverCache,
-    );
+        // If variables change and we reread, we should observe the new value.
+        const operationWithNewVariables = createOperationDescriptor(FooQuery, {
+          salutation: 'New Dynamic Greeting',
+        });
+        const {data: dataWithNewVariables} = read(
+          source,
+          operationWithNewVariables.fragment,
+          resolverCache,
+        );
 
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me: meWithNewVariables}: any = dataWithNewVariables;
-    expect(meWithNewVariables.dynamic_greeting).toEqual(
-      'New Dynamic Greeting, Alice!',
-    );
-  });
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me: meWithNewVariables}: any = dataWithNewVariables;
+        expect(meWithNewVariables.dynamic_greeting).toEqual(
+          'New Dynamic Greeting, Alice!',
+        );
+      });
 
-  describe('Relay resolver - Field Error Handling', () => {
-    it('propagates errors from the resolver up to the reader', () => {
-      const source = RelayRecordSource.create({
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          me: {__ref: '1'},
-        },
-        '1': {
-          __id: '1',
-          id: '1',
-          __typename: 'User',
-          lastName: null,
-          __errors: {
-            lastName: [
-              {
-                message: 'There was an error!',
-                path: ['me', 'lastName'],
+      describe('Relay resolver - Field Error Handling', () => {
+        it('propagates errors from the resolver up to the reader', () => {
+          const source = RelayRecordSource.create({
+            'client:root': {
+              __id: 'client:root',
+              __typename: '__Root',
+              me: {__ref: '1'},
+            },
+            '1': {
+              __id: '1',
+              id: '1',
+              __typename: 'User',
+              lastName: null,
+              __errors: {
+                lastName: [
+                  {
+                    message: 'There was an error!',
+                    path: ['me', 'lastName'],
+                  },
+                ],
               },
-            ],
+            },
+          });
+
+          const FooQuery = graphql`
+            query RelayReaderResolverTestFieldErrorQuery {
+              me {
+                lastName
+              }
+            }
+          `;
+
+          const operation = createOperationDescriptor(FooQuery, {});
+          const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+          const {errorResponseFields} = store.lookup(operation.fragment);
+          expect(errorResponseFields).toEqual([
+            {
+              error: {message: 'There was an error!', path: ['me', 'lastName']},
+              owner: 'RelayReaderResolverTestFieldErrorQuery',
+              type: 'PAYLOAD_ERROR',
+              path: 'me.lastName',
+            },
+          ]);
+        });
+      });
+
+      it('propagates @required errors from the resolver up to the reader', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
           },
-        },
-      });
-
-      const FooQuery = graphql`
-        query RelayReaderResolverTestFieldErrorQuery {
-          me {
-            lastName
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: null, // The missing field
+          },
+        });
+        const FooQuery = graphql`
+          query RelayReaderResolverTestRequiredQuery {
+            me {
+              required_name
+            }
           }
-        }
-      `;
+        `;
 
-      const operation = createOperationDescriptor(FooQuery, {});
-      const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-      const {errorResponseFields} = store.lookup(operation.fragment);
-      expect(errorResponseFields).toEqual([
-        {
-          error: {message: 'There was an error!', path: ['me', 'lastName']},
-          owner: 'RelayReaderResolverTestFieldErrorQuery',
-          type: 'PAYLOAD_ERROR',
-          path: 'me.lastName',
-        },
-      ]);
-    });
-  });
+        const operation = createOperationDescriptor(FooQuery, {});
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const {missingRequiredFields} = store.lookup(operation.fragment);
+        expect(missingRequiredFields).toEqual({
+          action: 'LOG',
+          fields: [{owner: 'UserRequiredNameResolver', path: 'name'}],
+        });
 
-  it('propagates @required errors from the resolver up to the reader', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: null, // The missing field
-      },
-    });
-    const FooQuery = graphql`
-      query RelayReaderResolverTestRequiredQuery {
-        me {
-          required_name
-        }
-      }
-    `;
+        // Lookup a second time to ensure that we still report the missing fields when
+        // reading from the cache.
+        const {missingRequiredFields: missingRequiredFieldsTakeTwo} =
+          store.lookup(operation.fragment);
 
-    const operation = createOperationDescriptor(FooQuery, {});
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const {missingRequiredFields} = store.lookup(operation.fragment);
-    expect(missingRequiredFields).toEqual({
-      action: 'LOG',
-      fields: [{owner: 'UserRequiredNameResolver', path: 'name'}],
-    });
-
-    // Lookup a second time to ensure that we still report the missing fields when
-    // reading from the cache.
-    const {missingRequiredFields: missingRequiredFieldsTakeTwo} = store.lookup(
-      operation.fragment,
-    );
-
-    expect(missingRequiredFieldsTakeTwo).toEqual({
-      action: 'LOG',
-      fields: [{owner: 'UserRequiredNameResolver', path: 'name'}],
-    });
-  });
-
-  it('propagates missing data errors from the resolver up to the reader', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: undefined, // The missing data
-      },
-    });
-    const FooQuery = graphql`
-      query RelayReaderResolverTestMissingDataQuery {
-        me {
-          greeting # Transiviely reads name
-        }
-      }
-    `;
-
-    const operation = createOperationDescriptor(FooQuery, {});
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const {isMissingData} = store.lookup(operation.fragment);
-    expect(isMissingData).toBe(true);
-
-    // Lookup a second time to ensure that we still report the missing fields when
-    // reading from the cache.
-    const {isMissingData: isStillMissingData} = store.lookup(
-      operation.fragment,
-    );
-    expect(isStillMissingData).toBe(true);
-  });
-
-  it('merges @required logs from resolver field with parent', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: null, // The missing field
-        lastName: null, // Another missing field
-      },
-    });
-    const FooQuery = graphql`
-      query RelayReaderResolverTestRequiredWithParentQuery {
-        me {
-          required_name
-          lastName @required(action: LOG)
-        }
-      }
-    `;
-
-    const operation = createOperationDescriptor(FooQuery, {});
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const {missingRequiredFields} = store.lookup(operation.fragment);
-    expect(missingRequiredFields).toEqual({
-      action: 'LOG',
-      fields: [
-        {owner: 'UserRequiredNameResolver', path: 'name'},
-        {
-          owner: 'RelayReaderResolverTestRequiredWithParentQuery',
-          path: 'me.lastName',
-        },
-      ],
-    });
-
-    // Lookup a second time to ensure that we still report the missing fields when
-    // reading from the cache.
-    const {missingRequiredFields: missingRequiredFieldsTakeTwo} = store.lookup(
-      operation.fragment,
-    );
-
-    expect(missingRequiredFieldsTakeTwo).toEqual({
-      action: 'LOG',
-      fields: [
-        {owner: 'UserRequiredNameResolver', path: 'name'},
-        {
-          owner: 'RelayReaderResolverTestRequiredWithParentQuery',
-          path: 'me.lastName',
-        },
-      ],
-    });
-  });
-
-  it('works when the field is aliased', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
-    const resolverCache = new ResolverCache(() => source);
-
-    const FooQuery = graphql`
-      query RelayReaderResolverTest11Query {
-        me {
-          the_alias: greeting
-        }
-      }
-    `;
-
-    const operation = createOperationDescriptor(FooQuery, {});
-
-    const {data} = read(source, operation.fragment, resolverCache);
-
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me.the_alias).toEqual('Hello, Alice!'); // Resolver result
-    expect(me.greeting).toEqual(undefined); // Unaliased name
-  });
-
-  it('re-computes when an upstream is updated', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
-
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store,
-    });
-
-    const FooQuery = graphql`
-      query RelayReaderResolverTest3Query {
-        me {
-          greeting
-        }
-      }
-    `;
-
-    const cb = jest.fn<[Snapshot], void>();
-    const operation = createOperationDescriptor(FooQuery, {});
-    const snapshot = store.lookup(operation.fragment);
-    const subscription = store.subscribe(snapshot, cb);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = snapshot.data;
-    expect(me.greeting).toEqual('Hello, Alice!');
-    environment.commitUpdate(theStore => {
-      const alice = nullthrows(theStore.get('1'));
-      alice.setValue('Alicia', 'name');
-    });
-    expect(cb).toHaveBeenCalledTimes(1);
-    expect(cb).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          me: expect.objectContaining({
-            greeting: 'Hello, Alicia!',
-          }),
-        }),
-      }),
-    );
-    subscription.dispose();
-  });
-
-  it('does not recompute if the upstream has the same value as before', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
-
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store,
-    });
-
-    const FooQuery = graphql`
-      query RelayReaderResolverTest2Query {
-        me {
-          constant_dependent
-        }
-      }
-    `;
-
-    const resolverInternals: {_relayResolverTestCallCount: number} =
-      // $FlowFixMe
-      (UserConstantDependentResolver: any);
-
-    expect(resolverInternals._relayResolverTestCallCount).toBe(undefined);
-    const cb = jest.fn<[Snapshot], void>();
-    const operation = createOperationDescriptor(FooQuery, {});
-    const snapshot = store.lookup(operation.fragment);
-    const subscription = store.subscribe(snapshot, cb);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = snapshot.data;
-    expect(me.constant_dependent).toEqual(1);
-    expect(resolverInternals._relayResolverTestCallCount).toBe(1);
-    environment.commitUpdate(theStore => {
-      const alice = nullthrows(theStore.get('1'));
-      alice.setValue('Alicia', 'name');
-    });
-    expect(cb).toHaveBeenCalledTimes(0);
-    subscription.dispose();
-    const newSnapshot = store.lookup(operation.fragment);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me: newMe}: any = newSnapshot.data;
-    expect(newMe.constant_dependent).toEqual(1);
-    expect(resolverInternals._relayResolverTestCallCount).toBe(1);
-  });
-
-  it.each([true, false])(
-    'marks the resolver cache as clean if the upstream has not changed with RelayFeatureFlags.MARK_RESOLVER_VALUES_AS_CLEAN_AFTER_FRAGMENT_REREAD=%s',
-    markClean => {
-      RelayFeatureFlags.MARK_RESOLVER_VALUES_AS_CLEAN_AFTER_FRAGMENT_REREAD =
-        markClean;
-      const source = RelayRecordSource.create({
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          me: {__ref: '1'},
-        },
-        '1': {
-          __id: '1',
-          id: '1',
-          __typename: 'User',
-          name: 'Alice',
-        },
+        expect(missingRequiredFieldsTakeTwo).toEqual({
+          action: 'LOG',
+          fields: [{owner: 'UserRequiredNameResolver', path: 'name'}],
+        });
       });
 
-      const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-      const environment = new RelayModernEnvironment({
-        network: RelayNetwork.create(jest.fn()),
-        store,
-      });
-
-      const FooQuery = graphql`
-        query RelayReaderResolverTestMarkCleanQuery {
-          me {
-            constant_dependent
+      it('propagates missing data errors from the resolver up to the reader', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: undefined, // The missing data
+          },
+        });
+        const FooQuery = graphql`
+          query RelayReaderResolverTestMissingDataQuery {
+            me {
+              greeting # Transiviely reads name
+            }
           }
-        }
-      `;
+        `;
 
-      const cb = jest.fn<[Snapshot], void>();
-      const operation = createOperationDescriptor(FooQuery, {});
-      const snapshot = store.lookup(operation.fragment);
-      const subscription = store.subscribe(snapshot, cb);
-      // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-      const {me}: any = snapshot.data;
-      expect(me.constant_dependent).toEqual(1);
-      environment.commitUpdate(theStore => {
-        const alice = nullthrows(theStore.get('1'));
-        alice.setValue('Alicia', 'name');
+        const operation = createOperationDescriptor(FooQuery, {});
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const {isMissingData} = store.lookup(operation.fragment);
+        expect(isMissingData).toBe(true);
+
+        // Lookup a second time to ensure that we still report the missing fields when
+        // reading from the cache.
+        const {isMissingData: isStillMissingData} = store.lookup(
+          operation.fragment,
+        );
+        expect(isStillMissingData).toBe(true);
       });
-      subscription.dispose();
 
-      // Rereading the resolver's fragment, only to find that no fields that we read have changed,
-      // should clear the RELAY_RESOLVER_INVALIDATION_KEY.
-      const resolverCacheRecord = environment
-        .getStore()
-        .getSource()
-        .get('client:1:constant_dependent');
-      invariant(
-        resolverCacheRecord != null,
-        'Expected a resolver cache record',
-      );
+      it('merges @required logs from resolver field with parent', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: null, // The missing field
+            lastName: null, // Another missing field
+          },
+        });
+        const FooQuery = graphql`
+          query RelayReaderResolverTestRequiredWithParentQuery {
+            me {
+              required_name
+              lastName @required(action: LOG)
+            }
+          }
+        `;
 
-      const isMaybeInvalid = RelayModernRecord.getValue(
-        resolverCacheRecord,
-        RELAY_RESOLVER_INVALIDATION_KEY,
-      );
+        const operation = createOperationDescriptor(FooQuery, {});
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const {missingRequiredFields} = store.lookup(operation.fragment);
+        expect(missingRequiredFields).toEqual({
+          action: 'LOG',
+          fields: [
+            {owner: 'UserRequiredNameResolver', path: 'name'},
+            {
+              owner: 'RelayReaderResolverTestRequiredWithParentQuery',
+              path: 'me.lastName',
+            },
+          ],
+        });
 
-      if (markClean) {
-        expect(isMaybeInvalid).toBe(false);
-      } else {
-        // Without the feature flag enabled, T185969900 still reproduces.
-        expect(isMaybeInvalid).toBe(true);
-      }
-    },
-  );
+        // Lookup a second time to ensure that we still report the missing fields when
+        // reading from the cache.
+        const {missingRequiredFields: missingRequiredFieldsTakeTwo} =
+          store.lookup(operation.fragment);
 
-  it('handles optimistic updates (applied after subscribing)', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
+        expect(missingRequiredFieldsTakeTwo).toEqual({
+          action: 'LOG',
+          fields: [
+            {owner: 'UserRequiredNameResolver', path: 'name'},
+            {
+              owner: 'RelayReaderResolverTestRequiredWithParentQuery',
+              path: 'me.lastName',
+            },
+          ],
+        });
+      });
 
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store,
-    });
+      it('works when the field is aliased', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
+        const resolverCache = new ResolverCache(() => source);
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest9Query {
-        me {
-          greeting
-        }
-      }
-    `;
+        const FooQuery = graphql`
+          query RelayReaderResolverTest11Query {
+            me {
+              the_alias: greeting
+            }
+          }
+        `;
 
-    const cb = jest.fn<[Snapshot], void>();
-    const operation = createOperationDescriptor(FooQuery, {});
-    const snapshot = store.lookup(operation.fragment);
-    const subscription = store.subscribe(snapshot, cb);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = snapshot.data;
-    expect(me.greeting).toEqual('Hello, Alice!');
+        const operation = createOperationDescriptor(FooQuery, {});
 
-    const checkUpdate = (
-      expectedCallbackCount: number,
-      expectedGreeting: string,
-    ) => {
-      expect(cb).toHaveBeenCalledTimes(expectedCallbackCount);
-      expect(cb).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            me: expect.objectContaining({
-              greeting: expectedGreeting,
+        const {data} = read(source, operation.fragment, resolverCache);
+
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me.the_alias).toEqual('Hello, Alice!'); // Resolver result
+        expect(me.greeting).toEqual(undefined); // Unaliased name
+      });
+
+      it('re-computes when an upstream is updated', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
+
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store,
+        });
+
+        const FooQuery = graphql`
+          query RelayReaderResolverTest3Query {
+            me {
+              greeting
+            }
+          }
+        `;
+
+        const cb = jest.fn<[Snapshot], void>();
+        const operation = createOperationDescriptor(FooQuery, {});
+        const snapshot = store.lookup(operation.fragment);
+        const subscription = store.subscribe(snapshot, cb);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = snapshot.data;
+        expect(me.greeting).toEqual('Hello, Alice!');
+        environment.commitUpdate(theStore => {
+          const alice = nullthrows(theStore.get('1'));
+          alice.setValue('Alicia', 'name');
+        });
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              me: expect.objectContaining({
+                greeting: 'Hello, Alicia!',
+              }),
             }),
           }),
-        }),
+        );
+        subscription.dispose();
+      });
+
+      it('does not recompute if the upstream has the same value as before', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
+
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store,
+        });
+
+        const FooQuery = graphql`
+          query RelayReaderResolverTest2Query {
+            me {
+              constant_dependent
+            }
+          }
+        `;
+
+        const resolverInternals: {_relayResolverTestCallCount: number} =
+          // $FlowFixMe
+          (UserConstantDependentResolver: any);
+
+        expect(resolverInternals._relayResolverTestCallCount).toBe(undefined);
+        const cb = jest.fn<[Snapshot], void>();
+        const operation = createOperationDescriptor(FooQuery, {});
+        const snapshot = store.lookup(operation.fragment);
+        const subscription = store.subscribe(snapshot, cb);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = snapshot.data;
+        expect(me.constant_dependent).toEqual(1);
+        expect(resolverInternals._relayResolverTestCallCount).toBe(1);
+        environment.commitUpdate(theStore => {
+          const alice = nullthrows(theStore.get('1'));
+          alice.setValue('Alicia', 'name');
+        });
+        expect(cb).toHaveBeenCalledTimes(0);
+        subscription.dispose();
+        const newSnapshot = store.lookup(operation.fragment);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me: newMe}: any = newSnapshot.data;
+        expect(newMe.constant_dependent).toEqual(1);
+        expect(resolverInternals._relayResolverTestCallCount).toBe(1);
+      });
+
+      it.each([true, false])(
+        'marks the resolver cache as clean if the upstream has not changed with RelayFeatureFlags.MARK_RESOLVER_VALUES_AS_CLEAN_AFTER_FRAGMENT_REREAD=%s',
+        markClean => {
+          RelayFeatureFlags.MARK_RESOLVER_VALUES_AS_CLEAN_AFTER_FRAGMENT_REREAD =
+            markClean;
+          const source = RelayRecordSource.create({
+            'client:root': {
+              __id: 'client:root',
+              __typename: '__Root',
+              me: {__ref: '1'},
+            },
+            '1': {
+              __id: '1',
+              id: '1',
+              __typename: 'User',
+              name: 'Alice',
+            },
+          });
+
+          const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+          const environment = new RelayModernEnvironment({
+            network: RelayNetwork.create(jest.fn()),
+            store,
+          });
+
+          const FooQuery = graphql`
+            query RelayReaderResolverTestMarkCleanQuery {
+              me {
+                constant_dependent
+              }
+            }
+          `;
+
+          const cb = jest.fn<[Snapshot], void>();
+          const operation = createOperationDescriptor(FooQuery, {});
+          const snapshot = store.lookup(operation.fragment);
+          const subscription = store.subscribe(snapshot, cb);
+          // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+          const {me}: any = snapshot.data;
+          expect(me.constant_dependent).toEqual(1);
+          environment.commitUpdate(theStore => {
+            const alice = nullthrows(theStore.get('1'));
+            alice.setValue('Alicia', 'name');
+          });
+          subscription.dispose();
+
+          // Rereading the resolver's fragment, only to find that no fields that we read have changed,
+          // should clear the RELAY_RESOLVER_INVALIDATION_KEY.
+          const resolverCacheRecord = environment
+            .getStore()
+            .getSource()
+            .get('client:1:constant_dependent');
+          invariant(
+            resolverCacheRecord != null,
+            'Expected a resolver cache record',
+          );
+
+          const isMaybeInvalid = RelayModernRecord.getValue(
+            resolverCacheRecord,
+            RELAY_RESOLVER_INVALIDATION_KEY,
+          );
+
+          if (markClean) {
+            expect(isMaybeInvalid).toBe(false);
+          } else {
+            // Without the feature flag enabled, T185969900 still reproduces.
+            expect(isMaybeInvalid).toBe(true);
+          }
+        },
       );
-      const newSnapshot = store.lookup(operation.fragment);
-      // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-      const {me: newMe}: any = newSnapshot.data;
-      expect(newMe.greeting).toEqual(expectedGreeting);
-    };
 
-    const update = environment.applyUpdate({
-      storeUpdater: theStore => {
-        const alice = nullthrows(theStore.get('1'));
-        alice.setValue('Alicia', 'name');
-      },
-    });
-    checkUpdate(1, 'Hello, Alicia!');
-    update.dispose();
-    checkUpdate(2, 'Hello, Alice!');
-    subscription.dispose();
-  });
+      it('handles optimistic updates (applied after subscribing)', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
 
-  it('handles optimistic updates (subscribed after applying)', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store,
+        });
 
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store,
-    });
+        const FooQuery = graphql`
+          query RelayReaderResolverTest9Query {
+            me {
+              greeting
+            }
+          }
+        `;
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest10Query {
-        me {
-          greeting
-        }
-      }
-    `;
+        const cb = jest.fn<[Snapshot], void>();
+        const operation = createOperationDescriptor(FooQuery, {});
+        const snapshot = store.lookup(operation.fragment);
+        const subscription = store.subscribe(snapshot, cb);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = snapshot.data;
+        expect(me.greeting).toEqual('Hello, Alice!');
 
-    const update = environment.applyUpdate({
-      storeUpdater: theStore => {
-        const alice = nullthrows(theStore.get('1'));
-        alice.setValue('Alicia', 'name');
-      },
-    });
+        const checkUpdate = (
+          expectedCallbackCount: number,
+          expectedGreeting: string,
+        ) => {
+          expect(cb).toHaveBeenCalledTimes(expectedCallbackCount);
+          expect(cb).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              data: expect.objectContaining({
+                me: expect.objectContaining({
+                  greeting: expectedGreeting,
+                }),
+              }),
+            }),
+          );
+          const newSnapshot = store.lookup(operation.fragment);
+          // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+          const {me: newMe}: any = newSnapshot.data;
+          expect(newMe.greeting).toEqual(expectedGreeting);
+        };
 
-    const cb = jest.fn<[Snapshot], void>();
-    const operation = createOperationDescriptor(FooQuery, {});
-    const snapshot = store.lookup(operation.fragment);
-    const subscription = store.subscribe(snapshot, cb);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = snapshot.data;
-    expect(me.greeting).toEqual('Hello, Alicia!');
+        const update = environment.applyUpdate({
+          storeUpdater: theStore => {
+            const alice = nullthrows(theStore.get('1'));
+            alice.setValue('Alicia', 'name');
+          },
+        });
+        checkUpdate(1, 'Hello, Alicia!');
+        update.dispose();
+        checkUpdate(2, 'Hello, Alice!');
+        subscription.dispose();
+      });
 
-    const checkUpdate = (
-      expectedCallbackCount: number,
-      expectedGreeting: string,
-    ) => {
-      expect(cb).toHaveBeenCalledTimes(expectedCallbackCount);
-      expect(cb).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            me: expect.objectContaining({
-              greeting: expectedGreeting,
+      it('handles optimistic updates (subscribed after applying)', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
+
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store,
+        });
+
+        const FooQuery = graphql`
+          query RelayReaderResolverTest10Query {
+            me {
+              greeting
+            }
+          }
+        `;
+
+        const update = environment.applyUpdate({
+          storeUpdater: theStore => {
+            const alice = nullthrows(theStore.get('1'));
+            alice.setValue('Alicia', 'name');
+          },
+        });
+
+        const cb = jest.fn<[Snapshot], void>();
+        const operation = createOperationDescriptor(FooQuery, {});
+        const snapshot = store.lookup(operation.fragment);
+        const subscription = store.subscribe(snapshot, cb);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = snapshot.data;
+        expect(me.greeting).toEqual('Hello, Alicia!');
+
+        const checkUpdate = (
+          expectedCallbackCount: number,
+          expectedGreeting: string,
+        ) => {
+          expect(cb).toHaveBeenCalledTimes(expectedCallbackCount);
+          expect(cb).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              data: expect.objectContaining({
+                me: expect.objectContaining({
+                  greeting: expectedGreeting,
+                }),
+              }),
+            }),
+          );
+          const newSnapshot = store.lookup(operation.fragment);
+          // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+          const {me: newMe}: any = newSnapshot.data;
+          expect(newMe.greeting).toEqual(expectedGreeting);
+        };
+
+        update.dispose();
+        checkUpdate(1, 'Hello, Alice!');
+        subscription.dispose();
+      });
+
+      it('re-computes when something other than its own record is updated', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+            'friends(first:1)': {__ref: 'client:1'},
+          },
+          'client:1': {
+            __id: 'client:1',
+            __typename: 'FriendsConnection',
+            edges: {
+              __refs: ['client:2'],
+            },
+          },
+          'client:2': {
+            __id: 'client:2',
+            __typename: 'FriendsConnectionEdge',
+            cursor: 'cursor:2',
+            node: {__ref: '2'},
+          },
+          '2': {
+            __id: '2',
+            id: '2',
+            __typename: 'User',
+            name: 'Bob',
+          },
+        });
+
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store,
+        });
+
+        const FooQuery = graphql`
+          query RelayReaderResolverTest4Query {
+            me {
+              best_friend_greeting
+            }
+          }
+        `;
+
+        const cb = jest.fn<[Snapshot], void>();
+        const operation = createOperationDescriptor(FooQuery, {});
+        const snapshot = store.lookup(operation.fragment);
+        const subscription = store.subscribe(snapshot, cb);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = snapshot.data;
+        expect(me.best_friend_greeting).toEqual('Hello, Bob!');
+        environment.commitUpdate(theStore => {
+          const bob = nullthrows(theStore.get('2'));
+          bob.setValue('Bilbo', 'name');
+        });
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              me: expect.objectContaining({
+                best_friend_greeting: 'Hello, Bilbo!',
+              }),
             }),
           }),
-        }),
-      );
-      const newSnapshot = store.lookup(operation.fragment);
-      // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-      const {me: newMe}: any = newSnapshot.data;
-      expect(newMe.greeting).toEqual(expectedGreeting);
-    };
+        );
+        const newSnapshot = store.lookup(operation.fragment);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me: newMe}: any = newSnapshot.data;
+        expect(newMe.best_friend_greeting).toEqual('Hello, Bilbo!');
+        subscription.dispose();
+      });
 
-    update.dispose();
-    checkUpdate(1, 'Hello, Alice!');
-    subscription.dispose();
-  });
+      it('re-computes when a resolver uses another resolver', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
 
-  it('re-computes when something other than its own record is updated', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-        'friends(first:1)': {__ref: 'client:1'},
-      },
-      'client:1': {
-        __id: 'client:1',
-        __typename: 'FriendsConnection',
-        edges: {
-          __refs: ['client:2'],
-        },
-      },
-      'client:2': {
-        __id: 'client:2',
-        __typename: 'FriendsConnectionEdge',
-        cursor: 'cursor:2',
-        node: {__ref: '2'},
-      },
-      '2': {
-        __id: '2',
-        id: '2',
-        __typename: 'User',
-        name: 'Bob',
-      },
-    });
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store,
+        });
 
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store,
-    });
+        const FooQuery = graphql`
+          query RelayReaderResolverTest5Query {
+            me {
+              shouted_greeting
+            }
+          }
+        `;
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest4Query {
-        me {
-          best_friend_greeting
-        }
-      }
-    `;
-
-    const cb = jest.fn<[Snapshot], void>();
-    const operation = createOperationDescriptor(FooQuery, {});
-    const snapshot = store.lookup(operation.fragment);
-    const subscription = store.subscribe(snapshot, cb);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = snapshot.data;
-    expect(me.best_friend_greeting).toEqual('Hello, Bob!');
-    environment.commitUpdate(theStore => {
-      const bob = nullthrows(theStore.get('2'));
-      bob.setValue('Bilbo', 'name');
-    });
-    expect(cb).toHaveBeenCalledTimes(1);
-    expect(cb).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          me: expect.objectContaining({
-            best_friend_greeting: 'Hello, Bilbo!',
+        const cb = jest.fn<[Snapshot], void>();
+        const operation = createOperationDescriptor(FooQuery, {});
+        const snapshot = store.lookup(operation.fragment);
+        const subscription = store.subscribe(snapshot, cb);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = snapshot.data;
+        expect(me.shouted_greeting).toEqual('HELLO, ALICE!');
+        environment.commitUpdate(theStore => {
+          const alice = nullthrows(theStore.get('1'));
+          alice.setValue('Alicia', 'name');
+        });
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              me: expect.objectContaining({
+                shouted_greeting: 'HELLO, ALICIA!',
+              }),
+            }),
           }),
-        }),
-      }),
-    );
-    const newSnapshot = store.lookup(operation.fragment);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me: newMe}: any = newSnapshot.data;
-    expect(newMe.best_friend_greeting).toEqual('Hello, Bilbo!');
-    subscription.dispose();
-  });
+        );
+        subscription.dispose();
+      });
 
-  it('re-computes when a resolver uses another resolver', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
+      it('re-computes when a resolver uses another resolver of another record', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+            'friends(first:1)': {__ref: 'client:1'},
+          },
+          'client:1': {
+            __id: 'client:1',
+            __typename: 'FriendsConnection',
+            edges: {
+              __refs: ['client:2'],
+            },
+          },
+          'client:2': {
+            __id: 'client:2',
+            __typename: 'FriendsConnectionEdge',
+            cursor: 'cursor:2',
+            node: {__ref: '2'},
+          },
+          '2': {
+            __id: '2',
+            id: '2',
+            __typename: 'User',
+            name: 'Bob',
+          },
+        });
 
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store,
-    });
+        const store = new RelayStore(source, {gcReleaseBufferSize: 0});
+        const environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(jest.fn()),
+          store,
+        });
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest5Query {
-        me {
-          shouted_greeting
-        }
-      }
-    `;
+        const FooQuery = graphql`
+          query RelayReaderResolverTest6Query {
+            me {
+              best_friend_shouted_greeting
+            }
+          }
+        `;
 
-    const cb = jest.fn<[Snapshot], void>();
-    const operation = createOperationDescriptor(FooQuery, {});
-    const snapshot = store.lookup(operation.fragment);
-    const subscription = store.subscribe(snapshot, cb);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = snapshot.data;
-    expect(me.shouted_greeting).toEqual('HELLO, ALICE!');
-    environment.commitUpdate(theStore => {
-      const alice = nullthrows(theStore.get('1'));
-      alice.setValue('Alicia', 'name');
-    });
-    expect(cb).toHaveBeenCalledTimes(1);
-    expect(cb).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          me: expect.objectContaining({
-            shouted_greeting: 'HELLO, ALICIA!',
+        const cb = jest.fn<[Snapshot], void>();
+        const operation = createOperationDescriptor(FooQuery, {});
+        const snapshot = store.lookup(operation.fragment);
+        const subscription = store.subscribe(snapshot, cb);
+        // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = snapshot.data;
+        expect(me.best_friend_shouted_greeting).toEqual('HELLO, BOB!');
+        environment.commitUpdate(updateStore => {
+          const bob = nullthrows(updateStore.get('2'));
+          bob.setValue('Bilbo', 'name');
+        });
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              me: expect.objectContaining({
+                best_friend_shouted_greeting: 'HELLO, BILBO!',
+              }),
+            }),
           }),
-        }),
-      }),
-    );
-    subscription.dispose();
-  });
+        );
+        subscription.dispose();
+      });
 
-  it('re-computes when a resolver uses another resolver of another record', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-        'friends(first:1)': {__ref: 'client:1'},
-      },
-      'client:1': {
-        __id: 'client:1',
-        __typename: 'FriendsConnection',
-        edges: {
-          __refs: ['client:2'],
-        },
-      },
-      'client:2': {
-        __id: 'client:2',
-        __typename: 'FriendsConnectionEdge',
-        cursor: 'cursor:2',
-        node: {__ref: '2'},
-      },
-      '2': {
-        __id: '2',
-        id: '2',
-        __typename: 'User',
-        name: 'Bob',
-      },
-    });
+      it('errors if the ENABLE_RELAY_RESOLVERS feature flag is not enabled', () => {
+        RelayFeatureFlags.ENABLE_RELAY_RESOLVERS = false;
 
-    const store = new RelayStore(source, {gcReleaseBufferSize: 0});
-    const environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(jest.fn()),
-      store,
-    });
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+        });
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest6Query {
-        me {
-          best_friend_shouted_greeting
-        }
-      }
-    `;
+        const FooQuery = graphql`
+          query RelayReaderResolverTest7Query {
+            me {
+              greeting
+            }
+          }
+        `;
 
-    const cb = jest.fn<[Snapshot], void>();
-    const operation = createOperationDescriptor(FooQuery, {});
-    const snapshot = store.lookup(operation.fragment);
-    const subscription = store.subscribe(snapshot, cb);
-    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = snapshot.data;
-    expect(me.best_friend_shouted_greeting).toEqual('HELLO, BOB!');
-    environment.commitUpdate(updateStore => {
-      const bob = nullthrows(updateStore.get('2'));
-      bob.setValue('Bilbo', 'name');
-    });
-    expect(cb).toHaveBeenCalledTimes(1);
-    expect(cb).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          me: expect.objectContaining({
-            best_friend_shouted_greeting: 'HELLO, BILBO!',
-          }),
-        }),
-      }),
-    );
-    subscription.dispose();
-  });
+        const operation = createOperationDescriptor(FooQuery, {});
 
-  it('errors if the ENABLE_RELAY_RESOLVERS feature flag is not enabled', () => {
-    RelayFeatureFlags.ENABLE_RELAY_RESOLVERS = false;
+        expect(() => {
+          read(source, operation.fragment);
+        }).toThrowErrorMatchingInlineSnapshot(
+          '"Relay Resolver fields are not yet supported."',
+        );
+      });
 
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: 'Alice',
-      },
-    });
+      it('Bubbles null when @required', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            name: null,
+          },
+        });
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest7Query {
-        me {
-          greeting
-        }
-      }
-    `;
+        const FooQuery = graphql`
+          query RelayReaderResolverTest8Query {
+            me {
+              name_passthrough @required(action: NONE)
+            }
+          }
+        `;
 
-    const operation = createOperationDescriptor(FooQuery, {});
+        const resolverCache = new ResolverCache(() => source);
 
-    expect(() => {
-      read(source, operation.fragment);
-    }).toThrowErrorMatchingInlineSnapshot(
-      '"Relay Resolver fields are not yet supported."',
-    );
-  });
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
 
-  it('Bubbles null when @required', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        name: null,
-      },
-    });
+        const {data} = read(source, operation.fragment, resolverCache);
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest8Query {
-        me {
-          name_passthrough @required(action: NONE)
-        }
-      }
-    `;
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {me}: any = data;
+        expect(me).toBe(null); // Resolver result
+      });
 
-    const resolverCache = new ResolverCache(() => source);
+      it('Returns null and includes errors when the resolver throws', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+          },
+        });
 
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const FooQuery = graphql`
+          query RelayReaderResolverTest12Query {
+            me {
+              always_throws
+            }
+          }
+        `;
 
-    const {data} = read(source, operation.fragment, resolverCache);
+        const resolverCache = new ResolverCache(() => source);
 
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {me}: any = data;
-    expect(me).toBe(null); // Resolver result
-  });
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
 
-  it('Returns null and includes errors when the resolver throws', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-      },
-    });
+        const {data, relayResolverErrors} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest12Query {
-        me {
-          always_throws
-        }
-      }
-    `;
-
-    const resolverCache = new ResolverCache(() => source);
-
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
-
-    const {data, relayResolverErrors} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-
-    expect(data).toEqual({me: {always_throws: null}}); // Resolver result
-    expect(relayResolverErrors).toMatchInlineSnapshot(`
+        expect(data).toEqual({me: {always_throws: null}}); // Resolver result
+        expect(relayResolverErrors).toMatchInlineSnapshot(`
       Array [
         Object {
           "error": [Error: I always throw. What did you expect?],
@@ -1009,15 +1015,15 @@ describe.each([
       ]
     `);
 
-    // Subsequent read should also read the same error/path
-    const {data: data2, relayResolverErrors: relayResolverErrors2} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
+        // Subsequent read should also read the same error/path
+        const {data: data2, relayResolverErrors: relayResolverErrors2} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
 
-    expect(data2).toEqual({me: {always_throws: null}}); // Resolver result
-    expect(relayResolverErrors2).toMatchInlineSnapshot(`
+        expect(data2).toEqual({me: {always_throws: null}}); // Resolver result
+        expect(relayResolverErrors2).toMatchInlineSnapshot(`
       Array [
         Object {
           "error": [Error: I always throw. What did you expect?],
@@ -1028,42 +1034,42 @@ describe.each([
         },
       ]
     `);
-  });
+      });
 
-  it('Returns null and includes errors when a transitive resolver throws', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-      },
-    });
+      it('Returns null and includes errors when a transitive resolver throws', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+          },
+        });
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest13Query {
-        me {
-          always_throws_transitively
-        }
-      }
-    `;
+        const FooQuery = graphql`
+          query RelayReaderResolverTest13Query {
+            me {
+              always_throws_transitively
+            }
+          }
+        `;
 
-    const resolverCache = new ResolverCache(() => source);
+        const resolverCache = new ResolverCache(() => source);
 
-    const operation = createOperationDescriptor(FooQuery, {id: '1'});
+        const operation = createOperationDescriptor(FooQuery, {id: '1'});
 
-    const {data, relayResolverErrors} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
+        const {data, relayResolverErrors} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
 
-    expect(data).toEqual({me: {always_throws_transitively: null}}); // Resolver result
-    expect(relayResolverErrors).toMatchInlineSnapshot(`
+        expect(data).toEqual({me: {always_throws_transitively: null}}); // Resolver result
+        expect(relayResolverErrors).toMatchInlineSnapshot(`
       Array [
         Object {
           "error": [Error: I always throw. What did you expect?],
@@ -1075,15 +1081,15 @@ describe.each([
       ]
     `);
 
-    // Subsequent read should also read the same error/path
-    const {data: data2, relayResolverErrors: relayResolverErrors2} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
+        // Subsequent read should also read the same error/path
+        const {data: data2, relayResolverErrors: relayResolverErrors2} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
 
-    expect(data2).toEqual({me: {always_throws_transitively: null}}); // Resolver result
-    expect(relayResolverErrors2).toMatchInlineSnapshot(`
+        expect(data2).toEqual({me: {always_throws_transitively: null}}); // Resolver result
+        expect(relayResolverErrors2).toMatchInlineSnapshot(`
       Array [
         Object {
           "error": [Error: I always throw. What did you expect?],
@@ -1094,35 +1100,35 @@ describe.each([
         },
       ]
     `);
-  });
+      });
 
-  it('Catches errors thrown before calling readFragment', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-      },
-    });
+      it('Catches errors thrown before calling readFragment', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+          },
+        });
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest14Query {
-        # A special resolver that triggers this edge case.
-        throw_before_read
-      }
-    `;
+        const FooQuery = graphql`
+          query RelayReaderResolverTest14Query {
+            # A special resolver that triggers this edge case.
+            throw_before_read
+          }
+        `;
 
-    const resolverCache = new ResolverCache(() => source);
+        const resolverCache = new ResolverCache(() => source);
 
-    const operation = createOperationDescriptor(FooQuery, {});
+        const operation = createOperationDescriptor(FooQuery, {});
 
-    const {data, relayResolverErrors} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
+        const {data, relayResolverErrors} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
 
-    expect(data).toEqual({throw_before_read: null}); // Resolver result
-    expect(relayResolverErrors).toMatchInlineSnapshot(`
+        expect(data).toEqual({throw_before_read: null}); // Resolver result
+        expect(relayResolverErrors).toMatchInlineSnapshot(`
       Array [
         Object {
           "error": [Error: Purposefully throwing before reading to exercise an edge case.],
@@ -1133,452 +1139,470 @@ describe.each([
         },
       ]
     `);
-  });
+      });
 
-  it('can return `undefined` without reporting missing data', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-      },
-    });
-    const resolverCache = new ResolverCache(() => source);
+      it('can return `undefined` without reporting missing data', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+          },
+        });
+        const resolverCache = new ResolverCache(() => source);
 
-    const FooQuery = graphql`
-      query RelayReaderResolverTest15Query {
-        undefined_field
-      }
-    `;
-
-    const operation = createOperationDescriptor(FooQuery, {});
-
-    const {data, isMissingData} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-
-    expect(isMissingData).toBe(false);
-
-    // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    const {undefined_field}: any = data;
-    expect(undefined_field).toBe(undefined); // Resolver result
-  });
-
-  it('return value for a field with arguments', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        'profile_picture(scale:1.5)': {__ref: '1:profile_picture(scale:1.5)'},
-      },
-      '1:profile_picture(scale:1.5)': {
-        __id: '1:profile_picture(scale:1.5)',
-        __typename: 'Image',
-        uri: 'http://my-url-1.5',
-      },
-    });
-    const resolverCache = new ResolverCache(() => source);
-
-    const FooQuery = graphql`
-      query RelayReaderResolverTest16Query($scale: Float!) {
-        me {
-          user_profile_picture_uri_with_scale(scale: $scale)
-        }
-      }
-    `;
-
-    const operation = createOperationDescriptor(FooQuery, {
-      scale: 1.5,
-    });
-
-    const {data, isMissingData} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    expect(isMissingData).toBe(false);
-
-    const {
-      me: {user_profile_picture_uri_with_scale}, // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    }: any = data;
-    expect(user_profile_picture_uri_with_scale).toBe('http://my-url-1.5'); // Resolver result
-  });
-
-  it('return value for a field with arguments and default value', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        'profile_picture(scale:1.5)': {__ref: '1:profile_picture(scale:1.5)'},
-      },
-      '1:profile_picture(scale:1.5)': {
-        __id: '1:profile_picture(scale:1.5)',
-        __typename: 'Image',
-        uri: 'http://my-url-1.5',
-      },
-    });
-    const resolverCache = new ResolverCache(() => source);
-
-    const FooQuery = graphql`
-      query RelayReaderResolverTest17Query {
-        me {
-          user_profile_picture_uri_with_scale_and_default_value
-        }
-      }
-    `;
-
-    const operation = createOperationDescriptor(FooQuery, {});
-
-    const {data, isMissingData} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-    expect(isMissingData).toBe(false);
-
-    const {
-      me: {user_profile_picture_uri_with_scale_and_default_value}, // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    }: any = data;
-    expect(user_profile_picture_uri_with_scale_and_default_value).toBe(
-      'http://my-url-1.5',
-    ); // Resolver result
-  });
-
-  it('return value for a field with literal argument', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
-      },
-      '1:profile_picture(scale:2)': {
-        __id: '1:profile_picture(scale:2)',
-        __typename: 'Image',
-        uri: 'http://my-url-2',
-      },
-    });
-    const resolverCache = new ResolverCache(() => source);
-
-    const FooQuery = graphql`
-      query RelayReaderResolverTest18Query {
-        me {
-          profile_picture2: user_profile_picture_uri_with_scale_and_default_value(
-            scale: 2
-          )
-        }
-      }
-    `;
-
-    const operation = createOperationDescriptor(FooQuery, {});
-
-    const {data, isMissingData} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-
-    expect(isMissingData).toBe(false);
-
-    const {
-      me: {profile_picture2}, // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    }: any = data;
-    expect(profile_picture2).toBe('http://my-url-2'); // Resolver result
-  });
-
-  it('return value for a field with literal argument and variable', () => {
-    const source = RelayRecordSource.create({
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
-      '1': {
-        __id: '1',
-        id: '1',
-        __typename: 'User',
-        'profile_picture(scale:1.5)': {__ref: '1:profile_picture(scale:1.5)'},
-        'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
-      },
-      '1:profile_picture(scale:2)': {
-        __id: '1:profile_picture(scale:2)',
-        __typename: 'Image',
-        uri: 'http://my-url-2',
-      },
-      '1:profile_picture(scale:1.5)': {
-        __id: '1:profile_picture(scale:1.5)',
-        __typename: 'Image',
-        uri: 'http://my-url-1.5',
-      },
-    });
-    const resolverCache = new ResolverCache(() => source);
-
-    const FooQuery = graphql`
-      query RelayReaderResolverTest19Query($scale: Float) {
-        me {
-          profile_picture2: user_profile_picture_uri_with_scale_and_default_value(
-            scale: 2
-          )
-          big_profile_picture: profile_picture(scale: $scale) {
-            uri
+        const FooQuery = graphql`
+          query RelayReaderResolverTest15Query {
+            undefined_field
           }
-        }
-      }
-    `;
+        `;
 
-    const operation = createOperationDescriptor(FooQuery, {
-      scale: 1.5,
+        const operation = createOperationDescriptor(FooQuery, {});
+
+        const {data, isMissingData} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+
+        expect(isMissingData).toBe(false);
+
+        // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        const {undefined_field}: any = data;
+        expect(undefined_field).toBe(undefined); // Resolver result
+      });
+
+      it('return value for a field with arguments', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            'profile_picture(scale:1.5)': {
+              __ref: '1:profile_picture(scale:1.5)',
+            },
+          },
+          '1:profile_picture(scale:1.5)': {
+            __id: '1:profile_picture(scale:1.5)',
+            __typename: 'Image',
+            uri: 'http://my-url-1.5',
+          },
+        });
+        const resolverCache = new ResolverCache(() => source);
+
+        const FooQuery = graphql`
+          query RelayReaderResolverTest16Query($scale: Float!) {
+            me {
+              user_profile_picture_uri_with_scale(scale: $scale)
+            }
+          }
+        `;
+
+        const operation = createOperationDescriptor(FooQuery, {
+          scale: 1.5,
+        });
+
+        const {data, isMissingData} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        expect(isMissingData).toBe(false);
+
+        const {
+          me: {user_profile_picture_uri_with_scale}, // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        }: any = data;
+        expect(user_profile_picture_uri_with_scale).toBe('http://my-url-1.5'); // Resolver result
+      });
+
+      it('return value for a field with arguments and default value', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            'profile_picture(scale:1.5)': {
+              __ref: '1:profile_picture(scale:1.5)',
+            },
+          },
+          '1:profile_picture(scale:1.5)': {
+            __id: '1:profile_picture(scale:1.5)',
+            __typename: 'Image',
+            uri: 'http://my-url-1.5',
+          },
+        });
+        const resolverCache = new ResolverCache(() => source);
+
+        const FooQuery = graphql`
+          query RelayReaderResolverTest17Query {
+            me {
+              user_profile_picture_uri_with_scale_and_default_value
+            }
+          }
+        `;
+
+        const operation = createOperationDescriptor(FooQuery, {});
+
+        const {data, isMissingData} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+        expect(isMissingData).toBe(false);
+
+        const {
+          me: {user_profile_picture_uri_with_scale_and_default_value}, // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        }: any = data;
+        expect(user_profile_picture_uri_with_scale_and_default_value).toBe(
+          'http://my-url-1.5',
+        ); // Resolver result
+      });
+
+      it('return value for a field with literal argument', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
+          },
+          '1:profile_picture(scale:2)': {
+            __id: '1:profile_picture(scale:2)',
+            __typename: 'Image',
+            uri: 'http://my-url-2',
+          },
+        });
+        const resolverCache = new ResolverCache(() => source);
+
+        const FooQuery = graphql`
+          query RelayReaderResolverTest18Query {
+            me {
+              profile_picture2: user_profile_picture_uri_with_scale_and_default_value(
+                scale: 2
+              )
+            }
+          }
+        `;
+
+        const operation = createOperationDescriptor(FooQuery, {});
+
+        const {data, isMissingData} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+
+        expect(isMissingData).toBe(false);
+
+        const {
+          me: {profile_picture2}, // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        }: any = data;
+        expect(profile_picture2).toBe('http://my-url-2'); // Resolver result
+      });
+
+      it('return value for a field with literal argument and variable', () => {
+        const source = RelayRecordSource.create({
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            me: {__ref: '1'},
+          },
+          '1': {
+            __id: '1',
+            id: '1',
+            __typename: 'User',
+            'profile_picture(scale:1.5)': {
+              __ref: '1:profile_picture(scale:1.5)',
+            },
+            'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
+          },
+          '1:profile_picture(scale:2)': {
+            __id: '1:profile_picture(scale:2)',
+            __typename: 'Image',
+            uri: 'http://my-url-2',
+          },
+          '1:profile_picture(scale:1.5)': {
+            __id: '1:profile_picture(scale:1.5)',
+            __typename: 'Image',
+            uri: 'http://my-url-1.5',
+          },
+        });
+        const resolverCache = new ResolverCache(() => source);
+
+        const FooQuery = graphql`
+          query RelayReaderResolverTest19Query($scale: Float) {
+            me {
+              profile_picture2: user_profile_picture_uri_with_scale_and_default_value(
+                scale: 2
+              )
+              big_profile_picture: profile_picture(scale: $scale) {
+                uri
+              }
+            }
+          }
+        `;
+
+        const operation = createOperationDescriptor(FooQuery, {
+          scale: 1.5,
+        });
+
+        const {data, isMissingData} = read(
+          source,
+          operation.fragment,
+          resolverCache,
+        );
+
+        expect(isMissingData).toBe(false);
+
+        const {
+          me: {profile_picture2, big_profile_picture}, // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
+        }: any = data;
+        expect(profile_picture2).toBe('http://my-url-2'); // Resolver result
+        expect(big_profile_picture).toEqual({
+          uri: 'http://my-url-1.5',
+        });
+      });
+
+      describe('Test arguments and their changes', () => {
+        it('should render resolver field and handle change of arguments', () => {
+          const Query = graphql`
+            query RelayReaderResolverTest20Query($scale: Float!) {
+              me {
+                profile_picture: user_profile_picture_uri_with_scale(
+                  scale: $scale
+                )
+              }
+            }
+          `;
+          const source = RelayRecordSource.create({
+            'client:root': {
+              __id: 'client:root',
+              __typename: '__Root',
+              me: {__ref: '1'},
+            },
+            '1': {
+              __id: '1',
+              id: '1',
+              __typename: 'User',
+              'profile_picture(scale:1.5)': {
+                __ref: '1:profile_picture(scale:1.5)',
+              },
+              'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
+            },
+            '1:profile_picture(scale:1.5)': {
+              __id: '1:profile_picture(scale:1.5)',
+              __typename: 'Image',
+              uri: 'http://my-url-1.5',
+            },
+            '1:profile_picture(scale:2)': {
+              __id: '1:profile_picture(scale:2)',
+              __typename: 'Image',
+              uri: 'http://my-url-2',
+            },
+          });
+          const resolverCache = new ResolverCache(() => source);
+
+          let operation = createOperationDescriptor(Query, {scale: 1.5});
+          let readResult = read(source, operation.fragment, resolverCache);
+          expect(readResult.isMissingData).toBe(false);
+          expect(readResult.data).toEqual({
+            me: {
+              profile_picture: 'http://my-url-1.5',
+            },
+          });
+
+          operation = createOperationDescriptor(Query, {scale: 2});
+          readResult = read(source, operation.fragment, resolverCache);
+          expect(readResult.isMissingData).toBe(false);
+          expect(readResult.data).toEqual({
+            me: {
+              profile_picture: 'http://my-url-2',
+            },
+          });
+        });
+
+        it('should render resolver field and handle change of arguments and missing data', () => {
+          const Query = graphql`
+            query RelayReaderResolverTest21Query($scale: Float!) {
+              me {
+                profile_picture: user_profile_picture_uri_with_scale(
+                  scale: $scale
+                )
+              }
+            }
+          `;
+          const source = RelayRecordSource.create({
+            'client:root': {
+              __id: 'client:root',
+              __typename: '__Root',
+              me: {__ref: '1'},
+            },
+            '1': {
+              __id: '1',
+              id: '1',
+              __typename: 'User',
+              'profile_picture(scale:1.5)': {
+                __ref: '1:profile_picture(scale:1.5)',
+              },
+              'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
+            },
+            '1:profile_picture(scale:1.5)': {
+              __id: '1:profile_picture(scale:1.5)',
+              __typename: 'Image',
+              uri: 'http://my-url-1.5',
+            },
+            '1:profile_picture(scale:2)': {
+              __id: '1:profile_picture(scale:2)',
+              __typename: 'Image',
+              // uri: 'http://my-url-2', this field now is missing
+            },
+          });
+          const resolverCache = new ResolverCache(() => source);
+
+          let operation = createOperationDescriptor(Query, {scale: 1.5});
+          let readResult = read(source, operation.fragment, resolverCache);
+          expect(readResult.isMissingData).toBe(false);
+          expect(readResult.data).toEqual({
+            me: {
+              profile_picture: 'http://my-url-1.5',
+            },
+          });
+
+          operation = createOperationDescriptor(Query, {scale: 2});
+          readResult = read(source, operation.fragment, resolverCache);
+          expect(readResult.isMissingData).toBe(true);
+          expect(readResult.data).toEqual({
+            me: {
+              profile_picture: undefined,
+            },
+          });
+        });
+
+        it('should render resolver field and handle change of fragment and runtime arguments', () => {
+          const Query = graphql`
+            query RelayReaderResolverTest22Query(
+              $scale: Float!
+              $name: String
+            ) {
+              me {
+                profile_picture: user_profile_picture_uri_with_scale_and_additional_argument(
+                  scale: $scale
+                  name: $name
+                )
+              }
+            }
+          `;
+          const source = RelayRecordSource.create({
+            'client:root': {
+              __id: 'client:root',
+              __typename: '__Root',
+              me: {__ref: '1'},
+            },
+            '1': {
+              __id: '1',
+              id: '1',
+              __typename: 'User',
+              'profile_picture(scale:1.5)': {
+                __ref: '1:profile_picture(scale:1.5)',
+              },
+              'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
+            },
+            '1:profile_picture(scale:1.5)': {
+              __id: '1:profile_picture(scale:1.5)',
+              __typename: 'Image',
+              uri: 'http://my-url-1.5',
+            },
+            '1:profile_picture(scale:2)': {
+              __id: '1:profile_picture(scale:2)',
+              __typename: 'Image',
+              uri: 'http://my-url-2',
+            },
+          });
+
+          const resolverCache = new ResolverCache(() => source);
+
+          let operation = createOperationDescriptor(Query, {
+            scale: 1.5,
+            name: 'Alice',
+          });
+          let readResult = read(source, operation.fragment, resolverCache);
+          expect(readResult.isMissingData).toBe(false);
+          expect(readResult.data).toEqual({
+            me: {
+              profile_picture: 'Alice: http://my-url-1.5',
+            },
+          });
+          // Changing runtime (field) arg
+          operation = createOperationDescriptor(Query, {
+            scale: 1.5,
+            name: 'Bob',
+          });
+          readResult = read(source, operation.fragment, resolverCache);
+          expect(readResult.isMissingData).toBe(false);
+          expect(readResult.data).toEqual({
+            me: {
+              profile_picture: 'Bob: http://my-url-1.5',
+            },
+          });
+          // Changing fragment arg
+          operation = createOperationDescriptor(Query, {scale: 2, name: 'Bob'});
+          readResult = read(source, operation.fragment, resolverCache);
+          expect(readResult.isMissingData).toBe(false);
+          expect(readResult.data).toEqual({
+            me: {
+              profile_picture: 'Bob: http://my-url-2',
+            },
+          });
+
+          // Changing both arguments
+          operation = createOperationDescriptor(Query, {
+            scale: 1.5,
+            name: 'Clair',
+          });
+          readResult = read(source, operation.fragment, resolverCache);
+          expect(readResult.isMissingData).toBe(false);
+          expect(readResult.data).toEqual({
+            me: {
+              profile_picture: 'Clair: http://my-url-1.5',
+            },
+          });
+        });
+      });
     });
 
-    const {data, isMissingData} = read(
-      source,
-      operation.fragment,
-      resolverCache,
-    );
-
-    expect(isMissingData).toBe(false);
-
-    const {
-      me: {profile_picture2, big_profile_picture}, // $FlowFixMe[unclear-type] - read() doesn't have the nice types of reading a fragment through the actual APIs:
-    }: any = data;
-    expect(profile_picture2).toBe('http://my-url-2'); // Resolver result
-    expect(big_profile_picture).toEqual({
-      uri: 'http://my-url-1.5',
-    });
-  });
-
-  describe('Test arguments and their changes', () => {
-    it('should render resolver field and handle change of arguments', () => {
-      const Query = graphql`
-        query RelayReaderResolverTest20Query($scale: Float!) {
+    it('can create a client edge query in our test enviornment that has valid import', () => {
+      // This is not really a runtime test, but more a test to confirm that this query generates
+      // an artifact with valid imports in our non-Haste test environment.
+      const clientEdgeRuntimeArtifact = graphql`
+        query RelayReaderResolverTest24Query {
           me {
-            profile_picture: user_profile_picture_uri_with_scale(scale: $scale)
+            client_edge @waterfall {
+              __typename
+            }
           }
         }
       `;
-      const source = RelayRecordSource.create({
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          me: {__ref: '1'},
-        },
-        '1': {
-          __id: '1',
-          id: '1',
-          __typename: 'User',
-          'profile_picture(scale:1.5)': {
-            __ref: '1:profile_picture(scale:1.5)',
-          },
-          'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
-        },
-        '1:profile_picture(scale:1.5)': {
-          __id: '1:profile_picture(scale:1.5)',
-          __typename: 'Image',
-          uri: 'http://my-url-1.5',
-        },
-        '1:profile_picture(scale:2)': {
-          __id: '1:profile_picture(scale:2)',
-          __typename: 'Image',
-          uri: 'http://my-url-2',
-        },
-      });
-      const resolverCache = new ResolverCache(() => source);
-
-      let operation = createOperationDescriptor(Query, {scale: 1.5});
-      let readResult = read(source, operation.fragment, resolverCache);
-      expect(readResult.isMissingData).toBe(false);
-      expect(readResult.data).toEqual({
-        me: {
-          profile_picture: 'http://my-url-1.5',
-        },
-      });
-
-      operation = createOperationDescriptor(Query, {scale: 2});
-      readResult = read(source, operation.fragment, resolverCache);
-      expect(readResult.isMissingData).toBe(false);
-      expect(readResult.data).toEqual({
-        me: {
-          profile_picture: 'http://my-url-2',
-        },
-      });
+      expect(clientEdgeRuntimeArtifact.operation.name).toBe(
+        'RelayReaderResolverTest24Query',
+      );
     });
-
-    it('should render resolver field and handle change of arguments and missing data', () => {
-      const Query = graphql`
-        query RelayReaderResolverTest21Query($scale: Float!) {
-          me {
-            profile_picture: user_profile_picture_uri_with_scale(scale: $scale)
-          }
-        }
-      `;
-      const source = RelayRecordSource.create({
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          me: {__ref: '1'},
-        },
-        '1': {
-          __id: '1',
-          id: '1',
-          __typename: 'User',
-          'profile_picture(scale:1.5)': {
-            __ref: '1:profile_picture(scale:1.5)',
-          },
-          'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
-        },
-        '1:profile_picture(scale:1.5)': {
-          __id: '1:profile_picture(scale:1.5)',
-          __typename: 'Image',
-          uri: 'http://my-url-1.5',
-        },
-        '1:profile_picture(scale:2)': {
-          __id: '1:profile_picture(scale:2)',
-          __typename: 'Image',
-          // uri: 'http://my-url-2', this field now is missing
-        },
-      });
-      const resolverCache = new ResolverCache(() => source);
-
-      let operation = createOperationDescriptor(Query, {scale: 1.5});
-      let readResult = read(source, operation.fragment, resolverCache);
-      expect(readResult.isMissingData).toBe(false);
-      expect(readResult.data).toEqual({
-        me: {
-          profile_picture: 'http://my-url-1.5',
-        },
-      });
-
-      operation = createOperationDescriptor(Query, {scale: 2});
-      readResult = read(source, operation.fragment, resolverCache);
-      expect(readResult.isMissingData).toBe(true);
-      expect(readResult.data).toEqual({
-        me: {
-          profile_picture: undefined,
-        },
-      });
-    });
-
-    it('should render resolver field and handle change of fragment and runtime arguments', () => {
-      const Query = graphql`
-        query RelayReaderResolverTest22Query($scale: Float!, $name: String) {
-          me {
-            profile_picture: user_profile_picture_uri_with_scale_and_additional_argument(
-              scale: $scale
-              name: $name
-            )
-          }
-        }
-      `;
-      const source = RelayRecordSource.create({
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          me: {__ref: '1'},
-        },
-        '1': {
-          __id: '1',
-          id: '1',
-          __typename: 'User',
-          'profile_picture(scale:1.5)': {
-            __ref: '1:profile_picture(scale:1.5)',
-          },
-          'profile_picture(scale:2)': {__ref: '1:profile_picture(scale:2)'},
-        },
-        '1:profile_picture(scale:1.5)': {
-          __id: '1:profile_picture(scale:1.5)',
-          __typename: 'Image',
-          uri: 'http://my-url-1.5',
-        },
-        '1:profile_picture(scale:2)': {
-          __id: '1:profile_picture(scale:2)',
-          __typename: 'Image',
-          uri: 'http://my-url-2',
-        },
-      });
-
-      const resolverCache = new ResolverCache(() => source);
-
-      let operation = createOperationDescriptor(Query, {
-        scale: 1.5,
-        name: 'Alice',
-      });
-      let readResult = read(source, operation.fragment, resolverCache);
-      expect(readResult.isMissingData).toBe(false);
-      expect(readResult.data).toEqual({
-        me: {
-          profile_picture: 'Alice: http://my-url-1.5',
-        },
-      });
-      // Changing runtime (field) arg
-      operation = createOperationDescriptor(Query, {scale: 1.5, name: 'Bob'});
-      readResult = read(source, operation.fragment, resolverCache);
-      expect(readResult.isMissingData).toBe(false);
-      expect(readResult.data).toEqual({
-        me: {
-          profile_picture: 'Bob: http://my-url-1.5',
-        },
-      });
-      // Changing fragment arg
-      operation = createOperationDescriptor(Query, {scale: 2, name: 'Bob'});
-      readResult = read(source, operation.fragment, resolverCache);
-      expect(readResult.isMissingData).toBe(false);
-      expect(readResult.data).toEqual({
-        me: {
-          profile_picture: 'Bob: http://my-url-2',
-        },
-      });
-
-      // Changing both arguments
-      operation = createOperationDescriptor(Query, {
-        scale: 1.5,
-        name: 'Clair',
-      });
-      readResult = read(source, operation.fragment, resolverCache);
-      expect(readResult.isMissingData).toBe(false);
-      expect(readResult.data).toEqual({
-        me: {
-          profile_picture: 'Clair: http://my-url-1.5',
-        },
-      });
-    });
-  });
-});
-
-it('can create a client edge query in our test enviornment that has valid import', () => {
-  // This is not really a runtime test, but more a test to confirm that this query generates
-  // an artifact with valid imports in our non-Haste test environment.
-  const clientEdgeRuntimeArtifact = graphql`
-    query RelayReaderResolverTest24Query {
-      me {
-        client_edge @waterfall {
-          __typename
-        }
-      }
-    }
-  `;
-  expect(clientEdgeRuntimeArtifact.operation.name).toBe(
-    'RelayReaderResolverTest24Query',
-  );
-});
+  },
+);

--- a/packages/relay-runtime/store/experimental-live-resolvers/LiveResolverCache.js
+++ b/packages/relay-runtime/store/experimental-live-resolvers/LiveResolverCache.js
@@ -642,6 +642,11 @@ class LiveResolverCache implements ResolverCache {
     return RelayModernRecord.getValue(resolverRecord, RELAY_RESOLVER_VALUE_KEY);
   }
 
+  /**
+   * Takes a set of IDs whose records have just changed and are therefore about
+   * to be notified, and mutate the set, adding the IDs of resolvers that are
+   * transitively invalidated by this update.
+   */
   invalidateDataIDs(
     updatedDataIDs: DataIDSet, // Mutated in place
   ): void {
@@ -650,6 +655,10 @@ class LiveResolverCache implements ResolverCache {
     const recordsToVisit = Array.from(updatedDataIDs);
     while (recordsToVisit.length) {
       const recordID = recordsToVisit.pop();
+      if (RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION) {
+        visited.add(recordID);
+      }
+
       // $FlowFixMe[incompatible-call]
       updatedDataIDs.add(recordID);
       // $FlowFixMe[incompatible-call]
@@ -659,6 +668,10 @@ class LiveResolverCache implements ResolverCache {
       }
       for (const fragment of fragmentSet) {
         if (!visited.has(fragment)) {
+          if (RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION) {
+            visited.add(fragment);
+          }
+
           const recordSet = this._resolverIDToRecordIDs.get(fragment);
           if (recordSet == null) {
             continue;
@@ -666,6 +679,9 @@ class LiveResolverCache implements ResolverCache {
           for (const anotherRecordID of recordSet) {
             markInvalidatedResolverRecord(anotherRecordID, recordSource);
             if (!visited.has(anotherRecordID)) {
+              if (RelayFeatureFlags.AVOID_CYCLES_IN_RESOLVER_NOTIFICATION) {
+                visited.add(anotherRecordID);
+              }
               recordsToVisit.push(anotherRecordID);
             }
           }

--- a/packages/relay-runtime/util/RelayFeatureFlags.js
+++ b/packages/relay-runtime/util/RelayFeatureFlags.js
@@ -53,6 +53,11 @@ export type FeatureFlags = {
 
   // Temporary flag to experiment with new useFragmentInternal implementation
   ENABLE_USE_FRAGMENT_EXPERIMENTAL: boolean,
+
+  // Gating a fix to prevent infinite loops when invalidating Relay Resolvers.
+  // We believe the fix to be correct but don't yet have a test to validate it
+  // fixes the error, so we're gating it for now.
+  AVOID_CYCLES_IN_RESOLVER_NOTIFICATION: Boolean,
 };
 
 const RelayFeatureFlags: FeatureFlags = {
@@ -76,6 +81,7 @@ const RelayFeatureFlags: FeatureFlags = {
   MARK_RESOLVER_VALUES_AS_CLEAN_AFTER_FRAGMENT_REREAD: false,
   ENABLE_CYLE_DETECTION_IN_VARIABLES: false,
   ENABLE_USE_FRAGMENT_EXPERIMENTAL: false,
+  AVOID_CYCLES_IN_RESOLVER_NOTIFICATION: false,
 };
 
 module.exports = RelayFeatureFlags;


### PR DESCRIPTION
We have seen a bug internally which appears to be a case where we encounter a cycle in this code and thus an infinite loop. I have yet to figure out how to reproduce that behavior, but it's clear that there is a bug in this code. We maintain a set of visited IDs but then never check that set as you progress.

For now I'm adding what I believe to be a more correct implementation, however I haven't yet been able to reproduce so I'm not 100% sure this will actually fix the issue. Additionally, it's in a sensitive part of the code, so I'm gating it to allow for a gradual rollout and the ability to quickly disable.

## Test Plan

I've ensured the relevant tests validate both paths. During rollout I'll also create Diffs to run e2e tests with the fix enabled.