### PR TITLE
Compiler Docs: Improve separators in JSON arrays and objects

### DIFF
--- a/website/src/compiler-config/CompilerConfig.js
+++ b/website/src/compiler-config/CompilerConfig.js
@@ -246,9 +246,11 @@ function RawJson({json}) {
         return (
           <span>
             [
-            {json.map((item, index) => (
-              <RawJson key={index} json={item} />
-            ))}
+            <Join separator={', '}>
+              {json.map((item, index) => (
+                <RawJson key={index} json={item} />
+              ))}
+            </Join>
             ]
           </span>
         );
@@ -259,6 +261,7 @@ function RawJson({json}) {
           {Object.entries(json).map(([key, value], index) => (
             <div key={index} className="inline-property">
               {key}: <RawJson json={value} />
+              {', '}
             </div>
           ))}
           {'}'}


### PR DESCRIPTION
## Before

<img width="799" alt="Screenshot 2025-05-10 at 9 40 55 AM" src="https://github.com/user-attachments/assets/808f78eb-257a-47ac-bb12-ee7195ee5b30" />

## After

<img width="802" alt="Screenshot 2025-05-10 at 9 40 17 AM" src="https://github.com/user-attachments/assets/844fb2f9-664f-4d48-99fa-a47fd65fa948" />
