### PR TITLE
Update compiler test project to reflect new default config option

### DIFF
--- a/compiler/test-project/src/__generated__/AppQuery.graphql.js
+++ b/compiler/test-project/src/__generated__/AppQuery.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a55377ccde8cd5c41e914b95c668b64b>>
+ * @generated SignedSource<<ecdf928eb3f2acad2a9c0245a8e0263d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -98,4 +98,4 @@ return {
 
 node.hash = "942e72826c882d3a02cb0cfbf267dd83";
 
-module.exports = node;
+export default node;

--- a/compiler/test-project/src/__generated__/Component_node.graphql.js
+++ b/compiler/test-project/src/__generated__/Component_node.graphql.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f4476ba720564b2622c9964ee06b81eb>>
+ * @generated SignedSource<<fb386627518893887661f121bf909b09>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,4 +33,4 @@ var node = {
 
 node.hash = "c1076fdf6414be9f597194edf35d01a0";
 
-module.exports = node;
+export default node;

--- a/scripts/check-git-status.sh
+++ b/scripts/check-git-status.sh
@@ -11,6 +11,6 @@ if [ -z "$(git status --porcelain)" ]; then
   exit 0
 else
   echo "Detected changes in the working directory:"
-  git --no-pager diff --stat HEAD
+  git --no-pager diff HEAD
   exit 1
 fi


### PR DESCRIPTION
Looks like this project is used to test the open source compiler CLI and is not built as part of our internal tests. As such, it wasn't updated as part of my internal diffs to change the default here.