### PR TITLE
Take advantage of @semanticNonNull within @catch

### DIFF
--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-semantic-non-null-with-catch.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-semantic-non-null-with-catch.expected
@@ -1,0 +1,25 @@
+==================================== INPUT ====================================
+fragment MyFragment on Query {
+  # Should be a Result of a non-nullable since it's semanticNonNull
+  my_user @catch {
+    name
+  }
+}
+
+%extensions%
+
+extend type Query {
+  my_user: User @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs, Result } from "relay-runtime";
+export type MyFragment$data = {
+  readonly my_user: Result<{
+    readonly name: string | null | undefined;
+  }, ReadonlyArray<unknown>>;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-semantic-non-null-with-catch.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/linked-semantic-non-null-with-catch.graphql
@@ -1,0 +1,12 @@
+fragment MyFragment on Query {
+  # Should be a Result of a non-nullable since it's semanticNonNull
+  my_user @catch {
+    name
+  }
+}
+
+%extensions%
+
+extend type Query {
+  my_user: User @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/scalar-semantic-non-null-with-catch.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/scalar-semantic-non-null-with-catch.expected
@@ -1,0 +1,21 @@
+==================================== INPUT ====================================
+fragment MyFragment on Query {
+  # Should be a Result of a non-nullable since it's semanticNonNull
+  my_string @catch
+}
+
+%extensions%
+
+extend type Query {
+  my_string: String @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs, Result } from "relay-runtime";
+export type MyFragment$data = {
+  readonly my_string: Result<string, ReadonlyArray<unknown>>;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/scalar-semantic-non-null-with-catch.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/scalar-semantic-non-null-with-catch.graphql
@@ -1,0 +1,10 @@
+fragment MyFragment on Query {
+  # Should be a Result of a non-nullable since it's semanticNonNull
+  my_string @catch
+}
+
+%extensions%
+
+extend type Query {
+  my_string: String @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic-non-null-deeply-nested-within-catch.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic-non-null-deeply-nested-within-catch.expected
@@ -1,0 +1,33 @@
+==================================== INPUT ====================================
+fragment MyFragment on Query {
+  me @catch(to: NULL) {
+    clientUser {
+      # Should be non-nullable since it's semanticNonNull within a catch
+      name
+    }
+  }
+}
+
+%extensions%
+
+extend type User {
+  clientUser: ClientUser
+}
+
+type ClientUser {
+  name: String @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly me: {
+    readonly clientUser: {
+      readonly name: string;
+    } | null | undefined;
+  } | null | undefined;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic-non-null-deeply-nested-within-catch.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic-non-null-deeply-nested-within-catch.graphql
@@ -1,0 +1,18 @@
+fragment MyFragment on Query {
+  me @catch(to: NULL) {
+    clientUser {
+      # Should be non-nullable since it's semanticNonNull within a catch
+      name
+    }
+  }
+}
+
+%extensions%
+
+extend type User {
+  clientUser: ClientUser
+}
+
+type ClientUser {
+  name: String @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic-non-null-within-catch.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic-non-null-within-catch.expected
@@ -1,0 +1,29 @@
+==================================== INPUT ====================================
+fragment MyFragment on Query {
+  clientUser @catch(to: NULL) {
+    # Should be non-nullable since it's semanticNonNull within a catch
+    name
+  }
+}
+
+%extensions%
+
+extend type Query {
+  clientUser: ClientUser
+}
+
+type ClientUser {
+  name: String @semanticNonNull
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly clientUser: {
+    readonly name: string;
+  } | null | undefined;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic-non-null-within-catch.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/semantic-non-null-within-catch.graphql
@@ -1,0 +1,16 @@
+fragment MyFragment on Query {
+  clientUser @catch(to: NULL) {
+    # Should be non-nullable since it's semanticNonNull within a catch
+    name
+  }
+}
+
+%extensions%
+
+extend type Query {
+  clientUser: ClientUser
+}
+
+type ClientUser {
+  name: String @semanticNonNull
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<40ee37b571f2844f07f55ccb1407a04a>>
+ * @generated SignedSource<<dc6df4bac160f12fe89c63e98c18f01d>>
  */
 
 mod generate_typescript;
@@ -171,6 +171,13 @@ async fn linked_field() {
     let input = include_str!("generate_typescript/fixtures/linked-field.graphql");
     let expected = include_str!("generate_typescript/fixtures/linked-field.expected");
     test_fixture(transform_fixture, file!(), "linked-field.graphql", "generate_typescript/fixtures/linked-field.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn linked_semantic_non_null_with_catch() {
+    let input = include_str!("generate_typescript/fixtures/linked-semantic-non-null-with-catch.graphql");
+    let expected = include_str!("generate_typescript/fixtures/linked-semantic-non-null-with-catch.expected");
+    test_fixture(transform_fixture, file!(), "linked-semantic-non-null-with-catch.graphql", "generate_typescript/fixtures/linked-semantic-non-null-with-catch.expected", input, expected).await;
 }
 
 #[tokio::test]
@@ -468,6 +475,20 @@ async fn scalar_field() {
 }
 
 #[tokio::test]
+async fn scalar_semantic_non_null_with_catch() {
+    let input = include_str!("generate_typescript/fixtures/scalar-semantic-non-null-with-catch.graphql");
+    let expected = include_str!("generate_typescript/fixtures/scalar-semantic-non-null-with-catch.expected");
+    test_fixture(transform_fixture, file!(), "scalar-semantic-non-null-with-catch.graphql", "generate_typescript/fixtures/scalar-semantic-non-null-with-catch.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_deeply_nested_within_catch() {
+    let input = include_str!("generate_typescript/fixtures/semantic-non-null-deeply-nested-within-catch.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic-non-null-deeply-nested-within-catch.expected");
+    test_fixture(transform_fixture, file!(), "semantic-non-null-deeply-nested-within-catch.graphql", "generate_typescript/fixtures/semantic-non-null-deeply-nested-within-catch.expected", input, expected).await;
+}
+
+#[tokio::test]
 async fn semantic_non_null_in_raw_response() {
     let input = include_str!("generate_typescript/fixtures/semantic_non_null_in_raw_response.graphql");
     let expected = include_str!("generate_typescript/fixtures/semantic_non_null_in_raw_response.expected");
@@ -542,6 +563,13 @@ async fn semantic_non_null_scalar_with_catch() {
     let input = include_str!("generate_typescript/fixtures/semantic_non_null_scalar_with_catch.graphql");
     let expected = include_str!("generate_typescript/fixtures/semantic_non_null_scalar_with_catch.expected");
     test_fixture(transform_fixture, file!(), "semantic_non_null_scalar_with_catch.graphql", "generate_typescript/fixtures/semantic_non_null_scalar_with_catch.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn semantic_non_null_within_catch() {
+    let input = include_str!("generate_typescript/fixtures/semantic-non-null-within-catch.graphql");
+    let expected = include_str!("generate_typescript/fixtures/semantic-non-null-within-catch.expected");
+    test_fixture(transform_fixture, file!(), "semantic-non-null-within-catch.graphql", "generate_typescript/fixtures/semantic-non-null-within-catch.expected", input, expected).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
For fields with `@catch(to: RESULT)` and fields nested within any `@catch` we are handling all errors which might have caused a field to become null. This means we can respect semantic non-null in these positions.