### PR TITLE
Docs: Fix fragments tutorial thumbnail typo

### DIFF
--- a/website/versioned_docs/version-v18.0.0/tutorial/fragments-1.md
+++ b/website/versioned_docs/version-v18.0.0/tutorial/fragments-1.md
@@ -25,7 +25,7 @@ const NewsfeedQuery = graphql`
           url
         }
       }
-      image {
+      thumbnail {
         url
       }
     }
@@ -95,7 +95,7 @@ const StoryFragment = graphql`
         url
       }
     }
-    image {
+    thumbnail {
       url
     }
   }
@@ -146,7 +146,7 @@ export default function Story({story}: Props) {
       <Heading>{data.title}</Heading>
       <PosterByline poster={data.poster} />
       <Timestamp time={data.createdAt} />
-      <Image image={data.image} />
+      <Image image={data.thumbnail} />
       <StorySummary summary={data.summary} />
     </Card>
   );


### PR DESCRIPTION
Hi, I just ran through the tutorial and think I found a small typo.

In the [example code](https://github.com/relayjs/relay-examples.git) referenced in the tutorial the field is called `thumbnail` and not `image`. Fixed tutorial example to reflect this.