### PR TITLE
Fix publishing npm packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
         run: |
           for pkg in dist/*; do
-            npm publish "$pkg" ${TAG}
+            npm publish "./$pkg" ${TAG}
           done
         env:
           TAG: ${{ github.ref == 'refs/heads/main' && '--tag=main' || ((contains(github.ref_name, '-rc.') && '--tag=dev') || '' )}}


### PR DESCRIPTION
This probably blames back to #4816 but I haven't completely proven that.

Essentially, this looks likely that something changed in npm. `npm-package-arg` thinks that `dist/foo` is a reference to a github repo, not a local path. Explicitly making that a relative path (`./dist/foo`) ensures it doesn't.

I haven't proven this will fix the issue but running `require('npm-package-arg')('dist/foo')` returns an object indicating it's treating it as a git repo. `require('npm-package-arg')('./dist/foo')` treats it like the directory it is.

My assumption is that this treatment like a git repo is that npm is deciding to go look it up and validate that the `main` tag exists. That might be fine but it's looking for `dist/foo` which doesn't exist and then that results in the git failure we're seeing.