### PR TITLE
Use field error events on snapshot

### DIFF
--- a/packages/react-relay/__tests__/RelayResolverNullableModelClientEdge-test.js
+++ b/packages/react-relay/__tests__/RelayResolverNullableModelClientEdge-test.js
@@ -503,9 +503,9 @@ describe.each([true, false])(
       expect(snapshot.relayResolverErrors).toEqual([
         {
           error: Error(ERROR_MESSAGE),
-          kind: 'relay_resolver.error',
           owner: 'RelayResolverNullableModelClientEdgeTest_ErrorModel_Query',
           fieldPath: 'edge_to_model_that_throws.__relay_model_instance',
+          kind: 'relay_resolver.error',
         },
       ]);
       const data: $FlowExpectedError = snapshot.data;
@@ -527,17 +527,17 @@ describe.each([true, false])(
       expect(snapshot.relayResolverErrors).toEqual([
         {
           error: Error(ERROR_MESSAGE),
-          kind: 'relay_resolver.error',
           owner:
             'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
           fieldPath: 'edge_to_plural_models_that_throw.__relay_model_instance',
+          kind: 'relay_resolver.error',
         },
         {
           error: Error(ERROR_MESSAGE),
-          kind: 'relay_resolver.error',
           owner:
             'RelayResolverNullableModelClientEdgeTest_PluralErrorModel_Query',
           fieldPath: 'edge_to_plural_models_that_throw.__relay_model_instance',
+          kind: 'relay_resolver.error',
         },
       ]);
       const data: $FlowExpectedError = snapshot.data;
@@ -559,10 +559,10 @@ describe.each([true, false])(
       expect(snapshot.relayResolverErrors).toEqual([
         {
           error: Error(ERROR_MESSAGE),
-          kind: 'relay_resolver.error',
           owner:
             'RelayResolverNullableModelClientEdgeTest_PluralSomeErrorModel_Query',
           fieldPath: 'edge_to_plural_models_some_throw.__relay_model_instance',
+          kind: 'relay_resolver.error',
         },
       ]);
       const data: $FlowExpectedError = snapshot.data;

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -337,7 +337,17 @@ class RelayReader {
       "Couldn't determine field name for this field. It might be a ReaderClientExtension - which is not yet supported.",
     );
 
-    let errors = this._errorResponseFields?.map(error => error.error);
+    let errors = this._errorResponseFields?.map(error => {
+      switch (error.kind) {
+        case 'relay_field_payload.error':
+          return error.error;
+        case 'missing_expected_data.throw':
+        case 'missing_expected_data.log':
+          return {
+            message: `Relay: Missing data for one or more fields in ${error.owner}`,
+          };
+      }
+    });
 
     if (this._resolverErrors.length > 0) {
       if (errors == null) {

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -346,6 +346,13 @@ class RelayReader {
           return {
             message: `Relay: Missing data for one or more fields in ${error.owner}`,
           };
+        default:
+          (error.kind: empty);
+          invariant(
+            false,
+            'Unexpected error errorResponseField kind: %s',
+            error.kind,
+          );
       }
     });
 

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -122,13 +122,6 @@ type FieldLocation = {
   owner: string,
 };
 
-type ErrorFieldLocation = {
-  ...FieldLocation,
-  error: TRelayFieldError,
-  type: FieldErrorType,
-  to?: CatchFieldTo,
-};
-
 export type MissingRequiredFields = $ReadOnly<
   | {action: 'THROW', field: FieldLocation}
   | {action: 'LOG', fields: Array<FieldLocation>},

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -134,7 +134,11 @@ export type MissingRequiredFields = $ReadOnly<
   | {action: 'LOG', fields: Array<FieldLocation>},
 >;
 
-export type ErrorResponseFields = Array<ErrorFieldLocation>;
+export type ErrorResponseFields = Array<
+  | RelayFieldPayloadErrorEvent
+  | MissingExpectedDataLogEvent
+  | MissingExpectedDataThrowEvent,
+>;
 
 export type ClientEdgeTraversalInfo = {
   +readerClientEdge: ReaderClientEdgeToServerObject,
@@ -1356,8 +1360,7 @@ export type RelayFieldPayloadErrorEvent = {
   +owner: string,
   +fieldPath: string,
   +error: TRelayFieldError,
-  // TODO: Should we add `shouldThrow` as a flag here, or perhaps have two
-  // different event types?
+  +shouldThrow: boolean,
 };
 
 /**

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-Subscriptions-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-Subscriptions-test.js
@@ -419,13 +419,14 @@ function cloneEventWithSets(event: LogEvent) {
           isMissingData: true,
           errorResponseFields: [
             {
-              error: {
-                message:
-                  'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
-              },
+              fieldPath: '',
+              kind: 'missing_expected_data.log',
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
-              type: 'MISSING_DATA',
-              path: '',
+            },
+            {
+              fieldPath: '',
+              kind: 'missing_expected_data.log',
+              owner: 'RelayModernStoreSubscriptionsTest1Fragment',
             },
           ],
           seenRecords: new Set(Object.keys(nextSource.toJSON())),
@@ -468,13 +469,14 @@ function cloneEventWithSets(event: LogEvent) {
           missingRequiredFields: null,
           errorResponseFields: [
             {
-              error: {
-                message:
-                  'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
-              },
+              fieldPath: '',
+              kind: 'missing_expected_data.log',
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
-              type: 'MISSING_DATA',
-              path: '',
+            },
+            {
+              fieldPath: '',
+              kind: 'missing_expected_data.log',
+              owner: 'RelayModernStoreSubscriptionsTest1Fragment',
             },
           ],
           missingLiveResolverFields: [],

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
@@ -728,6 +728,18 @@ function cloneEventWithSets(event: LogEvent) {
             name: 'Joe',
             profilePicture: undefined,
           },
+          errorResponseFields: [
+            {
+              owner: 'RelayModernStoreTest5Fragment',
+              kind: 'missing_expected_data.log',
+              fieldPath: '',
+            },
+            {
+              owner: 'RelayModernStoreTest5Fragment',
+              kind: 'missing_expected_data.log',
+              fieldPath: '',
+            },
+          ],
           missingRequiredFields: null,
           missingLiveResolverFields: [],
           missingClientEdges: null,
@@ -774,13 +786,14 @@ function cloneEventWithSets(event: LogEvent) {
           isMissingData: true,
           errorResponseFields: [
             {
-              error: {
-                message:
-                  'Relay: Missing data for one or more fields in RelayModernStoreTest5Fragment',
-              },
               owner: 'RelayModernStoreTest5Fragment',
-              type: 'MISSING_DATA',
-              path: '',
+              kind: 'missing_expected_data.log',
+              fieldPath: '',
+            },
+            {
+              owner: 'RelayModernStoreTest5Fragment',
+              kind: 'missing_expected_data.log',
+              fieldPath: '',
             },
           ],
           seenRecords: new Set(['842472']),

--- a/packages/relay-runtime/store/__tests__/RelayReader-CatchFields-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-CatchFields-test.js
@@ -140,13 +140,14 @@ describe('RelayReader @catch', () => {
 
       expect(errorResponseFields).toEqual([
         {
-          path: 'me.lastName',
+          fieldPath: 'me.lastName',
           error: {
             message: 'There was an error!',
             path: ['me', 'lastName'],
           },
           owner: 'RelayReaderCatchFieldsTestSiblingErrorQuery',
-          type: 'PAYLOAD_ERROR',
+          kind: 'relay_field_payload.error',
+          shouldThrow: false,
         },
       ]);
     });

--- a/packages/relay-runtime/store/__tests__/RelayReader-RelayErrorHandling-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-RelayErrorHandling-test.js
@@ -54,12 +54,13 @@ describe('RelayReader error fields', () => {
     expect(errorResponseFields).toEqual([
       {
         owner: 'RelayReaderRelayErrorHandlingTest1Query',
-        path: 'me.lastName',
+        fieldPath: 'me.lastName',
         error: {
           message: 'There was an error!',
           path: ['me', 'lastName'],
         },
-        type: 'PAYLOAD_ERROR',
+        kind: 'relay_field_payload.error',
+        shouldThrow: false,
       },
     ]);
   });
@@ -104,21 +105,18 @@ describe('RelayReader error fields', () => {
     expect(errorResponseFields).toEqual([
       {
         owner: 'RelayReaderRelayErrorHandlingTest4Query',
-        path: 'me.lastName',
-        type: 'PAYLOAD_ERROR',
+        fieldPath: 'me.lastName',
+        kind: 'relay_field_payload.error',
         error: {
           message: 'There was an error!',
           path: ['me', 'lastName'],
         },
+        shouldThrow: true,
       },
       {
         owner: 'RelayReaderRelayErrorHandlingTest4Query',
-        path: '',
-        type: 'MISSING_DATA',
-        error: {
-          message:
-            'Relay: Missing data for one or more fields in RelayReaderRelayErrorHandlingTest4Query',
-        },
+        fieldPath: '',
+        kind: 'missing_expected_data.throw',
       },
     ]);
   });

--- a/packages/relay-runtime/store/__tests__/RelayReader-Resolver-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-Resolver-test.js
@@ -208,10 +208,11 @@ describe.each([true, false])(
           const {errorResponseFields} = store.lookup(operation.fragment);
           expect(errorResponseFields).toEqual([
             {
+              fieldPath: 'me.lastName',
+              kind: 'relay_field_payload.error',
               error: {message: 'There was an error!', path: ['me', 'lastName']},
               owner: 'RelayReaderResolverTestFieldErrorQuery',
-              type: 'PAYLOAD_ERROR',
-              path: 'me.lastName',
+              shouldThrow: false,
             },
           ]);
         });

--- a/packages/relay-runtime/util/__tests__/handlePotentialSnapshotErrors-test.js
+++ b/packages/relay-runtime/util/__tests__/handlePotentialSnapshotErrors-test.js
@@ -274,6 +274,7 @@ describe('handlePotentialSnapshotErrors', () => {
         fieldPath: 'testPath',
         kind: 'relay_field_payload.error',
         owner: 'testOwner',
+        shouldThrow: false,
       });
     });
 
@@ -318,6 +319,7 @@ describe('handlePotentialSnapshotErrors', () => {
         fieldPath: 'testPath',
         kind: 'relay_field_payload.error',
         owner: 'testOwner',
+        shouldThrow: false,
       });
       // expect(relayFieldLogger).toHaveBeenCalledWith({
       //   fieldPath: '',
@@ -357,6 +359,7 @@ describe('handlePotentialSnapshotErrors', () => {
         fieldPath: 'testPath',
         kind: 'relay_field_payload.error',
         owner: 'testOwner',
+        shouldThrow: false,
       });
     });
 
@@ -377,7 +380,7 @@ describe('handlePotentialSnapshotErrors', () => {
                 path: ['testPath'],
                 severity: 'CRITICAL',
               },
-              shouldThrow: false,
+              shouldThrow: true,
             },
             {
               // error: {
@@ -405,6 +408,7 @@ describe('handlePotentialSnapshotErrors', () => {
         fieldPath: 'testPath',
         kind: 'relay_field_payload.error',
         owner: 'testOwner',
+        shouldThrow: true,
       });
 
       // expect(relayFieldLogger).toHaveBeenCalledWith({

--- a/packages/relay-runtime/util/__tests__/handlePotentialSnapshotErrors-test.js
+++ b/packages/relay-runtime/util/__tests__/handlePotentialSnapshotErrors-test.js
@@ -59,10 +59,6 @@ describe('handlePotentialSnapshotErrors', () => {
           [
             {
               kind: 'missing_expected_data.log',
-              // error: {
-              //   message:
-              //     'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
-              // },
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
               fieldPath: '',
             },
@@ -86,10 +82,6 @@ describe('handlePotentialSnapshotErrors', () => {
           [
             {
               kind: 'missing_expected_data.log',
-              // error: {
-              //   message:
-              //     'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
-              // },
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
               fieldPath: '',
             },
@@ -145,14 +137,13 @@ describe('handlePotentialSnapshotErrors', () => {
               kind: 'missing_expected_data.throw',
               owner: '',
               fieldPath: '',
-              // error: {
-              //   message: `Relay: Missing data for one or more fields`,
-              // },
             },
           ],
           true /* throwOnFieldError */,
         );
-      }).toThrowError(/^Relay: Missing data for one or more fields/);
+      }).toThrowError(
+        /^Relay: Unexpected response payload - this object includes an errors property in which you can access the underlying errors/,
+      );
 
       // expect(relayFieldLogger).toHaveBeenCalledTimes(1);
       // expect(relayFieldLogger).toHaveBeenCalledWith({
