### PR TITLE
Add plural fragment support to `observeFragment()`

### DIFF
--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestListUpdateFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestListUpdateFragment.graphql.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<dda30aab49d809d126154385fbf1746c>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type observeFragmentTestListUpdateFragment$fragmentType: FragmentType;
+export type observeFragmentTestListUpdateFragment$data = $ReadOnlyArray<{|
+  +name: ?string,
+  +$fragmentType: observeFragmentTestListUpdateFragment$fragmentType,
+|}>;
+export type observeFragmentTestListUpdateFragment$key = $ReadOnlyArray<{
+  +$data?: observeFragmentTestListUpdateFragment$data,
+  +$fragmentSpreads: observeFragmentTestListUpdateFragment$fragmentType,
+  ...
+}>;
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "observeFragmentTestListUpdateFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "30d272ba4e5c5a9eb1d9a79015a69ec3";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  observeFragmentTestListUpdateFragment$fragmentType,
+  observeFragmentTestListUpdateFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestListUpdateQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestListUpdateQuery.graphql.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<4337e2999734809a390206fb499f653e>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { observeFragmentTestListUpdateFragment$fragmentType } from "./observeFragmentTestListUpdateFragment.graphql";
+export type observeFragmentTestListUpdateQuery$variables = {||};
+export type observeFragmentTestListUpdateQuery$data = {|
+  +nodes: ?$ReadOnlyArray<?{|
+    +$fragmentSpreads: observeFragmentTestListUpdateFragment$fragmentType,
+  |}>,
+|};
+export type observeFragmentTestListUpdateQuery = {|
+  response: observeFragmentTestListUpdateQuery$data,
+  variables: observeFragmentTestListUpdateQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "ids",
+    "value": [
+      "1",
+      "2"
+    ]
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "observeFragmentTestListUpdateQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "observeFragmentTestListUpdateFragment"
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "observeFragmentTestListUpdateQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "17a222c7e13bc4a3b9c0c108377514da",
+    "id": null,
+    "metadata": {},
+    "name": "observeFragmentTestListUpdateQuery",
+    "operationKind": "query",
+    "text": "query observeFragmentTestListUpdateQuery {\n  nodes(ids: [\"1\", \"2\"]) {\n    __typename\n    ...observeFragmentTestListUpdateFragment\n    id\n  }\n}\n\nfragment observeFragmentTestListUpdateFragment on User {\n  name\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "493ccdbc127bfccc347fc16107f21b79";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  observeFragmentTestListUpdateQuery$variables,
+  observeFragmentTestListUpdateQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestMissingRequiredPluralFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestMissingRequiredPluralFragment.graphql.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<80e54ca26f89d2d71c3bb618efa15d49>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type observeFragmentTestMissingRequiredPluralFragment$fragmentType: FragmentType;
+export type observeFragmentTestMissingRequiredPluralFragment$data = $ReadOnlyArray<{|
+  +name: string,
+  +$fragmentType: observeFragmentTestMissingRequiredPluralFragment$fragmentType,
+|}>;
+export type observeFragmentTestMissingRequiredPluralFragment$key = $ReadOnlyArray<{
+  +$data?: observeFragmentTestMissingRequiredPluralFragment$data,
+  +$fragmentSpreads: observeFragmentTestMissingRequiredPluralFragment$fragmentType,
+  ...
+}>;
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "observeFragmentTestMissingRequiredPluralFragment",
+  "selections": [
+    {
+      "kind": "RequiredField",
+      "field": {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "name",
+        "storageKey": null
+      },
+      "action": "THROW"
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "0a62ca17583bf06a225f706e103dc11e";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  observeFragmentTestMissingRequiredPluralFragment$fragmentType,
+  observeFragmentTestMissingRequiredPluralFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestMissingRequiredPluralQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestMissingRequiredPluralQuery.graphql.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<0ee8f9cd4d1a4269af40172b0c55884d>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { observeFragmentTestMissingRequiredPluralFragment$fragmentType } from "./observeFragmentTestMissingRequiredPluralFragment.graphql";
+export type observeFragmentTestMissingRequiredPluralQuery$variables = {||};
+export type observeFragmentTestMissingRequiredPluralQuery$data = {|
+  +nodes: ?$ReadOnlyArray<?{|
+    +$fragmentSpreads: observeFragmentTestMissingRequiredPluralFragment$fragmentType,
+  |}>,
+|};
+export type observeFragmentTestMissingRequiredPluralQuery = {|
+  response: observeFragmentTestMissingRequiredPluralQuery$data,
+  variables: observeFragmentTestMissingRequiredPluralQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "ids",
+    "value": [
+      "1",
+      "2"
+    ]
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "observeFragmentTestMissingRequiredPluralQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "observeFragmentTestMissingRequiredPluralFragment"
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "observeFragmentTestMissingRequiredPluralQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d1213ecc01790c61de1e12d97a40c349",
+    "id": null,
+    "metadata": {},
+    "name": "observeFragmentTestMissingRequiredPluralQuery",
+    "operationKind": "query",
+    "text": "query observeFragmentTestMissingRequiredPluralQuery {\n  nodes(ids: [\"1\", \"2\"]) {\n    __typename\n    ...observeFragmentTestMissingRequiredPluralFragment\n    id\n  }\n}\n\nfragment observeFragmentTestMissingRequiredPluralFragment on User {\n  name\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "1eb9c5256c37c4d0e28695bb4dd64fa8";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  observeFragmentTestMissingRequiredPluralQuery$variables,
+  observeFragmentTestMissingRequiredPluralQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestPluralFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestPluralFragment.graphql.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<dad48f2a830a85c8d28eea49c2e5b996>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type observeFragmentTestPluralFragment$fragmentType: FragmentType;
+export type observeFragmentTestPluralFragment$data = $ReadOnlyArray<{|
+  +name: ?string,
+  +$fragmentType: observeFragmentTestPluralFragment$fragmentType,
+|}>;
+export type observeFragmentTestPluralFragment$key = $ReadOnlyArray<{
+  +$data?: observeFragmentTestPluralFragment$data,
+  +$fragmentSpreads: observeFragmentTestPluralFragment$fragmentType,
+  ...
+}>;
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "observeFragmentTestPluralFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "3b473578ee9b2f35ed7214e714f68334";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  observeFragmentTestPluralFragment$fragmentType,
+  observeFragmentTestPluralFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestPluralQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestPluralQuery.graphql.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<8ed3e238203c49288429f434ff0ef253>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { observeFragmentTestPluralFragment$fragmentType } from "./observeFragmentTestPluralFragment.graphql";
+export type observeFragmentTestPluralQuery$variables = {||};
+export type observeFragmentTestPluralQuery$data = {|
+  +nodes: ?$ReadOnlyArray<?{|
+    +$fragmentSpreads: observeFragmentTestPluralFragment$fragmentType,
+  |}>,
+|};
+export type observeFragmentTestPluralQuery = {|
+  response: observeFragmentTestPluralQuery$data,
+  variables: observeFragmentTestPluralQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "ids",
+    "value": [
+      "1",
+      "2"
+    ]
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "observeFragmentTestPluralQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "observeFragmentTestPluralFragment"
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "observeFragmentTestPluralQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ccff1412490c5e62d70031d41db0c7e4",
+    "id": null,
+    "metadata": {},
+    "name": "observeFragmentTestPluralQuery",
+    "operationKind": "query",
+    "text": "query observeFragmentTestPluralQuery {\n  nodes(ids: [\"1\", \"2\"]) {\n    __typename\n    ...observeFragmentTestPluralFragment\n    id\n  }\n}\n\nfragment observeFragmentTestPluralFragment on User {\n  name\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "c1a2f68df2ec25bc00b077d6cdecdce4";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  observeFragmentTestPluralQuery$variables,
+  observeFragmentTestPluralQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestPluralThrowOnFieldErrorFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestPluralThrowOnFieldErrorFragment.graphql.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<73dfa993cd14eb071971ec8ae446eea0>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type observeFragmentTestPluralThrowOnFieldErrorFragment$fragmentType: FragmentType;
+export type observeFragmentTestPluralThrowOnFieldErrorFragment$data = $ReadOnlyArray<{|
+  +name: ?string,
+  +$fragmentType: observeFragmentTestPluralThrowOnFieldErrorFragment$fragmentType,
+|}>;
+export type observeFragmentTestPluralThrowOnFieldErrorFragment$key = $ReadOnlyArray<{
+  +$data?: observeFragmentTestPluralThrowOnFieldErrorFragment$data,
+  +$fragmentSpreads: observeFragmentTestPluralThrowOnFieldErrorFragment$fragmentType,
+  ...
+}>;
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true,
+    "throwOnFieldError": true
+  },
+  "name": "observeFragmentTestPluralThrowOnFieldErrorFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "531291e1335ff8e4ffacf60c7a6064ed";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  observeFragmentTestPluralThrowOnFieldErrorFragment$fragmentType,
+  observeFragmentTestPluralThrowOnFieldErrorFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestPluralThrowOnFieldErrorQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestPluralThrowOnFieldErrorQuery.graphql.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<e8caa8681021706578a3370563abefe1>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { observeFragmentTestPluralThrowOnFieldErrorFragment$fragmentType } from "./observeFragmentTestPluralThrowOnFieldErrorFragment.graphql";
+export type observeFragmentTestPluralThrowOnFieldErrorQuery$variables = {||};
+export type observeFragmentTestPluralThrowOnFieldErrorQuery$data = {|
+  +nodes: ?$ReadOnlyArray<?{|
+    +$fragmentSpreads: observeFragmentTestPluralThrowOnFieldErrorFragment$fragmentType,
+  |}>,
+|};
+export type observeFragmentTestPluralThrowOnFieldErrorQuery = {|
+  response: observeFragmentTestPluralThrowOnFieldErrorQuery$data,
+  variables: observeFragmentTestPluralThrowOnFieldErrorQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "ids",
+    "value": [
+      "1",
+      "2"
+    ]
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "observeFragmentTestPluralThrowOnFieldErrorQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "observeFragmentTestPluralThrowOnFieldErrorFragment"
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "observeFragmentTestPluralThrowOnFieldErrorQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1e83abfe97b66be09a6642b3332e4d09",
+    "id": null,
+    "metadata": {},
+    "name": "observeFragmentTestPluralThrowOnFieldErrorQuery",
+    "operationKind": "query",
+    "text": "query observeFragmentTestPluralThrowOnFieldErrorQuery {\n  nodes(ids: [\"1\", \"2\"]) {\n    __typename\n    ...observeFragmentTestPluralThrowOnFieldErrorFragment\n    id\n  }\n}\n\nfragment observeFragmentTestPluralThrowOnFieldErrorFragment on User {\n  name\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "36cd146fd2db4ac80dfe226a3e20dd3e";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  observeFragmentTestPluralThrowOnFieldErrorQuery$variables,
+  observeFragmentTestPluralThrowOnFieldErrorQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment.graphql.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<f846da4628f6d0693e91756a40a1d248>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { UserAlwaysThrowsResolver$key } from "./../resolvers/__generated__/UserAlwaysThrowsResolver.graphql";
+import type { FragmentType } from "relay-runtime";
+import {always_throws as userAlwaysThrowsResolverType} from "../resolvers/UserAlwaysThrowsResolver.js";
+import type { TestResolverContextType } from "../../../mutations/__tests__/TestResolverContextType";
+// Type assertion validating that `userAlwaysThrowsResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(userAlwaysThrowsResolverType: (
+  rootKey: UserAlwaysThrowsResolver$key,
+  args: void,
+  context: TestResolverContextType,
+) => ?string);
+declare export opaque type observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$fragmentType: FragmentType;
+export type observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$data = $ReadOnlyArray<{|
+  +always_throws: ?string,
+  +$fragmentType: observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$fragmentType,
+|}>;
+export type observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$key = $ReadOnlyArray<{
+  +$data?: observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$data,
+  +$fragmentSpreads: observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$fragmentType,
+  ...
+}>;
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true,
+    "throwOnFieldError": true
+  },
+  "name": "observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "fragment": {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "UserAlwaysThrowsResolver"
+      },
+      "kind": "RelayResolver",
+      "name": "always_throws",
+      "resolverModule": require('./../resolvers/UserAlwaysThrowsResolver').always_throws,
+      "path": "always_throws"
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "59a6f5ddf61e54affd5726b8cf322183";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$fragmentType,
+  observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery.graphql.js
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<88f631a8a727158afc72c5ed15b804a4>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$fragmentType } from "./observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment.graphql";
+export type observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery$variables = {||};
+export type observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery$data = {|
+  +nodes: ?$ReadOnlyArray<?{|
+    +$fragmentSpreads: observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment$fragmentType,
+  |}>,
+|};
+export type observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery = {|
+  response: observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery$data,
+  variables: observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "ids",
+    "value": [
+      "7",
+      "8"
+    ]
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment"
+          }
+        ],
+        "storageKey": "nodes(ids:[\"7\",\"8\"])"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "name": "always_throws",
+                "args": null,
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    (v1/*: any*/)
+                  ],
+                  "type": "User",
+                  "abstractKey": null
+                },
+                "kind": "RelayResolver",
+                "storageKey": null,
+                "isOutputType": true
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "nodes(ids:[\"7\",\"8\"])"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "cda0054b75d8a0bc0abaacbb14186b4a",
+    "id": null,
+    "metadata": {},
+    "name": "observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery",
+    "operationKind": "query",
+    "text": "query observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery {\n  nodes(ids: [\"7\", \"8\"]) {\n    __typename\n    ...observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment\n    id\n  }\n}\n\nfragment UserAlwaysThrowsResolver on User {\n  __typename\n}\n\nfragment observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorFragment on User {\n  ...UserAlwaysThrowsResolver\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "412492582875c8c7b44e67794ed55763";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery$variables,
+  observeFragmentTestResolverErrorWithPluralThrowOnFieldErrorQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/waitForFragmentDataTestOkPluralFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/waitForFragmentDataTestOkPluralFragment.graphql.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<2ed8051023394e48547a26c640b8e13c>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type waitForFragmentDataTestOkPluralFragment$fragmentType: FragmentType;
+export type waitForFragmentDataTestOkPluralFragment$data = $ReadOnlyArray<{|
+  +name: ?string,
+  +$fragmentType: waitForFragmentDataTestOkPluralFragment$fragmentType,
+|}>;
+export type waitForFragmentDataTestOkPluralFragment$key = $ReadOnlyArray<{
+  +$data?: waitForFragmentDataTestOkPluralFragment$data,
+  +$fragmentSpreads: waitForFragmentDataTestOkPluralFragment$fragmentType,
+  ...
+}>;
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "waitForFragmentDataTestOkPluralFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "27b1b1a834949ad358eaf6d1396d3f9d";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  waitForFragmentDataTestOkPluralFragment$fragmentType,
+  waitForFragmentDataTestOkPluralFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/waitForFragmentDataTestOkPluralQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/waitForFragmentDataTestOkPluralQuery.graphql.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<5eca2a10e99142f6f4e5d99b02421ad1>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { waitForFragmentDataTestOkPluralFragment$fragmentType } from "./waitForFragmentDataTestOkPluralFragment.graphql";
+export type waitForFragmentDataTestOkPluralQuery$variables = {||};
+export type waitForFragmentDataTestOkPluralQuery$data = {|
+  +nodes: ?$ReadOnlyArray<?{|
+    +$fragmentSpreads: waitForFragmentDataTestOkPluralFragment$fragmentType,
+  |}>,
+|};
+export type waitForFragmentDataTestOkPluralQuery = {|
+  response: waitForFragmentDataTestOkPluralQuery$data,
+  variables: waitForFragmentDataTestOkPluralQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "ids",
+    "value": [
+      "1",
+      "2"
+    ]
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "waitForFragmentDataTestOkPluralQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "waitForFragmentDataTestOkPluralFragment"
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "waitForFragmentDataTestOkPluralQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nodes",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "nodes(ids:[\"1\",\"2\"])"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "91c66e0b45b06f9cc7a66477f8156418",
+    "id": null,
+    "metadata": {},
+    "name": "waitForFragmentDataTestOkPluralQuery",
+    "operationKind": "query",
+    "text": "query waitForFragmentDataTestOkPluralQuery {\n  nodes(ids: [\"1\", \"2\"]) {\n    __typename\n    ...waitForFragmentDataTestOkPluralFragment\n    id\n  }\n}\n\nfragment waitForFragmentDataTestOkPluralFragment on User {\n  name\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "139b32cebe816906461147bcb6b1db45";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  waitForFragmentDataTestOkPluralQuery$variables,
+  waitForFragmentDataTestOkPluralQuery$data,
+>*/);

