### PR TITLE
Remove Relay Resolver compiler feature flag from the docs

### DIFF
--- a/website/versioned_docs/version-v18.0.0/guides/relay-resolvers/enabling.md
+++ b/website/versioned_docs/version-v18.0.0/guides/relay-resolvers/enabling.md
@@ -43,20 +43,4 @@ To opt-in the new syntax in a file, add `//relay:enable-new-relay-resolver` to t
 
 To convert files to the new syntax, run codemode: `flow-runner codemod relay/migrateResolver <path>`. The codemod doesn't support all cases, so you might need to modify some files manually after it runs.
 </FbInternalOnly>
-
-## Compiler
-
-You must enable the `"enable_relay_resolver_transform"` feature flag in your Relay compiler config:
-
-
-```json title="relay.config.json"
-{
-  "src": "./src",
-  "schema": "./schema.graphql",
-  "language": "typescript",
-  "featureFlags": {
-    // highlight-next-line
-    "enable_relay_resolver_transform": true
-  }
-}
 ```


### PR DESCRIPTION
On my machine and Relay v18.2.5, using this flag will cause an error and prevent the compiler from starting

Looks like it was removed here: https://github.com/facebook/relay/commit/4e5377bd632037a46c044399f3e21aac2c41dad8