### PR TITLE
Fetch missing client edge server queries discovered in nested fragments

### DIFF
--- a/packages/react-relay/__tests__/ClientEdges-test.js
+++ b/packages/react-relay/__tests__/ClientEdges-test.js
@@ -461,42 +461,36 @@ describe.each([[true], [false]])(
 
       // This will be updated when we add the new assertions as part of a fix for
       // this bug.
-      // eslint-disable-next-line no-unused-vars
       let renderer;
       TestRenderer.act(() => {
         renderer = TestRenderer.create(<TestComponent />);
       });
 
-      // Oops, we didn't fetch the query!
-      expect(fetchFn.mock.calls.length).toEqual(0);
+      expect(fetchFn.mock.calls.length).toEqual(1);
+      // We should send the client-edge query
+      // $FlowFixMe[invalid-tuple-index] Error found while enabling LTI on this file
+      expect(fetchFn.mock.calls[0][0].name).toBe(
+        'ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge',
+      );
+      // Check variables
+      // $FlowFixMe[invalid-tuple-index] Error found while enabling LTI on this file
+      expect(fetchFn.mock.calls[0][1]).toEqual({id: '1'});
+      expect(renderer?.toJSON()).toBe('Loading');
 
-      // Following are the assertions that SHOULD pass.
-
-      // expect(fetchFn.mock.calls.length).toEqual(1);
-      // // We should send the client-edge query
-      // // $FlowFixMe[invalid-tuple-index] Error found while enabling LTI on this file
-      // expect(fetchFn.mock.calls[0][0].name).toBe(
-      //   'ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge',
-      // );
-      // // Check variables
-      // // $FlowFixMe[invalid-tuple-index] Error found while enabling LTI on this file
-      // expect(fetchFn.mock.calls[0][1]).toEqual({id: '1'});
-      // expect(renderer?.toJSON()).toBe('Loading');
-
-      // TestRenderer.act(() => {
-      //   // This should resolve client-edge query
-      //   networkSink.next({
-      //     data: {
-      //       node: {
-      //         id: '1',
-      //         __typename: 'User',
-      //         name: 'Alice',
-      //       },
-      //     },
-      //   });
-      //   jest.runAllImmediates();
-      // });
-      // expect(renderer?.toJSON()).toBe('ALICE');
+      TestRenderer.act(() => {
+        // This should resolve client-edge query
+        networkSink.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+              name: 'Alice',
+            },
+          },
+        });
+        jest.runAllImmediates();
+      });
+      expect(renderer?.toJSON()).toBe('ALICE');
     });
   },
 );

