### PR TITLE
Context not properly provided through data injector and subscriptions

### DIFF
--- a/packages/react-relay/__tests__/LiveResolvers-test.js
+++ b/packages/react-relay/__tests__/LiveResolvers-test.js
@@ -1876,3 +1876,88 @@ test('ResolverContext can contain observable values', async () => {
     counter_context: 1,
   });
 });
+
+test('ResolverContext as passed through nested resolver counters', async () => {
+  const source = RelayRecordSource.create({
+    'client:root': {
+      __id: 'client:root',
+      __typename: '__Root',
+      me: {__ref: '1'},
+    },
+    '1': {
+      __id: '1',
+      __typename: 'User',
+      id: '1',
+    },
+  });
+  const FooQuery = graphql`
+    query LiveResolversTestCounterContextBaseQuery {
+      base_counter_context {
+        count_plus_one
+      }
+    }
+  `;
+
+  let next: (v: number) => void = () => {
+    throw new Error('next() not initialized');
+  };
+
+  const operation = createOperationDescriptor(FooQuery, {});
+  const store = new RelayModernStore(source, {
+    gcReleaseBufferSize: 0,
+    resolverContext: {
+      counter: Observable.create<number>(observer => {
+        next = (value: number) => observer.next(value);
+      }),
+    },
+  });
+
+  const environment = new RelayModernEnvironment({
+    network: RelayNetwork.create(jest.fn()),
+    store,
+  });
+
+  let observedCounter = null;
+
+  const snapshot = environment.lookup(operation.fragment);
+  // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+  observedCounter = (snapshot.data: any).base_counter_context.count_plus_one;
+
+  const environmentUpdateHandler = jest.fn(() => {
+    const s = environment.lookup(operation.fragment);
+    // $FlowFixMe[unclear-type] - lookup() doesn't have the nice types of reading a fragment through the actual APIs:
+    observedCounter = (s.data: any).base_counter_context.count_plus_one;
+  });
+  const disposable = environment.subscribe(
+    snapshot,
+    // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
+    environmentUpdateHandler,
+  );
+
+  // SETUP COMPLETE
+
+  // Read the initial value
+  expect(observedCounter).toBe(0);
+  expect(environmentUpdateHandler).not.toHaveBeenCalled();
+
+  // Increment and assert we get notified of the new value
+  next(43);
+  expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
+  expect(observedCounter).toBe(44);
+
+  // Unsubscribe then increment and assert don't get notified.
+  disposable.dispose();
+  next(1);
+  expect(environmentUpdateHandler).toHaveBeenCalledTimes(1);
+  expect(observedCounter).toBe(44);
+
+  // Explicitly read and assert we see the incremented value
+  // missed before due to unsubscribing.
+  const nextSnapshot = environment.lookup(operation.fragment);
+
+  expect(nextSnapshot.data).toEqual({
+    base_counter_context: {
+      count_plus_one: 2,
+    },
+  });
+});

