### PR TITLE
Do not emit union type for __typename selection on non-abstract type

### DIFF
--- a/compiler/crates/relay-typegen/src/write.rs
+++ b/compiler/crates/relay-typegen/src/write.rs
@@ -139,6 +139,7 @@ pub(crate) fn write_operation_type_exports_section(
 
     let mut data_type = get_data_type(
         typegen_context,
+        &typegen_operation.type_,
         type_selections.into_iter(),
         MaskStatus::Masked, // Queries are never unmasked
         None,
@@ -461,6 +462,7 @@ pub(crate) fn write_fragment_type_exports_section(
 
     let mut data_type = get_data_type(
         typegen_context,
+        &fragment_definition.type_condition,
         type_selections.into_iter(),
         mask_status,
         if mask_status == MaskStatus::Unmasked {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/fragment-spread.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/fragment-spread.expected
@@ -113,11 +113,6 @@ declare export opaque type PageFragment$fragmentType: FragmentType;
 export type PageFragment$data = {|
   +__typename: "Page",
   +$fragmentType: PageFragment$fragmentType,
-|} | {|
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  +__typename: "%other",
-  +$fragmentType: PageFragment$fragmentType,
 |};
 export type PageFragment$key = {
   +$data?: PageFragment$data,
@@ -129,11 +124,6 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type PictureFragment$fragmentType: FragmentType;
 export type PictureFragment$data = {|
   +__typename: "Image",
-  +$fragmentType: PictureFragment$fragmentType,
-|} | {|
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  +__typename: "%other",
   +$fragmentType: PictureFragment$fragmentType,
 |};
 export type PictureFragment$key = {
@@ -147,11 +137,6 @@ declare export opaque type UserFrag1$fragmentType: FragmentType;
 export type UserFrag1$data = {|
   +__typename: "User",
   +$fragmentType: UserFrag1$fragmentType,
-|} | {|
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  +__typename: "%other",
-  +$fragmentType: UserFrag1$fragmentType,
 |};
 export type UserFrag1$key = {
   +$data?: UserFrag1$data,
@@ -163,11 +148,6 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type UserFrag2$fragmentType: FragmentType;
 export type UserFrag2$data = {|
   +__typename: "User",
-  +$fragmentType: UserFrag2$fragmentType,
-|} | {|
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  +__typename: "%other",
   +$fragmentType: UserFrag2$fragmentType,
 |};
 export type UserFrag2$key = {

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/inline-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/inline-fragment.expected
@@ -139,11 +139,6 @@ declare export opaque type SomeFragment$fragmentType: FragmentType;
 export type SomeFragment$data = {|
   +__typename: "User",
   +$fragmentType: SomeFragment$fragmentType,
-|} | {|
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  +__typename: "%other",
-  +$fragmentType: SomeFragment$fragmentType,
 |};
 export type SomeFragment$key = {
   +$data?: SomeFragment$data,

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/fragment-spread.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/fragment-spread.expected
@@ -101,11 +101,6 @@ import { FragmentRefs } from "relay-runtime";
 export type PageFragment$data = {
   readonly __typename: "Page";
   readonly " $fragmentType": "PageFragment";
-} | {
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  readonly __typename: "%other";
-  readonly " $fragmentType": "PageFragment";
 };
 export type PageFragment$key = {
   readonly " $data"?: PageFragment$data;
@@ -115,11 +110,6 @@ export type PageFragment$key = {
 import { FragmentRefs } from "relay-runtime";
 export type PictureFragment$data = {
   readonly __typename: "Image";
-  readonly " $fragmentType": "PictureFragment";
-} | {
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  readonly __typename: "%other";
   readonly " $fragmentType": "PictureFragment";
 };
 export type PictureFragment$key = {
@@ -131,11 +121,6 @@ import { FragmentRefs } from "relay-runtime";
 export type UserFrag1$data = {
   readonly __typename: "User";
   readonly " $fragmentType": "UserFrag1";
-} | {
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  readonly __typename: "%other";
-  readonly " $fragmentType": "UserFrag1";
 };
 export type UserFrag1$key = {
   readonly " $data"?: UserFrag1$data;
@@ -145,11 +130,6 @@ export type UserFrag1$key = {
 import { FragmentRefs } from "relay-runtime";
 export type UserFrag2$data = {
   readonly __typename: "User";
-  readonly " $fragmentType": "UserFrag2";
-} | {
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  readonly __typename: "%other";
   readonly " $fragmentType": "UserFrag2";
 };
 export type UserFrag2$key = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/inline-fragment.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/inline-fragment.expected
@@ -129,11 +129,6 @@ import { FragmentRefs } from "relay-runtime";
 export type SomeFragment$data = {
   readonly __typename: "User";
   readonly " $fragmentType": "SomeFragment";
-} | {
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  readonly __typename: "%other";
-  readonly " $fragmentType": "SomeFragment";
 };
 export type SomeFragment$key = {
   readonly " $data"?: SomeFragment$data;

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserAlwaysThrowsResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserAlwaysThrowsResolver.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<65000cc0a4b69bdffd1ff81454a9ea5e>>
+ * @generated SignedSource<<46c82d1a963162cda03157ec67d447fa>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -22,11 +22,6 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type UserAlwaysThrowsResolver$fragmentType: FragmentType;
 export type UserAlwaysThrowsResolver$data = {|
   +__typename: "User",
-  +$fragmentType: UserAlwaysThrowsResolver$fragmentType,
-|} | {|
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  +__typename: "%other",
   +$fragmentType: UserAlwaysThrowsResolver$fragmentType,
 |};
 export type UserAlwaysThrowsResolver$key = {

--- a/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserAnotherClientEdgeResolver.graphql.js
+++ b/packages/relay-runtime/store/__tests__/resolvers/__generated__/UserAnotherClientEdgeResolver.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<5d8624f4c97bb474b71fe652707728bc>>
+ * @generated SignedSource<<9b561042e59b39b66fc334d8324c0d70>>
  * @flow
  * @lightSyntaxTransform
  * @nogrep
@@ -22,11 +22,6 @@ import type { FragmentType } from "relay-runtime";
 declare export opaque type UserAnotherClientEdgeResolver$fragmentType: FragmentType;
 export type UserAnotherClientEdgeResolver$data = {|
   +__typename: "User",
-  +$fragmentType: UserAnotherClientEdgeResolver$fragmentType,
-|} | {|
-  // This will never be '%other', but we need some
-  // value in case none of the concrete values match.
-  +__typename: "%other",
   +$fragmentType: UserAnotherClientEdgeResolver$fragmentType,
 |};
 export type UserAnotherClientEdgeResolver$key = {


### PR DESCRIPTION
I've noticed that selecting only the `__typename` field on an object type

```graphql
fragment PageFragment on Page {
  __typename
}
```

currently leads to the generation of a union type:

```typescript
export type PageFragment$data = {
  readonly __typename: "Page";
  readonly " $fragmentType": "PageFragment";
} | {
  // This will never be '%other', but we need some
  // value in case none of the concrete values match.
  readonly __typename: "%other";
  readonly " $fragmentType": "PageFragment";
};
```

This PR corrects this behavior and no longer emits a union in this case:

```typescript
export type PageFragment$data = {
  readonly __typename: "Page";
  readonly " $fragmentType": "PageFragment";
};
```