--- a/packages/react-relay/__tests__/ClientEdges-test.js
+++ b/packages/react-relay/__tests__/ClientEdges-test.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+import type {ClientEdgesTestUpperName$key} from './__generated__/ClientEdgesTestUpperName.graphql';
+
 const React = require('react');
 const {
   RelayEnvironmentProvider,
@@ -24,6 +26,7 @@ const {
   RecordSource,
   RelayFeatureFlags,
   graphql,
+  readFragment,
 } = require('relay-runtime');
 const RelayObservable = require('relay-runtime/network/RelayObservable');
 const RelayModernStore = require('relay-runtime/store/RelayModernStore');
@@ -42,6 +45,23 @@ disallowConsoleErrors();
  */
 export function same_user_client_edge(): {id: string} {
   return {id: '1'};
+}
+
+/**
+ * @RelayResolver User.upper_name: String
+ * @rootFragment ClientEdgesTestUpperName
+ */
+
+export function upper_name(key: ClientEdgesTestUpperName$key): ?string {
+  const user = readFragment(
+    graphql`
+      fragment ClientEdgesTestUpperName on User {
+        name
+      }
+    `,
+    key,
+  );
+  return user?.name?.toUpperCase();
 }
 
 describe.each([[true], [false]])(
@@ -401,6 +421,82 @@ describe.each([[true], [false]])(
       //   jest.runAllImmediates();
       // });
       // expect(renderer?.toJSON()).toBe('Alice');
+    });
+
+    it('should fetch data missing client edge to server data in resolver @rootFragment', () => {
+      function TestComponent() {
+        return (
+          <RelayEnvironmentProvider environment={environment}>
+            <React.Suspense fallback="Loading">
+              <InnerComponent />
+            </React.Suspense>
+          </RelayEnvironmentProvider>
+        );
+      }
+
+      const variables = {};
+      function InnerComponent() {
+        const data = useLazyLoadQuery(
+          graphql`
+            query ClientEdgesTest6Query {
+              me {
+                same_user_client_edge @waterfall {
+                  # No fields here means that we render without detecting any
+                  # missing data here and don't attempt to fetch the @waterfall
+                  # query.
+                  #
+                  # The same bug can be triggered by adding a field that is already
+                  # in the store for an unrelated reason.
+                  upper_name
+                  # Adding "name" here will cause the query to be fetched.
+                }
+              }
+            }
+          `,
+          variables,
+        );
+
+        return data.me?.same_user_client_edge?.upper_name;
+      }
+
+      // This will be updated when we add the new assertions as part of a fix for
+      // this bug.
+      // eslint-disable-next-line no-unused-vars
+      let renderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<TestComponent />);
+      });
+
+      // Oops, we didn't fetch the query!
+      expect(fetchFn.mock.calls.length).toEqual(0);
+
+      // Following are the assertions that SHOULD pass.
+
+      // expect(fetchFn.mock.calls.length).toEqual(1);
+      // // We should send the client-edge query
+      // // $FlowFixMe[invalid-tuple-index] Error found while enabling LTI on this file
+      // expect(fetchFn.mock.calls[0][0].name).toBe(
+      //   'ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge',
+      // );
+      // // Check variables
+      // // $FlowFixMe[invalid-tuple-index] Error found while enabling LTI on this file
+      // expect(fetchFn.mock.calls[0][1]).toEqual({id: '1'});
+      // expect(renderer?.toJSON()).toBe('Loading');
+
+      // TestRenderer.act(() => {
+      //   // This should resolve client-edge query
+      //   networkSink.next({
+      //     data: {
+      //       node: {
+      //         id: '1',
+      //         __typename: 'User',
+      //         name: 'Alice',
+      //       },
+      //     },
+      //   });
+      //   jest.runAllImmediates();
+      // });
+      // expect(renderer?.toJSON()).toBe('ALICE');
     });
   },
 );

--- a/packages/react-relay/__tests__/__generated__/ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge.graphql.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<366f4676acbcbb62dabdb15fc6a1e6c9>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$fragmentType } from "./RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge.graphql";
+export type ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$variables = {|
+  id: string,
+|};
+export type ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$data = {|
+  +node: ?{|
+    +$fragmentSpreads: RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$fragmentType,
+  |},
+|};
+export type ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge = {|
+  response: ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$data,
+  variables: ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "name": "upper_name",
+                "args": null,
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    }
+                  ],
+                  "type": "User",
+                  "abstractKey": null
+                },
+                "kind": "RelayResolver",
+                "storageKey": null,
+                "isOutputType": true
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "4b0b7798dd0bfc7d7ff2e24c459cdccc",
+    "id": null,
+    "metadata": {},
+    "name": "ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge",
+    "operationKind": "query",
+    "text": "query ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge\n    id\n  }\n}\n\nfragment ClientEdgesTestUpperName on User {\n  name\n}\n\nfragment RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge on User {\n  ...ClientEdgesTestUpperName\n  id\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "330a0878ce30575d8c36e2fdd626c833";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$variables,
+  ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$data,
+>*/);

