### PR TITLE
Avoid panic in integration tests

### DIFF
--- a/compiler/crates/fixture-tests/src/lib.rs
+++ b/compiler/crates/fixture-tests/src/lib.rs
@@ -111,7 +111,7 @@ pub async fn test_fixture<T, U, V>(
     // race condition where if an async test is running at the same time as
     // another test is trying to check the workspace root, it will get the wrong
     // value. To mitigate that risk we compute the workspace root early.
-    let workspace_root = &WORKSPACE_ROOT;
+    let workspace_root = WORKSPACE_ROOT.clone();
     let fixture = Fixture {
         file_name: input_file_name,
         content: input,


### PR DESCRIPTION
Something very strange is going on here. When we [upgraded `smallvec`](https://github.com/facebook/relay/commit/01f72cba95764a9d5a3af741f892f532a1241cdc) and then [updated `cargo.lock` to reflect that upgrade](https://github.com/facebook/relay/commit/db5c63d3233e9fb6aa50f722851cf6aae76dc096) our integration tests started failing with a panic.

Full stack trace of panic: https://gist.github.com/captbaritone/7c8cafd4b85365f9ebd7c6c81b420a9a

The test failures do not seem to reproduce on my local mac.

I found it hard to tell where the actual panic was coming from. It seemed to be coming from accessing the lazy_static workspace root [here](https://github.com/facebook/relay/blob/2fcc6fa4d5612771485b4f35700b6b3a87849e18/compiler/crates/fixture-tests/src/lib.rs#L114). At first I thought the panic was coming from somewhere in the [lazy function](https://github.com/facebook/relay/blob/2fcc6fa4d5612771485b4f35700b6b3a87849e18/compiler/crates/fixture-tests/src/lib.rs#L201-L222) since it contains a few of its own unwraps and touches the file system which could reasonably a source of variance between local and CI. To validate I created a [branch](https://github.com/facebook/relay/pull/4959) which ran subsets of the function to see what triggered the error. However, I was able to run all the same logic without it panicking!

This got me thinking that maybe clone I was using the log out the results was somehow allowing us to avoid the issue. It seems it does.

So, I still have no idea how the upgrade to `smallvec` could have caused this issue, but it does seem that adding this `.clone()` resolves the issue.
