### PR TITLE
Update VSCode docs/errors to use pathToRelay

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -46,7 +46,7 @@ Specify the output level of the Relay language server. The available options are
 - verbose
 - debug
 
-#### `relay.pathToBinary` (default: `null`)
+#### `relay.pathToRelay` (default: `null`)
 
 A path to the Relay binary relative to the root of your project. If this is not specified, we will try to find one in your `node_modules` folder.
 

--- a/vscode-extension/src/utils/findRelayBinary.ts
+++ b/vscode-extension/src/utils/findRelayBinary.ts
@@ -185,7 +185,7 @@ export async function findRelayBinaryWithWarnings(
 
   if (config.pathToRelay) {
     outputChannel.appendLine(
-      "You've manually specified 'relay.pathToBinary'. We cannot confirm this version of the Relay Compiler is supported by this version of the extension. I hope you know what you're doing.",
+      "You've manually specified 'relay.pathToRelay'. We cannot confirm this version of the Relay Compiler is supported by this version of the extension. I hope you know what you're doing.",
     );
 
     return {path: config.pathToRelay};


### PR DESCRIPTION
We changed this config option but neglected to change it in the readme or in the error message