@@ -173,9 +164,6 @@ describe('handlePotentialSnapshotErrors', () => {
               kind: 'missing_expected_data.log',
               owner: '',
               fieldPath: '',
-              // error: {
-              //   message: 'Relay: Missing data for one or more fields',
-              // },
             },
           ],
           false /* throwOnFieldError */,
@@ -201,9 +189,6 @@ describe('handlePotentialSnapshotErrors', () => {
               kind: 'missing_expected_data.log',
               owner: '',
               fieldPath: '',
-              // error: {
-              //   message: 'Relay: Missing data for one or more fields',
-              // },
             },
           ],
           false /* throwOnFieldError */,
@@ -231,9 +216,6 @@ describe('handlePotentialSnapshotErrors', () => {
               kind: 'missing_expected_data.log',
               owner: '',
               fieldPath: '',
-              // error: {
-              //   message: 'Relay: Missing data for one or more fields',
-              // },
             },
           ],
           false /* throwOnFieldError */,
@@ -300,9 +282,6 @@ describe('handlePotentialSnapshotErrors', () => {
               kind: 'missing_expected_data.log',
               owner: '',
               fieldPath: '',
-              // error: {
-              //   message: 'Relay: Missing data for one or more fields',
-              // },
             },
           ],
           false /* throwOnFieldError */,