--- a/packages/react-relay/__tests__/__generated__/ClientEdgesTest6Query.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/ClientEdgesTest6Query.graphql.js
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<7b8a2fff0ac8a3e5b71333c58dbc823f>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { DataID } from "relay-runtime";
+import type { ClientEdgesTestUpperName$key } from "./ClientEdgesTestUpperName.graphql";
+import {same_user_client_edge as userSameUserClientEdgeResolverType} from "../ClientEdges-test.js";
+import type { TestResolverContextType } from "../../../relay-runtime/mutations/__tests__/TestResolverContextType";
+// Type assertion validating that `userSameUserClientEdgeResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(userSameUserClientEdgeResolverType: (
+  args: void,
+  context: TestResolverContextType,
+) => ?{|
+  +id: DataID,
+|});
+import {upper_name as userUpperNameResolverType} from "../ClientEdges-test.js";
+// Type assertion validating that `userUpperNameResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(userUpperNameResolverType: (
+  rootKey: ClientEdgesTestUpperName$key,
+  args: void,
+  context: TestResolverContextType,
+) => ?string);
+export type ClientEdgesTest6Query$variables = {||};
+export type ClientEdgesTest6Query$data = {|
+  +me: ?{|
+    +same_user_client_edge: ?{|
+      +upper_name: ?string,
+    |},
+  |},
+|};
+export type ClientEdgesTest6Query = {|
+  response: ClientEdgesTest6Query$data,
+  variables: ClientEdgesTest6Query$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": {
+      "hasClientEdges": true
+    },
+    "name": "ClientEdgesTest6Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ClientEdgeToServerObject",
+            "operation": require('./ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge.graphql'),
+            "backingField": {
+              "alias": null,
+              "args": null,
+              "fragment": null,
+              "kind": "RelayResolver",
+              "name": "same_user_client_edge",
+              "resolverModule": require('../ClientEdges-test').same_user_client_edge,
+              "path": "me.same_user_client_edge"
+            },
+            "linkedField": {
+              "alias": null,
+              "args": null,
+              "concreteType": "User",
+              "kind": "LinkedField",
+              "name": "same_user_client_edge",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "fragment": {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "ClientEdgesTestUpperName"
+                  },
+                  "kind": "RelayResolver",
+                  "name": "upper_name",
+                  "resolverModule": require('../ClientEdges-test').upper_name,
+                  "path": "me.same_user_client_edge.upper_name"
+                }
+              ],
+              "storageKey": null
+            }
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ClientEdgesTest6Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "name": "same_user_client_edge",
+            "args": null,
+            "fragment": null,
+            "kind": "RelayResolver",
+            "storageKey": null,
+            "isOutputType": false
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "e62271734cfff9eb7b0535fd011e32b3",
+    "id": null,
+    "metadata": {},
+    "name": "ClientEdgesTest6Query",
+    "operationKind": "query",
+    "text": "query ClientEdgesTest6Query {\n  me {\n    id\n  }\n}\n"
+  }
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "330a0878ce30575d8c36e2fdd626c833";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  ClientEdgesTest6Query$variables,
+  ClientEdgesTest6Query$data,
+>*/);

--- a/packages/react-relay/__tests__/__generated__/ClientEdgesTestUpperName.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/ClientEdgesTestUpperName.graphql.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<f82b706927023a7295be9cab4f877e31>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type ClientEdgesTestUpperName$fragmentType: FragmentType;
+export type ClientEdgesTestUpperName$data = {|
+  +name: ?string,
+  +$fragmentType: ClientEdgesTestUpperName$fragmentType,
+|};
+export type ClientEdgesTestUpperName$key = {
+  +$data?: ClientEdgesTestUpperName$data,
+  +$fragmentSpreads: ClientEdgesTestUpperName$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ClientEdgesTestUpperName",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "be2c514c21045e5df5e947adccc4f146";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  ClientEdgesTestUpperName$fragmentType,
+  ClientEdgesTestUpperName$data,
+>*/);