--- a/packages/relay-runtime/store/observeFragmentExperimental.js
+++ b/packages/relay-runtime/store/observeFragmentExperimental.js
@@ -183,6 +183,7 @@ function observePluralSelector<
   );
 
   return Observable.create(sink => {
+    // This array is mutable since each subscription updates the array in place.
     const states = snapshots.map((snapshot, index) =>
       snapshotToFragmentState(
         environment,
@@ -202,6 +203,8 @@ function observePluralSelector<
           fragmentSelector.selectors[index].owner,
           latestSnapshot,
         );
+        // This doesn't batch updates, so it will notify the subscriber multiple times
+        // if a store update impacting multiple items in the list is published.
         sink.next((mergeFragmentStates(states): $FlowFixMe));
       }),
     );

--- a/packages/relay-runtime/store/observeFragmentExperimental.js
+++ b/packages/relay-runtime/store/observeFragmentExperimental.js
@@ -187,7 +187,7 @@ function observePluralSelector<
       snapshotToFragmentState(
         environment,
         fragmentNode,
-        fragmentSelector.selectors[0].owner,
+        fragmentSelector.selectors[index].owner,
         snapshot,
       ),
     );
@@ -199,7 +199,7 @@ function observePluralSelector<
         states[index] = snapshotToFragmentState(
           environment,
           fragmentNode,
-          fragmentSelector.selectors[0].owner,
+          fragmentSelector.selectors[index].owner,
           latestSnapshot,
         );
         sink.next((mergeFragmentStates(states): $FlowFixMe));

