### PR TITLE
Add missing `readFragment` export in relay-runtime

### DIFF
--- a/packages/relay-runtime/index.js
+++ b/packages/relay-runtime/index.js
@@ -316,6 +316,7 @@ module.exports = {
   suspenseSentinel,
   isRequest: GraphQLTag.isRequest,
   readInlineData,
+  readFragment: ResolverFragments.readFragment,
 
   // Declarative mutation API
   MutationTypes: RelayDeclarativeMutationConfig.MutationTypes,


### PR DESCRIPTION
this PR fixes #4926 by adding export `readFragment`