--- a/packages/react-relay/__tests__/__generated__/RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge.graphql.js
+++ b/packages/react-relay/__tests__/__generated__/RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge.graphql.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<8ea39c0a6070c25a68e02cc8a3820ec5>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import type { ClientEdgesTestUpperName$key } from "./ClientEdgesTestUpperName.graphql";
+import type { FragmentType } from "relay-runtime";
+import {upper_name as userUpperNameResolverType} from "../ClientEdges-test.js";
+import type { TestResolverContextType } from "../../../relay-runtime/mutations/__tests__/TestResolverContextType";
+// Type assertion validating that `userUpperNameResolverType` resolver is correctly implemented.
+// A type error here indicates that the type signature of the resolver module is incorrect.
+(userUpperNameResolverType: (
+  rootKey: ClientEdgesTestUpperName$key,
+  args: void,
+  context: TestResolverContextType,
+) => ?string);
+declare export opaque type RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$fragmentType: FragmentType;
+type ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$variables = any;
+export type RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$data = {|
+  +id: string,
+  +upper_name: ?string,
+  +$fragmentType: RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$fragmentType,
+|};
+export type RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$key = {
+  +$data?: RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$data,
+  +$fragmentSpreads: RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": require('./ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge.graphql'),
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "fragment": {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "ClientEdgesTestUpperName"
+      },
+      "kind": "RelayResolver",
+      "name": "upper_name",
+      "resolverModule": require('../ClientEdges-test').upper_name,
+      "path": "upper_name"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "330a0878ce30575d8c36e2fdd626c833";
+}
+
+module.exports = ((node/*: any*/)/*: RefetchableFragment<
+  RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$fragmentType,
+  RefetchableClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$data,
+  ClientEdgeQuery_ClientEdgesTest6Query_me__same_user_client_edge$variables,
+>*/);