--- a/packages/relay-runtime/store/observeFragmentExperimental.js
+++ b/packages/relay-runtime/store/observeFragmentExperimental.js
@@ -9,7 +9,7 @@
  * @oncall relay
  */
 
-import type {RequestDescriptor} from './RelayStoreTypes';
+import type {PluralReaderSelector, RequestDescriptor} from './RelayStoreTypes';
 import type {
   Fragment,
   FragmentType,
@@ -47,8 +47,7 @@ export type HasSpread<TFragmentType> = {
 
 /**
  * EXPERIMENTAL: This API is experimental and does not yet support all Relay
- * features. Notably, it does not correectly handle plural fragments or some
- * features of Relay Resolvers.
+ * features. Notably, it does not correctly handle some features of Relay Resolvers.
  *
  * Given a fragment and a fragment reference, returns a promise that resolves
  * once the fragment data is available, or rejects if the fragment has an error.
@@ -63,7 +62,9 @@ export type HasSpread<TFragmentType> = {
 async function waitForFragmentData<TFragmentType: FragmentType, TData>(
   environment: IEnvironment,
   fragment: Fragment<TFragmentType, TData>,
-  fragmentRef: HasSpread<TFragmentType>,
+  fragmentRef:
+    | HasSpread<TFragmentType>
+    | $ReadOnlyArray<HasSpread<TFragmentType>>,
 ): Promise<TData> {
   let subscription: ?Subscription;
 
@@ -94,13 +95,14 @@ async function waitForFragmentData<TFragmentType: FragmentType, TData>(
 declare function observeFragment<TFragmentType: FragmentType, TData>(
   environment: IEnvironment,
   fragment: Fragment<TFragmentType, TData>,
-  fragmentRef: HasSpread<TFragmentType>,
+  fragmentRef:
+    | HasSpread<TFragmentType>
+    | $ReadOnlyArray<HasSpread<TFragmentType>>,
 ): Observable<FragmentState<TData>>;
 
 /**
  * EXPERIMENTAL: This API is experimental and does not yet support all Relay
- * features. Notably, it does not correectly handle plural fragments or some
- * features of Relay Resolvers.
+ * features. Notably, it does not correctly handle some features of Relay Resolvers.
  *
  * Given a fragment and a fragment reference, returns an observable that emits
  * the state of the fragment over time. The observable will emit the following
@@ -114,7 +116,7 @@ function observeFragment<TFragmentType: FragmentType, TData>(
   environment: IEnvironment,
   fragment: Fragment<TFragmentType, TData>,
   fragmentRef: mixed,
-): Observable<FragmentState<TData>> {
+): mixed {
   const fragmentNode = getFragment(fragment);
   const fragmentSelector = getSelector(fragmentNode, fragmentRef);
   invariant(
@@ -124,24 +126,19 @@ function observeFragment<TFragmentType: FragmentType, TData>(
   invariant(fragmentSelector != null, 'Expected a selector, got null.');
   switch (fragmentSelector.kind) {
     case 'SingularReaderSelector':
-      return observeSelector(environment, fragment, fragmentSelector);
+      return observeSingularSelector(environment, fragment, fragmentSelector);
     case 'PluralReaderSelector': {
-      // TODO: We could use something like this RXJS's combineLatest to create
-      // an observable for each selector and merge them.
-      // https://github.com/ReactiveX/rxjs/blob/master/packages/rxjs/src/internal/observable/combineLatest.ts
-      //
-      // Note that this problem is a bit tricky because Relay currently only
-      // lets you subscribe at a singular fragment granularity. This makes it
-      // hard to batch updates such that when a store update causes multiple
-      // fragments to change, we can only publish a single update to the
-      // fragment owner.
-      invariant(false, 'Plural fragments are not supported');
+      return observePluralSelector(
+        environment,
+        (fragment: $FlowFixMe),
+        fragmentSelector,
+      );
     }
   }
   invariant(false, 'Unsupported fragment selector kind');
 }
 
-function observeSelector<TFragmentType: FragmentType, TData>(
+function observeSingularSelector<TFragmentType: FragmentType, TData>(
   environment: IEnvironment,
   fragmentNode: Fragment<TFragmentType, TData>,
   fragmentSelector: SingularReaderSelector,
@@ -170,6 +167,67 @@ function observeSelector<TFragmentType: FragmentType, TData>(
     });
 
     return () => subscription.dispose();
+  });
+}
+
+function observePluralSelector<
+  TFragmentType: FragmentType,
+  TData: Array<mixed>,
+>(
+  environment: IEnvironment,
+  fragmentNode: Fragment<TFragmentType, TData>,
+  fragmentSelector: PluralReaderSelector,
+): Observable<FragmentState<TData>> {
+  const snapshots = fragmentSelector.selectors.map(selector =>
+    environment.lookup(selector),
+  );
+
+  return Observable.create(sink => {
+    const states = snapshots.map((snapshot, index) =>
+      snapshotToFragmentState(
+        environment,
+        fragmentNode,
+        fragmentSelector.selectors[0].owner,
+        snapshot,
+      ),
+    );
+
+    const reduceState = () =>
+      states.reduce<FragmentState<TData>>(
+        (acc, state) => {
+          if (acc.state !== 'ok') {
+            return acc;
+          }
+
+          if (state.state === 'ok') {
+            acc.value.push(state.value);
+            return acc;
+          } else {
+            return state;
+          }
+        },
+        {
+          state: 'ok',
+          // $FlowFixMe[incompatible-cast]: TData is enforced to be an array
+          value: ([]: TData),
+        },
+      );
+
+    sink.next(reduceState());
+
+    const subscriptions = snapshots.map((snapshot, index) =>
+      environment.subscribe(snapshot, latestSnapshot => {
+        states[index] = snapshotToFragmentState(
+          environment,
+          fragmentNode,
+          fragmentSelector.selectors[0].owner,
+          latestSnapshot,
+        );
+        sink.next(reduceState());
+      }),
+    );
+
+    return () => subscriptions.forEach(subscription => subscription.dispose());
   });
 }
 

--- a/packages/relay-runtime/store/waitForFragmentExperimental.js
+++ b/packages/relay-runtime/store/waitForFragmentExperimental.js
@@ -21,8 +21,7 @@ const {observeFragment} = require('./observeFragmentExperimental');
 
 /**
  * EXPERIMENTAL: This API is experimental and does not yet support all Relay
- * features. Notably, it does not correectly handle plural fragments or some
- * features of Relay Resolvers.
+ * features. Notably, it does not correctly handle some features of Relay Resolvers.
  *
  * Given a fragment and a fragment reference, returns a promise that resolves
  * once the fragment data is available, or rejects if the fragment has an error.
@@ -37,7 +36,9 @@ const {observeFragment} = require('./observeFragmentExperimental');
 async function waitForFragmentData<TFragmentType: FragmentType, TData>(
   environment: IEnvironment,
   fragment: Fragment<TFragmentType, TData>,
-  fragmentRef: HasSpread<TFragmentType>,
+  fragmentRef:
+    | HasSpread<TFragmentType>
+    | $ReadOnlyArray<HasSpread<TFragmentType>>,
 ): Promise<TData> {
   let subscription: ?Subscription;
 

--- a/website/docs/api-reference/relay-runtime/observe-fragment.md
+++ b/website/docs/api-reference/relay-runtime/observe-fragment.md
@@ -20,6 +20,10 @@ In some cases it can be useful to define data that you wish to read using a Grap
 
 To read a fragment's data just once, see [`waitForFragmentData`](./wait-for-fragment-data.md).
 
+:::caution
+When using `observeFragment` with a plural fragment, the current implementation notifies the subscription multiple times if a store update impacting multiple list items gets published. Since the notifications happen synchronously, it is advised to debounce for a tick and only use the last payload for batching.
+:::
+
 ### Example
 
 ```ts


### PR DESCRIPTION
This PR adds plural fragment support to `observeFragment()` (and `waitForFragmentData()` which uses `observeFragment()` under the hood)

It should be noted that the Relay environment currently doesn't support subscribing to plural fragment updates, so the implementation is done by subscribing to each selector and merging the states. Since the current implementation doesn't do any batching of notifications that are made from each selector subscription, it can be somewhat inefficient if the consumer doesn't batch on their own.