### PR TITLE
add missing generic type parameter for mutation tutorial example

### DIFF
--- a/website/docs/tutorial/mutations-updates.md
+++ b/website/docs/tutorial/mutations-updates.md
@@ -349,22 +349,18 @@ We pass this <span className="color2">fragment</span>, along with the <span clas
 ```
 function StoryLikeButton({story}) {
   ...
-      optimisticUpdater: store => {
+      optimisticUpdater: (store) => {
         const fragment = graphql`
           fragment StoryLikeButton_updatable on Story @updatable {
             likeCount
             doesViewerLike
           }
         `;
-        const {
-          // color1
-          updatableData
-        } = store.readUpdatableFragment(
-          // color2
-          fragment,
-          // color3
-          story
-        );
+        const { updatableData } =
+          store.readUpdatableFragment<StoryLikeButton_updatable$key>(
+            fragment,
+            story
+          );
       },
   ...
 }
@@ -377,19 +373,21 @@ Now `updatableData` is an object representing our existing Story as it exists in
 ```
 function StoryLikeButton({story}) {
   ...
-      optimisticUpdater: store => {
+      optimisticUpdater: (store) => {
         const fragment = graphql`
           fragment StoryLikeButton_updatable on Story @updatable {
             likeCount
             doesViewerLike
           }
         `;
-        const {updatableData} = store.readUpdatableFragment(fragment, story);
-        // change
+        const { updatableData } =
+          store.readUpdatableFragment<StoryLikeButton_updatable$key>(
+            fragment,
+            story
+          );
         const alreadyLikes = updatableData.doesViewerLike;
         updatableData.doesViewerLike = !alreadyLikes;
-        updatableData.likeCount += (alreadyLikes ? -1 : 1);
-        // end-change
+        updatableData.likeCount += alreadyLikes ? -1 : 1;
       },
   ...
 }

--- a/website/docs/tutorial/mutations-updates.md
+++ b/website/docs/tutorial/mutations-updates.md
@@ -377,7 +377,7 @@ Now `updatableData` is an object representing our existing Story as it exists in
 ```
 function StoryLikeButton({story}) {
   ...
-      optimisticUpdater: (store) => {
+      optimisticUpdater: store => {
         const fragment = graphql`
           fragment StoryLikeButton_updatable on Story @updatable {
             likeCount
@@ -392,7 +392,7 @@ function StoryLikeButton({story}) {
         // change
         const alreadyLikes = updatableData.doesViewerLike;
         updatableData.doesViewerLike = !alreadyLikes;
-        updatableData.likeCount += alreadyLikes ? -1 : 1;
+        updatableData.likeCount += (alreadyLikes ? -1 : 1);
         // end-change
       },
   ...

--- a/website/docs/tutorial/mutations-updates.md
+++ b/website/docs/tutorial/mutations-updates.md
@@ -349,18 +349,22 @@ We pass this <span className="color2">fragment</span>, along with the <span clas
 ```
 function StoryLikeButton({story}) {
   ...
-      optimisticUpdater: (store) => {
+      optimisticUpdater: store => {
         const fragment = graphql`
           fragment StoryLikeButton_updatable on Story @updatable {
             likeCount
             doesViewerLike
           }
         `;
-        const { updatableData } =
-          store.readUpdatableFragment<StoryLikeButton_updatable$key>(
-            fragment,
-            story
-          );
+        const {
+          // color1
+          updatableData
+        } = store.readUpdatableFragment<StoryLikeButton_updatable$key>(
+          // color2
+          fragment,
+          // color3
+          story
+        );
       },
   ...
 }
@@ -385,9 +389,11 @@ function StoryLikeButton({story}) {
             fragment,
             story
           );
+        // change
         const alreadyLikes = updatableData.doesViewerLike;
         updatableData.doesViewerLike = !alreadyLikes;
         updatableData.likeCount += alreadyLikes ? -1 : 1;
+        // end-change
       },
   ...
 }

--- a/website/versioned_docs/version-v19.0.0/tutorial/mutations-updates.md
+++ b/website/versioned_docs/version-v19.0.0/tutorial/mutations-updates.md
@@ -359,7 +359,7 @@ function StoryLikeButton({story}) {
         const {
           // color1
           updatableData
-        } = store.readUpdatableFragment(
+        } = store.readUpdatableFragment<StoryLikeButton_updatable$key>(
           // color2
           fragment,
           // color3
@@ -384,7 +384,11 @@ function StoryLikeButton({story}) {
             doesViewerLike
           }
         `;
-        const {updatableData} = store.readUpdatableFragment(fragment, story);
+        const { updatableData } =
+          store.readUpdatableFragment<StoryLikeButton_updatable$key>(
+            fragment,
+            story
+          );
         // change
         const alreadyLikes = updatableData.doesViewerLike;
         updatableData.doesViewerLike = !alreadyLikes;


### PR DESCRIPTION
https://relay.dev/docs/tutorial/mutations-updates/#step-4--modify-the-updatable-data

This step of the tutorial is currently giving us type errors. 

![CleanShot 2025-05-05 at 18 09 58@2x](https://github.com/user-attachments/assets/02359c4b-5910-4c81-9b12-2d914dbd7eca)

This is because we are missing the generic type parameter.

Note that this will also require us to upstream the relay dependencies in the example to the latest v19: https://github.com/relayjs/relay-examples/pull/333

After that, our tutorial will be working properly with no type error!