--- a/packages/react-relay/relay-hooks/readFragmentInternal.js
+++ b/packages/react-relay/relay-hooks/readFragmentInternal.js
@@ -213,7 +213,10 @@ function readFragmentInternal(
   // Handle the queries for any missing client edges; this may suspend.
   // FIXME handle client edges in parallel.
   let clientEdgeQueries = null;
-  if (fragmentNode.metadata?.hasClientEdges === true) {
+  if (
+    fragmentNode.metadata?.hasClientEdges === true ||
+    RelayFeatureFlags.CHECK_ALL_FRAGMENTS_FOR_MISSING_CLIENT_EDGES
+  ) {
     const missingClientEdges = getMissingClientEdges(state);
     if (missingClientEdges?.length) {
       clientEdgeQueries = ([]: Array<QueryResult>);

--- a/packages/react-relay/relay-hooks/useFragmentInternal_CURRENT.js
+++ b/packages/react-relay/relay-hooks/useFragmentInternal_CURRENT.js
@@ -461,7 +461,10 @@ hook useFragmentInternal(
 
   // Handle the queries for any missing client edges; this may suspend.
   // FIXME handle client edges in parallel.
-  if (fragmentNode.metadata?.hasClientEdges === true) {
+  if (
+    fragmentNode.metadata?.hasClientEdges === true ||
+    RelayFeatureFlags.CHECK_ALL_FRAGMENTS_FOR_MISSING_CLIENT_EDGES
+  ) {
     // The fragment is validated to be static (in useFragment) and hasClientEdges is
     // a static (constant) property of the fragment. In practice, this effect will
     // always or never run for a given invocation of this hook.

--- a/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
+++ b/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
@@ -476,7 +476,10 @@ hook useFragmentInternal_EXPERIMENTAL(
 
   // Handle the queries for any missing client edges; this may suspend.
   // FIXME handle client edges in parallel.
-  if (fragmentNode.metadata?.hasClientEdges === true) {
+  if (
+    fragmentNode.metadata?.hasClientEdges === true ||
+    RelayFeatureFlags.CHECK_ALL_FRAGMENTS_FOR_MISSING_CLIENT_EDGES
+  ) {
     // The fragment is validated to be static (in useFragment) and hasClientEdges is
     // a static (constant) property of the fragment. In practice, this effect will
     // always or never run for a given invocation of this hook.

--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -788,7 +788,7 @@ class RelayReader {
     //   `getResolverValue`) and converted into an error object.
     const evaluate = (): EvaluationResult<mixed> => {
       if (fragment != null) {
-        const key = {
+        const key: SelectorData = {
           __id: parentRecordID,
           __fragmentOwner: this._owner,
           __fragments: {
@@ -797,6 +797,14 @@ class RelayReader {
               : {},
           },
         };
+        if (
+          this._clientEdgeTraversalPath.length > 0 &&
+          this._clientEdgeTraversalPath[
+            this._clientEdgeTraversalPath.length - 1
+          ] !== null
+        ) {
+          key[CLIENT_EDGE_TRAVERSAL_PATH] = [...this._clientEdgeTraversalPath];
+        }
         const resolverContext = {getDataForResolverFragment};
         return withResolverContext(resolverContext, () => {
           const [resolverResult, resolverError] = getResolverValue(

--- a/packages/relay-runtime/util/RelayFeatureFlags.js
+++ b/packages/relay-runtime/util/RelayFeatureFlags.js
@@ -71,6 +71,15 @@ export type FeatureFlags = {
 
   // Enable prefixing of DataID in the store with __typename
   ENABLE_TYPENAME_PREFIXED_DATA_ID: boolean,
+
+  // Relay previously had a bug where it would fail to check for missing client
+  // edge to server data in fragments nested within client edge Relay Resolver
+  // fields. This feature flag fixes the behavior but comes with a perf cost.
+  // This flag is here to allow us to gradually rollout the fix and track the perf
+  // impact.
+  //
+  // See https://github.com/facebook/relay/issues/4882
+  CHECK_ALL_FRAGMENTS_FOR_MISSING_CLIENT_EDGES: boolean,
 };
 
 const RelayFeatureFlags: FeatureFlags = {
@@ -99,6 +108,7 @@ const RelayFeatureFlags: FeatureFlags = {
   DISALLOW_NESTED_UPDATES: false,
   ENABLE_TYPENAME_PREFIXED_DATA_ID: false,
   ENABLE_UI_CONTEXT_ON_RELAY_LOGGER: false,
+  CHECK_ALL_FRAGMENTS_FOR_MISSING_CLIENT_EDGES: false,
 };
 
 module.exports = RelayFeatureFlags;


### PR DESCRIPTION
Summary:
Initially reported here: https://github.com/facebook/relay/issues/4882

Fetching of client-edge-to-server generated queries is handled by detecting missing data in Relay Reader and Relay Reader maintaining a stack of client-edge-to-server fields. As we traverse into such fields we push information about that query onto the stack, and as we exit such fields we pop values off the stack.

In the case of fragments spread into selections where we have such a stack built up, we propagate it via a hidden [__clientEdgeTraversalPath](https://github.com/facebook/relay/blob/35229211f1198b956382c604f7787ba3b99ab5ed/packages/relay-runtime/store/RelayStoreUtils.js#L281) field on fragment keys.

This hidden property means that any fragment located somewhere underneath a client edge to server field might encounter missing data and need to trigger the fetch of that server query.

For example, if the selection includes only fragment spreads, or some other query had fetched all the fields that were read directly in the fragment which read the actual resolver field the fragment with the resolver field would render fine and we wouldn't discover we were missing data until we tried to read a child fragment. In theory that could be many fragments away. E.g. if I had a field `my_client_edge_to_server` that returned a `User,` any fragment spread into any selection nested under that edge (including `my_client_edge_to_server.best_friend.favorite_sports_team.coach.profile_picture` could technically uncover missing data in some totally generic `ProfilePicture` fragment.

However, we overlooked that possibility in D36684124 where we added an optimization which tries to avoid the overhead of these additional hooks in the common case by only checking for missing client edge data in the case that the fragment _itself_ contains at least one client edge field (as computed by the compiler).

As the example above demonstrates (and the test case in this diff also demonstrates) that turns out to not actually be safe.

This removes the optimization to allow the correct behavior to work. However, this adds a useMemo and useEffect to each useFragment, which may have some perf implications. Putting this behind a feature flag to let us ship this especially for folks who are blocked by it, but also so we can consider perf concerns before rolling out internally.

I'll invert the feature flag default in a future diff once we've configured it internally.

Differential Revision: D74593372


