### PR TITLE
Update vscode extension GitHub action to match CI

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -10,10 +10,10 @@ jobs:
       run:
         working-directory: ./vscode-extension
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
This brings this action (which is rarely run) in sync with updates we've recently made to https://github.com/facebook/relay/blob/main/.github/workflows/ci.yml