### PR TITLE
Fix feature flags in compiler explorer

### DIFF
--- a/compiler/crates/common/src/feature_flags.rs
+++ b/compiler/crates/common/src/feature_flags.rs
@@ -143,10 +143,10 @@ pub struct FeatureFlags {
 
     /// Skip the optimization which extracts common JavaScript structures in
     /// generated artifacts into numbered variables and uses them by reference
-    /// in each position in which they occure.
+    /// in each position in which they occur.
     ///
     /// This optimization can make it hard to follow changes to generated
-    /// code, so being able to disable it can be helpful for debgging.
+    /// code, so being able to disable it can be helpful for debugging.
     ///
     /// To disable deduping for just one fragment or operation's generated
     /// artifacts:

--- a/website/src/compiler-explorer/ExplorerStateConstants.js
+++ b/website/src/compiler-explorer/ExplorerStateConstants.js
@@ -74,12 +74,6 @@ export const FEATURE_FLAGS = [
     kind: 'enum',
     default: true,
   },
-  {
-    key: 'enable_catch_directive_transform',
-    label: '@catch',
-    kind: 'enum',
-    default: false,
-  },
 ];
 
 export const DEFAULT_STATE = {

--- a/website/src/compiler-explorer/ExplorerStateSerialization.js
+++ b/website/src/compiler-explorer/ExplorerStateSerialization.js
@@ -30,6 +30,8 @@ export function serializeState(state) {
         // If we ever have a feature flag which conflicts with a top-level state value
         // we will need to find a way to deal with that. However, it's unlikely
         // and it makes the URL easier to read.
+        //
+        // Note: URLSearchParam values are always strings, so this will be "true" or "false".
         params.set(flag, enabled);
       }
     } else {
@@ -52,7 +54,8 @@ export function deserializeState(params) {
     } else if (key == 'featureFlags') {
       const featureFlags = {};
       for (const {key} of FEATURE_FLAGS) {
-        featureFlags[key] = Boolean(params.get(key));
+        // Decode string boolean values into boolean.
+        featureFlags[key] = params.get(key) === 'true';
       }
       state[key] = featureFlags;
     } else {


### PR DESCRIPTION
We (I) forgot to update the feature flags in the compiler explorer when we removed `enable_catch_directive_transform`.

This also fixes a bug where we did not deserialize feature flags from the url correctly.

https://github.com/user-attachments/assets/012abecc-3ef0-4072-addd-3ba8eb2a143e


