### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/setup-node@v2
         if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'yarn'
       - name: Install dependencies
         if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
@@ -224,7 +224,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org/
           cache: 'yarn'
       - name: Install dependencies

--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "common",
  "intern",
  "log",
+ "relay-codemod",
  "relay-compiler",
  "relay-lsp",
  "schema",
@@ -1710,6 +1711,19 @@ dependencies = [
  "relay-transforms",
  "schema",
  "tokio",
+]
+
+[[package]]
+name = "relay-codemod"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "graphql-ir",
+ "log",
+ "lsp-types",
+ "relay-compiler",
+ "relay-lsp",
+ "relay-transforms",
 ]
 
 [[package]]

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
   },
   "private": true,
   "devEngines": {
-    "node": ">=4.x",
-    "npm": ">=2.x"
+    "node": ">=18.x",
+    "npm": ">=8.x"
   },
   "prettier": {
     "arrowParens": "avoid",


### PR DESCRIPTION
Two fixes for CI
- **Yarn**: Required updating the minimum node version to 18+ after installing `@testing-library/react`/`@testing-library/dom` in b221f96972fbb6e0074c7916101560ad8254a22a
  - I updated `14` with `18` and `16` with `20`
- **Cargo**: Required a `cargo build` after adding `relay-codemod` in https://github.com/facebook/relay/commit/bddf8a499ffcd3473409cb9b827305e0e09cd731