### PR TITLE
Bump VSCode extension version

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relay",
   "displayName": "Relay GraphQL",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Relay-powered IDE experience",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Needed to ship the fix from https://github.com/facebook/relay/pull/4961