### PR TITLE
Include React 19 in peerDependencies

### DIFF
--- a/packages/react-relay/package.json
+++ b/packages/react-relay/package.json
@@ -23,7 +23,7 @@
     "relay-runtime": "18.2.0"
   },
   "peerDependencies": {
-    "react": "^16.9.0 || ^17 || ^18"
+    "react": "^16.9.0 || ^17 || ^18 || ^19"
   },
   "directories": {
     "": "./"


### PR DESCRIPTION
Fixes
>npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: vite-react-typescript-starter@0.0.0
npm ERR! Found: react@19.1.0
npm ERR! node_modules/react
npm ERR!   react@"^19.1.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.9.0 || ^17 || ^18" from react-relay@18.2.0
npm ERR! node_modules/react-relay
npm ERR!   react-relay@"^18.2.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.