### PR TITLE
Update Rust compiler version in ci.yml to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # docusaurus.yml
-          toolchain: nightly-2024-10-13
+          toolchain: nightly-2025-03-29
           override: true
       - name: "Run tests"
         run: cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
@@ -124,7 +124,7 @@ jobs:
           # Should stay in sync with fbcode/buck2/rust-toolchain
          # And other similar references in this file and
           # docusaurus.yml
-          toolchain: nightly-2024-10-13
+          toolchain: nightly-2025-03-29
           override: true
       - name: "Update fixture tests"
         run: ./scripts/update-fixtures.sh
@@ -187,7 +187,7 @@ jobs:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # docusaurus.yml
-          toolchain: nightly-2024-10-13
+          toolchain: nightly-2025-03-29
           override: true
           target: ${{ matrix.target.target }}
       - uses: actions/setup-node@v4

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -24,7 +24,7 @@ jobs:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # ci.yml
-          toolchain: nightly-2024-10-13
+          toolchain: nightly-2025-03-29
           override: true
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -24,7 +24,7 @@ jobs:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # ci.yml
-          toolchain: nightly-2024-10-13
+          toolchain: nightly-2025-03-29
           override: true
       - name: cargo check
         run: cargo check --features vendored --manifest-path=compiler/Cargo.toml


### PR DESCRIPTION
https://github.com/facebook/relay/commit/7bb4b15a44cb325884767ab5e35b900cfd223161 broke CI by including a feature that needs a newer Rust compiler. This PR updates the compiler used in CI