### PR TITLE
Error on empty selections after fragment argument transform

### DIFF
--- a/compiler/crates/relay-transforms/tests/apply_fragment_arguments/fixtures/empty-selection-constant-include-false-argument.expected
+++ b/compiler/crates/relay-transforms/tests/apply_fragment_arguments/fixtures/empty-selection-constant-include-false-argument.expected
@@ -1,0 +1,20 @@
+==================================== INPUT ====================================
+# expected-to-throw
+query EmptyQuery($id: ID!) {
+  node(id: $id) {
+    ...Fragment @arguments(cond: false)
+  }
+}
+
+fragment Fragment on User
+  @argumentDefinitions(cond: {type: "Boolean!"}) {
+  lastName @include(if: $cond)
+}
+==================================== ERROR ====================================
+✖︎ After applying transforms to the query `EmptyQuery` selections of the `EmptyQuery` that would be sent to the server are empty. This is likely due to the use of `@skip`/`@include` directives with constant values that remove all selections in the query. 
+
+  empty-selection-constant-include-false-argument.graphql:2:7
+    1 │ # expected-to-throw
+    2 │ query EmptyQuery($id: ID!) {
+      │       ^^^^^^^^^^
+    3 │   node(id: $id) {

--- a/compiler/crates/relay-transforms/tests/apply_fragment_arguments/fixtures/empty-selection-constant-include-false-argument.graphql
+++ b/compiler/crates/relay-transforms/tests/apply_fragment_arguments/fixtures/empty-selection-constant-include-false-argument.graphql
@@ -1,0 +1,11 @@
+# expected-to-throw
+query EmptyQuery($id: ID!) {
+  node(id: $id) {
+    ...Fragment @arguments(cond: false)
+  }
+}
+
+fragment Fragment on User
+  @argumentDefinitions(cond: {type: "Boolean!"}) {
+  lastName @include(if: $cond)
+}

--- a/compiler/crates/relay-transforms/tests/apply_fragment_arguments/fixtures/empty-selection-constant-skip-true-argument.expected
+++ b/compiler/crates/relay-transforms/tests/apply_fragment_arguments/fixtures/empty-selection-constant-skip-true-argument.expected
@@ -1,0 +1,20 @@
+==================================== INPUT ====================================
+# expected-to-throw
+query EmptyQuery($id: ID!) {
+  node(id: $id) {
+    ...Fragment @arguments(cond: true)
+  }
+}
+
+fragment Fragment on User
+  @argumentDefinitions(cond: {type: "Boolean!"}) {
+  lastName @skip(if: $cond)
+}
+==================================== ERROR ====================================
+✖︎ After applying transforms to the query `EmptyQuery` selections of the `EmptyQuery` that would be sent to the server are empty. This is likely due to the use of `@skip`/`@include` directives with constant values that remove all selections in the query. 
+
+  empty-selection-constant-skip-true-argument.graphql:2:7
+    1 │ # expected-to-throw
+    2 │ query EmptyQuery($id: ID!) {
+      │       ^^^^^^^^^^
+    3 │   node(id: $id) {

--- a/compiler/crates/relay-transforms/tests/apply_fragment_arguments/fixtures/empty-selection-constant-skip-true-argument.graphql
+++ b/compiler/crates/relay-transforms/tests/apply_fragment_arguments/fixtures/empty-selection-constant-skip-true-argument.graphql
@@ -1,0 +1,11 @@
+# expected-to-throw
+query EmptyQuery($id: ID!) {
+  node(id: $id) {
+    ...Fragment @arguments(cond: true)
+  }
+}
+
+fragment Fragment on User
+  @argumentDefinitions(cond: {type: "Boolean!"}) {
+  lastName @skip(if: $cond)
+}

--- a/compiler/crates/relay-transforms/tests/apply_fragment_arguments_test.rs
+++ b/compiler/crates/relay-transforms/tests/apply_fragment_arguments_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7a0be220ee0ccec98d9d78d2768944ba>>
+ * @generated SignedSource<<015f5d0f887cfdca2bff8cd762cc2a55>>
  */
 
 mod apply_fragment_arguments;
@@ -24,6 +24,20 @@ async fn deletes_unreferenced_fragments() {
     let input = include_str!("apply_fragment_arguments/fixtures/deletes-unreferenced-fragments.graphql");
     let expected = include_str!("apply_fragment_arguments/fixtures/deletes-unreferenced-fragments.expected");
     test_fixture(transform_fixture, file!(), "deletes-unreferenced-fragments.graphql", "apply_fragment_arguments/fixtures/deletes-unreferenced-fragments.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn empty_selection_constant_include_false_argument() {
+    let input = include_str!("apply_fragment_arguments/fixtures/empty-selection-constant-include-false-argument.graphql");
+    let expected = include_str!("apply_fragment_arguments/fixtures/empty-selection-constant-include-false-argument.expected");
+    test_fixture(transform_fixture, file!(), "empty-selection-constant-include-false-argument.graphql", "apply_fragment_arguments/fixtures/empty-selection-constant-include-false-argument.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn empty_selection_constant_skip_true_argument() {
+    let input = include_str!("apply_fragment_arguments/fixtures/empty-selection-constant-skip-true-argument.graphql");
+    let expected = include_str!("apply_fragment_arguments/fixtures/empty-selection-constant-skip-true-argument.expected");
+    test_fixture(transform_fixture, file!(), "empty-selection-constant-skip-true-argument.graphql", "apply_fragment_arguments/fixtures/empty-selection-constant-skip-true-argument.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/fixtures/empty-selection-skip-true.expected
+++ b/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/fixtures/empty-selection-skip-true.expected
@@ -1,0 +1,19 @@
+==================================== INPUT ====================================
+# expected-to-throw
+query EmptyQuery($id: ID!) {
+  node(id: $id) {
+    ...Fragment
+  }
+}
+
+fragment Fragment on User {
+  lastName @skip(if: true)
+}
+==================================== ERROR ====================================
+✖︎ After applying transforms to the query `EmptyQuery` selections of the `EmptyQuery` that would be sent to the server are empty. This is likely due to the use of `@skip`/`@include` directives with constant values that remove all selections in the query. 
+
+  empty-selection-skip-true.graphql:2:7
+    1 │ # expected-to-throw
+    2 │ query EmptyQuery($id: ID!) {
+      │       ^^^^^^^^^^
+    3 │   node(id: $id) {

--- a/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/fixtures/empty-selection-skip-true.graphql
+++ b/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/fixtures/empty-selection-skip-true.graphql
@@ -1,0 +1,10 @@
+# expected-to-throw
+query EmptyQuery($id: ID!) {
+  node(id: $id) {
+    ...Fragment
+  }
+}
+
+fragment Fragment on User {
+  lastName @skip(if: true)
+}

--- a/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/fixtures/empty-selectoin-include-false.expected
+++ b/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/fixtures/empty-selectoin-include-false.expected
@@ -1,0 +1,19 @@
+==================================== INPUT ====================================
+# expected-to-throw
+query EmptyQuery($id: ID!) {
+  node(id: $id) {
+    ...Fragment
+  }
+}
+
+fragment Fragment on User {
+  lastName @include(if: false)
+}
+==================================== ERROR ====================================
+✖︎ After applying transforms to the query `EmptyQuery` selections of the `EmptyQuery` that would be sent to the server are empty. This is likely due to the use of `@skip`/`@include` directives with constant values that remove all selections in the query. 
+
+  empty-selectoin-include-false.graphql:2:7
+    1 │ # expected-to-throw
+    2 │ query EmptyQuery($id: ID!) {
+      │       ^^^^^^^^^^
+    3 │   node(id: $id) {

--- a/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/fixtures/empty-selectoin-include-false.graphql
+++ b/compiler/crates/relay-transforms/tests/skip_unreachable_nodes/fixtures/empty-selectoin-include-false.graphql
@@ -1,0 +1,10 @@
+# expected-to-throw
+query EmptyQuery($id: ID!) {
+  node(id: $id) {
+    ...Fragment
+  }
+}
+
+fragment Fragment on User {
+  lastName @include(if: false)
+}

--- a/compiler/crates/relay-transforms/tests/skip_unreachable_nodes_test.rs
+++ b/compiler/crates/relay-transforms/tests/skip_unreachable_nodes_test.rs
@@ -4,13 +4,27 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<256a993c631a9ebc61e38ac8a97f397a>>
+ * @generated SignedSource<<39dd352e5adf4e9487dc822994bb7306>>
  */
 
 mod skip_unreachable_nodes;
 
 use skip_unreachable_nodes::transform_fixture;
 use fixture_tests::test_fixture;
+
+#[tokio::test]
+async fn empty_selection_skip_true() {
+    let input = include_str!("skip_unreachable_nodes/fixtures/empty-selection-skip-true.graphql");
+    let expected = include_str!("skip_unreachable_nodes/fixtures/empty-selection-skip-true.expected");
+    test_fixture(transform_fixture, file!(), "empty-selection-skip-true.graphql", "skip_unreachable_nodes/fixtures/empty-selection-skip-true.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn empty_selectoin_include_false() {
+    let input = include_str!("skip_unreachable_nodes/fixtures/empty-selectoin-include-false.graphql");
+    let expected = include_str!("skip_unreachable_nodes/fixtures/empty-selectoin-include-false.expected");
+    test_fixture(transform_fixture, file!(), "empty-selectoin-include-false.graphql", "skip_unreachable_nodes/fixtures/empty-selectoin-include-false.expected", input, expected).await;
+}
 
 #[tokio::test]
 async fn keeps_other_fields() {


### PR DESCRIPTION
One of my colleagues contacted me today, because he received the following error from the compiler:
> thread 'main' panicked at crates/relay-compiler/src/build_project/generate_artifacts.rs:153:13:
Expected at least one of an @updatable reader AST, or normalization AST to be present

After some debugging I found out this happens because an `@include` was removing all selections on a linked field, because it received a `false` constant through fragment arguments from a test operation.

This PR updates the fragment argument transform to report an appropriate error earlier, outlining the cause of the problem.