@@ -383,10 +362,6 @@ describe('handlePotentialSnapshotErrors', () => {
               shouldThrow: true,
             },
             {
-              // error: {
-              //   message:
-              //     'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
-              // },
               kind: 'missing_expected_data.log',
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
               fieldPath: '',

--- a/packages/relay-runtime/util/__tests__/handlePotentialSnapshotErrors-test.js
+++ b/packages/relay-runtime/util/__tests__/handlePotentialSnapshotErrors-test.js
@@ -58,13 +58,13 @@ describe('handlePotentialSnapshotErrors', () => {
           [],
           [
             {
-              error: {
-                message:
-                  'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
-              },
+              kind: 'missing_expected_data.log',
+              // error: {
+              //   message:
+              //     'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
+              // },
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
-              type: 'MISSING_DATA',
-              path: '',
+              fieldPath: '',
             },
           ],
           false /* throwOnFieldError */,
@@ -85,23 +85,24 @@ describe('handlePotentialSnapshotErrors', () => {
           [],
           [
             {
-              error: {
-                message:
-                  'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
-              },
+              kind: 'missing_expected_data.log',
+              // error: {
+              //   message:
+              //     'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
+              // },
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
-              type: 'MISSING_DATA',
-              path: '',
+              fieldPath: '',
             },
             {
+              kind: 'relay_field_payload.error',
               owner: 'testOwner',
-              path: 'testPath',
+              fieldPath: 'testPath',
               error: {
                 message: 'testMessage',
                 path: ['testPath'],
                 severity: 'CRITICAL',
               },
-              type: 'PAYLOAD_ERROR',
+              shouldThrow: false,
             },
           ],
           false /* throwOnFieldError */,
@@ -141,12 +142,12 @@ describe('handlePotentialSnapshotErrors', () => {
           [],
           [
             {
+              kind: 'missing_expected_data.throw',
               owner: '',
-              path: '',
-              type: 'MISSING_DATA',
-              error: {
-                message: `Relay: Missing data for one or more fields`,
-              },
+              fieldPath: '',
+              // error: {
+              //   message: `Relay: Missing data for one or more fields`,
+              // },
             },
           ],
           true /* throwOnFieldError */,
@@ -169,12 +170,12 @@ describe('handlePotentialSnapshotErrors', () => {
           [],
           [
             {
+              kind: 'missing_expected_data.log',
               owner: '',
-              path: '',
-              type: 'MISSING_DATA',
-              error: {
-                message: 'Relay: Missing data for one or more fields',
-              },
+              fieldPath: '',
+              // error: {
+              //   message: 'Relay: Missing data for one or more fields',
+              // },
             },
           ],
           false /* throwOnFieldError */,
@@ -197,12 +198,12 @@ describe('handlePotentialSnapshotErrors', () => {
           [],
           [
             {
+              kind: 'missing_expected_data.log',
               owner: '',
-              path: '',
-              type: 'MISSING_DATA',
-              error: {
-                message: 'Relay: Missing data for one or more fields',
-              },
+              fieldPath: '',
+              // error: {
+              //   message: 'Relay: Missing data for one or more fields',
+              // },
             },
           ],
           false /* throwOnFieldError */,
@@ -227,12 +228,12 @@ describe('handlePotentialSnapshotErrors', () => {
           [],
           [
             {
+              kind: 'missing_expected_data.log',
               owner: '',
-              path: '',
-              type: 'MISSING_DATA',
-              error: {
-                message: 'Relay: Missing data for one or more fields',
-              },
+              fieldPath: '',
+              // error: {
+              //   message: 'Relay: Missing data for one or more fields',
+              // },
             },
           ],
           false /* throwOnFieldError */,
@@ -248,14 +249,15 @@ describe('handlePotentialSnapshotErrors', () => {
           [],
           [
             {
+              kind: 'relay_field_payload.error',
               owner: 'testOwner',
-              path: 'testPath',
-              type: 'PAYLOAD_ERROR',
+              fieldPath: 'testPath',
               error: {
                 message: 'testMessage',
                 path: ['testPath'],
                 severity: 'CRITICAL',
               },
+              shouldThrow: false,
             },
           ],
           false /* throwOnFieldError */,
@@ -283,22 +285,23 @@ describe('handlePotentialSnapshotErrors', () => {
           [],
           [
             {
+              kind: 'relay_field_payload.error',
               owner: 'testOwner',
-              path: 'testPath',
-              type: 'PAYLOAD_ERROR',
+              fieldPath: 'testPath',
               error: {
                 message: 'testMessage',
                 path: ['testPath'],
                 severity: 'CRITICAL',
               },
+              shouldThrow: false,
             },
             {
+              kind: 'missing_expected_data.log',
               owner: '',
-              path: '',
-              type: 'MISSING_DATA',
-              error: {
-                message: 'Relay: Missing data for one or more fields',
-              },
+              fieldPath: '',
+              // error: {
+              //   message: 'Relay: Missing data for one or more fields',
+              // },
             },
           ],
           false /* throwOnFieldError */,
@@ -330,14 +333,15 @@ describe('handlePotentialSnapshotErrors', () => {
         [],
         [
           {
+            kind: 'relay_field_payload.error',
             owner: 'testOwner',
-            path: 'testPath',
+            fieldPath: 'testPath',
             error: {
               message: 'testMessage',
               path: ['testPath'],
               severity: 'CRITICAL',
             },
-            type: 'PAYLOAD_ERROR',
+            shouldThrow: false,
           },
         ],
         false /* throwOnFieldError */,
@@ -365,23 +369,24 @@ describe('handlePotentialSnapshotErrors', () => {
           [],
           [
             {
+              kind: 'relay_field_payload.error',
               owner: 'testOwner',
-              path: 'testPath',
-              type: 'PAYLOAD_ERROR',
+              fieldPath: 'testPath',
               error: {
                 message: 'testMessage',
                 path: ['testPath'],
                 severity: 'CRITICAL',
               },
+              shouldThrow: false,
             },
             {
-              error: {
-                message:
-                  'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
-              },
+              // error: {
+              //   message:
+              //     'Relay: Missing data for one or more fields in RelayModernStoreSubscriptionsTest1Fragment',
+              // },
+              kind: 'missing_expected_data.log',
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
-              type: 'MISSING_DATA',
-              path: '',
+              fieldPath: '',
             },
           ],
           true /* throwOnFieldError */,

--- a/packages/relay-runtime/util/handlePotentialSnapshotErrors.js
+++ b/packages/relay-runtime/util/handlePotentialSnapshotErrors.js
@@ -47,16 +47,13 @@ function handleFieldErrors(
   shouldThrow: boolean,
 ) {
   for (const fieldError of errorResponseFields) {
-    const {path, owner, error} = fieldError;
-    if (fieldError.type === 'MISSING_DATA') {
+    if (
+      fieldError.kind === 'missing_expected_data.log' ||
+      fieldError.kind === 'missing_expected_data.throw'
+    ) {
       // _logMissingData(environment, shouldThrow);
     } else {
-      environment.relayFieldLogger({
-        kind: 'relay_field_payload.error',
-        owner: owner,
-        fieldPath: path,
-        error,
-      });
+      environment.relayFieldLogger(fieldError);
     }
   }
 
@@ -137,7 +134,11 @@ function handlePotentialSnapshotErrors(
   throwOnFieldError: boolean,
 ) {
   const onlyHasMissingDataErrors = Boolean(
-    errorResponseFields?.every(field => field.type === 'MISSING_DATA'),
+    errorResponseFields?.every(
+      field =>
+        field.kind === 'missing_expected_data.log' ||
+        field.kind === 'missing_expected_data.throw',
+    ),
   );
 
   // if isMissingData is the only error - we should throw that separately

--- a/packages/relay-runtime/util/handlePotentialSnapshotErrors.js
+++ b/packages/relay-runtime/util/handlePotentialSnapshotErrors.js
@@ -129,7 +129,8 @@ function handlePotentialSnapshotErrors(
     handleMissingRequiredFields(environment, missingRequiredFields);
   }
 
-  /* inside handleFieldErrors, we check for throwOnFieldError - but this fn logs the error anyway by default
+  /**
+   * Inside handleFieldErrors, we check for throwOnFieldError - but this fn logs the error anyway by default
    * which is why this still should run in any case there's errors.
    */
   if (errorResponseFields != null) {

--- a/packages/relay-runtime/util/handlePotentialSnapshotErrors.js
+++ b/packages/relay-runtime/util/handlePotentialSnapshotErrors.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+import type {TRelayFieldError} from '../store/RelayErrorTrie';
 import type {
   ErrorResponseFields,
   IEnvironment,
@@ -61,7 +62,19 @@ function handleFieldErrors(
   if (shouldThrow) {
     throw new RelayFieldError(
       `Relay: Unexpected response payload - this object includes an errors property in which you can access the underlying errors`,
-      errorResponseFields.map(({error}) => error),
+      errorResponseFields.map((event): TRelayFieldError => {
+        switch (event.kind) {
+          case 'relay_field_payload.error':
+            return event.error;
+          case 'missing_expected_data.throw':
+            return {message: 'Missing expected data'};
+          case 'missing_expected_data.log':
+            return {message: 'Missing expected data'};
+          default:
+            (event.kind: empty);
+            throw new Error('Relay: Unexpected event kind');
+        }
+      }),
     );
   }
 }


### PR DESCRIPTION
Previously we had two different object shapes which were nearly the same. One for stashing on the snapshot, and another for logging. By unifying the two shapes we simplify things a bit and avoid the transformation.

As part of this simplification, I've also removed the special case handling for snapshots which contain only missing data errors. This means we will end up with duplicate events if the snapshot is missing multiple fields. This is noisier, but perhaps more correct because it captures the fact that multiple fields were missing. Once/when/if we add runtime pathName to RelayReader, these multiple events will be even more helpful.