### PR TITLE
Pass compiler config json schema as a prop

### DIFF
--- a/website/docs/getting-started/compiler-config.md
+++ b/website/docs/getting-started/compiler-config.md
@@ -10,6 +10,7 @@ keywords:
 hide_table_of_contents: false
 ---
 import CompilerConfig from '@site/src/compiler-config/CompilerConfig';
+import schema from '@compilerConfigJsonSchema';
 
 ## Compiler Config Options
 
@@ -21,4 +22,4 @@ If you need more advanced options of the Relay Compiler Config, the exhaustive f
 Install the [Relay VSCode extension](../editor-support.md) to get autocomplete, hover tips, and type checking for the options in your Relay config.
 :::
 
-<CompilerConfig />
+<CompilerConfig schema={schema} />


### PR DESCRIPTION
This should make it possible for us to have versioned docs which include the compiler config for that specific version.

<img width="1797" alt="Screenshot 2025-05-13 at 8 58 23 PM" src="https://github.com/user-attachments/assets/a61db673-0ee4-4416-8a04-b36ec18522da" />
