### PR TITLE
Minor updates to docs on enabling relay resolvers

### DIFF
--- a/website/versioned_docs/version-v18.0.0/guides/relay-resolvers/enabling.md
+++ b/website/versioned_docs/version-v18.0.0/guides/relay-resolvers/enabling.md
@@ -14,7 +14,7 @@ Relay Resolvers must be enabled in your runtime code by using our experimental `
 ```ts
 import { Environment, RecordSource, RelayFeatureFlags } from "relay-runtime";
 // highlight-next-line
-import LiveResolverStore from "relay-runtime/lib/store/experimental-live-resolvers/LiveResolverStore";
+import LiveResolverStore from "relay-runtime/lib/store/live-resolvers/LiveResolverStore";
 
 RelayFeatureFlags.ENABLE_RELAY_RESOLVERS = true;
 
@@ -30,7 +30,7 @@ function fieldLogger(event) {
 const environment = new Environment({
   network: Network.create(/* your fetch function here */),
   store: new LiveResolverStore(new RecordSource()),
-  relayFieldLogger: fieldLogger
+  requiredFieldLogger: fieldLogger
 });
 
 // ... create your Relay context with your environment


### PR DESCRIPTION
The docs seem a little out of date. On my machine and relay v18.0, `LiveResolverStore` has a new path and `relayFieldLogger` doesn't seem to exist (I assume `requiredFieldLogger` does the same thing, but I'm not sure)

Filled out the CLA shortly before submitting this PR, please let me know if there's anything else I should do