--- a/packages/react-relay/__tests__/RelayResolverModelWithContext-test.js
+++ b/packages/react-relay/__tests__/RelayResolverModelWithContext-test.js
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {LogEvent} from 'relay-runtime/store/RelayStoreTypes';
+import type {RelayResolverModelWithContextTestFragment$key} from './__generated__/RelayResolverModelWithContextTestFragment.graphql';
+import type {TestResolverContextType} from 'relay-runtime/mutations/__tests__/TestResolverContextType';
+import type {
+  RecordSourceProxy,
+  Snapshot,
+} from 'relay-runtime/store/RelayStoreTypes';
+
+const {Observable} = require('relay-runtime');
+
+const React = require('react');
+const {
+  RelayEnvironmentProvider,
+  useClientQuery,
+  useFragment,
+} = require('react-relay');
+const TestRenderer = require('react-test-renderer');
+const RelayNetwork = require('relay-runtime/network/RelayNetwork');
+const {graphql} = require('relay-runtime/query/GraphQLTag');
+const {
+  addTodo,
+  resetStore,
+} = require('relay-runtime/store/__tests__/resolvers/ExampleTodoStore');
+const RelayModernEnvironment = require('relay-runtime/store/RelayModernEnvironment');
+const RelayModernStore = require('relay-runtime/store/RelayModernStore.js');
+const RelayRecordSource = require('relay-runtime/store/RelayRecordSource');
+const {
+  createOperationDescriptor,
+} = require('relay-runtime/store/RelayModernOperationDescriptor');
+const {
+  createReaderSelector,
+} = require('relay-runtime/store/RelayModernSelector');
+const {
+  disallowConsoleErrors,
+  disallowWarnings,
+  injectPromisePolyfill__DEPRECATED,
+} = require('relay-test-utils-internal');
+
+injectPromisePolyfill__DEPRECATED();
+disallowWarnings();
+disallowConsoleErrors();
+
+beforeEach(() => {
+  resetStore(() => {});
+});
+
+function EnvironmentWrapper({
+  children,
+  environment,
+}: {
+  children: React.Node,
+  environment: RelayModernEnvironment,
+}) {
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      <React.Suspense fallback="Loading...">{children}</React.Suspense>
+    </RelayEnvironmentProvider>
+  );
+}
+
+const RelayResolverModelWithContextTestFragment = graphql`
+  fragment RelayResolverModelWithContextTestFragment on TodoModel {
+    id
+    description
+    another_value_from_context
+  }
+`;
+
+const RelayResolverModelWithContextTestQuery = graphql`
+  query RelayResolverModelWithContextTestQuery($id: ID!) {
+    todo_model(todoID: $id) {
+      ...RelayResolverModelWithContextTestFragment
+    }
+  }
+`;
+
+describe('RelayResolverModelWithContext', () => {
+  function TodoComponent(props: {
+    fragmentKey: ?RelayResolverModelWithContextTestFragment$key,
+  }) {
+    const data = useFragment(
+      RelayResolverModelWithContextTestFragment,
+      props.fragmentKey,
+    );
+    if (data == null) {
+      return null;
+    }
+
+    return data.another_value_from_context;
+  }
+
+  function TodoRootComponent(props: {todoID: string}) {
+    const data = useClientQuery(RelayResolverModelWithContextTestQuery, {
+      id: props.todoID,
+    });
+    if (data?.todo_model == null) {
+      return null;
+    }
+
+    return <TodoComponent fragmentKey={data?.todo_model} />;
+  }
+
+  test('returns a value from context when resolverDataInjector is used', () => {
+    const resolverContext: TestResolverContextType = {
+      greeting: {
+        myHello: 'This is a value from context',
+      },
+      counter: Observable.create<number>(observer => {
+        observer.next(10);
+      }),
+    };
+
+    const store = new RelayModernStore(RelayRecordSource.create(), {
+      resolverContext,
+    });
+    const environment = new RelayModernEnvironment({
+      network: RelayNetwork.create(jest.fn()),
+      store,
+    });
+
+    addTodo('Test todo');
+
+    let renderer;
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(
+        <EnvironmentWrapper environment={environment}>
+          <TodoRootComponent todoID="todo-1" />
+        </EnvironmentWrapper>,
+      );
+    });
+    expect(renderer?.toJSON()).toEqual('This is a value from context');
+  });
+});

--- a/packages/react-relay/__tests__/RelayResolverModelWithContext-test.js
+++ b/packages/react-relay/__tests__/RelayResolverModelWithContext-test.js
@@ -11,15 +11,8 @@
 
 'use strict';
 
-import type {LogEvent} from 'relay-runtime/store/RelayStoreTypes';
 import type {RelayResolverModelWithContextTestFragment$key} from './__generated__/RelayResolverModelWithContextTestFragment.graphql';
 import type {TestResolverContextType} from 'relay-runtime/mutations/__tests__/TestResolverContextType';
