### PR TITLE
Handle CRLF when parsing docblocks

### DIFF
--- a/compiler/crates/docblock-syntax/src/lib.rs
+++ b/compiler/crates/docblock-syntax/src/lib.rs
@@ -238,7 +238,11 @@ impl<'a> DocblockParser<'a> {
     /// Read until the end of the line.
     fn parse_free_text_line(&mut self) -> ParseResult<SpanString> {
         let start = self.offset;
-        let free_text = self.take_while(|c| c != &'\n');
+        let mut free_text: String = self.take_while(|c| c != &'\n');
+        // Handle CRLF by stripping `\r` suffix.
+        if free_text.ends_with('\r') {
+            free_text.pop();
+        }
         let end = self.offset;
         Ok(SpanString::new(Span::new(start, end), free_text))
     }


### PR DESCRIPTION
The dockblock parser doesn't support CRLF, so the \r character becomes part of the identifiers.

This fix strips the \r suffix from the text until newline.

This fixes #4864 