### PR TITLE
Handle relay:// json schema requests even outside of Relay projects

### DIFF
--- a/vscode-extension/.eslintrc.js
+++ b/vscode-extension/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
           {functions: false},
         ],
         'class-methods-use-this': 'off',
+        'max-classes-per-file': 'off',
       },
     },
   ],

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -89,7 +89,7 @@ export async function activate(extensionContext: ExtensionContext) {
     }
   } else {
     // We still need to register a handler for `relay://` otherwise non-Relay
-    // projects will get an error at the top of their `package.json` files.
+    // projects will get a warning at the top of their `package.json` files.
     registerNoopProviders(extensionContext);
   }
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8,7 +8,7 @@
 import path = require('path');
 import {ExtensionContext, window, workspace} from 'vscode';
 import {registerCommands} from './commands/register';
-import {registerProviders} from './providers/register';
+import {registerProviders, registerNoopProviders} from './providers/register';
 import {createAndStartCompiler} from './compiler';
 import {getConfig} from './config';
 
@@ -87,6 +87,10 @@ export async function activate(extensionContext: ExtensionContext) {
         ].join(' '),
       );
     }
+  } else {
+    // We still need to register a handler for `relay://` otherwise non-Relay
+    // projects will get an error at the top of their `package.json` files.
+    registerNoopProviders(extensionContext);
   }
 }
 

--- a/vscode-extension/src/providers/register.ts
+++ b/vscode-extension/src/providers/register.ts
@@ -5,15 +5,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {workspace} from 'vscode';
+import {workspace, ExtensionContext} from 'vscode';
 import {RelayExtensionContext} from '../context';
-import {RelayTextDocumentContentProvider} from './textDocumentContentProvider';
+import {
+  RelayTextDocumentContentProvider,
+  NoopTextDocumentContentProvider,
+} from './textDocumentContentProvider';
 
 export function registerProviders(context: RelayExtensionContext) {
   context.extensionContext.subscriptions.push(
     workspace.registerTextDocumentContentProvider(
       RelayTextDocumentContentProvider.scheme,
       new RelayTextDocumentContentProvider(context),
+    ),
+  );
+}
+
+export function registerNoopProviders(extensionContext: ExtensionContext) {
+  extensionContext.subscriptions.push(
+    workspace.registerTextDocumentContentProvider(
+      RelayTextDocumentContentProvider.scheme,
+      new NoopTextDocumentContentProvider(),
     ),
   );
 }

--- a/vscode-extension/src/providers/textDocumentContentProvider.ts
+++ b/vscode-extension/src/providers/textDocumentContentProvider.ts
@@ -46,7 +46,7 @@ export class RelayTextDocumentContentProvider
 
       if (!this.cachedJsonSchema) {
         // We return an empty JSON schema instead of undefined to prevent
-        // an error being shown in the user's IDE.
+        // a warning being shown in the user's IDE.
         return '{}';
       }
 
@@ -86,7 +86,7 @@ export class NoopTextDocumentContentProvider
       uri.authority === RELAY_CONFIG_SCHEMA_PATH
     ) {
       // We return an empty JSON schema instead of undefined to prevent
-      // an error being shown in the user's IDE.
+      // a warning being shown in the user's IDE.
       return '{}';
     }
     return undefined;

--- a/vscode-extension/src/providers/textDocumentContentProvider.ts
+++ b/vscode-extension/src/providers/textDocumentContentProvider.ts
@@ -76,3 +76,19 @@ export class RelayTextDocumentContentProvider
     }
   }
 }
+
+export class NoopTextDocumentContentProvider
+  implements TextDocumentContentProvider
+{
+  provideTextDocumentContent(uri: Uri): ProviderResult<string> {
+    if (
+      uri.authority === PACKAGE_JSON_RELAY_CONFIG_SCHEMA_PATH ||
+      uri.authority === RELAY_CONFIG_SCHEMA_PATH
+    ) {
+      // We return an empty JSON schema instead of undefined to prevent
+      // an error being shown in the user's IDE.
+      return '{}';
+    }
+    return undefined;
+  }
+}


### PR DESCRIPTION
Previously if you opened a `package.json` file in a non-Relay projects you would see an error like this:

![Screenshot 2025-04-22 at 4 36 36 PM](https://github.com/user-attachments/assets/0625fce8-a25c-49bc-912d-52d1f2c95784)

This was because we didn't register a handler if no Relay project was detected. Now we register a noop handler, and there is no error.

![Screenshot 2025-04-22 at 4 32 28 PM](https://github.com/user-attachments/assets/011037cb-b349-4b41-8002-a2f6d8b59482)


Thanks to @cpojer for the report.