-import type {
-  RecordSourceProxy,
-  Snapshot,
-} from 'relay-runtime/store/RelayStoreTypes';
-
-const {Observable} = require('relay-runtime');
 
 const React = require('react');
 const {
@@ -28,6 +21,7 @@ const {
   useFragment,
 } = require('react-relay');
 const TestRenderer = require('react-test-renderer');
+const {Observable} = require('relay-runtime');
 const RelayNetwork = require('relay-runtime/network/RelayNetwork');
 const {graphql} = require('relay-runtime/query/GraphQLTag');
 const {
@@ -37,12 +31,6 @@ const {
 const RelayModernEnvironment = require('relay-runtime/store/RelayModernEnvironment');
 const RelayModernStore = require('relay-runtime/store/RelayModernStore.js');
 const RelayRecordSource = require('relay-runtime/store/RelayRecordSource');
-const {
-  createOperationDescriptor,
-} = require('relay-runtime/store/RelayModernOperationDescriptor');
-const {
-  createReaderSelector,
-} = require('relay-runtime/store/RelayModernSelector');
 const {
   disallowConsoleErrors,
   disallowWarnings,

--- a/packages/react-relay/__tests__/__generated__/LiveResolversTestCounterContextBaseQuery.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/LiveResolversTestCounterContextBaseQuery.graphql.js
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<743370490ceef61e2730285c6cb8f8cf>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ClientRequest, ClientQuery } from 'relay-runtime';
+import type { LiveState } from "relay-runtime";
+import type { BaseCounter____relay_model_instance$data } from "./../../../relay-runtime/store/__tests__/resolvers/__generated__/BaseCounter____relay_model_instance.graphql";
+import {count_plus_one as baseCounterCountPlusOneResolverType} from "../../../relay-runtime/store/__tests__/resolvers/LiveCounterContextResolver.js";
+import type { TestResolverContextType } from "../../../relay-runtime/mutations/__tests__/TestResolverContextType";
+// Type assertion validating that `baseCounterCountPlusOneResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(baseCounterCountPlusOneResolverType: (
+  __relay_model_instance: BaseCounter____relay_model_instance$data['__relay_model_instance'],
+  args: void,
+  context: TestResolverContextType,
+) => LiveState<?number>);
+import {base_counter_context as queryBaseCounterContextResolverType} from "../../../relay-runtime/store/__tests__/resolvers/LiveCounterContextResolver.js";
+// Type assertion validating that `queryBaseCounterContextResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(queryBaseCounterContextResolverType: (
+  args: void,
+  context: TestResolverContextType,
+) => LiveState<?BaseCounter>);
+import type { BaseCounter } from "../../../relay-runtime/store/__tests__/resolvers/LiveCounterContextResolver.js";
+export type LiveResolversTestCounterContextBaseQuery$variables = {||};
+export type LiveResolversTestCounterContextBaseQuery$data = {|
+  +base_counter_context: ?{|
+    +count_plus_one: ?number,
+  |},
+|};
+export type LiveResolversTestCounterContextBaseQuery = {|
+  response: LiveResolversTestCounterContextBaseQuery$data,
+  variables: LiveResolversTestCounterContextBaseQuery$variables,
+|};
+*/
+
+var node/*: ClientRequest*/ = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": {
+      "hasClientEdges": true
+    },
+    "name": "LiveResolversTestCounterContextBaseQuery",
+    "selections": [
+      {
+        "kind": "ClientEdgeToClientObject",
+        "concreteType": "BaseCounter",
+        "modelResolvers": null,
+        "backingField": {
+          "alias": null,
+          "args": null,
+          "fragment": null,
+          "kind": "RelayLiveResolver",
+          "name": "base_counter_context",
+          "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterContextResolver').base_counter_context,
+          "path": "base_counter_context",
+          "normalizationInfo": {
+            "kind": "WeakModel",
+            "concreteType": "BaseCounter",
+            "plural": false
+          }
+        },
+        "linkedField": {
+          "alias": null,
+          "args": null,
+          "concreteType": "BaseCounter",
+          "kind": "LinkedField",
+          "name": "base_counter_context",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "fragment": {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "BaseCounter____relay_model_instance"
+              },
+              "kind": "RelayLiveResolver",
+              "name": "count_plus_one",
+              "resolverModule": require('relay-runtime/experimental').resolverDataInjector(require('./../../../relay-runtime/store/__tests__/resolvers/__generated__/BaseCounter____relay_model_instance.graphql'), require('./../../../relay-runtime/store/__tests__/resolvers/LiveCounterContextResolver').count_plus_one, '__relay_model_instance', true),
+              "path": "base_counter_context.count_plus_one"
+            }
+          ],
+          "storageKey": null
+        }
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "LiveResolversTestCounterContextBaseQuery",
+    "selections": [
+      {
+        "kind": "ClientEdgeToClientObject",
+        "backingField": {
+          "name": "base_counter_context",
+          "args": null,
+          "fragment": null,
+          "kind": "RelayResolver",
+          "storageKey": null,
+          "isOutputType": true
+        },
+        "linkedField": {
+          "alias": null,
+          "args": null,
+          "concreteType": "BaseCounter",
+          "kind": "LinkedField",
+          "name": "base_counter_context",
+          "plural": false,
+          "selections": [
+            {
+              "name": "count_plus_one",
+              "args": null,
+              "fragment": {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__relay_model_instance",
+                    "storageKey": null
+                  }
+                ],
+                "type": "BaseCounter",
+                "abstractKey": null
+              },
+              "kind": "RelayResolver",
+              "storageKey": null,
+              "isOutputType": true
+            }
+          ],
+          "storageKey": null
+        }
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "97f0edeb9700f58debe76b3ab0ca4f82",
+    "id": null,
+    "metadata": {},
+    "name": "LiveResolversTestCounterContextBaseQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "a7ba71ed7b3caaefa42c8686bc81819c";
+}
+
+module.exports = ((node/*: any*/)/*: ClientQuery<
+  LiveResolversTestCounterContextBaseQuery$variables,
+  LiveResolversTestCounterContextBaseQuery$data,
+>*/);

