### PR TITLE
Fixups to quickstart

### DIFF
--- a/website/versioned_docs/version-v19.0.0/getting-started/quick-start.md
+++ b/website/versioned_docs/version-v19.0.0/getting-started/quick-start.md
@@ -70,7 +70,8 @@ And define our `relay.config.json` config file which tells the [Relay Compiler](
 {
   "src": "./src",
   "schema": "./schema.graphql",
-  "language": "typescript"
+  "language": "typescript",
+  "eagerEsModules": true
 }
 ```
 
@@ -104,6 +105,8 @@ const fetchGraphQL: FetchFunction = async (request, variables) => {
 
 const environment = new Environment({
   network: Network.create(fetchGraphQL),
+  // Note: This will error in TypeScript until our updated types land in
+  // DefinitelyTyped https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72689
 });
 
 createRoot(document.getElementById("root")!).render(

--- a/website/versioned_docs/version-v19.0.0/getting-started/quick-start.md
+++ b/website/versioned_docs/version-v19.0.0/getting-started/quick-start.md
@@ -32,9 +32,9 @@ cd relay-example
 # Runtime dependencies
 npm install relay-runtime react-relay
 # Dev dependencies
-npm install --dev babel-plugin-relay graphql relay-compiler
+npm install --save-dev babel-plugin-relay graphql relay-compiler
 # Types
-npm install --dev @types/relay-runtime @types/react-relay
+npm install --save-dev @types/relay-runtime @types/react-relay
 ```
 
 ## Configure Vite to use Relay
@@ -105,8 +105,6 @@ const fetchGraphQL: FetchFunction = async (request, variables) => {
 
 const environment = new Environment({
   network: Network.create(fetchGraphQL),
-  // Note: This will error in TypeScript until our updated types land in
-  // DefinitelyTyped https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72689
 });
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
I tried running the quickstart with 19 and hit two issues:

1. We need to update Babel to match the new compiler default of es modules: https://github.com/facebook/relay/pull/4982
2. We need to update our TS types to allow omitting store: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72689

Until those land, we should not have users expect those things to work


