### PR TITLE
Fix edge case issue around unsubscribing live queries

### DIFF
--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useLazyLoadQueryNodeTestUserLiveQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useLazyLoadQueryNodeTestUserLiveQuery.graphql.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<0a6b9599d79748694f4a358e93246fc0>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type useLazyLoadQueryNodeTestUserLiveQuery$variables = {|
+  id?: ?string,
+|};
+export type useLazyLoadQueryNodeTestUserLiveQuery$data = {|
+  +node: ?{|
+    +id: string,
+    +name: ?string,
+  |},
+|};
+export type useLazyLoadQueryNodeTestUserLiveQuery = {|
+  response: useLazyLoadQueryNodeTestUserLiveQuery$data,
+  variables: useLazyLoadQueryNodeTestUserLiveQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useLazyLoadQueryNodeTestUserLiveQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useLazyLoadQueryNodeTestUserLiveQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "98600f06e5e443016716645b4cb89c38",
+    "id": null,
+    "metadata": {
+      "live": {
+        "polling_interval": 10000
+      }
+    },
+    "name": "useLazyLoadQueryNodeTestUserLiveQuery",
+    "operationKind": "query",
+    "text": "query useLazyLoadQueryNodeTestUserLiveQuery(\n  $id: ID\n) @live_query(polling_interval: 10000) {\n  node(id: $id) {\n    __typename\n    id\n    name\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "d4cd3d6c368c829da68df929e577f449";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  useLazyLoadQueryNodeTestUserLiveQuery$variables,
+  useLazyLoadQueryNodeTestUserLiveQuery$data,
+>*/);

--- a/packages/react-relay/relay-hooks/useLazyLoadQueryNode.js
+++ b/packages/react-relay/relay-hooks/useLazyLoadQueryNode.js
@@ -29,6 +29,7 @@ const useFetchTrackingRef = require('./useFetchTrackingRef');
 const useFragmentInternal = require('./useFragmentInternal');
 const useRelayEnvironment = require('./useRelayEnvironment');
 const React = require('react');
+const {RelayFeatureFlags} = require('relay-runtime');
 
 const {useContext, useEffect, useState, useRef} = React;
 
@@ -52,7 +53,11 @@ hook useLazyLoadQueryNode<TQuery: OperationType>({
   const QueryResource = getQueryResourceForEnvironment(environment);
 
   const [forceUpdateKey, forceUpdate] = useState(0);
-  const {startFetch, completeFetch} = useFetchTrackingRef();
+  const {startFetch, completeFetch} =
+    RelayFeatureFlags.ENABLE_LIVE_QUERY_UNSUBSCRIBE_FIX
+      ? {}
+      : // $FlowFixMe[react-rule-hook] - the condition is static
+        useFetchTrackingRef();
   const cacheBreaker = `${forceUpdateKey}-${fetchKey ?? ''}`;
   const cacheIdentifier = getQueryCacheIdentifier(
     environment,
@@ -69,7 +74,9 @@ hook useLazyLoadQueryNode<TQuery: OperationType>({
       fetchObservable,
       fetchPolicy,
       renderPolicy,
-      {start: startFetch, complete: completeFetch, error: completeFetch},
+      RelayFeatureFlags.ENABLE_LIVE_QUERY_UNSUBSCRIBE_FIX
+        ? undefined
+        : {start: startFetch, complete: completeFetch, error: completeFetch},
       profilerContext,
     );
   });

--- a/packages/relay-runtime/util/RelayFeatureFlags.js
+++ b/packages/relay-runtime/util/RelayFeatureFlags.js
@@ -70,6 +70,9 @@ export type FeatureFlags = {
 
   // Enable the fix for usePaginationFragment stucking in loading state
   ENABLE_USE_PAGINATION_IS_LOADING_FIX: boolean,
+
+  // Enable the fix for unsubscribing live queries
+  ENABLE_LIVE_QUERY_UNSUBSCRIBE_FIX: boolean,
 };
 
 const RelayFeatureFlags: FeatureFlags = {
@@ -96,6 +99,7 @@ const RelayFeatureFlags: FeatureFlags = {
   ENABLE_READ_TIME_RESOLVER_STORAGE_KEY_PREFIX: true,
   ENABLE_RESOURCE_EFFECTS: false,
   ENABLE_USE_PAGINATION_IS_LOADING_FIX: false,
+  ENABLE_LIVE_QUERY_UNSUBSCRIBE_FIX: false,
 };
 
 module.exports = RelayFeatureFlags;


### PR DESCRIPTION
This only happens when...

- A live query is passed to `useLazyLoadQueryNode()`
- The initial fetch doesn't suspend
- Two components subscribe to the same query with the same operation descriptor
- The first subscribed component gets unmounted first

The fix is pretty simple though 😋 