--- a/packages/react-relay/__tests__/__generated__/RelayResolverModelWithContextTestFragment.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/RelayResolverModelWithContextTestFragment.graphql.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<c9a76d766f3255433503b0f7c4f4dd16>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { TodoModel____relay_model_instance$data } from "./../../../relay-runtime/store/__tests__/resolvers/__generated__/TodoModel____relay_model_instance.graphql";
+import type { FragmentType } from "relay-runtime";
+import {another_value_from_context as todoModelAnotherValueFromContextResolverType} from "../../../relay-runtime/store/__tests__/resolvers/TodoModel.js";
+import type { TestResolverContextType } from "../../../relay-runtime/mutations/__tests__/TestResolverContextType";
+// Type assertion validating that `todoModelAnotherValueFromContextResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(todoModelAnotherValueFromContextResolverType: (
+  __relay_model_instance: TodoModel____relay_model_instance$data['__relay_model_instance'],
+  args: void,
+  context: TestResolverContextType,
+) => ?string);
+import {description as todoModelDescriptionResolverType} from "../../../relay-runtime/store/__tests__/resolvers/TodoModel.js";
+// Type assertion validating that `todoModelDescriptionResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(todoModelDescriptionResolverType: (
+  __relay_model_instance: TodoModel____relay_model_instance$data['__relay_model_instance'],
+  args: void,
+  context: TestResolverContextType,
+) => ?string);
+declare export opaque type RelayResolverModelWithContextTestFragment$fragmentType: FragmentType;
+export type RelayResolverModelWithContextTestFragment$data = {|
+  +another_value_from_context: ?string,
+  +description: ?string,
+  +id: string,
+  +$fragmentType: RelayResolverModelWithContextTestFragment$fragmentType,
+|};
+export type RelayResolverModelWithContextTestFragment$key = {
+  +$data?: RelayResolverModelWithContextTestFragment$data,
+  +$fragmentSpreads: RelayResolverModelWithContextTestFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = (function(){
+var v0 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "TodoModel____relay_model_instance"
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayResolverModelWithContextTestFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "fragment": (v0/*: any*/),
+      "kind": "RelayResolver",
+      "name": "description",
+      "resolverModule": require('relay-runtime/experimental').resolverDataInjector(require('./../../../relay-runtime/store/__tests__/resolvers/__generated__/TodoModel____relay_model_instance.graphql'), require('./../../../relay-runtime/store/__tests__/resolvers/TodoModel').description, '__relay_model_instance', true),
+      "path": "description"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "fragment": (v0/*: any*/),
+      "kind": "RelayResolver",
+      "name": "another_value_from_context",
+      "resolverModule": require('relay-runtime/experimental').resolverDataInjector(require('./../../../relay-runtime/store/__tests__/resolvers/__generated__/TodoModel____relay_model_instance.graphql'), require('./../../../relay-runtime/store/__tests__/resolvers/TodoModel').another_value_from_context, '__relay_model_instance', true),
+      "path": "another_value_from_context"
+    },
+    {
+      "kind": "ClientExtension",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "TodoModel",
+  "abstractKey": null
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "5373c916bad7d7b7c83e32558cfde3d4";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  RelayResolverModelWithContextTestFragment$fragmentType,
+  RelayResolverModelWithContextTestFragment$data,
+>*/);

--- a/packages/react-relay/__tests__/__generated__/RelayResolverModelWithContextTestQuery.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/RelayResolverModelWithContextTestQuery.graphql.js
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<da08e77fcbbf533ad837fd49990c2af1>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ClientRequest, ClientQuery } from 'relay-runtime';
+import type { DataID } from "relay-runtime";
+import type { RelayResolverModelWithContextTestFragment$fragmentType } from "./RelayResolverModelWithContextTestFragment.graphql";
+import {todo_model as queryTodoModelResolverType} from "../../../relay-runtime/store/__tests__/resolvers/QueryTodoModel.js";
+import type { TestResolverContextType } from "../../../relay-runtime/mutations/__tests__/TestResolverContextType";
+// Type assertion validating that `queryTodoModelResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(queryTodoModelResolverType: (
+  args: {|
+    todoID: string,
+  |},
+  context: TestResolverContextType,
+) => ?{|
+  +id: DataID,
+|});
+export type RelayResolverModelWithContextTestQuery$variables = {|
+  id: string,
+|};
+export type RelayResolverModelWithContextTestQuery$data = {|
+  +todo_model: ?{|
+    +$fragmentSpreads: RelayResolverModelWithContextTestFragment$fragmentType,
+  |},
+|};
+export type RelayResolverModelWithContextTestQuery = {|
+  response: RelayResolverModelWithContextTestQuery$data,
+  variables: RelayResolverModelWithContextTestQuery$variables,
+|};
+*/
+
+var node/*: ClientRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "todoID",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "name": "__relay_model_instance",
+      "args": null,
+      "fragment": {
+        "kind": "InlineFragment",
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "type": "TodoModel",
+        "abstractKey": null
+      },
+      "kind": "RelayResolver",
+      "storageKey": null,
+      "isOutputType": false
+    }
+  ],
+  "type": "TodoModel",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": {
+      "hasClientEdges": true
+    },
+    "name": "RelayResolverModelWithContextTestQuery",
+    "selections": [
+      {
+        "kind": "ClientEdgeToClientObject",
+        "concreteType": "TodoModel",
+        "modelResolvers": {
+          "TodoModel": {
+            "alias": null,
+            "args": [],
+            "fragment": {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "TodoModel__id"
+            },
+            "kind": "RelayLiveResolver",
+            "name": "todo_model",
+            "resolverModule": require('relay-runtime/experimental').resolverDataInjector(require('./../../../relay-runtime/store/__tests__/resolvers/__generated__/TodoModel__id.graphql'), require('./../../../relay-runtime/store/__tests__/resolvers/TodoModel').TodoModel, 'id', true),
+            "path": "todo_model.__relay_model_instance"
+          }
+        },
+        "backingField": {
+          "alias": null,
+          "args": (v1/*: any*/),
+          "fragment": null,
+          "kind": "RelayResolver",
+          "name": "todo_model",
+          "resolverModule": require('./../../../relay-runtime/store/__tests__/resolvers/QueryTodoModel').todo_model,
+          "path": "todo_model"
+        },
+        "linkedField": {
+          "alias": null,
+          "args": (v1/*: any*/),
+          "concreteType": "TodoModel",
+          "kind": "LinkedField",
+          "name": "todo_model",
+          "plural": false,
+          "selections": [
+            {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "RelayResolverModelWithContextTestFragment"
+            }
+          ],
+          "storageKey": null
+        }
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RelayResolverModelWithContextTestQuery",
+    "selections": [
+      {
+        "kind": "ClientEdgeToClientObject",
+        "backingField": {
+          "name": "todo_model",
+          "args": (v1/*: any*/),
+          "fragment": null,
+          "kind": "RelayResolver",
+          "storageKey": null,
+          "isOutputType": false
+        },
+        "linkedField": {
+          "alias": null,
+          "args": (v1/*: any*/),
+          "concreteType": "TodoModel",
+          "kind": "LinkedField",
+          "name": "todo_model",
+          "plural": false,
+          "selections": [
+            (v2/*: any*/),
+            {
+              "name": "description",
+              "args": null,
+              "fragment": (v3/*: any*/),
+              "kind": "RelayResolver",
+              "storageKey": null,
+              "isOutputType": true
+            },
+            {
+              "name": "another_value_from_context",
+              "args": null,
+              "fragment": (v3/*: any*/),
+              "kind": "RelayResolver",
+              "storageKey": null,
+              "isOutputType": true
+            }
+          ],
+          "storageKey": null
+        }
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "0196832cb242ac4177d6b6eede119e96",
+    "id": null,
+    "metadata": {},
+    "name": "RelayResolverModelWithContextTestQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "5322e368bc0ab0fd2107e5680043ba4c";
+}
+
+module.exports = ((node/*: any*/)/*: ClientQuery<
+  RelayResolverModelWithContextTestQuery$variables,
+  RelayResolverModelWithContextTestQuery$data,
+>*/);

--- a/packages/relay-runtime/store/RelayModernStore.js
+++ b/packages/relay-runtime/store/RelayModernStore.js
@@ -165,14 +165,15 @@ class RelayModernStore implements Store {
       () => this._getMutableRecordSource(),
       this,
     );
+    this._resolverContext = options?.resolverContext;
     this._storeSubscriptions = new RelayStoreSubscriptions(
       options?.log,
       this._resolverCache,
+      this._resolverContext,
     );
     this._updatedRecordIDs = new Set();
     this._shouldProcessClientComponents =
       options?.shouldProcessClientComponents ?? false;
-    this._resolverContext = options?.resolverContext;
 
     this._treatMissingFieldsAsNull = options?.treatMissingFieldsAsNull ?? false;
     this._actorIdentifier = options?.actorIdentifier;

--- a/packages/relay-runtime/store/RelayStoreSubscriptions.js
+++ b/packages/relay-runtime/store/RelayStoreSubscriptions.js
@@ -42,12 +42,12 @@ class RelayStoreSubscriptions implements StoreSubscriptions {
   _subscriptions: Set<Subscription>;
   __log: ?LogFunction;
   _resolverCache: ResolverCache;
-  _resolverContext: ?ResolverContext;
+  _resolverContext: ResolverContext;
 
   constructor(
     log?: ?LogFunction,
     resolverCache: ResolverCache,
-    resolverContext?: ResolverContext,
+    resolverContext: ResolverContext,
   ) {
     this._subscriptions = new Set();
     this.__log = log;

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-SubscriptionWithResolverContext-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-SubscriptionWithResolverContext-test.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+import type {Snapshot} from '../RelayStoreTypes';
+import type {RecordSourceProxy} from 'relay-runtime/store/RelayStoreTypes';
+
+const {
+  MultiActorEnvironment,
+  getActorIdentifier,
+} = require('../../multi-actor-environment');
+const RelayNetwork = require('../../network/RelayNetwork');
+const {graphql} = require('../../query/GraphQLTag');
+const RelayModernEnvironment = require('../RelayModernEnvironment');
+const {
+  createOperationDescriptor,
+} = require('../RelayModernOperationDescriptor');
+const {createReaderSelector} = require('../RelayModernSelector');
+const RelayModernStore = require('../RelayModernStore');
+const RelayRecordSource = require('../RelayRecordSource');
+const {disallowWarnings} = require('relay-test-utils-internal');
+
+disallowWarnings();
+
+describe('RelayContext works when applying updates and gets passed through to the RelayStoreSubscriptions', () => {
+  it('correctly using the resolver data from the context', () => {
+    const ParentQuery = graphql`
+      query RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery {
+        me {
+          ...RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment
+        }
+      }
+    `;
+    const UserFragment = graphql`
+      fragment RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment on User {
+        id
+        name
+        age
+      }
+    `;
+
+    const source = RelayRecordSource.create();
+    const store = new RelayModernStore(source, {
+      resolverContext: {
+        age: 42,
+      },
+    });
+    const multiActorEnvironment = new MultiActorEnvironment({
+      createNetworkForActor: _actorID => RelayNetwork.create(jest.fn()),
+      createStoreForActor: _actorID => store,
+    });
+    const environment = new RelayModernEnvironment({
+      network: RelayNetwork.create(jest.fn()),
+      store,
+    });
+    const operation = createOperationDescriptor(ParentQuery, {});
+
+    const selector = createReaderSelector(
+      UserFragment,
+      '4',
+      {},
+      operation.request,
+    );
+    const callback = jest.fn<[Snapshot], void>();
+    const snapshot = environment.lookup(selector);
+    environment.subscribe(snapshot, callback);
+
+    callback.mockClear();
+    const updater = {
+      storeUpdater: (proxyStore: RecordSourceProxy) => {
+        const zuck = proxyStore.create('4', 'User');
+        zuck.setValue('4', 'id');
+      },
+    };
+    environment.applyUpdate(updater);
+    environment.replaceUpdate(updater, {
+      storeUpdater: proxyStore => {
+        const zuck = proxyStore.create('4', 'User');
+        zuck.setValue('4', 'id');
+        zuck.setValue('zuck', 'name');
+      },
+    });
+    expect(callback.mock.calls.length).toBe(2);
+    expect(callback.mock.calls[0][0].data).toEqual({
+      id: '4',
+      age: 42,
+    });
+    expect(callback.mock.calls[1][0].data).toEqual({
+      id: '4',
+      name: 'zuck',
+      age: 42,
+    });
+  });
+});

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-SubscriptionWithResolverContext-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-SubscriptionWithResolverContext-test.js
@@ -13,10 +13,6 @@
 import type {Snapshot} from '../RelayStoreTypes';
 import type {RecordSourceProxy} from 'relay-runtime/store/RelayStoreTypes';
 
-const {
-  MultiActorEnvironment,
-  getActorIdentifier,
-} = require('../../multi-actor-environment');
 const RelayNetwork = require('../../network/RelayNetwork');
 const {graphql} = require('../../query/GraphQLTag');
 const RelayModernEnvironment = require('../RelayModernEnvironment');
@@ -52,10 +48,6 @@ describe('RelayContext works when applying updates and gets passed through to th
       resolverContext: {
         age: 42,
       },
-    });
-    const multiActorEnvironment = new MultiActorEnvironment({
-      createNetworkForActor: _actorID => RelayNetwork.create(jest.fn()),
-      createStoreForActor: _actorID => store,
     });
     const environment = new RelayModernEnvironment({
       network: RelayNetwork.create(jest.fn()),

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery.graphql.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<ae33f4ea5c0717fc08b0a1597597cb9f>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$fragmentType } from "./RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment.graphql";
+export type RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery$variables = {||};
+export type RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery$data = {|
+  +me: ?{|
+    +$fragmentSpreads: RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$fragmentType,
+  |},
+|};
+export type RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery = {|
+  response: RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery$data,
+  variables: RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "kind": "ClientExtension",
+            "selections": [
+              {
+                "name": "age",
+                "args": null,
+                "fragment": null,
+                "kind": "RelayResolver",
+                "storageKey": null,
+                "isOutputType": true
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c498bb05241f280bc2224c29335322d9",
+    "id": null,
+    "metadata": {},
+    "name": "RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery",
+    "operationKind": "query",
+    "text": "query RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery {\n  me {\n    ...RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment\n    id\n  }\n}\n\nfragment RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment on User {\n  id\n  name\n}\n"
+  }
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "51bb39abe5fa87455d7805c59b5def94";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery$variables,
+  RelayModernEnvironmentSubscriptionWithResolverContextTestParentQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment.graphql.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<c229babd67df2794fa89b520672b0fc5>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+import {age as userAgeResolverType} from "../resolvers/UserAgeResolvers.js";
+import type { TestResolverContextType } from "../../../mutations/__tests__/TestResolverContextType";
+// Type assertion validating that `userAgeResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(userAgeResolverType: (
+  args: void,
+  context: TestResolverContextType,
+) => ?number);
+declare export opaque type RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$fragmentType: FragmentType;
+export type RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$data = {|
+  +age: ?number,
+  +id: string,
+  +name: ?string,
+  +$fragmentType: RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$fragmentType,
+|};
+export type RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$key = {
+  +$data?: RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$data,
+  +$fragmentSpreads: RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "kind": "ClientExtension",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "fragment": null,
+          "kind": "RelayResolver",
+          "name": "age",
+          "resolverModule": require('./../resolvers/UserAgeResolvers').age,
+          "path": "age"
+        }
+      ]
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "66a7aeaa5486c95229787503c12b1aa0";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$fragmentType,
+  RelayModernEnvironmentSubscriptionWithResolverContextTestUserFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/resolvers/LiveCounterContextResolver.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/LiveCounterContextResolver.js
@@ -44,6 +44,79 @@ function counter_context(
   };
 }
 
+/**
+ * @RelayResolver BaseCounter
+ * @weak
+ */
+export type BaseCounter = {
+  count: number,
+};
+
+/**
+ * @RelayResolver Query.base_counter_context: BaseCounter
+ * @live
+ *
+ * A Relay Resolver that returns an object implementing the External State
+ * Resolver interface.
+ */
+function base_counter_context(
+  _args: void,
+  context: TestResolverContextType,
+): LiveState<BaseCounter> {
+  let value = 0;
+
+  return {
+    read() {
+      return {
+        count: value,
+      };
+    },
+    subscribe(cb): () => void {
+      const subscription = context.counter.subscribe({
+        next: v => {
+          value = v;
+          cb();
+        },
+      });
+
+      return () => subscription.unsubscribe();
+    },
+  };
+}
+
+/**
+ * @RelayResolver BaseCounter.count_plus_one: Int
+ * @live
+ *
+ * A Relay Resolver that returns an object implementing the External State
+ * Resolver interface.
+ */
+function count_plus_one(
+  _parent: mixed,
+  _args: void,
+  context: TestResolverContextType,
+): LiveState<number> {
+  let value = 0;
+
+  return {
+    read() {
+      return value;
+    },
+    subscribe(cb): () => void {
+      const subscription = context.counter.subscribe({
+        next: v => {
+          value = v + 1;
+          cb();
+        },
+      });
+
+      return () => subscription.unsubscribe();
+    },
+  };
+}
+
 module.exports = {
   counter_context,
+  base_counter_context,
+  count_plus_one,
 };

--- a/packages/relay-runtime/store/__tests__/resolvers/TodoModel.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/TodoModel.js
@@ -11,6 +11,7 @@
 
 'use strict';
 
+import type {TestResolverContextType} from '../../../mutations/__tests__/TestResolverContextType';
 import type {TodoModelCapitalizedID$key} from './__generated__/TodoModelCapitalizedID.graphql';
 import type {TodoModelCapitalizedIDLegacy$key} from './__generated__/TodoModelCapitalizedIDLegacy.graphql';
 import type {TodoDescription} from './TodoDescription';
@@ -25,7 +26,6 @@ const {
   Selectors,
   TODO_STORE,
 } = require('relay-runtime/store/__tests__/resolvers/ExampleTodoStore');
-import type {TestResolverContextType} from '../../../mutations/__tests__/TestResolverContextType';
 
 type TodoModelType = ?TodoItem;
 

--- a/packages/relay-runtime/store/__tests__/resolvers/TodoModel.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/TodoModel.js
@@ -25,6 +25,7 @@ const {
   Selectors,
   TODO_STORE,
 } = require('relay-runtime/store/__tests__/resolvers/ExampleTodoStore');
+import type {TestResolverContextType} from '../../../mutations/__tests__/TestResolverContextType';
 
 type TodoModelType = ?TodoItem;
 
@@ -48,6 +49,17 @@ function TodoModel(id: string): LiveState<TodoModelType> {
  */
 function description(model: TodoModelType): ?string {
   return model?.description;
+}
+
+/**
+ * @RelayResolver TodoModel.another_value_from_context: String
+ */
+function another_value_from_context(
+  model: TodoModelType,
+  _: mixed,
+  context: TestResolverContextType,
+): ?string {
+  return context?.greeting.myHello;
 }
 
 /**
@@ -180,6 +192,7 @@ module.exports = {
   todo_model_null,
   TodoModel,
   description,
+  another_value_from_context,
   fancy_description,
   fancy_description_null,
   fancy_description_suspends,

--- a/packages/relay-runtime/store/__tests__/resolvers/UserAgeResolvers.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/UserAgeResolvers.js
@@ -1,5 +1,3 @@
-import type { LiveState} from 'relay-runtime/store/RelayStoreTypes';
-
 /**
  * @RelayResolver User.age: Int
  */

--- a/packages/relay-runtime/store/__tests__/resolvers/UserAgeResolvers.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/UserAgeResolvers.js
@@ -1,0 +1,12 @@
+import type { LiveState} from 'relay-runtime/store/RelayStoreTypes';
+
+/**
+ * @RelayResolver User.age: Int
+ */
+function age(_: mixed, context: { age: number }): number {
+    return context.age;
+}
+
+module.exports = {
+    age,
+};

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/BaseCounter____relay_model_instance.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/BaseCounter____relay_model_instance.graphql.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<7a18458e8e74a97968fd3346963dee05>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { BaseCounter } from "../LiveCounterContextResolver.js";
+import type { FragmentType } from "relay-runtime";
+declare export opaque type BaseCounter____relay_model_instance$fragmentType: FragmentType;
+export type BaseCounter____relay_model_instance$data = {|
+  +__relay_model_instance: BaseCounter,
+  +$fragmentType: BaseCounter____relay_model_instance$fragmentType,
+|};
+export type BaseCounter____relay_model_instance$key = {
+  +$data?: BaseCounter____relay_model_instance$data,
+  +$fragmentSpreads: BaseCounter____relay_model_instance$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "BaseCounter____relay_model_instance",
+  "selections": [
+    {
+      "kind": "ClientExtension",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__relay_model_instance",
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "BaseCounter",
+  "abstractKey": null
+};
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  BaseCounter____relay_model_instance$fragmentType,
+  BaseCounter____relay_model_instance$data,
+>*/);

--- a/packages/relay-runtime/store/live-resolvers/resolverDataInjector.js
+++ b/packages/relay-runtime/store/live-resolvers/resolverDataInjector.js
@@ -12,12 +12,12 @@
 'use strict';
 
 import type {Fragment} from '../../util/RelayRuntimeTypes';
-import type {FragmentType} from '../RelayStoreTypes';
+import type {FragmentType, ResolverContext} from '../RelayStoreTypes';
 
 const {readFragment} = require('../ResolverFragments');
 const invariant = require('invariant');
 
-type ResolverFn = ($FlowFixMe, ?$FlowFixMe) => mixed;
+type ResolverFn = ($FlowFixMe, ?$FlowFixMe, ResolverContext) => mixed;
 
 /**
  *
@@ -40,7 +40,11 @@ function resolverDataInjector<TFragmentType: FragmentType, TData: ?{...}>(
   isRequiredField?: boolean,
 ): (fragmentKey: TFragmentType, args: mixed) => mixed {
   const resolverFn: ResolverFn = _resolverFn;
-  return (fragmentKey: TFragmentType, args: mixed): mixed => {
+  return (
+    fragmentKey: TFragmentType,
+    args: mixed,
+    resolverContext: ResolverContext,
+  ): mixed => {
     const data = readFragment(fragment, fragmentKey);
     if (fieldName != null) {
       if (data == null) {
@@ -52,7 +56,7 @@ function resolverDataInjector<TFragmentType: FragmentType, TData: ?{...}>(
             fragment.name,
           );
         } else {
-          return resolverFn(null, args);
+          return resolverFn(null, args, resolverContext); // TODO: This statement does not seem to be covered by a test?
         }
       }
 
@@ -70,7 +74,7 @@ function resolverDataInjector<TFragmentType: FragmentType, TData: ?{...}>(
         }
 
         // $FlowFixMe[invalid-computed-prop]
-        return resolverFn(data[fieldName], args);
+        return resolverFn(data[fieldName], args, resolverContext);
       } else {
         // If both `data` and `fieldName` is available, we expect the
         // `fieldName` field in the `data` object.
@@ -83,7 +87,7 @@ function resolverDataInjector<TFragmentType: FragmentType, TData: ?{...}>(
       }
     } else {
       // By default we will pass the full set of the fragment data to the resolver
-      return resolverFn(data, args);
+      return resolverFn(null, args, resolverContext); // TODO: This statement does not seem to be covered by a test?
     }
   };
 }


### PR DESCRIPTION
This PR fixes two issues we've encountered.

1. ResolverContext isn't passed through the `resolverDataInjector`. This surfaces specifically when using nested resolvers.
2. When updates propagate through the RelayStoreSubscriptions the context value is lost due the RelayStoreSubscriptions instance not receiving the context correctly.

I noticed two of the 3 paths in `resolverDataInjector` do not seem to be covered by tests.