### PR TITLE
Add fieldPath to missing data field error logs

### DIFF
--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -1274,7 +1274,7 @@ export type MissingFieldHandler =
 export type MissingExpectedDataLogEvent = {
   +kind: 'missing_expected_data.log',
   +owner: string,
-  +fieldPath: string,
+  fieldPath: string,
 };
 
 /**
@@ -1300,7 +1300,7 @@ export type MissingExpectedDataLogEvent = {
 export type MissingExpectedDataThrowEvent = {
   +kind: 'missing_expected_data.throw',
   +owner: string,
-  +fieldPath: string,
+  fieldPath: string,
   +handled: boolean,
 };
 

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-Subscriptions-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-Subscriptions-test.js
@@ -417,12 +417,12 @@ function cloneEventWithSets(event: LogEvent) {
           isMissingData: true,
           errorResponseFields: [
             {
-              fieldPath: '',
+              fieldPath: 'profilePicture',
               kind: 'missing_expected_data.log',
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
             },
             {
-              fieldPath: '',
+              fieldPath: 'emailAddresses',
               kind: 'missing_expected_data.log',
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
             },
@@ -466,12 +466,12 @@ function cloneEventWithSets(event: LogEvent) {
           },
           errorResponseFields: [
             {
-              fieldPath: '',
+              fieldPath: 'profilePicture',
               kind: 'missing_expected_data.log',
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
             },
             {
-              fieldPath: '',
+              fieldPath: 'emailAddresses',
               kind: 'missing_expected_data.log',
               owner: 'RelayModernStoreSubscriptionsTest1Fragment',
             },

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
@@ -728,12 +728,12 @@ function cloneEventWithSets(event: LogEvent) {
             {
               owner: 'RelayModernStoreTest5Fragment',
               kind: 'missing_expected_data.log',
-              fieldPath: '',
+              fieldPath: 'profilePicture',
             },
             {
               owner: 'RelayModernStoreTest5Fragment',
               kind: 'missing_expected_data.log',
-              fieldPath: '',
+              fieldPath: 'emailAddresses',
             },
           ],
           missingLiveResolverFields: [],
@@ -782,12 +782,12 @@ function cloneEventWithSets(event: LogEvent) {
             {
               owner: 'RelayModernStoreTest5Fragment',
               kind: 'missing_expected_data.log',
-              fieldPath: '',
+              fieldPath: 'profilePicture',
             },
             {
               owner: 'RelayModernStoreTest5Fragment',
               kind: 'missing_expected_data.log',
-              fieldPath: '',
+              fieldPath: 'emailAddresses',
             },
           ],
           seenRecords: new Set(['842472']),

--- a/packages/relay-runtime/store/__tests__/RelayReader-AliasedFragments-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-AliasedFragments-test.js
@@ -1041,7 +1041,7 @@ describe('Inline Fragments', () => {
     );
     expect(errorResponseFields).toEqual([
       {
-        fieldPath: '',
+        fieldPath: 'node.aliased_fragment.name',
         kind: 'missing_expected_data.log',
         owner:
           'RelayReaderAliasedFragmentsTestRequiredBubblesOnAbstractTypeQuery',
@@ -1101,7 +1101,7 @@ describe('Inline Fragments', () => {
     );
     expect(errorResponseFields).toEqual([
       {
-        fieldPath: '',
+        fieldPath: 'node.aliased_fragment.<abstract-type-hint>',
         kind: 'missing_expected_data.log',
         owner:
           'RelayReaderAliasedFragmentsTestRequiredBubblesOnAbstractWithMissingTypeInfoQuery',

--- a/packages/relay-runtime/store/__tests__/RelayReader-CatchFields-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-CatchFields-test.js
@@ -297,7 +297,7 @@ describe('RelayReader @catch', () => {
 
       expect(errorResponseFields).toEqual([
         {
-          fieldPath: '',
+          fieldPath: 'me.firstName',
           kind: 'missing_expected_data.log',
           owner: 'RelayReaderCatchFieldsTestCatchMissingToNullErrorQuery',
         },

--- a/packages/relay-runtime/store/__tests__/RelayReader-RelayErrorHandling-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-RelayErrorHandling-test.js
@@ -14,6 +14,7 @@ const {graphql} = require('../../query/GraphQLTag');
 const {
   createOperationDescriptor,
 } = require('../RelayModernOperationDescriptor');
+const RelayModernStore = require('../RelayModernStore');
 const {read} = require('../RelayReader');
 const RelayRecordSource = require('../RelayRecordSource');
 
@@ -117,7 +118,65 @@ describe('RelayReader error fields', () => {
       },
       {
         owner: 'RelayReaderRelayErrorHandlingTest4Query',
-        fieldPath: '',
+        fieldPath: 'me.profilePicture',
+        kind: 'missing_expected_data.throw',
+        handled: false,
+      },
+    ]);
+  });
+
+  it('adds the errors to errorResponseFields including missingData within plural fields - without @catch', () => {
+    const source = RelayRecordSource.create({
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        nodes: {__refs: ['1']},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        lastName: null,
+        __errors: {
+          lastName: [
+            {
+              message: 'There was an error!',
+              path: ['me', 'lastName'],
+            },
+          ],
+        },
+      },
+    });
+
+    const FooQuery = graphql`
+      query RelayReaderRelayErrorHandlingTestMissingPluralQuery($size: [Int])
+      @throwOnFieldError {
+        nodes {
+          lastName
+          profilePicture(size: $size) {
+            uri
+          }
+        }
+      }
+    `;
+    const operation = createOperationDescriptor(FooQuery, {size: 42});
+    const {errorResponseFields} = read(source, operation.fragment);
+
+    expect(errorResponseFields).toEqual([
+      {
+        owner: 'RelayReaderRelayErrorHandlingTestMissingPluralQuery',
+        fieldPath: 'me.lastName',
+        kind: 'relay_field_payload.error',
+        error: {
+          message: 'There was an error!',
+          path: ['me', 'lastName'],
+        },
+        shouldThrow: true,
+        handled: false,
+      },
+      {
+        owner: 'RelayReaderRelayErrorHandlingTestMissingPluralQuery',
+        fieldPath: 'nodes.0.profilePicture',
         kind: 'missing_expected_data.throw',
         handled: false,
       },
@@ -169,7 +228,7 @@ describe('RelayReader error fields', () => {
             path: ['me', 'lastName'],
           },
           {
-            path: [''],
+            path: ['me', 'profilePicture'],
           },
         ],
       },
@@ -185,7 +244,7 @@ describe('RelayReader error fields', () => {
         shouldThrow: false,
       },
       {
-        fieldPath: '',
+        fieldPath: 'me.profilePicture',
         kind: 'missing_expected_data.log',
         owner: 'RelayReaderRelayErrorHandlingTest3Query',
       },
@@ -292,6 +351,102 @@ describe('RelayReader error fields', () => {
       },
     ]);
   });
+
+  test('@throwOnFieldError reading a client edge resolver which points to a record with missing data logs the correct path', () => {
+    const source = RelayRecordSource.create({
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        name: 'Proto Mark', // Read by the resolver fragment
+      },
+      '1337': {
+        __id: '1337',
+        id: '1337',
+        __typename: 'User',
+        // firstName is missing
+      },
+    });
+
+    const FooQuery = graphql`
+      query RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery
+      @throwOnFieldError {
+        me {
+          client_edge @waterfall {
+            firstName
+          }
+        }
+      }
+    `;
+
+    const operation = createOperationDescriptor(FooQuery, {size: 42});
+    const {errorResponseFields} = read(source, operation.fragment);
+
+    expect(errorResponseFields).toEqual([
+      {
+        fieldPath: 'me.client_edge.firstName',
+        kind: 'missing_expected_data.throw',
+        handled: false,
+        owner:
+          'RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery',
+      },
+    ]);
+  });
+
+  test('@throwOnFieldError reading a client edge to client object resolver which points to a record with missing data logs the correct path', () => {
+    const source = RelayRecordSource.create({
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        birthdate: {__ref: '2'},
+      },
+      '2': {
+        __id: '2',
+        id: '2',
+        __typename: 'Date',
+        day: 6,
+        month: 1,
+        year: 1985,
+      },
+    });
+    const store = new RelayModernStore(source);
+
+    const FooQuery = graphql`
+      query RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery
+      @throwOnFieldError {
+        me {
+          astrological_sign {
+            notes # Not in the store!
+          }
+        }
+      }
+    `;
+
+    const operation = createOperationDescriptor(FooQuery, {});
+    const {errorResponseFields} = store.lookup(operation.fragment);
+
+    expect(errorResponseFields).toEqual([
+      {
+        fieldPath: 'me.astrological_sign.notes',
+        kind: 'missing_expected_data.throw',
+        handled: false,
+        owner:
+          'RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery',
+      },
+    ]);
+  });
+
   it('does not report missing data within an inline fragment that does not match', () => {
     const source = RelayRecordSource.create({
       'client:root': {
@@ -371,7 +526,7 @@ describe('RelayReader error fields', () => {
     expect(errorResponseFields).toEqual([
       // We are missing the metadata bout the interface
       {
-        fieldPath: '',
+        fieldPath: 'node.<abstract-type-hint>',
         handled: false,
         kind: 'missing_expected_data.throw',
         owner: 'RelayReaderRelayErrorHandlingTestInlineFragmentMatchesQuery',
@@ -379,7 +534,7 @@ describe('RelayReader error fields', () => {
       // We don't know if we should traverse into the inline fragment, but we do
       // anyway and find that the field is missing
       {
-        fieldPath: '',
+        fieldPath: 'node.name',
         handled: false,
         kind: 'missing_expected_data.throw',
         owner: 'RelayReaderRelayErrorHandlingTestInlineFragmentMatchesQuery',

--- a/packages/relay-runtime/store/__tests__/__generated__/ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge.graphql.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<c53005a92baed2db5ba0e470c2501249>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$fragmentType } from "./RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge.graphql";
+export type ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$variables = {|
+  id: string,
+|};
+export type ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$data = {|
+  +node: ?{|
+    +$fragmentSpreads: RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$fragmentType,
+  |},
+|};
+export type ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge = {|
+  response: ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$data,
+  variables: ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "firstName",
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "e47549d74855f68f97e2b686ad601ea7",
+    "id": null,
+    "metadata": {},
+    "name": "ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge",
+    "operationKind": "query",
+    "text": "query ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge\n    id\n  }\n}\n\nfragment RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge on User {\n  firstName\n  id\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "d3fd8c798ab7357a229e7b8e79799744";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$variables,
+  ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge.graphql.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<dfd4847df83d75e611690708e59c1023>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$fragmentType: FragmentType;
+type ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$variables = any;
+export type RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$data = {|
+  +firstName: ?string,
+  +id: string,
+  +$fragmentType: RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$fragmentType,
+|};
+export type RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$key = {
+  +$data?: RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$data,
+  +$fragmentSpreads: RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": require('./ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge.graphql'),
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "firstName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "d3fd8c798ab7357a229e7b8e79799744";
+}
+
+module.exports = ((node/*: any*/)/*: RefetchableFragment<
+  RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$fragmentType,
+  RefetchableClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$data,
+  ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge$variables,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderRelayErrorHandlingTestMissingPluralQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderRelayErrorHandlingTestMissingPluralQuery.graphql.js
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<0952e46c01e925f5f9d6d46a37b10f66>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type RelayReaderRelayErrorHandlingTestMissingPluralQuery$variables = {|
+  size?: ?$ReadOnlyArray<?number>,
+|};
+export type RelayReaderRelayErrorHandlingTestMissingPluralQuery$data = {|
+  +nodes: ?$ReadOnlyArray<?{|
+    +lastName: ?string,
+    +profilePicture: ?{|
+      +uri: ?string,
+    |},
+  |}>,
+|};
+export type RelayReaderRelayErrorHandlingTestMissingPluralQuery = {|
+  response: RelayReaderRelayErrorHandlingTestMissingPluralQuery$data,
+  variables: RelayReaderRelayErrorHandlingTestMissingPluralQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "size"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lastName",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "size",
+      "variableName": "size"
+    }
+  ],
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "profilePicture",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "uri",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": {
+      "throwOnFieldError": true
+    },
+    "name": "RelayReaderRelayErrorHandlingTestMissingPluralQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RelayReaderRelayErrorHandlingTestMissingPluralQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v1/*: any*/),
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "17bef05ba3a737b778497587e3c4bb6c",
+    "id": null,
+    "metadata": {},
+    "name": "RelayReaderRelayErrorHandlingTestMissingPluralQuery",
+    "operationKind": "query",
+    "text": "query RelayReaderRelayErrorHandlingTestMissingPluralQuery(\n  $size: [Int]\n) {\n  nodes {\n    __typename\n    lastName\n    profilePicture(size: $size) {\n      uri\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "9e91ce9da23ac341e9d3815c9f9cf2f2";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  RelayReaderRelayErrorHandlingTestMissingPluralQuery$variables,
+  RelayReaderRelayErrorHandlingTestMissingPluralQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery.graphql.js
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<ee65709e3fff0ef65250cb9271cba571>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { DataID } from "relay-runtime";
+import type { UserAstrologicalSignResolver$key } from "./../resolvers/__generated__/UserAstrologicalSignResolver.graphql";
+import {astrological_sign as userAstrologicalSignResolverType} from "../resolvers/UserAstrologicalSignResolver.js";
+import type { TestResolverContextType } from "../../../mutations/__tests__/TestResolverContextType";
+// Type assertion validating that `userAstrologicalSignResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(userAstrologicalSignResolverType: (
+  rootKey: UserAstrologicalSignResolver$key,
+  args: void,
+  context: TestResolverContextType,
+) => ?{|
+  +id: DataID,
+|});
+export type RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery$variables = {||};
+export type RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery$data = {|
+  +me: ?{|
+    +astrological_sign: ?{|
+      +notes: ?string,
+    |},
+  |},
+|};
+export type RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery = {|
+  response: RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery$data,
+  variables: RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "notes",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": {
+      "hasClientEdges": true,
+      "throwOnFieldError": true
+    },
+    "name": "RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ClientEdgeToClientObject",
+            "concreteType": "AstrologicalSign",
+            "modelResolvers": null,
+            "backingField": {
+              "alias": null,
+              "args": null,
+              "fragment": {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "UserAstrologicalSignResolver"
+              },
+              "kind": "RelayResolver",
+              "name": "astrological_sign",
+              "resolverModule": require('./../resolvers/UserAstrologicalSignResolver').astrological_sign,
+              "path": "me.astrological_sign"
+            },
+            "linkedField": {
+              "alias": null,
+              "args": null,
+              "concreteType": "AstrologicalSign",
+              "kind": "LinkedField",
+              "name": "astrological_sign",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/)
+              ],
+              "storageKey": null
+            }
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ClientEdgeToClientObject",
+            "backingField": {
+              "name": "astrological_sign",
+              "args": null,
+              "fragment": {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Date",
+                    "kind": "LinkedField",
+                    "name": "birthdate",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "month",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "day",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "User",
+                "abstractKey": null
+              },
+              "kind": "RelayResolver",
+              "storageKey": null,
+              "isOutputType": false
+            },
+            "linkedField": {
+              "alias": null,
+              "args": null,
+              "concreteType": "AstrologicalSign",
+              "kind": "LinkedField",
+              "name": "astrological_sign",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                (v1/*: any*/)
+              ],
+              "storageKey": null
+            }
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "4e9dfd987ed85231c755f6c748db249d",
+    "id": null,
+    "metadata": {},
+    "name": "RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery",
+    "operationKind": "query",
+    "text": "query RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery {\n  me {\n    ...UserAstrologicalSignResolver\n    id\n  }\n}\n\nfragment UserAstrologicalSignResolver on User {\n  birthdate {\n    month\n    day\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "f58793dca8d722401223f2d241a24705";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery$variables,
+  RelayReaderRelayErrorHandlingTestResolverClientEdgeClientObjectWithMissingDataQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery.graphql.js
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<78b08a8df8f4ca89e6a949e9e8ff4453>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { DataID } from "relay-runtime";
+import type { UserClientEdgeResolver$key } from "./../resolvers/__generated__/UserClientEdgeResolver.graphql";
+import {client_edge as userClientEdgeResolverType} from "../resolvers/UserClientEdgeResolver.js";
+import type { TestResolverContextType } from "../../../mutations/__tests__/TestResolverContextType";
+// Type assertion validating that `userClientEdgeResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(userClientEdgeResolverType: (
+  rootKey: UserClientEdgeResolver$key,
+  args: void,
+  context: TestResolverContextType,
+) => ?{|
+  +id: DataID,
+|});
+export type RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery$variables = {||};
+export type RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery$data = {|
+  +me: ?{|
+    +client_edge: ?{|
+      +firstName: ?string,
+    |},
+  |},
+|};
+export type RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery = {|
+  response: RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery$data,
+  variables: RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": {
+      "hasClientEdges": true,
+      "throwOnFieldError": true
+    },
+    "name": "RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ClientEdgeToServerObject",
+            "operation": require('./ClientEdgeQuery_RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery_me__client_edge.graphql'),
+            "backingField": {
+              "alias": null,
+              "args": null,
+              "fragment": {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "UserClientEdgeResolver"
+              },
+              "kind": "RelayResolver",
+              "name": "client_edge",
+              "resolverModule": require('./../resolvers/UserClientEdgeResolver').client_edge,
+              "path": "me.client_edge"
+            },
+            "linkedField": {
+              "alias": null,
+              "args": null,
+              "concreteType": "User",
+              "kind": "LinkedField",
+              "name": "client_edge",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "firstName",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "name": "client_edge",
+            "args": null,
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "RelayResolver",
+            "storageKey": null,
+            "isOutputType": false
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "68091edecbac75c5fae7fbf31dc6ff71",
+    "id": null,
+    "metadata": {},
+    "name": "RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery",
+    "operationKind": "query",
+    "text": "query RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery {\n  me {\n    ...UserClientEdgeResolver\n    id\n  }\n}\n\nfragment UserClientEdgeResolver on User {\n  name\n}\n"
+  }
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "d3fd8c798ab7357a229e7b8e79799744";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery$variables,
+  RelayReaderRelayErrorHandlingTestResolverClientEdgeWithMissingDataQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/resolvers/ResolverGC-test.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/ResolverGC-test.js
@@ -175,7 +175,7 @@ test('Regular resolver with fragment reads live resovler with fragment', async (
       expect(snapshot.data).toEqual({counter_plus_one: null});
       expect(snapshot.errorResponseFields).toEqual([
         {
-          fieldPath: '',
+          fieldPath: 'me.<record>',
           kind: 'missing_expected_data.log',
           owner: 'LiveCounterResolver',
         },
@@ -730,7 +730,7 @@ test('Resolver reading a plural client-edge to a client type', async () => {
       expect(snapshot.data).toEqual({all_astrological_signs: null});
       expect(snapshot.errorResponseFields).toEqual([
         {
-          fieldPath: '',
+          fieldPath: 'me.<record>',
           kind: 'missing_expected_data.log',
           owner: 'QueryAllAstrologicalSignsResolver',
         },

--- a/packages/relay-runtime/store/__tests__/waitForFragmentData-test.js
+++ b/packages/relay-runtime/store/__tests__/waitForFragmentData-test.js
@@ -184,6 +184,6 @@ test('data goes missing due to unrelated query response (@throwOnFieldErrro)', a
     result = e;
   }
   expect(result?.message).toEqual(
-    "Relay: Missing expected data at path '' in 'waitForFragmentDataTestMissingDataThrowOnFieldErrorFragment'.",
+    "Relay: Missing expected data at path 'me.name' in 'waitForFragmentDataTestMissingDataThrowOnFieldErrorFragment'.",
   );
 });


### PR DESCRIPTION
For `@required` fields and Relay Resolvers which might error, we include the field's path (relative to its parent fragment/query) in the generated artifact.

This allows us to avoid maintaining a field path during read traversal, which would require a large number of push/pops of an array as we traverse through the reader AST.

However, with the addition of `@throwFieldOnError` we also report _missing data_ as field errors, but these errors can occur for any field, and including every field's path in the generated artifact is likely too heavy.

This PR attempt to use an efficient approach where we build up the path on the trailing edge of the reader recursion, which allows us to avoid pushing/popping in the common case where there are no errors. The cost in the happy path is just an additional method call and a few null checks as we exit each level of recursion that impacts the path.

If this approach proves effective, we should be able to adopt the same approach for `@requried` and resolver errors, simplifying the compiler and making our generated artifacts a bit lighter.