### PR TITLE
Update docs on usePaginationFragement & transitions in Relay tutorial.

### DIFF
--- a/website/docs/tutorial/connections-pagination.md
+++ b/website/docs/tutorial/connections-pagination.md
@@ -247,17 +247,13 @@ Run `npm run relay`. Now the Load More button should cause another three comment
 
 As it stands, there’s no user feedback when you click the “Load More” button until the new comments have finished loading and then appear. Every user action should result in immediate feedback, so let’s show a spinner while the new data is loading — but without hiding the existing UI.
 
-To do that, we need to wrap our call to `loadNext` inside a React transition. Here’s the change’s we need to make:
+To do that, we need can use the `isLoadingNext` boolean value returned from `usePaginationFragment`. Here’s the change’s we need to make:
 
 ```
 function StoryCommentsSection({story}) {
   // change-line
-  const [isPending, startTransition] = useTransition();
   const {data, loadNext} = usePaginationFragment(StoryCommentsSectionFragment, story);
-  // change
-  const onLoadMore = () => startTransition(() => {
-    loadNext(3);
-  });
+  const {data, loadNext, isLoadingNext} = usePaginationFragment(StoryCommentsSectionFragment, story);
   // end-change
   return (
     <>
@@ -268,17 +264,15 @@ function StoryCommentsSection({story}) {
         <LoadMoreCommentsButton
           onClick={onLoadMore}
             // change-line
-          disabled={isPending}
+          disabled={isLoadingNext}
         />
       )}
       // change-line
-      {isPending && <CommentsLoadingSpinner />}
+      {isLoadingNext && <SmallSpinner />}
     </>
   );
 }
 ```
-
-Every user action with results that aren’t immediate should be wrapped in a React transition. This allows React to prioritize different updates: for example, if when the data becomes available and React is rendering the new comments, the user clicks on another tab to navigate to a different page, React can interrupt rendering the comments in order to render the new page that the user wanted.
 
 * * *
 


### PR DESCRIPTION
I found out that `useTransition` doesn't work when using `usePaginationFragement`. To get it to work the way it's intended in the tutorial I had to use `isLoadingNext` boolean prop that is returned from `usePaginationFragement` instead. Not sure if this a bug, or by design.

As a beginner, I spent quite some time trying to figure out why my code wasn't working, after a bit of digging I ran into some potenially related issues:
- https://github.com/facebook/relay/issues/4531#issuecomment-1867831999
- https://github.com/facebook/relay/issues/4526
- https://github.com/facebook/relay/issues/3082

In this PR I've updated the code in "Improving the Loading Experience with useTransition" example not to confuse newcomers. Also the section about "results that aren’t immediate should be wrapped in a React transition" as it no longer applies in this particular context.

I also replaced `<CommentsLoadingSpinner />` (which doesn't exist?) with `<SmallSpinner />` which seems more appropriate in the particular example. 