### PR TITLE
Fix `observeFragment` triggering unhandled rejections on network error

### DIFF
--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestNetworkErrorFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestNetworkErrorFragment.graphql.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<63c81af48f685c620838abbe0a6ff26e>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type observeFragmentTestNetworkErrorFragment$fragmentType: FragmentType;
+export type observeFragmentTestNetworkErrorFragment$data = {|
+  +me: ?{|
+    +name: ?string,
+  |},
+  +$fragmentType: observeFragmentTestNetworkErrorFragment$fragmentType,
+|};
+export type observeFragmentTestNetworkErrorFragment$key = {
+  +$data?: observeFragmentTestNetworkErrorFragment$data,
+  +$fragmentSpreads: observeFragmentTestNetworkErrorFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "observeFragmentTestNetworkErrorFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "User",
+      "kind": "LinkedField",
+      "name": "me",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "08727ee370f3e8859731dc1535a5c718";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  observeFragmentTestNetworkErrorFragment$fragmentType,
+  observeFragmentTestNetworkErrorFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestNetworkErrorQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/observeFragmentTestNetworkErrorQuery.graphql.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<bd67d422ffd9395e08048e1b358a9c4d>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { observeFragmentTestNetworkErrorFragment$fragmentType } from "./observeFragmentTestNetworkErrorFragment.graphql";
+export type observeFragmentTestNetworkErrorQuery$variables = {||};
+export type observeFragmentTestNetworkErrorQuery$data = {|
+  +$fragmentSpreads: observeFragmentTestNetworkErrorFragment$fragmentType,
+|};
+export type observeFragmentTestNetworkErrorQuery = {|
+  response: observeFragmentTestNetworkErrorQuery$data,
+  variables: observeFragmentTestNetworkErrorQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "observeFragmentTestNetworkErrorQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "observeFragmentTestNetworkErrorFragment"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "observeFragmentTestNetworkErrorQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ea59f42835e1af47e66fc74d78ea34fb",
+    "id": null,
+    "metadata": {},
+    "name": "observeFragmentTestNetworkErrorQuery",
+    "operationKind": "query",
+    "text": "query observeFragmentTestNetworkErrorQuery {\n  ...observeFragmentTestNetworkErrorFragment\n}\n\nfragment observeFragmentTestNetworkErrorFragment on Query {\n  me {\n    name\n    id\n  }\n}\n"
+  }
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "ab0f402fbc738d3f90847297471bd4b3";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  observeFragmentTestNetworkErrorQuery$variables,
+  observeFragmentTestNetworkErrorQuery$data,
+>*/);

--- a/packages/relay-runtime/store/observeFragmentExperimental.js
+++ b/packages/relay-runtime/store/observeFragmentExperimental.js
@@ -20,8 +20,8 @@ import type {
 } from 'relay-runtime';
 
 const Observable = require('../network/RelayObservable');
+const {getObservableForActiveRequest} = require('../query/fetchQueryInternal');
 const {getFragment} = require('../query/GraphQLTag');
-const getPendingOperationsForFragment = require('../util/getPendingOperationsForFragment');
 const {
   handlePotentialSnapshotErrors,
 } = require('../util/handlePotentialSnapshotErrors');
@@ -241,12 +241,12 @@ function snapshotToFragmentState<TFragmentType: FragmentType, TData>(
   }
 
   if (snapshot.isMissingData) {
-    const pendingOperations = getPendingOperationsForFragment(
-      environment,
-      fragmentNode,
-      owner,
-    );
-    if (pendingOperations != null) {
+    if (
+      getObservableForActiveRequest(environment, owner) != null ||
+      environment
+        .getOperationTracker()
+        .getPendingOperationsAffectingOwner(owner) != null
+    ) {
       return {state: 'loading'};
     }
   }


### PR DESCRIPTION
This PR fixes an issue where `observeFragment` triggers unhandled rejections on network error, which happens because of the dangling promise created and dropped.