### PR TITLE
Unify resolver error type

### DIFF
--- a/packages/react-relay/__tests__/LiveResolvers-test.js
+++ b/packages/react-relay/__tests__/LiveResolvers-test.js
@@ -1709,10 +1709,9 @@ describe.each([true, false])(
       const data = environment.lookup(operation.fragment);
       expect(data.relayResolverErrors).toEqual([
         {
-          field: {
-            owner: 'LiveResolversTest18Query',
-            path: 'live_resolver_throws',
-          },
+          kind: 'relay_resolver.error',
+          owner: 'LiveResolversTest18Query',
+          fieldPath: 'live_resolver_throws',
           error: new Error('What?'),
         },
       ]);

--- a/packages/react-relay/__tests__/RelayResolverNullableModelClientEdge-test.js
+++ b/packages/react-relay/__tests__/RelayResolverNullableModelClientEdge-test.js
@@ -503,10 +503,9 @@ describe.each([true, false])(
       expect(snapshot.relayResolverErrors).toEqual([
         {
           error: Error(ERROR_MESSAGE),
-          field: {
-            owner: 'RelayResolverNullableModelClientEdgeTest_ErrorModel_Query',
-            path: 'edge_to_model_that_throws.__relay_model_instance',
-          },
+          kind: 'relay_resolver.error',
+          owner: 'RelayResolverNullableModelClientEdgeTest_ErrorModel_Query',
+          fieldPath: 'edge_to_model_that_throws.__relay_model_instance',
         },
       ]);
       const data: $FlowExpectedError = snapshot.data;
@@ -528,19 +527,17 @@ describe.each([true, false])(
       expect(snapshot.relayResolverErrors).toEqual([
         {
           error: Error(ERROR_MESSAGE),
-          field: {
-            owner:
-              'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
-            path: 'edge_to_plural_models_that_throw.__relay_model_instance',
-          },
+          kind: 'relay_resolver.error',
+          owner:
+            'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
+          fieldPath: 'edge_to_plural_models_that_throw.__relay_model_instance',
         },
         {
           error: Error(ERROR_MESSAGE),
-          field: {
-            owner:
-              'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
-            path: 'edge_to_plural_models_that_throw.__relay_model_instance',
-          },
+          kind: 'relay_resolver.error',
+          owner:
+            'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
+          fieldPath: 'edge_to_plural_models_that_throw.__relay_model_instance',
         },
       ]);
       const data: $FlowExpectedError = snapshot.data;
@@ -562,11 +559,10 @@ describe.each([true, false])(
       expect(snapshot.relayResolverErrors).toEqual([
         {
           error: Error(ERROR_MESSAGE),
-          field: {
-            owner:
-              'RelayResolverNullableModelClientEdgeTest_PluralSomeErrorModel_Query',
-            path: 'edge_to_plural_models_some_throw.__relay_model_instance',
-          },
+          kind: 'relay_resolver.error',
+          owner:
+            'RelayResolverNullableModelClientEdgeTest_PluralSomeErrorModel_Query',
+          fieldPath: 'edge_to_plural_models_some_throw.__relay_model_instance',
         },
       ]);
       const data: $FlowExpectedError = snapshot.data;

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -355,7 +355,7 @@ class RelayReader {
       for (let i = 0; i < this._resolverErrors.length; i++) {
         const resolverError = this._resolverErrors[i];
         errors.push({
-          message: `Relay: Error in resolver for field at ${resolverError.field.path} in ${resolverError.field.owner}`,
+          message: `Relay: Error in resolver for field at ${resolverError.fieldPath} in ${resolverError.owner}`,
         });
       }
     }
@@ -776,7 +776,9 @@ class RelayReader {
     // to be logged.
     if (resolverError) {
       this._resolverErrors.push({
-        field: {path: fieldPath, owner: this._fragmentName},
+        kind: 'relay_resolver.error',
+        fieldPath,
+        owner: this._fragmentName,
         error: resolverError,
       });
     }

--- a/packages/relay-runtime/store/__tests__/RelayReader-Resolver-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-Resolver-test.js
@@ -1007,10 +1007,9 @@ describe.each([true, false])(
       Array [
         Object {
           "error": [Error: I always throw. What did you expect?],
-          "field": Object {
-            "owner": "RelayReaderResolverTest12Query",
-            "path": "me.always_throws",
-          },
+          "fieldPath": "me.always_throws",
+          "kind": "relay_resolver.error",
+          "owner": "RelayReaderResolverTest12Query",
         },
       ]
     `);
@@ -1027,10 +1026,9 @@ describe.each([true, false])(
       Array [
         Object {
           "error": [Error: I always throw. What did you expect?],
-          "field": Object {
-            "owner": "RelayReaderResolverTest12Query",
-            "path": "me.always_throws",
-          },
+          "fieldPath": "me.always_throws",
+          "kind": "relay_resolver.error",
+          "owner": "RelayReaderResolverTest12Query",
         },
       ]
     `);
@@ -1073,10 +1071,9 @@ describe.each([true, false])(
       Array [
         Object {
           "error": [Error: I always throw. What did you expect?],
-          "field": Object {
-            "owner": "UserAlwaysThrowsTransitivelyResolver",
-            "path": "always_throws",
-          },
+          "fieldPath": "always_throws",
+          "kind": "relay_resolver.error",
+          "owner": "UserAlwaysThrowsTransitivelyResolver",
         },
       ]
     `);
@@ -1093,10 +1090,9 @@ describe.each([true, false])(
       Array [
         Object {
           "error": [Error: I always throw. What did you expect?],
-          "field": Object {
-            "owner": "UserAlwaysThrowsTransitivelyResolver",
-            "path": "always_throws",
-          },
+          "fieldPath": "always_throws",
+          "kind": "relay_resolver.error",
+          "owner": "UserAlwaysThrowsTransitivelyResolver",
         },
       ]
     `);
@@ -1132,10 +1128,9 @@ describe.each([true, false])(
       Array [
         Object {
           "error": [Error: Purposefully throwing before reading to exercise an edge case.],
-          "field": Object {
-            "owner": "RelayReaderResolverTest14Query",
-            "path": "throw_before_read",
-          },
+          "fieldPath": "throw_before_read",
+          "kind": "relay_resolver.error",
+          "owner": "RelayReaderResolverTest14Query",
         },
       ]
     `);

--- a/packages/relay-runtime/store/__tests__/resolvers/LiveResolvers-test.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/LiveResolvers-test.js
@@ -263,11 +263,10 @@ test('Errors thrown during _initial_ read() are caught as resolver errors', () =
   const snapshot = environment.lookup(operation.fragment);
   expect(snapshot.relayResolverErrors).toEqual([
     {
+      kind: 'relay_resolver.error',
       error: Error('What?'),
-      field: {
-        owner: 'LiveResolversTestHandlesErrorOnReadQuery',
-        path: 'counter_throws_when_odd',
-      },
+      owner: 'LiveResolversTestHandlesErrorOnReadQuery',
+      fieldPath: 'counter_throws_when_odd',
     },
   ]);
   const data: $FlowExpectedError = snapshot.data;
@@ -316,11 +315,10 @@ test('Errors thrown during read() _after update_ are caught as resolver errors',
 
   expect(nextSnapshot.relayResolverErrors).toEqual([
     {
+      kind: 'relay_resolver.error',
       error: Error('What?'),
-      field: {
-        owner: 'LiveResolversTestHandlesErrorOnUpdateQuery',
-        path: 'counter_throws_when_odd',
-      },
+      owner: 'LiveResolversTestHandlesErrorOnUpdateQuery',
+      fieldPath: 'counter_throws_when_odd',
     },
   ]);
   const nextData: $FlowExpectedError = nextSnapshot.data;

--- a/packages/relay-runtime/util/__tests__/handlePotentialSnapshotErrors-test.js
+++ b/packages/relay-runtime/util/__tests__/handlePotentialSnapshotErrors-test.js
@@ -417,7 +417,9 @@ describe('handlePotentialSnapshotErrors', () => {
         null,
         [
           {
-            field: {owner: 'testOwner', path: 'testPath'},
+            kind: 'relay_resolver.error',
+            fieldPath: 'testPath',
+            owner: 'testOwner',
             error: Error('testError'),
           },
         ],
@@ -441,7 +443,9 @@ describe('handlePotentialSnapshotErrors', () => {
           null,
           [
             {
-              field: {owner: 'testOwner', path: 'testPath'},
+              kind: 'relay_resolver.error',
+              fieldPath: 'testPath',
+              owner: 'testOwner',
               error: Error('testError'),
             },
           ],

--- a/packages/relay-runtime/util/handlePotentialSnapshotErrors.js
+++ b/packages/relay-runtime/util/handlePotentialSnapshotErrors.js
@@ -27,12 +27,7 @@ function handleResolverErrors(
   throwOnFieldError: boolean,
 ) {
   for (const resolverError of relayResolverErrors) {
-    environment.relayFieldLogger({
-      kind: 'relay_resolver.error',
-      owner: resolverError.field.owner,
-      fieldPath: resolverError.field.path,
-      error: resolverError.error,
-    });
+    environment.relayFieldLogger(resolverError);
   }
 
   if (


### PR DESCRIPTION
We had two types here, my larger goal is to unify each of these field error types to the point where RelayReader collects up a list of field events and they get passed to the logger (or throw) untransformed.