### PR TITLE
Avoid expensive for-of loops in RelayReader

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,8 +89,51 @@ module.exports = {
     // Custom rules for our own codebase
     'relay-internal/no-mixed-import-and-require': 'error',
     'relay-internal/sort-imports': 'error',
-    // OSS will fail if we enable this even as a warning. We will look at
-    // enabling this as part of a separate diff that fixes existing issues.
-    'relay-internal/no-for-of-loops': 'off',
   },
+  overrides: [
+    {
+      files: ['packages/relay-runtime/**/*.js', 'packages/react-relay/**/*.js'],
+      excludedFiles: [
+        '**/__tests__/**',
+
+        // The following files should eventually be migrated to not break this
+        // rule. Until then, we'll grandfather them in here.
+        // If anyone feels inspired, they can:
+        //
+        // 1. Remove a file from this list
+        // 2. Run `yarn lint`
+        // 3. Fix/supress all warnings
+        // 4. Open a PR
+        // 5. Profit?
+        'packages/react-relay/relay-hooks/readFragmentInternal.js',
+        'packages/react-relay/relay-hooks/useEntryPointLoader.js',
+        'packages/react-relay/relay-hooks/useFragmentInternal_CURRENT.js',
+        'packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js',
+        'packages/react-relay/relay-hooks/useQueryLoader.js',
+        'packages/react-relay/relay-hooks/useQueryLoader_EXPERIMENTAL.js',
+        'packages/relay-runtime/handlers/connection/MutationHandlers.js',
+        'packages/relay-runtime/multi-actor-environment/MultiActorEnvironment.js',
+        'packages/relay-runtime/mutations/RelayDeclarativeMutationConfig.js',
+        'packages/relay-runtime/mutations/createUpdatableProxy.js',
+        'packages/relay-runtime/store/DataChecker.js',
+        'packages/relay-runtime/store/OperationExecutor.js',
+        'packages/relay-runtime/store/RelayErrorTrie.js',
+        'packages/relay-runtime/store/RelayExperimentalGraphResponseHandler.js',
+        'packages/relay-runtime/store/RelayExperimentalGraphResponseTransform.js',
+        'packages/relay-runtime/store/RelayModernStore.js',
+        'packages/relay-runtime/store/RelayOperationTracker.js',
+        'packages/relay-runtime/store/RelayRecordSource.js',
+        'packages/relay-runtime/store/RelayReferenceMarker.js',
+        'packages/relay-runtime/store/RelayResponseNormalizer.js',
+        'packages/relay-runtime/store/live-resolvers/LiveResolverCache.js',
+        'packages/relay-runtime/store/observeFragmentExperimental.js',
+        'packages/relay-runtime/util/RelayReplaySubject.js',
+        'packages/relay-runtime/util/getValueAtPath.js',
+        'packages/relay-runtime/util/handlePotentialSnapshotErrors.js',
+      ],
+      rules: {
+        'relay-internal/no-for-of-loops': 'error',
+      },
+    },
+  ],
 };

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -224,7 +224,8 @@ class RelayReader {
     if (this._fieldErrors == null) {
       this._fieldErrors = [];
     }
-    for (const error of errors) {
+    for (let i = 0; i < errors.length; i++) {
+      const error = errors[i];
       this._fieldErrors.push({
         kind: 'relay_field_payload.error',
         owner,
@@ -860,7 +861,8 @@ class RelayReader {
     // upwards to mimic the behavior of having traversed into that fragment directly.
     if (cachedSnapshot != null) {
       if (cachedSnapshot.missingClientEdges != null) {
-        for (const missing of cachedSnapshot.missingClientEdges) {
+        for (let i = 0; i < cachedSnapshot.missingClientEdges.length; i++) {
+          const missing = cachedSnapshot.missingClientEdges[i];
           this._missingClientEdges.push(missing);
         }
       }
@@ -869,7 +871,13 @@ class RelayReader {
           this._isMissingData ||
           cachedSnapshot.missingLiveResolverFields.length > 0;
 
-        for (const missingResolverField of cachedSnapshot.missingLiveResolverFields) {
+        for (
+          let i = 0;
+          i < cachedSnapshot.missingLiveResolverFields.length;
+          i++
+        ) {
+          const missingResolverField =
+            cachedSnapshot.missingLiveResolverFields[i];
           this._missingLiveResolverFields.push(missingResolverField);
         }
       }
@@ -877,7 +885,8 @@ class RelayReader {
         if (this._fieldErrors == null) {
           this._fieldErrors = [];
         }
-        for (const error of cachedSnapshot.fieldErrors) {
+        for (let i = 0; i < cachedSnapshot.fieldErrors.length; i++) {
+          const error = cachedSnapshot.fieldErrors[i];
           if (this._selector.node.metadata?.throwOnFieldError === true) {
             // If this fragment is @throwOnFieldError, any destructive error
             // encountered inside a resolver's fragment is equivilent to the
@@ -935,6 +944,8 @@ class RelayReader {
       this._missingLiveResolverFields.push(suspenseID);
     }
     if (updatedDataIDs != null) {
+      // Iterating a Set with for of is okay
+      // eslint-disable-next-line relay-internal/no-for-of-loops
       for (const recordID of updatedDataIDs) {
         this._updatedDataIDs.add(recordID);
       }


### PR DESCRIPTION
These loops are generally more expensive than old style `for(i = 0...i++)` loops, but it's even worse than that currently because they get transformed (both internally an in our bundles) into something even more complicated:

![Screenshot 2025-05-01 at 2 31 00 PM](https://github.com/user-attachments/assets/3682b38c-360b-4bcd-9e00-7466b2dc908f)

This leverages our new lint rule to give us a path to banning the use of these loops everywhere, starting with RelayReader