### PR TITLE
Disable persisted queries in validate mode

### DIFF
--- a/compiler/crates/schema-flatbuffer/src/graphqlschema_generated.rs
+++ b/compiler/crates/schema-flatbuffer/src/graphqlschema_generated.rs
@@ -20,27 +20,36 @@
 
 // @generated
 
-use core::mem;
 use core::cmp::Ordering;
+use core::mem;
 
 extern crate flatbuffers;
 use self::flatbuffers::{EndianScalar, Follow};
 
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MIN_CONST_VALUE_KIND: i8 = 0;
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MAX_CONST_VALUE_KIND: i8 = 7;
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 #[allow(non_camel_case_types)]
 pub const ENUM_VALUES_CONST_VALUE_KIND: [ConstValueKind; 8] = [
-  ConstValueKind::Null,
-  ConstValueKind::String,
-  ConstValueKind::Bool,
-  ConstValueKind::Int,
-  ConstValueKind::Float,
-  ConstValueKind::Enum,
-  ConstValueKind::List,
-  ConstValueKind::Object,
+    ConstValueKind::Null,
+    ConstValueKind::String,
+    ConstValueKind::Bool,
+    ConstValueKind::Int,
+    ConstValueKind::Float,
+    ConstValueKind::Enum,
+    ConstValueKind::List,
+    ConstValueKind::Object,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -48,108 +57,118 @@ pub const ENUM_VALUES_CONST_VALUE_KIND: [ConstValueKind; 8] = [
 pub struct ConstValueKind(pub i8);
 #[allow(non_upper_case_globals)]
 impl ConstValueKind {
-  pub const Null: Self = Self(0);
-  pub const String: Self = Self(1);
-  pub const Bool: Self = Self(2);
-  pub const Int: Self = Self(3);
-  pub const Float: Self = Self(4);
-  pub const Enum: Self = Self(5);
-  pub const List: Self = Self(6);
-  pub const Object: Self = Self(7);
+    pub const Null: Self = Self(0);
+    pub const String: Self = Self(1);
+    pub const Bool: Self = Self(2);
+    pub const Int: Self = Self(3);
+    pub const Float: Self = Self(4);
+    pub const Enum: Self = Self(5);
+    pub const List: Self = Self(6);
+    pub const Object: Self = Self(7);
 
-  pub const ENUM_MIN: i8 = 0;
-  pub const ENUM_MAX: i8 = 7;
-  pub const ENUM_VALUES: &'static [Self] = &[
-    Self::Null,
-    Self::String,
-    Self::Bool,
-    Self::Int,
-    Self::Float,
-    Self::Enum,
-    Self::List,
-    Self::Object,
-  ];
-  /// Returns the variant's name or "" if unknown.
-  pub fn variant_name(self) -> Option<&'static str> {
-    match self {
-      Self::Null => Some("Null"),
-      Self::String => Some("String"),
-      Self::Bool => Some("Bool"),
-      Self::Int => Some("Int"),
-      Self::Float => Some("Float"),
-      Self::Enum => Some("Enum"),
-      Self::List => Some("List"),
-      Self::Object => Some("Object"),
-      _ => None,
+    pub const ENUM_MIN: i8 = 0;
+    pub const ENUM_MAX: i8 = 7;
+    pub const ENUM_VALUES: &'static [Self] = &[
+        Self::Null,
+        Self::String,
+        Self::Bool,
+        Self::Int,
+        Self::Float,
+        Self::Enum,
+        Self::List,
+        Self::Object,
+    ];
+    /// Returns the variant's name or "" if unknown.
+    pub fn variant_name(self) -> Option<&'static str> {
+        match self {
+            Self::Null => Some("Null"),
+            Self::String => Some("String"),
+            Self::Bool => Some("Bool"),
+            Self::Int => Some("Int"),
+            Self::Float => Some("Float"),
+            Self::Enum => Some("Enum"),
+            Self::List => Some("List"),
+            Self::Object => Some("Object"),
+            _ => None,
+        }
     }
-  }
 }
 impl core::fmt::Debug for ConstValueKind {
-  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    if let Some(name) = self.variant_name() {
-      f.write_str(name)
-    } else {
-      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if let Some(name) = self.variant_name() {
+            f.write_str(name)
+        } else {
+            f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+        }
     }
-  }
 }
 impl<'a> flatbuffers::Follow<'a> for ConstValueKind {
-  type Inner = Self;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    let b = unsafe {
-      flatbuffers::read_scalar_at::<i8>(buf, loc)
-    };
-    Self(b)
-  }
+    type Inner = Self;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        let b = unsafe { flatbuffers::read_scalar_at::<i8>(buf, loc) };
+        Self(b)
+    }
 }
 
 impl flatbuffers::Push for ConstValueKind {
     type Output = ConstValueKind;
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-        unsafe { flatbuffers::emplace_scalar::<i8>(dst, self.0); }
+        unsafe {
+            flatbuffers::emplace_scalar::<i8>(dst, self.0);
+        }
     }
 }
 
 impl flatbuffers::EndianScalar for ConstValueKind {
-  #[inline]
-  fn to_little_endian(self) -> Self {
-    let b = i8::to_le(self.0);
-    Self(b)
-  }
-  #[inline]
-  #[allow(clippy::wrong_self_convention)]
-  fn from_little_endian(self) -> Self {
-    let b = i8::from_le(self.0);
-    Self(b)
-  }
+    #[inline]
+    fn to_little_endian(self) -> Self {
+        let b = i8::to_le(self.0);
+        Self(b)
+    }
+    #[inline]
+    #[allow(clippy::wrong_self_convention)]
+    fn from_little_endian(self) -> Self {
+        let b = i8::from_le(self.0);
+        Self(b)
+    }
 }
 
 impl<'a> flatbuffers::Verifiable for ConstValueKind {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    i8::run_verifier(v, pos)
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        i8::run_verifier(v, pos)
+    }
 }
 
 impl flatbuffers::SimpleToVerifyInSlice for ConstValueKind {}
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MIN_TYPE_KIND: i8 = 0;
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MAX_TYPE_KIND: i8 = 5;
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 #[allow(non_camel_case_types)]
 pub const ENUM_VALUES_TYPE_KIND: [TypeKind; 6] = [
-  TypeKind::Scalar,
-  TypeKind::InputObject,
-  TypeKind::Enum,
-  TypeKind::Object,
-  TypeKind::Interface,
-  TypeKind::Union,
+    TypeKind::Scalar,
+    TypeKind::InputObject,
+    TypeKind::Enum,
+    TypeKind::Object,
+    TypeKind::Interface,
+    TypeKind::Union,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -157,99 +176,109 @@ pub const ENUM_VALUES_TYPE_KIND: [TypeKind; 6] = [
 pub struct TypeKind(pub i8);
 #[allow(non_upper_case_globals)]
 impl TypeKind {
-  pub const Scalar: Self = Self(0);
-  pub const InputObject: Self = Self(1);
-  pub const Enum: Self = Self(2);
-  pub const Object: Self = Self(3);
-  pub const Interface: Self = Self(4);
-  pub const Union: Self = Self(5);
+    pub const Scalar: Self = Self(0);
+    pub const InputObject: Self = Self(1);
+    pub const Enum: Self = Self(2);
+    pub const Object: Self = Self(3);
+    pub const Interface: Self = Self(4);
+    pub const Union: Self = Self(5);
 
-  pub const ENUM_MIN: i8 = 0;
-  pub const ENUM_MAX: i8 = 5;
-  pub const ENUM_VALUES: &'static [Self] = &[
-    Self::Scalar,
-    Self::InputObject,
-    Self::Enum,
-    Self::Object,
-    Self::Interface,
-    Self::Union,
-  ];
-  /// Returns the variant's name or "" if unknown.
-  pub fn variant_name(self) -> Option<&'static str> {
-    match self {
-      Self::Scalar => Some("Scalar"),
-      Self::InputObject => Some("InputObject"),
-      Self::Enum => Some("Enum"),
-      Self::Object => Some("Object"),
-      Self::Interface => Some("Interface"),
-      Self::Union => Some("Union"),
-      _ => None,
+    pub const ENUM_MIN: i8 = 0;
+    pub const ENUM_MAX: i8 = 5;
+    pub const ENUM_VALUES: &'static [Self] = &[
+        Self::Scalar,
+        Self::InputObject,
+        Self::Enum,
+        Self::Object,
+        Self::Interface,
+        Self::Union,
+    ];
+    /// Returns the variant's name or "" if unknown.
+    pub fn variant_name(self) -> Option<&'static str> {
+        match self {
+            Self::Scalar => Some("Scalar"),
+            Self::InputObject => Some("InputObject"),
+            Self::Enum => Some("Enum"),
+            Self::Object => Some("Object"),
+            Self::Interface => Some("Interface"),
+            Self::Union => Some("Union"),
+            _ => None,
+        }
     }
-  }
 }
 impl core::fmt::Debug for TypeKind {
-  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    if let Some(name) = self.variant_name() {
-      f.write_str(name)
-    } else {
-      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if let Some(name) = self.variant_name() {
+            f.write_str(name)
+        } else {
+            f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+        }
     }
-  }
 }
 impl<'a> flatbuffers::Follow<'a> for TypeKind {
-  type Inner = Self;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    let b = unsafe {
-      flatbuffers::read_scalar_at::<i8>(buf, loc)
-    };
-    Self(b)
-  }
+    type Inner = Self;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        let b = unsafe { flatbuffers::read_scalar_at::<i8>(buf, loc) };
+        Self(b)
+    }
 }
 
 impl flatbuffers::Push for TypeKind {
     type Output = TypeKind;
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-        unsafe { flatbuffers::emplace_scalar::<i8>(dst, self.0); }
+        unsafe {
+            flatbuffers::emplace_scalar::<i8>(dst, self.0);
+        }
     }
 }
 
 impl flatbuffers::EndianScalar for TypeKind {
-  #[inline]
-  fn to_little_endian(self) -> Self {
-    let b = i8::to_le(self.0);
-    Self(b)
-  }
-  #[inline]
-  #[allow(clippy::wrong_self_convention)]
-  fn from_little_endian(self) -> Self {
-    let b = i8::from_le(self.0);
-    Self(b)
-  }
+    #[inline]
+    fn to_little_endian(self) -> Self {
+        let b = i8::to_le(self.0);
+        Self(b)
+    }
+    #[inline]
+    #[allow(clippy::wrong_self_convention)]
+    fn from_little_endian(self) -> Self {
+        let b = i8::from_le(self.0);
+        Self(b)
+    }
 }
 
 impl<'a> flatbuffers::Verifiable for TypeKind {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    i8::run_verifier(v, pos)
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        i8::run_verifier(v, pos)
+    }
 }
 
 impl flatbuffers::SimpleToVerifyInSlice for TypeKind {}
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MIN_TYPE_REFERENCE_KIND: i8 = 0;
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MAX_TYPE_REFERENCE_KIND: i8 = 2;
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 #[allow(non_camel_case_types)]
 pub const ENUM_VALUES_TYPE_REFERENCE_KIND: [TypeReferenceKind; 3] = [
-  TypeReferenceKind::Named,
-  TypeReferenceKind::NonNull,
-  TypeReferenceKind::List,
+    TypeReferenceKind::Named,
+    TypeReferenceKind::NonNull,
+    TypeReferenceKind::List,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -257,107 +286,113 @@ pub const ENUM_VALUES_TYPE_REFERENCE_KIND: [TypeReferenceKind; 3] = [
 pub struct TypeReferenceKind(pub i8);
 #[allow(non_upper_case_globals)]
 impl TypeReferenceKind {
-  pub const Named: Self = Self(0);
-  pub const NonNull: Self = Self(1);
-  pub const List: Self = Self(2);
-  pub const Catchable: Self = Self(3);
+    pub const Named: Self = Self(0);
+    pub const NonNull: Self = Self(1);
+    pub const List: Self = Self(2);
+    pub const Catchable: Self = Self(3);
 
-  pub const ENUM_MIN: i8 = 0;
-  pub const ENUM_MAX: i8 = 2;
-  pub const ENUM_VALUES: &'static [Self] = &[
-    Self::Named,
-    Self::NonNull,
-    Self::List,
-  ];
-  /// Returns the variant's name or "" if unknown.
-  pub fn variant_name(self) -> Option<&'static str> {
-    match self {
-      Self::Named => Some("Named"),
-      Self::NonNull => Some("NonNull"),
-      Self::List => Some("List"),
-      _ => None,
+    pub const ENUM_MIN: i8 = 0;
+    pub const ENUM_MAX: i8 = 2;
+    pub const ENUM_VALUES: &'static [Self] = &[Self::Named, Self::NonNull, Self::List];
+    /// Returns the variant's name or "" if unknown.
+    pub fn variant_name(self) -> Option<&'static str> {
+        match self {
+            Self::Named => Some("Named"),
+            Self::NonNull => Some("NonNull"),
+            Self::List => Some("List"),
+            _ => None,
+        }
     }
-  }
 }
 impl core::fmt::Debug for TypeReferenceKind {
-  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    if let Some(name) = self.variant_name() {
-      f.write_str(name)
-    } else {
-      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if let Some(name) = self.variant_name() {
+            f.write_str(name)
+        } else {
+            f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+        }
     }
-  }
 }
 impl<'a> flatbuffers::Follow<'a> for TypeReferenceKind {
-  type Inner = Self;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    let b = unsafe {
-      flatbuffers::read_scalar_at::<i8>(buf, loc)
-    };
-    Self(b)
-  }
+    type Inner = Self;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        let b = unsafe { flatbuffers::read_scalar_at::<i8>(buf, loc) };
+        Self(b)
+    }
 }
 
 impl flatbuffers::Push for TypeReferenceKind {
     type Output = TypeReferenceKind;
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-        unsafe { flatbuffers::emplace_scalar::<i8>(dst, self.0); }
+        unsafe {
+            flatbuffers::emplace_scalar::<i8>(dst, self.0);
+        }
     }
 }
 
 impl flatbuffers::EndianScalar for TypeReferenceKind {
-  #[inline]
-  fn to_little_endian(self) -> Self {
-    let b = i8::to_le(self.0);
-    Self(b)
-  }
-  #[inline]
-  #[allow(clippy::wrong_self_convention)]
-  fn from_little_endian(self) -> Self {
-    let b = i8::from_le(self.0);
-    Self(b)
-  }
+    #[inline]
+    fn to_little_endian(self) -> Self {
+        let b = i8::to_le(self.0);
+        Self(b)
+    }
+    #[inline]
+    #[allow(clippy::wrong_self_convention)]
+    fn from_little_endian(self) -> Self {
+        let b = i8::from_le(self.0);
+        Self(b)
+    }
 }
 
 impl<'a> flatbuffers::Verifiable for TypeReferenceKind {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    i8::run_verifier(v, pos)
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        i8::run_verifier(v, pos)
+    }
 }
 
 impl flatbuffers::SimpleToVerifyInSlice for TypeReferenceKind {}
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MIN_DIRECTIVE_LOCATION: i8 = 0;
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MAX_DIRECTIVE_LOCATION: i8 = 18;
-#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 #[allow(non_camel_case_types)]
 pub const ENUM_VALUES_DIRECTIVE_LOCATION: [DirectiveLocation; 19] = [
-  DirectiveLocation::Query,
-  DirectiveLocation::Mutation,
-  DirectiveLocation::Subscription,
-  DirectiveLocation::Field,
-  DirectiveLocation::FragmentDefinition,
-  DirectiveLocation::FragmentSpread,
-  DirectiveLocation::InlineFragment,
-  DirectiveLocation::Schema,
-  DirectiveLocation::Scalar,
-  DirectiveLocation::Object,
-  DirectiveLocation::FieldDefinition,
-  DirectiveLocation::ArgumentDefinition,
-  DirectiveLocation::Interface,
-  DirectiveLocation::Union,
-  DirectiveLocation::Enum,
-  DirectiveLocation::EnumValue,
-  DirectiveLocation::InputObject,
-  DirectiveLocation::InputFieldDefinition,
-  DirectiveLocation::VariableDefinition,
+    DirectiveLocation::Query,
+    DirectiveLocation::Mutation,
+    DirectiveLocation::Subscription,
+    DirectiveLocation::Field,
+    DirectiveLocation::FragmentDefinition,
+    DirectiveLocation::FragmentSpread,
+    DirectiveLocation::InlineFragment,
+    DirectiveLocation::Schema,
+    DirectiveLocation::Scalar,
+    DirectiveLocation::Object,
+    DirectiveLocation::FieldDefinition,
+    DirectiveLocation::ArgumentDefinition,
+    DirectiveLocation::Interface,
+    DirectiveLocation::Union,
+    DirectiveLocation::Enum,
+    DirectiveLocation::EnumValue,
+    DirectiveLocation::InputObject,
+    DirectiveLocation::InputFieldDefinition,
+    DirectiveLocation::VariableDefinition,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -365,125 +400,126 @@ pub const ENUM_VALUES_DIRECTIVE_LOCATION: [DirectiveLocation; 19] = [
 pub struct DirectiveLocation(pub i8);
 #[allow(non_upper_case_globals)]
 impl DirectiveLocation {
-  pub const Query: Self = Self(0);
-  pub const Mutation: Self = Self(1);
-  pub const Subscription: Self = Self(2);
-  pub const Field: Self = Self(3);
-  pub const FragmentDefinition: Self = Self(4);
-  pub const FragmentSpread: Self = Self(5);
-  pub const InlineFragment: Self = Self(6);
-  pub const Schema: Self = Self(7);
-  pub const Scalar: Self = Self(8);
-  pub const Object: Self = Self(9);
-  pub const FieldDefinition: Self = Self(10);
-  pub const ArgumentDefinition: Self = Self(11);
-  pub const Interface: Self = Self(12);
-  pub const Union: Self = Self(13);
-  pub const Enum: Self = Self(14);
-  pub const EnumValue: Self = Self(15);
-  pub const InputObject: Self = Self(16);
-  pub const InputFieldDefinition: Self = Self(17);
-  pub const VariableDefinition: Self = Self(18);
+    pub const Query: Self = Self(0);
+    pub const Mutation: Self = Self(1);
+    pub const Subscription: Self = Self(2);
+    pub const Field: Self = Self(3);
+    pub const FragmentDefinition: Self = Self(4);
+    pub const FragmentSpread: Self = Self(5);
+    pub const InlineFragment: Self = Self(6);
+    pub const Schema: Self = Self(7);
+    pub const Scalar: Self = Self(8);
+    pub const Object: Self = Self(9);
+    pub const FieldDefinition: Self = Self(10);
+    pub const ArgumentDefinition: Self = Self(11);
+    pub const Interface: Self = Self(12);
+    pub const Union: Self = Self(13);
+    pub const Enum: Self = Self(14);
+    pub const EnumValue: Self = Self(15);
+    pub const InputObject: Self = Self(16);
+    pub const InputFieldDefinition: Self = Self(17);
+    pub const VariableDefinition: Self = Self(18);
 
-  pub const ENUM_MIN: i8 = 0;
-  pub const ENUM_MAX: i8 = 18;
-  pub const ENUM_VALUES: &'static [Self] = &[
-    Self::Query,
-    Self::Mutation,
-    Self::Subscription,
-    Self::Field,
-    Self::FragmentDefinition,
-    Self::FragmentSpread,
-    Self::InlineFragment,
-    Self::Schema,
-    Self::Scalar,
-    Self::Object,
-    Self::FieldDefinition,
-    Self::ArgumentDefinition,
-    Self::Interface,
-    Self::Union,
-    Self::Enum,
-    Self::EnumValue,
-    Self::InputObject,
-    Self::InputFieldDefinition,
-    Self::VariableDefinition,
-  ];
-  /// Returns the variant's name or "" if unknown.
-  pub fn variant_name(self) -> Option<&'static str> {
-    match self {
-      Self::Query => Some("Query"),
-      Self::Mutation => Some("Mutation"),
-      Self::Subscription => Some("Subscription"),
-      Self::Field => Some("Field"),
-      Self::FragmentDefinition => Some("FragmentDefinition"),
-      Self::FragmentSpread => Some("FragmentSpread"),
-      Self::InlineFragment => Some("InlineFragment"),
-      Self::Schema => Some("Schema"),
-      Self::Scalar => Some("Scalar"),
-      Self::Object => Some("Object"),
-      Self::FieldDefinition => Some("FieldDefinition"),
-      Self::ArgumentDefinition => Some("ArgumentDefinition"),
-      Self::Interface => Some("Interface"),
-      Self::Union => Some("Union"),
-      Self::Enum => Some("Enum"),
-      Self::EnumValue => Some("EnumValue"),
-      Self::InputObject => Some("InputObject"),
-      Self::InputFieldDefinition => Some("InputFieldDefinition"),
-      Self::VariableDefinition => Some("VariableDefinition"),
-      _ => None,
+    pub const ENUM_MIN: i8 = 0;
+    pub const ENUM_MAX: i8 = 18;
+    pub const ENUM_VALUES: &'static [Self] = &[
+        Self::Query,
+        Self::Mutation,
+        Self::Subscription,
+        Self::Field,
+        Self::FragmentDefinition,
+        Self::FragmentSpread,
+        Self::InlineFragment,
+        Self::Schema,
+        Self::Scalar,
+        Self::Object,
+        Self::FieldDefinition,
+        Self::ArgumentDefinition,
+        Self::Interface,
+        Self::Union,
+        Self::Enum,
+        Self::EnumValue,
+        Self::InputObject,
+        Self::InputFieldDefinition,
+        Self::VariableDefinition,
+    ];
+    /// Returns the variant's name or "" if unknown.
+    pub fn variant_name(self) -> Option<&'static str> {
+        match self {
+            Self::Query => Some("Query"),
+            Self::Mutation => Some("Mutation"),
+            Self::Subscription => Some("Subscription"),
+            Self::Field => Some("Field"),
+            Self::FragmentDefinition => Some("FragmentDefinition"),
+            Self::FragmentSpread => Some("FragmentSpread"),
+            Self::InlineFragment => Some("InlineFragment"),
+            Self::Schema => Some("Schema"),
+            Self::Scalar => Some("Scalar"),
+            Self::Object => Some("Object"),
+            Self::FieldDefinition => Some("FieldDefinition"),
+            Self::ArgumentDefinition => Some("ArgumentDefinition"),
+            Self::Interface => Some("Interface"),
+            Self::Union => Some("Union"),
+            Self::Enum => Some("Enum"),
+            Self::EnumValue => Some("EnumValue"),
+            Self::InputObject => Some("InputObject"),
+            Self::InputFieldDefinition => Some("InputFieldDefinition"),
+            Self::VariableDefinition => Some("VariableDefinition"),
+            _ => None,
+        }
     }
-  }
 }
 impl core::fmt::Debug for DirectiveLocation {
-  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    if let Some(name) = self.variant_name() {
-      f.write_str(name)
-    } else {
-      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if let Some(name) = self.variant_name() {
+            f.write_str(name)
+        } else {
+            f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+        }
     }
-  }
 }
 impl<'a> flatbuffers::Follow<'a> for DirectiveLocation {
-  type Inner = Self;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    let b = unsafe {
-      flatbuffers::read_scalar_at::<i8>(buf, loc)
-    };
-    Self(b)
-  }
+    type Inner = Self;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        let b = unsafe { flatbuffers::read_scalar_at::<i8>(buf, loc) };
+        Self(b)
+    }
 }
 
 impl flatbuffers::Push for DirectiveLocation {
     type Output = DirectiveLocation;
     #[inline]
     fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-        unsafe { flatbuffers::emplace_scalar::<i8>(dst, self.0); }
+        unsafe {
+            flatbuffers::emplace_scalar::<i8>(dst, self.0);
+        }
     }
 }
 
 impl flatbuffers::EndianScalar for DirectiveLocation {
-  #[inline]
-  fn to_little_endian(self) -> Self {
-    let b = i8::to_le(self.0);
-    Self(b)
-  }
-  #[inline]
-  #[allow(clippy::wrong_self_convention)]
-  fn from_little_endian(self) -> Self {
-    let b = i8::from_le(self.0);
-    Self(b)
-  }
+    #[inline]
+    fn to_little_endian(self) -> Self {
+        let b = i8::to_le(self.0);
+        Self(b)
+    }
+    #[inline]
+    #[allow(clippy::wrong_self_convention)]
+    fn from_little_endian(self) -> Self {
+        let b = i8::from_le(self.0);
+        Self(b)
+    }
 }
 
 impl<'a> flatbuffers::Verifiable for DirectiveLocation {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    i8::run_verifier(v, pos)
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        i8::run_verifier(v, pos)
+    }
 }
 
 impl flatbuffers::SimpleToVerifyInSlice for DirectiveLocation {}
@@ -491,100 +527,149 @@ pub enum ConstValueOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct ConstValue<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for ConstValue<'a> {
-  type Inner = ConstValue<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = ConstValue<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> ConstValue<'a> {
-  pub const VT_KIND: flatbuffers::VOffsetT = 4;
-  pub const VT_STRING_VALUE: flatbuffers::VOffsetT = 6;
-  pub const VT_BOOL_VALUE: flatbuffers::VOffsetT = 8;
-  pub const VT_INT_VALUE: flatbuffers::VOffsetT = 10;
-  pub const VT_FLOAT_VALUE: flatbuffers::VOffsetT = 12;
-  pub const VT_ENUM_VALUE: flatbuffers::VOffsetT = 14;
-  pub const VT_LIST_VALUE: flatbuffers::VOffsetT = 16;
-  pub const VT_OBJECT_VALUE: flatbuffers::VOffsetT = 18;
+    pub const VT_KIND: flatbuffers::VOffsetT = 4;
+    pub const VT_STRING_VALUE: flatbuffers::VOffsetT = 6;
+    pub const VT_BOOL_VALUE: flatbuffers::VOffsetT = 8;
+    pub const VT_INT_VALUE: flatbuffers::VOffsetT = 10;
+    pub const VT_FLOAT_VALUE: flatbuffers::VOffsetT = 12;
+    pub const VT_ENUM_VALUE: flatbuffers::VOffsetT = 14;
+    pub const VT_LIST_VALUE: flatbuffers::VOffsetT = 16;
+    pub const VT_OBJECT_VALUE: flatbuffers::VOffsetT = 18;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    ConstValue { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args ConstValueArgs<'args>
-  ) -> flatbuffers::WIPOffset<ConstValue<'bldr>> {
-    let mut builder = ConstValueBuilder::new(_fbb);
-    if let Some(x) = args.object_value { builder.add_object_value(x); }
-    if let Some(x) = args.list_value { builder.add_list_value(x); }
-    if let Some(x) = args.enum_value { builder.add_enum_value(x); }
-    if let Some(x) = args.float_value { builder.add_float_value(x); }
-    if let Some(x) = args.int_value { builder.add_int_value(x); }
-    if let Some(x) = args.string_value { builder.add_string_value(x); }
-    builder.add_bool_value(args.bool_value);
-    builder.add_kind(args.kind);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        ConstValue { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args ConstValueArgs<'args>,
+    ) -> flatbuffers::WIPOffset<ConstValue<'bldr>> {
+        let mut builder = ConstValueBuilder::new(_fbb);
+        if let Some(x) = args.object_value {
+            builder.add_object_value(x);
+        }
+        if let Some(x) = args.list_value {
+            builder.add_list_value(x);
+        }
+        if let Some(x) = args.enum_value {
+            builder.add_enum_value(x);
+        }
+        if let Some(x) = args.float_value {
+            builder.add_float_value(x);
+        }
+        if let Some(x) = args.int_value {
+            builder.add_int_value(x);
+        }
+        if let Some(x) = args.string_value {
+            builder.add_string_value(x);
+        }
+        builder.add_bool_value(args.bool_value);
+        builder.add_kind(args.kind);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn kind(&self) -> ConstValueKind {
-    self._tab.get::<ConstValueKind>(ConstValue::VT_KIND, Some(ConstValueKind::Null)).unwrap()
-  }
-  #[inline]
-  pub fn string_value(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(ConstValue::VT_STRING_VALUE, None)
-  }
-  #[inline]
-  pub fn bool_value(&self) -> bool {
-    self._tab.get::<bool>(ConstValue::VT_BOOL_VALUE, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn int_value(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(ConstValue::VT_INT_VALUE, None)
-  }
-  #[inline]
-  pub fn float_value(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(ConstValue::VT_FLOAT_VALUE, None)
-  }
-  #[inline]
-  pub fn enum_value(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(ConstValue::VT_ENUM_VALUE, None)
-  }
-  #[inline]
-  pub fn list_value(&self) -> Option<ListValue<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<ListValue>>(ConstValue::VT_LIST_VALUE, None)
-  }
-  #[inline]
-  pub fn object_value(&self) -> Option<ObjectValue<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<ObjectValue>>(ConstValue::VT_OBJECT_VALUE, None)
-  }
+    #[inline]
+    pub fn kind(&self) -> ConstValueKind {
+        self._tab
+            .get::<ConstValueKind>(ConstValue::VT_KIND, Some(ConstValueKind::Null))
+            .unwrap()
+    }
+    #[inline]
+    pub fn string_value(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(ConstValue::VT_STRING_VALUE, None)
+    }
+    #[inline]
+    pub fn bool_value(&self) -> bool {
+        self._tab
+            .get::<bool>(ConstValue::VT_BOOL_VALUE, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn int_value(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(ConstValue::VT_INT_VALUE, None)
+    }
+    #[inline]
+    pub fn float_value(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(ConstValue::VT_FLOAT_VALUE, None)
+    }
+    #[inline]
+    pub fn enum_value(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(ConstValue::VT_ENUM_VALUE, None)
+    }
+    #[inline]
+    pub fn list_value(&self) -> Option<ListValue<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<ListValue>>(ConstValue::VT_LIST_VALUE, None)
+    }
+    #[inline]
+    pub fn object_value(&self) -> Option<ObjectValue<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<ObjectValue>>(ConstValue::VT_OBJECT_VALUE, None)
+    }
 }
 
 impl flatbuffers::Verifiable for ConstValue<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<ConstValueKind>("kind", Self::VT_KIND, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("string_value", Self::VT_STRING_VALUE, false)?
-     .visit_field::<bool>("bool_value", Self::VT_BOOL_VALUE, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("int_value", Self::VT_INT_VALUE, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("float_value", Self::VT_FLOAT_VALUE, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("enum_value", Self::VT_ENUM_VALUE, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<ListValue>>("list_value", Self::VT_LIST_VALUE, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<ObjectValue>>("object_value", Self::VT_OBJECT_VALUE, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<ConstValueKind>("kind", Self::VT_KIND, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "string_value",
+                Self::VT_STRING_VALUE,
+                false,
+            )?
+            .visit_field::<bool>("bool_value", Self::VT_BOOL_VALUE, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "int_value",
+                Self::VT_INT_VALUE,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "float_value",
+                Self::VT_FLOAT_VALUE,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "enum_value",
+                Self::VT_ENUM_VALUE,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<ListValue>>(
+                "list_value",
+                Self::VT_LIST_VALUE,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<ObjectValue>>(
+                "object_value",
+                Self::VT_OBJECT_VALUE,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
 }
 pub struct ConstValueArgs<'a> {
     pub kind: ConstValueKind,
@@ -597,471 +682,549 @@ pub struct ConstValueArgs<'a> {
     pub object_value: Option<flatbuffers::WIPOffset<ObjectValue<'a>>>,
 }
 impl<'a> Default for ConstValueArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    ConstValueArgs {
-      kind: ConstValueKind::Null,
-      string_value: None,
-      bool_value: false,
-      int_value: None,
-      float_value: None,
-      enum_value: None,
-      list_value: None,
-      object_value: None,
+    #[inline]
+    fn default() -> Self {
+        ConstValueArgs {
+            kind: ConstValueKind::Null,
+            string_value: None,
+            bool_value: false,
+            int_value: None,
+            float_value: None,
+            enum_value: None,
+            list_value: None,
+            object_value: None,
+        }
     }
-  }
 }
 
 pub struct ConstValueBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> ConstValueBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_kind(&mut self, kind: ConstValueKind) {
-    self.fbb_.push_slot::<ConstValueKind>(ConstValue::VT_KIND, kind, ConstValueKind::Null);
-  }
-  #[inline]
-  pub fn add_string_value(&mut self, string_value: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ConstValue::VT_STRING_VALUE, string_value);
-  }
-  #[inline]
-  pub fn add_bool_value(&mut self, bool_value: bool) {
-    self.fbb_.push_slot::<bool>(ConstValue::VT_BOOL_VALUE, bool_value, false);
-  }
-  #[inline]
-  pub fn add_int_value(&mut self, int_value: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ConstValue::VT_INT_VALUE, int_value);
-  }
-  #[inline]
-  pub fn add_float_value(&mut self, float_value: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ConstValue::VT_FLOAT_VALUE, float_value);
-  }
-  #[inline]
-  pub fn add_enum_value(&mut self, enum_value: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ConstValue::VT_ENUM_VALUE, enum_value);
-  }
-  #[inline]
-  pub fn add_list_value(&mut self, list_value: flatbuffers::WIPOffset<ListValue<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<ListValue>>(ConstValue::VT_LIST_VALUE, list_value);
-  }
-  #[inline]
-  pub fn add_object_value(&mut self, object_value: flatbuffers::WIPOffset<ObjectValue<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<ObjectValue>>(ConstValue::VT_OBJECT_VALUE, object_value);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ConstValueBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    ConstValueBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_kind(&mut self, kind: ConstValueKind) {
+        self.fbb_
+            .push_slot::<ConstValueKind>(ConstValue::VT_KIND, kind, ConstValueKind::Null);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<ConstValue<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_string_value(&mut self, string_value: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            ConstValue::VT_STRING_VALUE,
+            string_value,
+        );
+    }
+    #[inline]
+    pub fn add_bool_value(&mut self, bool_value: bool) {
+        self.fbb_
+            .push_slot::<bool>(ConstValue::VT_BOOL_VALUE, bool_value, false);
+    }
+    #[inline]
+    pub fn add_int_value(&mut self, int_value: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(ConstValue::VT_INT_VALUE, int_value);
+    }
+    #[inline]
+    pub fn add_float_value(&mut self, float_value: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(ConstValue::VT_FLOAT_VALUE, float_value);
+    }
+    #[inline]
+    pub fn add_enum_value(&mut self, enum_value: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(ConstValue::VT_ENUM_VALUE, enum_value);
+    }
+    #[inline]
+    pub fn add_list_value(&mut self, list_value: flatbuffers::WIPOffset<ListValue<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<ListValue>>(
+                ConstValue::VT_LIST_VALUE,
+                list_value,
+            );
+    }
+    #[inline]
+    pub fn add_object_value(&mut self, object_value: flatbuffers::WIPOffset<ObjectValue<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<ObjectValue>>(
+                ConstValue::VT_OBJECT_VALUE,
+                object_value,
+            );
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ConstValueBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        ConstValueBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<ConstValue<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for ConstValue<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("ConstValue");
-      ds.field("kind", &self.kind());
-      ds.field("string_value", &self.string_value());
-      ds.field("bool_value", &self.bool_value());
-      ds.field("int_value", &self.int_value());
-      ds.field("float_value", &self.float_value());
-      ds.field("enum_value", &self.enum_value());
-      ds.field("list_value", &self.list_value());
-      ds.field("object_value", &self.object_value());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("ConstValue");
+        ds.field("kind", &self.kind());
+        ds.field("string_value", &self.string_value());
+        ds.field("bool_value", &self.bool_value());
+        ds.field("int_value", &self.int_value());
+        ds.field("float_value", &self.float_value());
+        ds.field("enum_value", &self.enum_value());
+        ds.field("list_value", &self.list_value());
+        ds.field("object_value", &self.object_value());
+        ds.finish()
+    }
 }
 pub enum ListValueOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct ListValue<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for ListValue<'a> {
-  type Inner = ListValue<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = ListValue<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> ListValue<'a> {
-  pub const VT_VALUES: flatbuffers::VOffsetT = 4;
+    pub const VT_VALUES: flatbuffers::VOffsetT = 4;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    ListValue { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args ListValueArgs<'args>
-  ) -> flatbuffers::WIPOffset<ListValue<'bldr>> {
-    let mut builder = ListValueBuilder::new(_fbb);
-    if let Some(x) = args.values { builder.add_values(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        ListValue { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args ListValueArgs<'args>,
+    ) -> flatbuffers::WIPOffset<ListValue<'bldr>> {
+        let mut builder = ListValueBuilder::new(_fbb);
+        if let Some(x) = args.values {
+            builder.add_values(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn values(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ConstValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ConstValue>>>>(ListValue::VT_VALUES, None)
-  }
+    #[inline]
+    pub fn values(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ConstValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ConstValue>>,
+        >>(ListValue::VT_VALUES, None)
+    }
 }
 
 impl flatbuffers::Verifiable for ListValue<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ConstValue>>>>("values", Self::VT_VALUES, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ConstValue>>,
+            >>("values", Self::VT_VALUES, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct ListValueArgs<'a> {
-    pub values: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ConstValue<'a>>>>>,
+    pub values: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ConstValue<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for ListValueArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    ListValueArgs {
-      values: None,
+    #[inline]
+    fn default() -> Self {
+        ListValueArgs { values: None }
     }
-  }
 }
 
 pub struct ListValueBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> ListValueBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_values(&mut self, values: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<ConstValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ListValue::VT_VALUES, values);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ListValueBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    ListValueBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_values(
+        &mut self,
+        values: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<ConstValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(ListValue::VT_VALUES, values);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<ListValue<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ListValueBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        ListValueBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<ListValue<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for ListValue<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("ListValue");
-      ds.field("values", &self.values());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("ListValue");
+        ds.field("values", &self.values());
+        ds.finish()
+    }
 }
 pub enum ObjectFieldOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct ObjectField<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for ObjectField<'a> {
-  type Inner = ObjectField<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = ObjectField<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> ObjectField<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_VALUE: flatbuffers::VOffsetT = 6;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_VALUE: flatbuffers::VOffsetT = 6;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    ObjectField { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args ObjectFieldArgs<'args>
-  ) -> flatbuffers::WIPOffset<ObjectField<'bldr>> {
-    let mut builder = ObjectFieldBuilder::new(_fbb);
-    if let Some(x) = args.value { builder.add_value(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        ObjectField { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args ObjectFieldArgs<'args>,
+    ) -> flatbuffers::WIPOffset<ObjectField<'bldr>> {
+        let mut builder = ObjectFieldBuilder::new(_fbb);
+        if let Some(x) = args.value {
+            builder.add_value(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(ObjectField::VT_NAME, None)
-  }
-  #[inline]
-  pub fn value(&self) -> Option<ConstValue<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<ConstValue>>(ObjectField::VT_VALUE, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(ObjectField::VT_NAME, None)
+    }
+    #[inline]
+    pub fn value(&self) -> Option<ConstValue<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<ConstValue>>(ObjectField::VT_VALUE, None)
+    }
 }
 
 impl flatbuffers::Verifiable for ObjectField<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<ConstValue>>("value", Self::VT_VALUE, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<ConstValue>>(
+                "value",
+                Self::VT_VALUE,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
 }
 pub struct ObjectFieldArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub value: Option<flatbuffers::WIPOffset<ConstValue<'a>>>,
 }
 impl<'a> Default for ObjectFieldArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    ObjectFieldArgs {
-      name: None,
-      value: None,
+    #[inline]
+    fn default() -> Self {
+        ObjectFieldArgs {
+            name: None,
+            value: None,
+        }
     }
-  }
 }
 
 pub struct ObjectFieldBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> ObjectFieldBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ObjectField::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_value(&mut self, value: flatbuffers::WIPOffset<ConstValue<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<ConstValue>>(ObjectField::VT_VALUE, value);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ObjectFieldBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    ObjectFieldBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(ObjectField::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<ObjectField<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_value(&mut self, value: flatbuffers::WIPOffset<ConstValue<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<ConstValue>>(ObjectField::VT_VALUE, value);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ObjectFieldBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        ObjectFieldBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<ObjectField<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for ObjectField<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("ObjectField");
-      ds.field("name", &self.name());
-      ds.field("value", &self.value());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("ObjectField");
+        ds.field("name", &self.name());
+        ds.field("value", &self.value());
+        ds.finish()
+    }
 }
 pub enum ObjectValueOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct ObjectValue<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for ObjectValue<'a> {
-  type Inner = ObjectValue<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = ObjectValue<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> ObjectValue<'a> {
-  pub const VT_FIELDS: flatbuffers::VOffsetT = 4;
+    pub const VT_FIELDS: flatbuffers::VOffsetT = 4;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    ObjectValue { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args ObjectValueArgs<'args>
-  ) -> flatbuffers::WIPOffset<ObjectValue<'bldr>> {
-    let mut builder = ObjectValueBuilder::new(_fbb);
-    if let Some(x) = args.fields { builder.add_fields(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        ObjectValue { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args ObjectValueArgs<'args>,
+    ) -> flatbuffers::WIPOffset<ObjectValue<'bldr>> {
+        let mut builder = ObjectValueBuilder::new(_fbb);
+        if let Some(x) = args.fields {
+            builder.add_fields(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn fields(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ObjectField<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ObjectField>>>>(ObjectValue::VT_FIELDS, None)
-  }
+    #[inline]
+    pub fn fields(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ObjectField<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ObjectField>>,
+        >>(ObjectValue::VT_FIELDS, None)
+    }
 }
 
 impl flatbuffers::Verifiable for ObjectValue<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ObjectField>>>>("fields", Self::VT_FIELDS, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ObjectField>>,
+            >>("fields", Self::VT_FIELDS, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct ObjectValueArgs<'a> {
-    pub fields: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ObjectField<'a>>>>>,
+    pub fields: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ObjectField<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for ObjectValueArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    ObjectValueArgs {
-      fields: None,
+    #[inline]
+    fn default() -> Self {
+        ObjectValueArgs { fields: None }
     }
-  }
 }
 
 pub struct ObjectValueBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> ObjectValueBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_fields(&mut self, fields: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<ObjectField<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ObjectValue::VT_FIELDS, fields);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ObjectValueBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    ObjectValueBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_fields(
+        &mut self,
+        fields: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<ObjectField<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(ObjectValue::VT_FIELDS, fields);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<ObjectValue<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ObjectValueBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        ObjectValueBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<ObjectValue<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for ObjectValue<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("ObjectValue");
-      ds.field("fields", &self.fields());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("ObjectValue");
+        ds.field("fields", &self.fields());
+        ds.finish()
+    }
 }
 pub enum TypeOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Type<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Type<'a> {
-  type Inner = Type<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Type<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Type<'a> {
-  pub const VT_KIND: flatbuffers::VOffsetT = 4;
-  pub const VT_SCALAR_ID: flatbuffers::VOffsetT = 6;
-  pub const VT_INPUT_OBJECT_ID: flatbuffers::VOffsetT = 8;
-  pub const VT_ENUM_ID: flatbuffers::VOffsetT = 10;
-  pub const VT_OBJECT_ID: flatbuffers::VOffsetT = 12;
-  pub const VT_INTERFACE_ID: flatbuffers::VOffsetT = 14;
-  pub const VT_UNION_ID: flatbuffers::VOffsetT = 16;
+    pub const VT_KIND: flatbuffers::VOffsetT = 4;
+    pub const VT_SCALAR_ID: flatbuffers::VOffsetT = 6;
+    pub const VT_INPUT_OBJECT_ID: flatbuffers::VOffsetT = 8;
+    pub const VT_ENUM_ID: flatbuffers::VOffsetT = 10;
+    pub const VT_OBJECT_ID: flatbuffers::VOffsetT = 12;
+    pub const VT_INTERFACE_ID: flatbuffers::VOffsetT = 14;
+    pub const VT_UNION_ID: flatbuffers::VOffsetT = 16;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Type { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args TypeArgs
-  ) -> flatbuffers::WIPOffset<Type<'bldr>> {
-    let mut builder = TypeBuilder::new(_fbb);
-    builder.add_union_id(args.union_id);
-    builder.add_interface_id(args.interface_id);
-    builder.add_object_id(args.object_id);
-    builder.add_enum_id(args.enum_id);
-    builder.add_input_object_id(args.input_object_id);
-    builder.add_scalar_id(args.scalar_id);
-    builder.add_kind(args.kind);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Type { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args TypeArgs,
+    ) -> flatbuffers::WIPOffset<Type<'bldr>> {
+        let mut builder = TypeBuilder::new(_fbb);
+        builder.add_union_id(args.union_id);
+        builder.add_interface_id(args.interface_id);
+        builder.add_object_id(args.object_id);
+        builder.add_enum_id(args.enum_id);
+        builder.add_input_object_id(args.input_object_id);
+        builder.add_scalar_id(args.scalar_id);
+        builder.add_kind(args.kind);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn kind(&self) -> TypeKind {
-    self._tab.get::<TypeKind>(Type::VT_KIND, Some(TypeKind::Scalar)).unwrap()
-  }
-  #[inline]
-  pub fn scalar_id(&self) -> u32 {
-    self._tab.get::<u32>(Type::VT_SCALAR_ID, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn input_object_id(&self) -> u32 {
-    self._tab.get::<u32>(Type::VT_INPUT_OBJECT_ID, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn enum_id(&self) -> u32 {
-    self._tab.get::<u32>(Type::VT_ENUM_ID, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn object_id(&self) -> u32 {
-    self._tab.get::<u32>(Type::VT_OBJECT_ID, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn interface_id(&self) -> u32 {
-    self._tab.get::<u32>(Type::VT_INTERFACE_ID, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn union_id(&self) -> u32 {
-    self._tab.get::<u32>(Type::VT_UNION_ID, Some(0)).unwrap()
-  }
+    #[inline]
+    pub fn kind(&self) -> TypeKind {
+        self._tab
+            .get::<TypeKind>(Type::VT_KIND, Some(TypeKind::Scalar))
+            .unwrap()
+    }
+    #[inline]
+    pub fn scalar_id(&self) -> u32 {
+        self._tab.get::<u32>(Type::VT_SCALAR_ID, Some(0)).unwrap()
+    }
+    #[inline]
+    pub fn input_object_id(&self) -> u32 {
+        self._tab
+            .get::<u32>(Type::VT_INPUT_OBJECT_ID, Some(0))
+            .unwrap()
+    }
+    #[inline]
+    pub fn enum_id(&self) -> u32 {
+        self._tab.get::<u32>(Type::VT_ENUM_ID, Some(0)).unwrap()
+    }
+    #[inline]
+    pub fn object_id(&self) -> u32 {
+        self._tab.get::<u32>(Type::VT_OBJECT_ID, Some(0)).unwrap()
+    }
+    #[inline]
+    pub fn interface_id(&self) -> u32 {
+        self._tab
+            .get::<u32>(Type::VT_INTERFACE_ID, Some(0))
+            .unwrap()
+    }
+    #[inline]
+    pub fn union_id(&self) -> u32 {
+        self._tab.get::<u32>(Type::VT_UNION_ID, Some(0)).unwrap()
+    }
 }
 
 impl flatbuffers::Verifiable for Type<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<TypeKind>("kind", Self::VT_KIND, false)?
-     .visit_field::<u32>("scalar_id", Self::VT_SCALAR_ID, false)?
-     .visit_field::<u32>("input_object_id", Self::VT_INPUT_OBJECT_ID, false)?
-     .visit_field::<u32>("enum_id", Self::VT_ENUM_ID, false)?
-     .visit_field::<u32>("object_id", Self::VT_OBJECT_ID, false)?
-     .visit_field::<u32>("interface_id", Self::VT_INTERFACE_ID, false)?
-     .visit_field::<u32>("union_id", Self::VT_UNION_ID, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<TypeKind>("kind", Self::VT_KIND, false)?
+            .visit_field::<u32>("scalar_id", Self::VT_SCALAR_ID, false)?
+            .visit_field::<u32>("input_object_id", Self::VT_INPUT_OBJECT_ID, false)?
+            .visit_field::<u32>("enum_id", Self::VT_ENUM_ID, false)?
+            .visit_field::<u32>("object_id", Self::VT_OBJECT_ID, false)?
+            .visit_field::<u32>("interface_id", Self::VT_INTERFACE_ID, false)?
+            .visit_field::<u32>("union_id", Self::VT_UNION_ID, false)?
+            .finish();
+        Ok(())
+    }
 }
 #[derive(Copy, Clone)]
 pub struct TypeArgs {
@@ -1074,151 +1237,176 @@ pub struct TypeArgs {
     pub union_id: u32,
 }
 impl<'a> Default for TypeArgs {
-  #[inline]
-  fn default() -> Self {
-    TypeArgs {
-      kind: TypeKind::Scalar,
-      scalar_id: 0,
-      input_object_id: 0,
-      enum_id: 0,
-      object_id: 0,
-      interface_id: 0,
-      union_id: 0,
+    #[inline]
+    fn default() -> Self {
+        TypeArgs {
+            kind: TypeKind::Scalar,
+            scalar_id: 0,
+            input_object_id: 0,
+            enum_id: 0,
+            object_id: 0,
+            interface_id: 0,
+            union_id: 0,
+        }
     }
-  }
 }
 
 pub struct TypeBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> TypeBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_kind(&mut self, kind: TypeKind) {
-    self.fbb_.push_slot::<TypeKind>(Type::VT_KIND, kind, TypeKind::Scalar);
-  }
-  #[inline]
-  pub fn add_scalar_id(&mut self, scalar_id: u32) {
-    self.fbb_.push_slot::<u32>(Type::VT_SCALAR_ID, scalar_id, 0);
-  }
-  #[inline]
-  pub fn add_input_object_id(&mut self, input_object_id: u32) {
-    self.fbb_.push_slot::<u32>(Type::VT_INPUT_OBJECT_ID, input_object_id, 0);
-  }
-  #[inline]
-  pub fn add_enum_id(&mut self, enum_id: u32) {
-    self.fbb_.push_slot::<u32>(Type::VT_ENUM_ID, enum_id, 0);
-  }
-  #[inline]
-  pub fn add_object_id(&mut self, object_id: u32) {
-    self.fbb_.push_slot::<u32>(Type::VT_OBJECT_ID, object_id, 0);
-  }
-  #[inline]
-  pub fn add_interface_id(&mut self, interface_id: u32) {
-    self.fbb_.push_slot::<u32>(Type::VT_INTERFACE_ID, interface_id, 0);
-  }
-  #[inline]
-  pub fn add_union_id(&mut self, union_id: u32) {
-    self.fbb_.push_slot::<u32>(Type::VT_UNION_ID, union_id, 0);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TypeBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    TypeBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_kind(&mut self, kind: TypeKind) {
+        self.fbb_
+            .push_slot::<TypeKind>(Type::VT_KIND, kind, TypeKind::Scalar);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Type<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_scalar_id(&mut self, scalar_id: u32) {
+        self.fbb_.push_slot::<u32>(Type::VT_SCALAR_ID, scalar_id, 0);
+    }
+    #[inline]
+    pub fn add_input_object_id(&mut self, input_object_id: u32) {
+        self.fbb_
+            .push_slot::<u32>(Type::VT_INPUT_OBJECT_ID, input_object_id, 0);
+    }
+    #[inline]
+    pub fn add_enum_id(&mut self, enum_id: u32) {
+        self.fbb_.push_slot::<u32>(Type::VT_ENUM_ID, enum_id, 0);
+    }
+    #[inline]
+    pub fn add_object_id(&mut self, object_id: u32) {
+        self.fbb_.push_slot::<u32>(Type::VT_OBJECT_ID, object_id, 0);
+    }
+    #[inline]
+    pub fn add_interface_id(&mut self, interface_id: u32) {
+        self.fbb_
+            .push_slot::<u32>(Type::VT_INTERFACE_ID, interface_id, 0);
+    }
+    #[inline]
+    pub fn add_union_id(&mut self, union_id: u32) {
+        self.fbb_.push_slot::<u32>(Type::VT_UNION_ID, union_id, 0);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TypeBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        TypeBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Type<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Type<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Type");
-      ds.field("kind", &self.kind());
-      ds.field("scalar_id", &self.scalar_id());
-      ds.field("input_object_id", &self.input_object_id());
-      ds.field("enum_id", &self.enum_id());
-      ds.field("object_id", &self.object_id());
-      ds.field("interface_id", &self.interface_id());
-      ds.field("union_id", &self.union_id());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Type");
+        ds.field("kind", &self.kind());
+        ds.field("scalar_id", &self.scalar_id());
+        ds.field("input_object_id", &self.input_object_id());
+        ds.field("enum_id", &self.enum_id());
+        ds.field("object_id", &self.object_id());
+        ds.field("interface_id", &self.interface_id());
+        ds.field("union_id", &self.union_id());
+        ds.finish()
+    }
 }
 pub enum TypeReferenceOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct TypeReference<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for TypeReference<'a> {
-  type Inner = TypeReference<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = TypeReference<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> TypeReference<'a> {
-  pub const VT_KIND: flatbuffers::VOffsetT = 4;
-  pub const VT_NAMED: flatbuffers::VOffsetT = 6;
-  pub const VT_NULL: flatbuffers::VOffsetT = 8;
-  pub const VT_LIST: flatbuffers::VOffsetT = 10;
+    pub const VT_KIND: flatbuffers::VOffsetT = 4;
+    pub const VT_NAMED: flatbuffers::VOffsetT = 6;
+    pub const VT_NULL: flatbuffers::VOffsetT = 8;
+    pub const VT_LIST: flatbuffers::VOffsetT = 10;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    TypeReference { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args TypeReferenceArgs<'args>
-  ) -> flatbuffers::WIPOffset<TypeReference<'bldr>> {
-    let mut builder = TypeReferenceBuilder::new(_fbb);
-    if let Some(x) = args.list { builder.add_list(x); }
-    if let Some(x) = args.null { builder.add_null(x); }
-    if let Some(x) = args.named { builder.add_named(x); }
-    builder.add_kind(args.kind);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        TypeReference { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args TypeReferenceArgs<'args>,
+    ) -> flatbuffers::WIPOffset<TypeReference<'bldr>> {
+        let mut builder = TypeReferenceBuilder::new(_fbb);
+        if let Some(x) = args.list {
+            builder.add_list(x);
+        }
+        if let Some(x) = args.null {
+            builder.add_null(x);
+        }
+        if let Some(x) = args.named {
+            builder.add_named(x);
+        }
+        builder.add_kind(args.kind);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn kind(&self) -> TypeReferenceKind {
-    self._tab.get::<TypeReferenceKind>(TypeReference::VT_KIND, Some(TypeReferenceKind::Named)).unwrap()
-  }
-  #[inline]
-  pub fn named(&self) -> Option<Type<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Type>>(TypeReference::VT_NAMED, None)
-  }
-  #[inline]
-  pub fn null(&self) -> Option<TypeReference<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<TypeReference>>(TypeReference::VT_NULL, None)
-  }
-  #[inline]
-  pub fn list(&self) -> Option<TypeReference<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<TypeReference>>(TypeReference::VT_LIST, None)
-  }
+    #[inline]
+    pub fn kind(&self) -> TypeReferenceKind {
+        self._tab
+            .get::<TypeReferenceKind>(TypeReference::VT_KIND, Some(TypeReferenceKind::Named))
+            .unwrap()
+    }
+    #[inline]
+    pub fn named(&self) -> Option<Type<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<Type>>(TypeReference::VT_NAMED, None)
+    }
+    #[inline]
+    pub fn null(&self) -> Option<TypeReference<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<TypeReference>>(TypeReference::VT_NULL, None)
+    }
+    #[inline]
+    pub fn list(&self) -> Option<TypeReference<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<TypeReference>>(TypeReference::VT_LIST, None)
+    }
 }
 
 impl flatbuffers::Verifiable for TypeReference<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<TypeReferenceKind>("kind", Self::VT_KIND, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<Type>>("named", Self::VT_NAMED, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<TypeReference>>("null", Self::VT_NULL, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<TypeReference>>("list", Self::VT_LIST, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<TypeReferenceKind>("kind", Self::VT_KIND, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<Type>>("named", Self::VT_NAMED, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<TypeReference>>(
+                "null",
+                Self::VT_NULL,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<TypeReference>>(
+                "list",
+                Self::VT_LIST,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
 }
 pub struct TypeReferenceArgs<'a> {
     pub kind: TypeReferenceKind,
@@ -1227,340 +1415,413 @@ pub struct TypeReferenceArgs<'a> {
     pub list: Option<flatbuffers::WIPOffset<TypeReference<'a>>>,
 }
 impl<'a> Default for TypeReferenceArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    TypeReferenceArgs {
-      kind: TypeReferenceKind::Named,
-      named: None,
-      null: None,
-      list: None,
+    #[inline]
+    fn default() -> Self {
+        TypeReferenceArgs {
+            kind: TypeReferenceKind::Named,
+            named: None,
+            null: None,
+            list: None,
+        }
     }
-  }
 }
 
 pub struct TypeReferenceBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> TypeReferenceBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_kind(&mut self, kind: TypeReferenceKind) {
-    self.fbb_.push_slot::<TypeReferenceKind>(TypeReference::VT_KIND, kind, TypeReferenceKind::Named);
-  }
-  #[inline]
-  pub fn add_named(&mut self, named: flatbuffers::WIPOffset<Type<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Type>>(TypeReference::VT_NAMED, named);
-  }
-  #[inline]
-  pub fn add_null(&mut self, null: flatbuffers::WIPOffset<TypeReference<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<TypeReference>>(TypeReference::VT_NULL, null);
-  }
-  #[inline]
-  pub fn add_list(&mut self, list: flatbuffers::WIPOffset<TypeReference<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<TypeReference>>(TypeReference::VT_LIST, list);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TypeReferenceBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    TypeReferenceBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_kind(&mut self, kind: TypeReferenceKind) {
+        self.fbb_.push_slot::<TypeReferenceKind>(
+            TypeReference::VT_KIND,
+            kind,
+            TypeReferenceKind::Named,
+        );
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<TypeReference<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_named(&mut self, named: flatbuffers::WIPOffset<Type<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<Type>>(TypeReference::VT_NAMED, named);
+    }
+    #[inline]
+    pub fn add_null(&mut self, null: flatbuffers::WIPOffset<TypeReference<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<TypeReference>>(
+                TypeReference::VT_NULL,
+                null,
+            );
+    }
+    #[inline]
+    pub fn add_list(&mut self, list: flatbuffers::WIPOffset<TypeReference<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<TypeReference>>(
+                TypeReference::VT_LIST,
+                list,
+            );
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TypeReferenceBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        TypeReferenceBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<TypeReference<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for TypeReference<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("TypeReference");
-      ds.field("kind", &self.kind());
-      ds.field("named", &self.named());
-      ds.field("null", &self.null());
-      ds.field("list", &self.list());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("TypeReference");
+        ds.field("kind", &self.kind());
+        ds.field("named", &self.named());
+        ds.field("null", &self.null());
+        ds.field("list", &self.list());
+        ds.finish()
+    }
 }
 pub enum ArgumentValueOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct ArgumentValue<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for ArgumentValue<'a> {
-  type Inner = ArgumentValue<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = ArgumentValue<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> ArgumentValue<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_VALUE: flatbuffers::VOffsetT = 6;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_VALUE: flatbuffers::VOffsetT = 6;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    ArgumentValue { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args ArgumentValueArgs<'args>
-  ) -> flatbuffers::WIPOffset<ArgumentValue<'bldr>> {
-    let mut builder = ArgumentValueBuilder::new(_fbb);
-    if let Some(x) = args.value { builder.add_value(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        ArgumentValue { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args ArgumentValueArgs<'args>,
+    ) -> flatbuffers::WIPOffset<ArgumentValue<'bldr>> {
+        let mut builder = ArgumentValueBuilder::new(_fbb);
+        if let Some(x) = args.value {
+            builder.add_value(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(ArgumentValue::VT_NAME, None)
-  }
-  #[inline]
-  pub fn value(&self) -> Option<ConstValue<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<ConstValue>>(ArgumentValue::VT_VALUE, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(ArgumentValue::VT_NAME, None)
+    }
+    #[inline]
+    pub fn value(&self) -> Option<ConstValue<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<ConstValue>>(ArgumentValue::VT_VALUE, None)
+    }
 }
 
 impl flatbuffers::Verifiable for ArgumentValue<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<ConstValue>>("value", Self::VT_VALUE, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<ConstValue>>(
+                "value",
+                Self::VT_VALUE,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
 }
 pub struct ArgumentValueArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub value: Option<flatbuffers::WIPOffset<ConstValue<'a>>>,
 }
 impl<'a> Default for ArgumentValueArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    ArgumentValueArgs {
-      name: None,
-      value: None,
+    #[inline]
+    fn default() -> Self {
+        ArgumentValueArgs {
+            name: None,
+            value: None,
+        }
     }
-  }
 }
 
 pub struct ArgumentValueBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> ArgumentValueBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ArgumentValue::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_value(&mut self, value: flatbuffers::WIPOffset<ConstValue<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<ConstValue>>(ArgumentValue::VT_VALUE, value);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ArgumentValueBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    ArgumentValueBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(ArgumentValue::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<ArgumentValue<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_value(&mut self, value: flatbuffers::WIPOffset<ConstValue<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<ConstValue>>(ArgumentValue::VT_VALUE, value);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ArgumentValueBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        ArgumentValueBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<ArgumentValue<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for ArgumentValue<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("ArgumentValue");
-      ds.field("name", &self.name());
-      ds.field("value", &self.value());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("ArgumentValue");
+        ds.field("name", &self.name());
+        ds.field("value", &self.value());
+        ds.finish()
+    }
 }
 pub enum DirectiveValueOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct DirectiveValue<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for DirectiveValue<'a> {
-  type Inner = DirectiveValue<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = DirectiveValue<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> DirectiveValue<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_ARGUMENTS: flatbuffers::VOffsetT = 6;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_ARGUMENTS: flatbuffers::VOffsetT = 6;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    DirectiveValue { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args DirectiveValueArgs<'args>
-  ) -> flatbuffers::WIPOffset<DirectiveValue<'bldr>> {
-    let mut builder = DirectiveValueBuilder::new(_fbb);
-    if let Some(x) = args.arguments { builder.add_arguments(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        DirectiveValue { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args DirectiveValueArgs<'args>,
+    ) -> flatbuffers::WIPOffset<DirectiveValue<'bldr>> {
+        let mut builder = DirectiveValueBuilder::new(_fbb);
+        if let Some(x) = args.arguments {
+            builder.add_arguments(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(DirectiveValue::VT_NAME, None)
-  }
-  #[inline]
-  pub fn arguments(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArgumentValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArgumentValue>>>>(DirectiveValue::VT_ARGUMENTS, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(DirectiveValue::VT_NAME, None)
+    }
+    #[inline]
+    pub fn arguments(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArgumentValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArgumentValue>>,
+        >>(DirectiveValue::VT_ARGUMENTS, None)
+    }
 }
 
 impl flatbuffers::Verifiable for DirectiveValue<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ArgumentValue>>>>("arguments", Self::VT_ARGUMENTS, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ArgumentValue>>,
+            >>("arguments", Self::VT_ARGUMENTS, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct DirectiveValueArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub arguments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArgumentValue<'a>>>>>,
+    pub arguments: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ArgumentValue<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for DirectiveValueArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    DirectiveValueArgs {
-      name: None,
-      arguments: None,
+    #[inline]
+    fn default() -> Self {
+        DirectiveValueArgs {
+            name: None,
+            arguments: None,
+        }
     }
-  }
 }
 
 pub struct DirectiveValueBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> DirectiveValueBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(DirectiveValue::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_arguments(&mut self, arguments: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<ArgumentValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(DirectiveValue::VT_ARGUMENTS, arguments);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> DirectiveValueBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    DirectiveValueBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(DirectiveValue::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<DirectiveValue<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_arguments(
+        &mut self,
+        arguments: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<ArgumentValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(DirectiveValue::VT_ARGUMENTS, arguments);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> DirectiveValueBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        DirectiveValueBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<DirectiveValue<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for DirectiveValue<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("DirectiveValue");
-      ds.field("name", &self.name());
-      ds.field("arguments", &self.arguments());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("DirectiveValue");
+        ds.field("name", &self.name());
+        ds.field("arguments", &self.arguments());
+        ds.finish()
+    }
 }
 pub enum ArgumentOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Argument<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Argument<'a> {
-  type Inner = Argument<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Argument<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Argument<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_TYPE_: flatbuffers::VOffsetT = 6;
-  pub const VT_VALUE: flatbuffers::VOffsetT = 8;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_TYPE_: flatbuffers::VOffsetT = 6;
+    pub const VT_VALUE: flatbuffers::VOffsetT = 8;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Argument { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args ArgumentArgs<'args>
-  ) -> flatbuffers::WIPOffset<Argument<'bldr>> {
-    let mut builder = ArgumentBuilder::new(_fbb);
-    if let Some(x) = args.value { builder.add_value(x); }
-    if let Some(x) = args.type_ { builder.add_type_(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Argument { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args ArgumentArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Argument<'bldr>> {
+        let mut builder = ArgumentBuilder::new(_fbb);
+        if let Some(x) = args.value {
+            builder.add_value(x);
+        }
+        if let Some(x) = args.type_ {
+            builder.add_type_(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(Argument::VT_NAME, None)
-  }
-  #[inline]
-  pub fn type_(&self) -> Option<TypeReference<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<TypeReference>>(Argument::VT_TYPE_, None)
-  }
-  #[inline]
-  pub fn value(&self) -> Option<ConstValue<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<ConstValue>>(Argument::VT_VALUE, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(Argument::VT_NAME, None)
+    }
+    #[inline]
+    pub fn type_(&self) -> Option<TypeReference<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<TypeReference>>(Argument::VT_TYPE_, None)
+    }
+    #[inline]
+    pub fn value(&self) -> Option<ConstValue<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<ConstValue>>(Argument::VT_VALUE, None)
+    }
 }
 
 impl flatbuffers::Verifiable for Argument<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<TypeReference>>("type_", Self::VT_TYPE_, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<ConstValue>>("value", Self::VT_VALUE, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<TypeReference>>(
+                "type_",
+                Self::VT_TYPE_,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<ConstValue>>(
+                "value",
+                Self::VT_VALUE,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
 }
 pub struct ArgumentArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
@@ -1568,930 +1829,1219 @@ pub struct ArgumentArgs<'a> {
     pub value: Option<flatbuffers::WIPOffset<ConstValue<'a>>>,
 }
 impl<'a> Default for ArgumentArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    ArgumentArgs {
-      name: None,
-      type_: None,
-      value: None,
+    #[inline]
+    fn default() -> Self {
+        ArgumentArgs {
+            name: None,
+            type_: None,
+            value: None,
+        }
     }
-  }
 }
 
 pub struct ArgumentBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> ArgumentBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Argument::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_type_(&mut self, type_: flatbuffers::WIPOffset<TypeReference<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<TypeReference>>(Argument::VT_TYPE_, type_);
-  }
-  #[inline]
-  pub fn add_value(&mut self, value: flatbuffers::WIPOffset<ConstValue<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<ConstValue>>(Argument::VT_VALUE, value);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ArgumentBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    ArgumentBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Argument::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Argument<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_type_(&mut self, type_: flatbuffers::WIPOffset<TypeReference<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<TypeReference>>(Argument::VT_TYPE_, type_);
+    }
+    #[inline]
+    pub fn add_value(&mut self, value: flatbuffers::WIPOffset<ConstValue<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<ConstValue>>(Argument::VT_VALUE, value);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ArgumentBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        ArgumentBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Argument<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Argument<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Argument");
-      ds.field("name", &self.name());
-      ds.field("type_", &self.type_());
-      ds.field("value", &self.value());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Argument");
+        ds.field("name", &self.name());
+        ds.field("type_", &self.type_());
+        ds.field("value", &self.value());
+        ds.finish()
+    }
 }
 pub enum DirectiveOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Directive<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Directive<'a> {
-  type Inner = Directive<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Directive<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Directive<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
-  pub const VT_ARGUMENTS: flatbuffers::VOffsetT = 8;
-  pub const VT_LOCATIONS: flatbuffers::VOffsetT = 10;
-  pub const VT_REPEATABLE: flatbuffers::VOffsetT = 12;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
+    pub const VT_ARGUMENTS: flatbuffers::VOffsetT = 8;
+    pub const VT_LOCATIONS: flatbuffers::VOffsetT = 10;
+    pub const VT_REPEATABLE: flatbuffers::VOffsetT = 12;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Directive { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args DirectiveArgs<'args>
-  ) -> flatbuffers::WIPOffset<Directive<'bldr>> {
-    let mut builder = DirectiveBuilder::new(_fbb);
-    if let Some(x) = args.locations { builder.add_locations(x); }
-    if let Some(x) = args.arguments { builder.add_arguments(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.add_repeatable(args.repeatable);
-    builder.add_is_extension(args.is_extension);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Directive { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args DirectiveArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Directive<'bldr>> {
+        let mut builder = DirectiveBuilder::new(_fbb);
+        if let Some(x) = args.locations {
+            builder.add_locations(x);
+        }
+        if let Some(x) = args.arguments {
+            builder.add_arguments(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.add_repeatable(args.repeatable);
+        builder.add_is_extension(args.is_extension);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(Directive::VT_NAME, None)
-  }
-  #[inline]
-  pub fn is_extension(&self) -> bool {
-    self._tab.get::<bool>(Directive::VT_IS_EXTENSION, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn arguments(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument>>>>(Directive::VT_ARGUMENTS, None)
-  }
-  #[inline]
-  pub fn locations(&self) -> Option<flatbuffers::Vector<'a, DirectiveLocation>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, DirectiveLocation>>>(Directive::VT_LOCATIONS, None)
-  }
-  #[inline]
-  pub fn repeatable(&self) -> bool {
-    self._tab.get::<bool>(Directive::VT_REPEATABLE, Some(false)).unwrap()
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(Directive::VT_NAME, None)
+    }
+    #[inline]
+    pub fn is_extension(&self) -> bool {
+        self._tab
+            .get::<bool>(Directive::VT_IS_EXTENSION, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn arguments(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument>>,
+        >>(Directive::VT_ARGUMENTS, None)
+    }
+    #[inline]
+    pub fn locations(&self) -> Option<flatbuffers::Vector<'a, DirectiveLocation>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, DirectiveLocation>>>(
+                Directive::VT_LOCATIONS,
+                None,
+            )
+    }
+    #[inline]
+    pub fn repeatable(&self) -> bool {
+        self._tab
+            .get::<bool>(Directive::VT_REPEATABLE, Some(false))
+            .unwrap()
+    }
 }
 
 impl flatbuffers::Verifiable for Directive<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
      .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
      .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Argument>>>>("arguments", Self::VT_ARGUMENTS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, DirectiveLocation>>>("locations", Self::VT_LOCATIONS, false)?
      .visit_field::<bool>("repeatable", Self::VT_REPEATABLE, false)?
      .finish();
-    Ok(())
-  }
+        Ok(())
+    }
 }
 pub struct DirectiveArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub is_extension: bool,
-    pub arguments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>>>,
+    pub arguments: Option<
+        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>>,
+    >,
     pub locations: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, DirectiveLocation>>>,
     pub repeatable: bool,
 }
 impl<'a> Default for DirectiveArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    DirectiveArgs {
-      name: None,
-      is_extension: false,
-      arguments: None,
-      locations: None,
-      repeatable: false,
+    #[inline]
+    fn default() -> Self {
+        DirectiveArgs {
+            name: None,
+            is_extension: false,
+            arguments: None,
+            locations: None,
+            repeatable: false,
+        }
     }
-  }
 }
 
 pub struct DirectiveBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> DirectiveBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Directive::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_is_extension(&mut self, is_extension: bool) {
-    self.fbb_.push_slot::<bool>(Directive::VT_IS_EXTENSION, is_extension, false);
-  }
-  #[inline]
-  pub fn add_arguments(&mut self, arguments: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Argument<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Directive::VT_ARGUMENTS, arguments);
-  }
-  #[inline]
-  pub fn add_locations(&mut self, locations: flatbuffers::WIPOffset<flatbuffers::Vector<'b , DirectiveLocation>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Directive::VT_LOCATIONS, locations);
-  }
-  #[inline]
-  pub fn add_repeatable(&mut self, repeatable: bool) {
-    self.fbb_.push_slot::<bool>(Directive::VT_REPEATABLE, repeatable, false);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> DirectiveBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    DirectiveBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Directive::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Directive<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_is_extension(&mut self, is_extension: bool) {
+        self.fbb_
+            .push_slot::<bool>(Directive::VT_IS_EXTENSION, is_extension, false);
+    }
+    #[inline]
+    pub fn add_arguments(
+        &mut self,
+        arguments: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Argument<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Directive::VT_ARGUMENTS, arguments);
+    }
+    #[inline]
+    pub fn add_locations(
+        &mut self,
+        locations: flatbuffers::WIPOffset<flatbuffers::Vector<'b, DirectiveLocation>>,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Directive::VT_LOCATIONS, locations);
+    }
+    #[inline]
+    pub fn add_repeatable(&mut self, repeatable: bool) {
+        self.fbb_
+            .push_slot::<bool>(Directive::VT_REPEATABLE, repeatable, false);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> DirectiveBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        DirectiveBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Directive<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Directive<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Directive");
-      ds.field("name", &self.name());
-      ds.field("is_extension", &self.is_extension());
-      ds.field("arguments", &self.arguments());
-      ds.field("locations", &self.locations());
-      ds.field("repeatable", &self.repeatable());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Directive");
+        ds.field("name", &self.name());
+        ds.field("is_extension", &self.is_extension());
+        ds.field("arguments", &self.arguments());
+        ds.field("locations", &self.locations());
+        ds.field("repeatable", &self.repeatable());
+        ds.finish()
+    }
 }
 pub enum EnumValueOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct EnumValue<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for EnumValue<'a> {
-  type Inner = EnumValue<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = EnumValue<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> EnumValue<'a> {
-  pub const VT_VALUE: flatbuffers::VOffsetT = 4;
-  pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 6;
+    pub const VT_VALUE: flatbuffers::VOffsetT = 4;
+    pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 6;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    EnumValue { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args EnumValueArgs<'args>
-  ) -> flatbuffers::WIPOffset<EnumValue<'bldr>> {
-    let mut builder = EnumValueBuilder::new(_fbb);
-    if let Some(x) = args.directives { builder.add_directives(x); }
-    if let Some(x) = args.value { builder.add_value(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        EnumValue { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args EnumValueArgs<'args>,
+    ) -> flatbuffers::WIPOffset<EnumValue<'bldr>> {
+        let mut builder = EnumValueBuilder::new(_fbb);
+        if let Some(x) = args.directives {
+            builder.add_directives(x);
+        }
+        if let Some(x) = args.value {
+            builder.add_value(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn value(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(EnumValue::VT_VALUE, None)
-  }
-  #[inline]
-  pub fn directives(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>>>(EnumValue::VT_DIRECTIVES, None)
-  }
+    #[inline]
+    pub fn value(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(EnumValue::VT_VALUE, None)
+    }
+    #[inline]
+    pub fn directives(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+        >>(EnumValue::VT_DIRECTIVES, None)
+    }
 }
 
 impl flatbuffers::Verifiable for EnumValue<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("value", Self::VT_VALUE, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>>>("directives", Self::VT_DIRECTIVES, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("value", Self::VT_VALUE, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+            >>("directives", Self::VT_DIRECTIVES, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct EnumValueArgs<'a> {
     pub value: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub directives: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>>>,
+    pub directives: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for EnumValueArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    EnumValueArgs {
-      value: None,
-      directives: None,
+    #[inline]
+    fn default() -> Self {
+        EnumValueArgs {
+            value: None,
+            directives: None,
+        }
     }
-  }
 }
 
 pub struct EnumValueBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> EnumValueBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_value(&mut self, value: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(EnumValue::VT_VALUE, value);
-  }
-  #[inline]
-  pub fn add_directives(&mut self, directives: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<DirectiveValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(EnumValue::VT_DIRECTIVES, directives);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> EnumValueBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    EnumValueBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_value(&mut self, value: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(EnumValue::VT_VALUE, value);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<EnumValue<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_directives(
+        &mut self,
+        directives: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<DirectiveValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(EnumValue::VT_DIRECTIVES, directives);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> EnumValueBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        EnumValueBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<EnumValue<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for EnumValue<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("EnumValue");
-      ds.field("value", &self.value());
-      ds.field("directives", &self.directives());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("EnumValue");
+        ds.field("value", &self.value());
+        ds.field("directives", &self.directives());
+        ds.finish()
+    }
 }
 pub enum ScalarOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Scalar<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Scalar<'a> {
-  type Inner = Scalar<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Scalar<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Scalar<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
-  pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 8;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
+    pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 8;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Scalar { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args ScalarArgs<'args>
-  ) -> flatbuffers::WIPOffset<Scalar<'bldr>> {
-    let mut builder = ScalarBuilder::new(_fbb);
-    if let Some(x) = args.directives { builder.add_directives(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.add_is_extension(args.is_extension);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Scalar { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args ScalarArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Scalar<'bldr>> {
+        let mut builder = ScalarBuilder::new(_fbb);
+        if let Some(x) = args.directives {
+            builder.add_directives(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.add_is_extension(args.is_extension);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(Scalar::VT_NAME, None)
-  }
-  #[inline]
-  pub fn is_extension(&self) -> bool {
-    self._tab.get::<bool>(Scalar::VT_IS_EXTENSION, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn directives(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>>>(Scalar::VT_DIRECTIVES, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(Scalar::VT_NAME, None)
+    }
+    #[inline]
+    pub fn is_extension(&self) -> bool {
+        self._tab
+            .get::<bool>(Scalar::VT_IS_EXTENSION, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn directives(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+        >>(Scalar::VT_DIRECTIVES, None)
+    }
 }
 
 impl flatbuffers::Verifiable for Scalar<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>>>("directives", Self::VT_DIRECTIVES, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+            >>("directives", Self::VT_DIRECTIVES, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct ScalarArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub is_extension: bool,
-    pub directives: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>>>,
+    pub directives: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for ScalarArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    ScalarArgs {
-      name: None,
-      is_extension: false,
-      directives: None,
+    #[inline]
+    fn default() -> Self {
+        ScalarArgs {
+            name: None,
+            is_extension: false,
+            directives: None,
+        }
     }
-  }
 }
 
 pub struct ScalarBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> ScalarBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Scalar::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_is_extension(&mut self, is_extension: bool) {
-    self.fbb_.push_slot::<bool>(Scalar::VT_IS_EXTENSION, is_extension, false);
-  }
-  #[inline]
-  pub fn add_directives(&mut self, directives: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<DirectiveValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Scalar::VT_DIRECTIVES, directives);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ScalarBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    ScalarBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Scalar::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Scalar<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_is_extension(&mut self, is_extension: bool) {
+        self.fbb_
+            .push_slot::<bool>(Scalar::VT_IS_EXTENSION, is_extension, false);
+    }
+    #[inline]
+    pub fn add_directives(
+        &mut self,
+        directives: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<DirectiveValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Scalar::VT_DIRECTIVES, directives);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ScalarBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        ScalarBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Scalar<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Scalar<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Scalar");
-      ds.field("name", &self.name());
-      ds.field("is_extension", &self.is_extension());
-      ds.field("directives", &self.directives());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Scalar");
+        ds.field("name", &self.name());
+        ds.field("is_extension", &self.is_extension());
+        ds.field("directives", &self.directives());
+        ds.finish()
+    }
 }
 pub enum InputObjectOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct InputObject<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for InputObject<'a> {
-  type Inner = InputObject<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = InputObject<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> InputObject<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_FIELDS: flatbuffers::VOffsetT = 6;
-  pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 8;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_FIELDS: flatbuffers::VOffsetT = 6;
+    pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 8;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    InputObject { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args InputObjectArgs<'args>
-  ) -> flatbuffers::WIPOffset<InputObject<'bldr>> {
-    let mut builder = InputObjectBuilder::new(_fbb);
-    if let Some(x) = args.directives { builder.add_directives(x); }
-    if let Some(x) = args.fields { builder.add_fields(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        InputObject { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args InputObjectArgs<'args>,
+    ) -> flatbuffers::WIPOffset<InputObject<'bldr>> {
+        let mut builder = InputObjectBuilder::new(_fbb);
+        if let Some(x) = args.directives {
+            builder.add_directives(x);
+        }
+        if let Some(x) = args.fields {
+            builder.add_fields(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(InputObject::VT_NAME, None)
-  }
-  #[inline]
-  pub fn fields(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument>>>>(InputObject::VT_FIELDS, None)
-  }
-  #[inline]
-  pub fn directives(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>>>(InputObject::VT_DIRECTIVES, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(InputObject::VT_NAME, None)
+    }
+    #[inline]
+    pub fn fields(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument>>,
+        >>(InputObject::VT_FIELDS, None)
+    }
+    #[inline]
+    pub fn directives(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+        >>(InputObject::VT_DIRECTIVES, None)
+    }
 }
 
 impl flatbuffers::Verifiable for InputObject<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Argument>>>>("fields", Self::VT_FIELDS, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>>>("directives", Self::VT_DIRECTIVES, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Argument>>,
+            >>("fields", Self::VT_FIELDS, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+            >>("directives", Self::VT_DIRECTIVES, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct InputObjectArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
-    pub fields: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>>>,
-    pub directives: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>>>,
+    pub fields: Option<
+        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>>,
+    >,
+    pub directives: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for InputObjectArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    InputObjectArgs {
-      name: None,
-      fields: None,
-      directives: None,
+    #[inline]
+    fn default() -> Self {
+        InputObjectArgs {
+            name: None,
+            fields: None,
+            directives: None,
+        }
     }
-  }
 }
 
 pub struct InputObjectBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> InputObjectBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(InputObject::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_fields(&mut self, fields: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Argument<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(InputObject::VT_FIELDS, fields);
-  }
-  #[inline]
-  pub fn add_directives(&mut self, directives: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<DirectiveValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(InputObject::VT_DIRECTIVES, directives);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> InputObjectBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    InputObjectBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(InputObject::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<InputObject<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_fields(
+        &mut self,
+        fields: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Argument<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(InputObject::VT_FIELDS, fields);
+    }
+    #[inline]
+    pub fn add_directives(
+        &mut self,
+        directives: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<DirectiveValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(InputObject::VT_DIRECTIVES, directives);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> InputObjectBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        InputObjectBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<InputObject<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for InputObject<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("InputObject");
-      ds.field("name", &self.name());
-      ds.field("fields", &self.fields());
-      ds.field("directives", &self.directives());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("InputObject");
+        ds.field("name", &self.name());
+        ds.field("fields", &self.fields());
+        ds.field("directives", &self.directives());
+        ds.finish()
+    }
 }
 pub enum EnumOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Enum<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Enum<'a> {
-  type Inner = Enum<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Enum<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Enum<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
-  pub const VT_VALUES: flatbuffers::VOffsetT = 8;
-  pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 10;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
+    pub const VT_VALUES: flatbuffers::VOffsetT = 8;
+    pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 10;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Enum { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args EnumArgs<'args>
-  ) -> flatbuffers::WIPOffset<Enum<'bldr>> {
-    let mut builder = EnumBuilder::new(_fbb);
-    if let Some(x) = args.directives { builder.add_directives(x); }
-    if let Some(x) = args.values { builder.add_values(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.add_is_extension(args.is_extension);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Enum { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args EnumArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Enum<'bldr>> {
+        let mut builder = EnumBuilder::new(_fbb);
+        if let Some(x) = args.directives {
+            builder.add_directives(x);
+        }
+        if let Some(x) = args.values {
+            builder.add_values(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.add_is_extension(args.is_extension);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(Enum::VT_NAME, None)
-  }
-  #[inline]
-  pub fn is_extension(&self) -> bool {
-    self._tab.get::<bool>(Enum::VT_IS_EXTENSION, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn values(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<EnumValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<EnumValue>>>>(Enum::VT_VALUES, None)
-  }
-  #[inline]
-  pub fn directives(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>>>(Enum::VT_DIRECTIVES, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(Enum::VT_NAME, None)
+    }
+    #[inline]
+    pub fn is_extension(&self) -> bool {
+        self._tab
+            .get::<bool>(Enum::VT_IS_EXTENSION, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn values(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<EnumValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<EnumValue>>,
+        >>(Enum::VT_VALUES, None)
+    }
+    #[inline]
+    pub fn directives(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+        >>(Enum::VT_DIRECTIVES, None)
+    }
 }
 
 impl flatbuffers::Verifiable for Enum<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<EnumValue>>>>("values", Self::VT_VALUES, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>>>("directives", Self::VT_DIRECTIVES, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<EnumValue>>,
+            >>("values", Self::VT_VALUES, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+            >>("directives", Self::VT_DIRECTIVES, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct EnumArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub is_extension: bool,
-    pub values: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<EnumValue<'a>>>>>,
-    pub directives: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>>>,
+    pub values: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<EnumValue<'a>>>,
+        >,
+    >,
+    pub directives: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for EnumArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    EnumArgs {
-      name: None,
-      is_extension: false,
-      values: None,
-      directives: None,
+    #[inline]
+    fn default() -> Self {
+        EnumArgs {
+            name: None,
+            is_extension: false,
+            values: None,
+            directives: None,
+        }
     }
-  }
 }
 
 pub struct EnumBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> EnumBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Enum::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_is_extension(&mut self, is_extension: bool) {
-    self.fbb_.push_slot::<bool>(Enum::VT_IS_EXTENSION, is_extension, false);
-  }
-  #[inline]
-  pub fn add_values(&mut self, values: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<EnumValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Enum::VT_VALUES, values);
-  }
-  #[inline]
-  pub fn add_directives(&mut self, directives: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<DirectiveValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Enum::VT_DIRECTIVES, directives);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> EnumBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    EnumBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Enum::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Enum<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_is_extension(&mut self, is_extension: bool) {
+        self.fbb_
+            .push_slot::<bool>(Enum::VT_IS_EXTENSION, is_extension, false);
+    }
+    #[inline]
+    pub fn add_values(
+        &mut self,
+        values: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<EnumValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Enum::VT_VALUES, values);
+    }
+    #[inline]
+    pub fn add_directives(
+        &mut self,
+        directives: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<DirectiveValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Enum::VT_DIRECTIVES, directives);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> EnumBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        EnumBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Enum<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Enum<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Enum");
-      ds.field("name", &self.name());
-      ds.field("is_extension", &self.is_extension());
-      ds.field("values", &self.values());
-      ds.field("directives", &self.directives());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Enum");
+        ds.field("name", &self.name());
+        ds.field("is_extension", &self.is_extension());
+        ds.field("values", &self.values());
+        ds.field("directives", &self.directives());
+        ds.finish()
+    }
 }
 pub enum ObjectOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Object<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Object<'a> {
-  type Inner = Object<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Object<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Object<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
-  pub const VT_FIELDS: flatbuffers::VOffsetT = 8;
-  pub const VT_INTERFACES: flatbuffers::VOffsetT = 10;
-  pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 12;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
+    pub const VT_FIELDS: flatbuffers::VOffsetT = 8;
+    pub const VT_INTERFACES: flatbuffers::VOffsetT = 10;
+    pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 12;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Object { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args ObjectArgs<'args>
-  ) -> flatbuffers::WIPOffset<Object<'bldr>> {
-    let mut builder = ObjectBuilder::new(_fbb);
-    if let Some(x) = args.directives { builder.add_directives(x); }
-    if let Some(x) = args.interfaces { builder.add_interfaces(x); }
-    if let Some(x) = args.fields { builder.add_fields(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.add_is_extension(args.is_extension);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Object { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args ObjectArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Object<'bldr>> {
+        let mut builder = ObjectBuilder::new(_fbb);
+        if let Some(x) = args.directives {
+            builder.add_directives(x);
+        }
+        if let Some(x) = args.interfaces {
+            builder.add_interfaces(x);
+        }
+        if let Some(x) = args.fields {
+            builder.add_fields(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.add_is_extension(args.is_extension);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(Object::VT_NAME, None)
-  }
-  #[inline]
-  pub fn is_extension(&self) -> bool {
-    self._tab.get::<bool>(Object::VT_IS_EXTENSION, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn fields(&self) -> Option<flatbuffers::Vector<'a, u32>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(Object::VT_FIELDS, None)
-  }
-  #[inline]
-  pub fn interfaces(&self) -> Option<flatbuffers::Vector<'a, u32>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(Object::VT_INTERFACES, None)
-  }
-  #[inline]
-  pub fn directives(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>>>(Object::VT_DIRECTIVES, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(Object::VT_NAME, None)
+    }
+    #[inline]
+    pub fn is_extension(&self) -> bool {
+        self._tab
+            .get::<bool>(Object::VT_IS_EXTENSION, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn fields(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                Object::VT_FIELDS,
+                None,
+            )
+    }
+    #[inline]
+    pub fn interfaces(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                Object::VT_INTERFACES,
+                None,
+            )
+    }
+    #[inline]
+    pub fn directives(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+        >>(Object::VT_DIRECTIVES, None)
+    }
 }
 
 impl flatbuffers::Verifiable for Object<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("fields", Self::VT_FIELDS, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("interfaces", Self::VT_INTERFACES, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>>>("directives", Self::VT_DIRECTIVES, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "fields",
+                Self::VT_FIELDS,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "interfaces",
+                Self::VT_INTERFACES,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+            >>("directives", Self::VT_DIRECTIVES, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct ObjectArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub is_extension: bool,
     pub fields: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub interfaces: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
-    pub directives: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>>>,
+    pub directives: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for ObjectArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    ObjectArgs {
-      name: None,
-      is_extension: false,
-      fields: None,
-      interfaces: None,
-      directives: None,
+    #[inline]
+    fn default() -> Self {
+        ObjectArgs {
+            name: None,
+            is_extension: false,
+            fields: None,
+            interfaces: None,
+            directives: None,
+        }
     }
-  }
 }
 
 pub struct ObjectBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> ObjectBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Object::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_is_extension(&mut self, is_extension: bool) {
-    self.fbb_.push_slot::<bool>(Object::VT_IS_EXTENSION, is_extension, false);
-  }
-  #[inline]
-  pub fn add_fields(&mut self, fields: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Object::VT_FIELDS, fields);
-  }
-  #[inline]
-  pub fn add_interfaces(&mut self, interfaces: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Object::VT_INTERFACES, interfaces);
-  }
-  #[inline]
-  pub fn add_directives(&mut self, directives: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<DirectiveValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Object::VT_DIRECTIVES, directives);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ObjectBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    ObjectBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Object::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Object<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_is_extension(&mut self, is_extension: bool) {
+        self.fbb_
+            .push_slot::<bool>(Object::VT_IS_EXTENSION, is_extension, false);
+    }
+    #[inline]
+    pub fn add_fields(&mut self, fields: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Object::VT_FIELDS, fields);
+    }
+    #[inline]
+    pub fn add_interfaces(
+        &mut self,
+        interfaces: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Object::VT_INTERFACES, interfaces);
+    }
+    #[inline]
+    pub fn add_directives(
+        &mut self,
+        directives: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<DirectiveValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Object::VT_DIRECTIVES, directives);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ObjectBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        ObjectBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Object<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Object<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Object");
-      ds.field("name", &self.name());
-      ds.field("is_extension", &self.is_extension());
-      ds.field("fields", &self.fields());
-      ds.field("interfaces", &self.interfaces());
-      ds.field("directives", &self.directives());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Object");
+        ds.field("name", &self.name());
+        ds.field("is_extension", &self.is_extension());
+        ds.field("fields", &self.fields());
+        ds.field("interfaces", &self.interfaces());
+        ds.field("directives", &self.directives());
+        ds.finish()
+    }
 }
 pub enum InterfaceOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Interface<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Interface<'a> {
-  type Inner = Interface<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Interface<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Interface<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
-  pub const VT_FIELDS: flatbuffers::VOffsetT = 8;
-  pub const VT_INTERFACES: flatbuffers::VOffsetT = 10;
-  pub const VT_IMPLEMENTING_INTERFACES: flatbuffers::VOffsetT = 12;
-  pub const VT_IMPLEMENTING_OBJECTS: flatbuffers::VOffsetT = 14;
-  pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 16;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
+    pub const VT_FIELDS: flatbuffers::VOffsetT = 8;
+    pub const VT_INTERFACES: flatbuffers::VOffsetT = 10;
+    pub const VT_IMPLEMENTING_INTERFACES: flatbuffers::VOffsetT = 12;
+    pub const VT_IMPLEMENTING_OBJECTS: flatbuffers::VOffsetT = 14;
+    pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 16;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Interface { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args InterfaceArgs<'args>
-  ) -> flatbuffers::WIPOffset<Interface<'bldr>> {
-    let mut builder = InterfaceBuilder::new(_fbb);
-    if let Some(x) = args.directives { builder.add_directives(x); }
-    if let Some(x) = args.implementing_objects { builder.add_implementing_objects(x); }
-    if let Some(x) = args.implementing_interfaces { builder.add_implementing_interfaces(x); }
-    if let Some(x) = args.interfaces { builder.add_interfaces(x); }
-    if let Some(x) = args.fields { builder.add_fields(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.add_is_extension(args.is_extension);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Interface { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args InterfaceArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Interface<'bldr>> {
+        let mut builder = InterfaceBuilder::new(_fbb);
+        if let Some(x) = args.directives {
+            builder.add_directives(x);
+        }
+        if let Some(x) = args.implementing_objects {
+            builder.add_implementing_objects(x);
+        }
+        if let Some(x) = args.implementing_interfaces {
+            builder.add_implementing_interfaces(x);
+        }
+        if let Some(x) = args.interfaces {
+            builder.add_interfaces(x);
+        }
+        if let Some(x) = args.fields {
+            builder.add_fields(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.add_is_extension(args.is_extension);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(Interface::VT_NAME, None)
-  }
-  #[inline]
-  pub fn is_extension(&self) -> bool {
-    self._tab.get::<bool>(Interface::VT_IS_EXTENSION, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn fields(&self) -> Option<flatbuffers::Vector<'a, u32>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(Interface::VT_FIELDS, None)
-  }
-  #[inline]
-  pub fn interfaces(&self) -> Option<flatbuffers::Vector<'a, u32>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(Interface::VT_INTERFACES, None)
-  }
-  #[inline]
-  pub fn implementing_interfaces(&self) -> Option<flatbuffers::Vector<'a, u32>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(Interface::VT_IMPLEMENTING_INTERFACES, None)
-  }
-  #[inline]
-  pub fn implementing_objects(&self) -> Option<flatbuffers::Vector<'a, u32>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(Interface::VT_IMPLEMENTING_OBJECTS, None)
-  }
-  #[inline]
-  pub fn directives(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>>>(Interface::VT_DIRECTIVES, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(Interface::VT_NAME, None)
+    }
+    #[inline]
+    pub fn is_extension(&self) -> bool {
+        self._tab
+            .get::<bool>(Interface::VT_IS_EXTENSION, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn fields(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                Interface::VT_FIELDS,
+                None,
+            )
+    }
+    #[inline]
+    pub fn interfaces(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                Interface::VT_INTERFACES,
+                None,
+            )
+    }
+    #[inline]
+    pub fn implementing_interfaces(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                Interface::VT_IMPLEMENTING_INTERFACES,
+                None,
+            )
+    }
+    #[inline]
+    pub fn implementing_objects(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                Interface::VT_IMPLEMENTING_OBJECTS,
+                None,
+            )
+    }
+    #[inline]
+    pub fn directives(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+        >>(Interface::VT_DIRECTIVES, None)
+    }
 }
 
 impl flatbuffers::Verifiable for Interface<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("fields", Self::VT_FIELDS, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("interfaces", Self::VT_INTERFACES, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("implementing_interfaces", Self::VT_IMPLEMENTING_INTERFACES, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("implementing_objects", Self::VT_IMPLEMENTING_OBJECTS, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>>>("directives", Self::VT_DIRECTIVES, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "fields",
+                Self::VT_FIELDS,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "interfaces",
+                Self::VT_INTERFACES,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "implementing_interfaces",
+                Self::VT_IMPLEMENTING_INTERFACES,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "implementing_objects",
+                Self::VT_IMPLEMENTING_OBJECTS,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+            >>("directives", Self::VT_DIRECTIVES, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct InterfaceArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
@@ -2500,758 +3050,1010 @@ pub struct InterfaceArgs<'a> {
     pub interfaces: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub implementing_interfaces: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub implementing_objects: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
-    pub directives: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>>>,
+    pub directives: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for InterfaceArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    InterfaceArgs {
-      name: None,
-      is_extension: false,
-      fields: None,
-      interfaces: None,
-      implementing_interfaces: None,
-      implementing_objects: None,
-      directives: None,
+    #[inline]
+    fn default() -> Self {
+        InterfaceArgs {
+            name: None,
+            is_extension: false,
+            fields: None,
+            interfaces: None,
+            implementing_interfaces: None,
+            implementing_objects: None,
+            directives: None,
+        }
     }
-  }
 }
 
 pub struct InterfaceBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> InterfaceBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_is_extension(&mut self, is_extension: bool) {
-    self.fbb_.push_slot::<bool>(Interface::VT_IS_EXTENSION, is_extension, false);
-  }
-  #[inline]
-  pub fn add_fields(&mut self, fields: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_FIELDS, fields);
-  }
-  #[inline]
-  pub fn add_interfaces(&mut self, interfaces: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_INTERFACES, interfaces);
-  }
-  #[inline]
-  pub fn add_implementing_interfaces(&mut self, implementing_interfaces: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_IMPLEMENTING_INTERFACES, implementing_interfaces);
-  }
-  #[inline]
-  pub fn add_implementing_objects(&mut self, implementing_objects: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_IMPLEMENTING_OBJECTS, implementing_objects);
-  }
-  #[inline]
-  pub fn add_directives(&mut self, directives: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<DirectiveValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_DIRECTIVES, directives);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> InterfaceBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    InterfaceBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Interface<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_is_extension(&mut self, is_extension: bool) {
+        self.fbb_
+            .push_slot::<bool>(Interface::VT_IS_EXTENSION, is_extension, false);
+    }
+    #[inline]
+    pub fn add_fields(&mut self, fields: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_FIELDS, fields);
+    }
+    #[inline]
+    pub fn add_interfaces(
+        &mut self,
+        interfaces: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_INTERFACES, interfaces);
+    }
+    #[inline]
+    pub fn add_implementing_interfaces(
+        &mut self,
+        implementing_interfaces: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>,
+    ) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            Interface::VT_IMPLEMENTING_INTERFACES,
+            implementing_interfaces,
+        );
+    }
+    #[inline]
+    pub fn add_implementing_objects(
+        &mut self,
+        implementing_objects: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>,
+    ) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            Interface::VT_IMPLEMENTING_OBJECTS,
+            implementing_objects,
+        );
+    }
+    #[inline]
+    pub fn add_directives(
+        &mut self,
+        directives: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<DirectiveValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Interface::VT_DIRECTIVES, directives);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> InterfaceBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        InterfaceBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Interface<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Interface<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Interface");
-      ds.field("name", &self.name());
-      ds.field("is_extension", &self.is_extension());
-      ds.field("fields", &self.fields());
-      ds.field("interfaces", &self.interfaces());
-      ds.field("implementing_interfaces", &self.implementing_interfaces());
-      ds.field("implementing_objects", &self.implementing_objects());
-      ds.field("directives", &self.directives());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Interface");
+        ds.field("name", &self.name());
+        ds.field("is_extension", &self.is_extension());
+        ds.field("fields", &self.fields());
+        ds.field("interfaces", &self.interfaces());
+        ds.field("implementing_interfaces", &self.implementing_interfaces());
+        ds.field("implementing_objects", &self.implementing_objects());
+        ds.field("directives", &self.directives());
+        ds.finish()
+    }
 }
 pub enum UnionOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Union<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Union<'a> {
-  type Inner = Union<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Union<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Union<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
-  pub const VT_MEMBERS: flatbuffers::VOffsetT = 8;
-  pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 10;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
+    pub const VT_MEMBERS: flatbuffers::VOffsetT = 8;
+    pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 10;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Union { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args UnionArgs<'args>
-  ) -> flatbuffers::WIPOffset<Union<'bldr>> {
-    let mut builder = UnionBuilder::new(_fbb);
-    if let Some(x) = args.directives { builder.add_directives(x); }
-    if let Some(x) = args.members { builder.add_members(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.add_is_extension(args.is_extension);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Union { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args UnionArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Union<'bldr>> {
+        let mut builder = UnionBuilder::new(_fbb);
+        if let Some(x) = args.directives {
+            builder.add_directives(x);
+        }
+        if let Some(x) = args.members {
+            builder.add_members(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.add_is_extension(args.is_extension);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(Union::VT_NAME, None)
-  }
-  #[inline]
-  pub fn is_extension(&self) -> bool {
-    self._tab.get::<bool>(Union::VT_IS_EXTENSION, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn members(&self) -> Option<flatbuffers::Vector<'a, u32>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(Union::VT_MEMBERS, None)
-  }
-  #[inline]
-  pub fn directives(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>>>(Union::VT_DIRECTIVES, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(Union::VT_NAME, None)
+    }
+    #[inline]
+    pub fn is_extension(&self) -> bool {
+        self._tab
+            .get::<bool>(Union::VT_IS_EXTENSION, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn members(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                Union::VT_MEMBERS,
+                None,
+            )
+    }
+    #[inline]
+    pub fn directives(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+        >>(Union::VT_DIRECTIVES, None)
+    }
 }
 
 impl flatbuffers::Verifiable for Union<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("members", Self::VT_MEMBERS, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>>>("directives", Self::VT_DIRECTIVES, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "members",
+                Self::VT_MEMBERS,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+            >>("directives", Self::VT_DIRECTIVES, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct UnionArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub is_extension: bool,
     pub members: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
-    pub directives: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>>>,
+    pub directives: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>,
+        >,
+    >,
 }
 impl<'a> Default for UnionArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    UnionArgs {
-      name: None,
-      is_extension: false,
-      members: None,
-      directives: None,
+    #[inline]
+    fn default() -> Self {
+        UnionArgs {
+            name: None,
+            is_extension: false,
+            members: None,
+            directives: None,
+        }
     }
-  }
 }
 
 pub struct UnionBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> UnionBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Union::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_is_extension(&mut self, is_extension: bool) {
-    self.fbb_.push_slot::<bool>(Union::VT_IS_EXTENSION, is_extension, false);
-  }
-  #[inline]
-  pub fn add_members(&mut self, members: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Union::VT_MEMBERS, members);
-  }
-  #[inline]
-  pub fn add_directives(&mut self, directives: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<DirectiveValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Union::VT_DIRECTIVES, directives);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> UnionBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    UnionBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Union::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Union<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_is_extension(&mut self, is_extension: bool) {
+        self.fbb_
+            .push_slot::<bool>(Union::VT_IS_EXTENSION, is_extension, false);
+    }
+    #[inline]
+    pub fn add_members(&mut self, members: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Union::VT_MEMBERS, members);
+    }
+    #[inline]
+    pub fn add_directives(
+        &mut self,
+        directives: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<DirectiveValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Union::VT_DIRECTIVES, directives);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> UnionBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        UnionBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Union<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Union<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Union");
-      ds.field("name", &self.name());
-      ds.field("is_extension", &self.is_extension());
-      ds.field("members", &self.members());
-      ds.field("directives", &self.directives());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Union");
+        ds.field("name", &self.name());
+        ds.field("is_extension", &self.is_extension());
+        ds.field("members", &self.members());
+        ds.field("directives", &self.directives());
+        ds.finish()
+    }
 }
 pub enum FieldOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Field<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Field<'a> {
-  type Inner = Field<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Field<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Field<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
-  pub const VT_ARGUMENTS: flatbuffers::VOffsetT = 8;
-  pub const VT_TYPE_: flatbuffers::VOffsetT = 10;
-  pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 12;
-  pub const VT_PARENT_TYPE: flatbuffers::VOffsetT = 14;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_IS_EXTENSION: flatbuffers::VOffsetT = 6;
+    pub const VT_ARGUMENTS: flatbuffers::VOffsetT = 8;
+    pub const VT_TYPE_: flatbuffers::VOffsetT = 10;
+    pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 12;
+    pub const VT_PARENT_TYPE: flatbuffers::VOffsetT = 14;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Field { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args FieldArgs<'args>
-  ) -> flatbuffers::WIPOffset<Field<'bldr>> {
-    let mut builder = FieldBuilder::new(_fbb);
-    if let Some(x) = args.parent_type { builder.add_parent_type(x); }
-    if let Some(x) = args.directives { builder.add_directives(x); }
-    if let Some(x) = args.type_ { builder.add_type_(x); }
-    if let Some(x) = args.arguments { builder.add_arguments(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.add_is_extension(args.is_extension);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Field { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args FieldArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Field<'bldr>> {
+        let mut builder = FieldBuilder::new(_fbb);
+        if let Some(x) = args.parent_type {
+            builder.add_parent_type(x);
+        }
+        if let Some(x) = args.directives {
+            builder.add_directives(x);
+        }
+        if let Some(x) = args.type_ {
+            builder.add_type_(x);
+        }
+        if let Some(x) = args.arguments {
+            builder.add_arguments(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.add_is_extension(args.is_extension);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> Option<&'a str> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(Field::VT_NAME, None)
-  }
-  #[inline]
-  pub fn is_extension(&self) -> bool {
-    self._tab.get::<bool>(Field::VT_IS_EXTENSION, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn arguments(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument>>>>(Field::VT_ARGUMENTS, None)
-  }
-  #[inline]
-  pub fn type_(&self) -> Option<TypeReference<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<TypeReference>>(Field::VT_TYPE_, None)
-  }
-  #[inline]
-  pub fn directives(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>>>(Field::VT_DIRECTIVES, None)
-  }
-  #[inline]
-  pub fn parent_type(&self) -> Option<Type<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Type>>(Field::VT_PARENT_TYPE, None)
-  }
+    #[inline]
+    pub fn name(&self) -> Option<&'a str> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(Field::VT_NAME, None)
+    }
+    #[inline]
+    pub fn is_extension(&self) -> bool {
+        self._tab
+            .get::<bool>(Field::VT_IS_EXTENSION, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn arguments(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument>>,
+        >>(Field::VT_ARGUMENTS, None)
+    }
+    #[inline]
+    pub fn type_(&self) -> Option<TypeReference<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<TypeReference>>(Field::VT_TYPE_, None)
+    }
+    #[inline]
+    pub fn directives(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+        >>(Field::VT_DIRECTIVES, None)
+    }
+    #[inline]
+    pub fn parent_type(&self) -> Option<Type<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<Type>>(Field::VT_PARENT_TYPE, None)
+    }
 }
 
 impl flatbuffers::Verifiable for Field<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
-     .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Argument>>>>("arguments", Self::VT_ARGUMENTS, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<TypeReference>>("type_", Self::VT_TYPE_, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>>>("directives", Self::VT_DIRECTIVES, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<Type>>("parent_type", Self::VT_PARENT_TYPE, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+            .visit_field::<bool>("is_extension", Self::VT_IS_EXTENSION, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Argument>>,
+            >>("arguments", Self::VT_ARGUMENTS, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<TypeReference>>(
+                "type_",
+                Self::VT_TYPE_,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveValue>>,
+            >>("directives", Self::VT_DIRECTIVES, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<Type>>(
+                "parent_type",
+                Self::VT_PARENT_TYPE,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
 }
 pub struct FieldArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub is_extension: bool,
-    pub arguments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>>>,
+    pub arguments: Option<
+        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Argument<'a>>>>,
+    >,
     pub type_: Option<flatbuffers::WIPOffset<TypeReference<'a>>>,
-    pub directives: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>>>,
+    pub directives: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveValue<'a>>>,
+        >,
+    >,
     pub parent_type: Option<flatbuffers::WIPOffset<Type<'a>>>,
 }
 impl<'a> Default for FieldArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    FieldArgs {
-      name: None,
-      is_extension: false,
-      arguments: None,
-      type_: None,
-      directives: None,
-      parent_type: None,
+    #[inline]
+    fn default() -> Self {
+        FieldArgs {
+            name: None,
+            is_extension: false,
+            arguments: None,
+            type_: None,
+            directives: None,
+            parent_type: None,
+        }
     }
-  }
 }
 
 pub struct FieldBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> FieldBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Field::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_is_extension(&mut self, is_extension: bool) {
-    self.fbb_.push_slot::<bool>(Field::VT_IS_EXTENSION, is_extension, false);
-  }
-  #[inline]
-  pub fn add_arguments(&mut self, arguments: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Argument<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Field::VT_ARGUMENTS, arguments);
-  }
-  #[inline]
-  pub fn add_type_(&mut self, type_: flatbuffers::WIPOffset<TypeReference<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<TypeReference>>(Field::VT_TYPE_, type_);
-  }
-  #[inline]
-  pub fn add_directives(&mut self, directives: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<DirectiveValue<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Field::VT_DIRECTIVES, directives);
-  }
-  #[inline]
-  pub fn add_parent_type(&mut self, parent_type: flatbuffers::WIPOffset<Type<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Type>>(Field::VT_PARENT_TYPE, parent_type);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> FieldBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    FieldBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Field::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Field<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_is_extension(&mut self, is_extension: bool) {
+        self.fbb_
+            .push_slot::<bool>(Field::VT_IS_EXTENSION, is_extension, false);
+    }
+    #[inline]
+    pub fn add_arguments(
+        &mut self,
+        arguments: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Argument<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Field::VT_ARGUMENTS, arguments);
+    }
+    #[inline]
+    pub fn add_type_(&mut self, type_: flatbuffers::WIPOffset<TypeReference<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<TypeReference>>(Field::VT_TYPE_, type_);
+    }
+    #[inline]
+    pub fn add_directives(
+        &mut self,
+        directives: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<DirectiveValue<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Field::VT_DIRECTIVES, directives);
+    }
+    #[inline]
+    pub fn add_parent_type(&mut self, parent_type: flatbuffers::WIPOffset<Type<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<Type>>(Field::VT_PARENT_TYPE, parent_type);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> FieldBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        FieldBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Field<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Field<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Field");
-      ds.field("name", &self.name());
-      ds.field("is_extension", &self.is_extension());
-      ds.field("arguments", &self.arguments());
-      ds.field("type_", &self.type_());
-      ds.field("directives", &self.directives());
-      ds.field("parent_type", &self.parent_type());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Field");
+        ds.field("name", &self.name());
+        ds.field("is_extension", &self.is_extension());
+        ds.field("arguments", &self.arguments());
+        ds.field("type_", &self.type_());
+        ds.field("directives", &self.directives());
+        ds.field("parent_type", &self.parent_type());
+        ds.finish()
+    }
 }
 pub enum TypeMapEntryOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct TypeMapEntry<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for TypeMapEntry<'a> {
-  type Inner = TypeMapEntry<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = TypeMapEntry<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> TypeMapEntry<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_VALUE: flatbuffers::VOffsetT = 6;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_VALUE: flatbuffers::VOffsetT = 6;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    TypeMapEntry { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args TypeMapEntryArgs<'args>
-  ) -> flatbuffers::WIPOffset<TypeMapEntry<'bldr>> {
-    let mut builder = TypeMapEntryBuilder::new(_fbb);
-    if let Some(x) = args.value { builder.add_value(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        TypeMapEntry { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args TypeMapEntryArgs<'args>,
+    ) -> flatbuffers::WIPOffset<TypeMapEntry<'bldr>> {
+        let mut builder = TypeMapEntryBuilder::new(_fbb);
+        if let Some(x) = args.value {
+            builder.add_value(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> &'a str {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(TypeMapEntry::VT_NAME, None).unwrap()
-  }
-  #[inline]
-  pub fn key_compare_less_than(&self, o: &TypeMapEntry) -> bool {
-    self.name() < o.name()
-  }
+    #[inline]
+    pub fn name(&self) -> &'a str {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(TypeMapEntry::VT_NAME, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn key_compare_less_than(&self, o: &TypeMapEntry) -> bool {
+        self.name() < o.name()
+    }
 
-  #[inline]
-  pub fn key_compare_with_value(&self, val: & str) -> ::core::cmp::Ordering {
-    let key = self.name();
-    key.cmp(val)
-  }
-  #[inline]
-  pub fn value(&self) -> Option<Type<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Type>>(TypeMapEntry::VT_VALUE, None)
-  }
+    #[inline]
+    pub fn key_compare_with_value(&self, val: &str) -> ::core::cmp::Ordering {
+        let key = self.name();
+        key.cmp(val)
+    }
+    #[inline]
+    pub fn value(&self) -> Option<Type<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<Type>>(TypeMapEntry::VT_VALUE, None)
+    }
 }
 
 impl flatbuffers::Verifiable for TypeMapEntry<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<Type>>("value", Self::VT_VALUE, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<Type>>("value", Self::VT_VALUE, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct TypeMapEntryArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub value: Option<flatbuffers::WIPOffset<Type<'a>>>,
 }
 impl<'a> Default for TypeMapEntryArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    TypeMapEntryArgs {
-      name: None, // required field
-      value: None,
+    #[inline]
+    fn default() -> Self {
+        TypeMapEntryArgs {
+            name: None, // required field
+            value: None,
+        }
     }
-  }
 }
 
 pub struct TypeMapEntryBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> TypeMapEntryBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TypeMapEntry::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_value(&mut self, value: flatbuffers::WIPOffset<Type<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Type>>(TypeMapEntry::VT_VALUE, value);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TypeMapEntryBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    TypeMapEntryBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(TypeMapEntry::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<TypeMapEntry<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    self.fbb_.required(o, TypeMapEntry::VT_NAME,"name");
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_value(&mut self, value: flatbuffers::WIPOffset<Type<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<Type>>(TypeMapEntry::VT_VALUE, value);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> TypeMapEntryBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        TypeMapEntryBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<TypeMapEntry<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        self.fbb_.required(o, TypeMapEntry::VT_NAME, "name");
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for TypeMapEntry<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("TypeMapEntry");
-      ds.field("name", &self.name());
-      ds.field("value", &self.value());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("TypeMapEntry");
+        ds.field("name", &self.name());
+        ds.field("value", &self.value());
+        ds.finish()
+    }
 }
 pub enum DirectiveMapEntryOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct DirectiveMapEntry<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for DirectiveMapEntry<'a> {
-  type Inner = DirectiveMapEntry<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = DirectiveMapEntry<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> DirectiveMapEntry<'a> {
-  pub const VT_NAME: flatbuffers::VOffsetT = 4;
-  pub const VT_VALUE: flatbuffers::VOffsetT = 6;
+    pub const VT_NAME: flatbuffers::VOffsetT = 4;
+    pub const VT_VALUE: flatbuffers::VOffsetT = 6;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    DirectiveMapEntry { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args DirectiveMapEntryArgs<'args>
-  ) -> flatbuffers::WIPOffset<DirectiveMapEntry<'bldr>> {
-    let mut builder = DirectiveMapEntryBuilder::new(_fbb);
-    if let Some(x) = args.value { builder.add_value(x); }
-    if let Some(x) = args.name { builder.add_name(x); }
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        DirectiveMapEntry { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args DirectiveMapEntryArgs<'args>,
+    ) -> flatbuffers::WIPOffset<DirectiveMapEntry<'bldr>> {
+        let mut builder = DirectiveMapEntryBuilder::new(_fbb);
+        if let Some(x) = args.value {
+            builder.add_value(x);
+        }
+        if let Some(x) = args.name {
+            builder.add_name(x);
+        }
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn name(&self) -> &'a str {
-    self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(DirectiveMapEntry::VT_NAME, None).unwrap()
-  }
-  #[inline]
-  pub fn key_compare_less_than(&self, o: &DirectiveMapEntry) -> bool {
-    self.name() < o.name()
-  }
+    #[inline]
+    pub fn name(&self) -> &'a str {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<&str>>(DirectiveMapEntry::VT_NAME, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn key_compare_less_than(&self, o: &DirectiveMapEntry) -> bool {
+        self.name() < o.name()
+    }
 
-  #[inline]
-  pub fn key_compare_with_value(&self, val: & str) -> ::core::cmp::Ordering {
-    let key = self.name();
-    key.cmp(val)
-  }
-  #[inline]
-  pub fn value(&self) -> Option<Directive<'a>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<Directive>>(DirectiveMapEntry::VT_VALUE, None)
-  }
+    #[inline]
+    pub fn key_compare_with_value(&self, val: &str) -> ::core::cmp::Ordering {
+        let key = self.name();
+        key.cmp(val)
+    }
+    #[inline]
+    pub fn value(&self) -> Option<Directive<'a>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<Directive>>(DirectiveMapEntry::VT_VALUE, None)
+    }
 }
 
 impl flatbuffers::Verifiable for DirectiveMapEntry<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<Directive>>("value", Self::VT_VALUE, false)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<Directive>>("value", Self::VT_VALUE, false)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct DirectiveMapEntryArgs<'a> {
     pub name: Option<flatbuffers::WIPOffset<&'a str>>,
     pub value: Option<flatbuffers::WIPOffset<Directive<'a>>>,
 }
 impl<'a> Default for DirectiveMapEntryArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    DirectiveMapEntryArgs {
-      name: None, // required field
-      value: None,
+    #[inline]
+    fn default() -> Self {
+        DirectiveMapEntryArgs {
+            name: None, // required field
+            value: None,
+        }
     }
-  }
 }
 
 pub struct DirectiveMapEntryBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> DirectiveMapEntryBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(DirectiveMapEntry::VT_NAME, name);
-  }
-  #[inline]
-  pub fn add_value(&mut self, value: flatbuffers::WIPOffset<Directive<'b >>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Directive>>(DirectiveMapEntry::VT_VALUE, value);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> DirectiveMapEntryBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    DirectiveMapEntryBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(DirectiveMapEntry::VT_NAME, name);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<DirectiveMapEntry<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    self.fbb_.required(o, DirectiveMapEntry::VT_NAME,"name");
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_value(&mut self, value: flatbuffers::WIPOffset<Directive<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<Directive>>(
+                DirectiveMapEntry::VT_VALUE,
+                value,
+            );
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> DirectiveMapEntryBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        DirectiveMapEntryBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<DirectiveMapEntry<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        self.fbb_.required(o, DirectiveMapEntry::VT_NAME, "name");
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for DirectiveMapEntry<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("DirectiveMapEntry");
-      ds.field("name", &self.name());
-      ds.field("value", &self.value());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("DirectiveMapEntry");
+        ds.field("name", &self.name());
+        ds.field("value", &self.value());
+        ds.finish()
+    }
 }
 pub enum SchemaOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
 pub struct Schema<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for Schema<'a> {
-  type Inner = Schema<'a>;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    Self { _tab: flatbuffers::Table { buf, loc } }
-  }
+    type Inner = Schema<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf, loc },
+        }
+    }
 }
 
 impl<'a> Schema<'a> {
-  pub const VT_QUERY_TYPE: flatbuffers::VOffsetT = 4;
-  pub const VT_HAS_MUTATION_TYPE: flatbuffers::VOffsetT = 6;
-  pub const VT_MUTATION_TYPE: flatbuffers::VOffsetT = 8;
-  pub const VT_HAS_SUBSCRIPTION_TYPE: flatbuffers::VOffsetT = 10;
-  pub const VT_SUBSCRIPTION_TYPE: flatbuffers::VOffsetT = 12;
-  pub const VT_TYPES: flatbuffers::VOffsetT = 14;
-  pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 16;
-  pub const VT_SCALARS: flatbuffers::VOffsetT = 18;
-  pub const VT_INPUT_OBJECTS: flatbuffers::VOffsetT = 20;
-  pub const VT_ENUMS: flatbuffers::VOffsetT = 22;
-  pub const VT_OBJECTS: flatbuffers::VOffsetT = 24;
-  pub const VT_INTERFACES: flatbuffers::VOffsetT = 26;
-  pub const VT_UNIONS: flatbuffers::VOffsetT = 28;
-  pub const VT_FIELDS: flatbuffers::VOffsetT = 30;
+    pub const VT_QUERY_TYPE: flatbuffers::VOffsetT = 4;
+    pub const VT_HAS_MUTATION_TYPE: flatbuffers::VOffsetT = 6;
+    pub const VT_MUTATION_TYPE: flatbuffers::VOffsetT = 8;
+    pub const VT_HAS_SUBSCRIPTION_TYPE: flatbuffers::VOffsetT = 10;
+    pub const VT_SUBSCRIPTION_TYPE: flatbuffers::VOffsetT = 12;
+    pub const VT_TYPES: flatbuffers::VOffsetT = 14;
+    pub const VT_DIRECTIVES: flatbuffers::VOffsetT = 16;
+    pub const VT_SCALARS: flatbuffers::VOffsetT = 18;
+    pub const VT_INPUT_OBJECTS: flatbuffers::VOffsetT = 20;
+    pub const VT_ENUMS: flatbuffers::VOffsetT = 22;
+    pub const VT_OBJECTS: flatbuffers::VOffsetT = 24;
+    pub const VT_INTERFACES: flatbuffers::VOffsetT = 26;
+    pub const VT_UNIONS: flatbuffers::VOffsetT = 28;
+    pub const VT_FIELDS: flatbuffers::VOffsetT = 30;
 
-  #[inline]
-  pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Schema { _tab: table }
-  }
-  #[allow(unused_mut)]
-  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-    args: &'args SchemaArgs<'args>
-  ) -> flatbuffers::WIPOffset<Schema<'bldr>> {
-    let mut builder = SchemaBuilder::new(_fbb);
-    if let Some(x) = args.fields { builder.add_fields(x); }
-    if let Some(x) = args.unions { builder.add_unions(x); }
-    if let Some(x) = args.interfaces { builder.add_interfaces(x); }
-    if let Some(x) = args.objects { builder.add_objects(x); }
-    if let Some(x) = args.enums { builder.add_enums(x); }
-    if let Some(x) = args.input_objects { builder.add_input_objects(x); }
-    if let Some(x) = args.scalars { builder.add_scalars(x); }
-    if let Some(x) = args.directives { builder.add_directives(x); }
-    if let Some(x) = args.types { builder.add_types(x); }
-    builder.add_subscription_type(args.subscription_type);
-    builder.add_mutation_type(args.mutation_type);
-    builder.add_query_type(args.query_type);
-    builder.add_has_subscription_type(args.has_subscription_type);
-    builder.add_has_mutation_type(args.has_mutation_type);
-    builder.finish()
-  }
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Schema { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args SchemaArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Schema<'bldr>> {
+        let mut builder = SchemaBuilder::new(_fbb);
+        if let Some(x) = args.fields {
+            builder.add_fields(x);
+        }
+        if let Some(x) = args.unions {
+            builder.add_unions(x);
+        }
+        if let Some(x) = args.interfaces {
+            builder.add_interfaces(x);
+        }
+        if let Some(x) = args.objects {
+            builder.add_objects(x);
+        }
+        if let Some(x) = args.enums {
+            builder.add_enums(x);
+        }
+        if let Some(x) = args.input_objects {
+            builder.add_input_objects(x);
+        }
+        if let Some(x) = args.scalars {
+            builder.add_scalars(x);
+        }
+        if let Some(x) = args.directives {
+            builder.add_directives(x);
+        }
+        if let Some(x) = args.types {
+            builder.add_types(x);
+        }
+        builder.add_subscription_type(args.subscription_type);
+        builder.add_mutation_type(args.mutation_type);
+        builder.add_query_type(args.query_type);
+        builder.add_has_subscription_type(args.has_subscription_type);
+        builder.add_has_mutation_type(args.has_mutation_type);
+        builder.finish()
+    }
 
-  #[inline]
-  pub fn query_type(&self) -> u32 {
-    self._tab.get::<u32>(Schema::VT_QUERY_TYPE, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn has_mutation_type(&self) -> bool {
-    self._tab.get::<bool>(Schema::VT_HAS_MUTATION_TYPE, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn mutation_type(&self) -> u32 {
-    self._tab.get::<u32>(Schema::VT_MUTATION_TYPE, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn has_subscription_type(&self) -> bool {
-    self._tab.get::<bool>(Schema::VT_HAS_SUBSCRIPTION_TYPE, Some(false)).unwrap()
-  }
-  #[inline]
-  pub fn subscription_type(&self) -> u32 {
-    self._tab.get::<u32>(Schema::VT_SUBSCRIPTION_TYPE, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn types(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<TypeMapEntry<'a>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<TypeMapEntry>>>>(Schema::VT_TYPES, None).unwrap()
-  }
-  #[inline]
-  pub fn directives(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveMapEntry<'a>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveMapEntry>>>>(Schema::VT_DIRECTIVES, None).unwrap()
-  }
-  #[inline]
-  pub fn scalars(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Scalar<'a>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Scalar>>>>(Schema::VT_SCALARS, None).unwrap()
-  }
-  #[inline]
-  pub fn input_objects(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InputObject<'a>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InputObject>>>>(Schema::VT_INPUT_OBJECTS, None).unwrap()
-  }
-  #[inline]
-  pub fn enums(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Enum<'a>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Enum>>>>(Schema::VT_ENUMS, None).unwrap()
-  }
-  #[inline]
-  pub fn objects(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Object<'a>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Object>>>>(Schema::VT_OBJECTS, None).unwrap()
-  }
-  #[inline]
-  pub fn interfaces(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Interface<'a>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Interface>>>>(Schema::VT_INTERFACES, None).unwrap()
-  }
-  #[inline]
-  pub fn unions(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Union<'a>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Union>>>>(Schema::VT_UNIONS, None).unwrap()
-  }
-  #[inline]
-  pub fn fields(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Field<'a>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Field>>>>(Schema::VT_FIELDS, None).unwrap()
-  }
+    #[inline]
+    pub fn query_type(&self) -> u32 {
+        self._tab
+            .get::<u32>(Schema::VT_QUERY_TYPE, Some(0))
+            .unwrap()
+    }
+    #[inline]
+    pub fn has_mutation_type(&self) -> bool {
+        self._tab
+            .get::<bool>(Schema::VT_HAS_MUTATION_TYPE, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn mutation_type(&self) -> u32 {
+        self._tab
+            .get::<u32>(Schema::VT_MUTATION_TYPE, Some(0))
+            .unwrap()
+    }
+    #[inline]
+    pub fn has_subscription_type(&self) -> bool {
+        self._tab
+            .get::<bool>(Schema::VT_HAS_SUBSCRIPTION_TYPE, Some(false))
+            .unwrap()
+    }
+    #[inline]
+    pub fn subscription_type(&self) -> u32 {
+        self._tab
+            .get::<u32>(Schema::VT_SUBSCRIPTION_TYPE, Some(0))
+            .unwrap()
+    }
+    #[inline]
+    pub fn types(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<TypeMapEntry<'a>>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<TypeMapEntry>>,
+            >>(Schema::VT_TYPES, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn directives(
+        &self,
+    ) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveMapEntry<'a>>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveMapEntry>>,
+            >>(Schema::VT_DIRECTIVES, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn scalars(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Scalar<'a>>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Scalar>>,
+            >>(Schema::VT_SCALARS, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn input_objects(
+        &self,
+    ) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InputObject<'a>>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InputObject>>,
+            >>(Schema::VT_INPUT_OBJECTS, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn enums(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Enum<'a>>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Enum>>,
+            >>(Schema::VT_ENUMS, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn objects(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Object<'a>>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Object>>,
+            >>(Schema::VT_OBJECTS, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn interfaces(
+        &self,
+    ) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Interface<'a>>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Interface>>,
+            >>(Schema::VT_INTERFACES, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn unions(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Union<'a>>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Union>>,
+            >>(Schema::VT_UNIONS, None)
+            .unwrap()
+    }
+    #[inline]
+    pub fn fields(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Field<'a>>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Field>>,
+            >>(Schema::VT_FIELDS, None)
+            .unwrap()
+    }
 }
 
 impl flatbuffers::Verifiable for Schema<'_> {
-  #[inline]
-  fn run_verifier(
-    v: &mut flatbuffers::Verifier, pos: usize
-  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
-    use self::flatbuffers::Verifiable;
-    v.visit_table(pos)?
-     .visit_field::<u32>("query_type", Self::VT_QUERY_TYPE, false)?
-     .visit_field::<bool>("has_mutation_type", Self::VT_HAS_MUTATION_TYPE, false)?
-     .visit_field::<u32>("mutation_type", Self::VT_MUTATION_TYPE, false)?
-     .visit_field::<bool>("has_subscription_type", Self::VT_HAS_SUBSCRIPTION_TYPE, false)?
-     .visit_field::<u32>("subscription_type", Self::VT_SUBSCRIPTION_TYPE, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<TypeMapEntry>>>>("types", Self::VT_TYPES, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveMapEntry>>>>("directives", Self::VT_DIRECTIVES, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Scalar>>>>("scalars", Self::VT_SCALARS, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<InputObject>>>>("input_objects", Self::VT_INPUT_OBJECTS, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Enum>>>>("enums", Self::VT_ENUMS, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Object>>>>("objects", Self::VT_OBJECTS, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Interface>>>>("interfaces", Self::VT_INTERFACES, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Union>>>>("unions", Self::VT_UNIONS, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Field>>>>("fields", Self::VT_FIELDS, true)?
-     .finish();
-    Ok(())
-  }
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<u32>("query_type", Self::VT_QUERY_TYPE, false)?
+            .visit_field::<bool>("has_mutation_type", Self::VT_HAS_MUTATION_TYPE, false)?
+            .visit_field::<u32>("mutation_type", Self::VT_MUTATION_TYPE, false)?
+            .visit_field::<bool>(
+                "has_subscription_type",
+                Self::VT_HAS_SUBSCRIPTION_TYPE,
+                false,
+            )?
+            .visit_field::<u32>("subscription_type", Self::VT_SUBSCRIPTION_TYPE, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<TypeMapEntry>>,
+            >>("types", Self::VT_TYPES, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<DirectiveMapEntry>>,
+            >>("directives", Self::VT_DIRECTIVES, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Scalar>>,
+            >>("scalars", Self::VT_SCALARS, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<InputObject>>,
+            >>("input_objects", Self::VT_INPUT_OBJECTS, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Enum>>,
+            >>("enums", Self::VT_ENUMS, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Object>>,
+            >>("objects", Self::VT_OBJECTS, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Interface>>,
+            >>("interfaces", Self::VT_INTERFACES, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Union>>,
+            >>("unions", Self::VT_UNIONS, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Field>>,
+            >>("fields", Self::VT_FIELDS, true)?
+            .finish();
+        Ok(())
+    }
 }
 pub struct SchemaArgs<'a> {
     pub query_type: u32,
@@ -3259,153 +4061,242 @@ pub struct SchemaArgs<'a> {
     pub mutation_type: u32,
     pub has_subscription_type: bool,
     pub subscription_type: u32,
-    pub types: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<TypeMapEntry<'a>>>>>,
-    pub directives: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveMapEntry<'a>>>>>,
-    pub scalars: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Scalar<'a>>>>>,
-    pub input_objects: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InputObject<'a>>>>>,
-    pub enums: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Enum<'a>>>>>,
-    pub objects: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Object<'a>>>>>,
-    pub interfaces: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Interface<'a>>>>>,
-    pub unions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Union<'a>>>>>,
-    pub fields: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Field<'a>>>>>,
+    pub types: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<TypeMapEntry<'a>>>,
+        >,
+    >,
+    pub directives: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<DirectiveMapEntry<'a>>>,
+        >,
+    >,
+    pub scalars: Option<
+        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Scalar<'a>>>>,
+    >,
+    pub input_objects: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<InputObject<'a>>>,
+        >,
+    >,
+    pub enums: Option<
+        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Enum<'a>>>>,
+    >,
+    pub objects: Option<
+        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Object<'a>>>>,
+    >,
+    pub interfaces: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Interface<'a>>>,
+        >,
+    >,
+    pub unions: Option<
+        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Union<'a>>>>,
+    >,
+    pub fields: Option<
+        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Field<'a>>>>,
+    >,
 }
 impl<'a> Default for SchemaArgs<'a> {
-  #[inline]
-  fn default() -> Self {
-    SchemaArgs {
-      query_type: 0,
-      has_mutation_type: false,
-      mutation_type: 0,
-      has_subscription_type: false,
-      subscription_type: 0,
-      types: None, // required field
-      directives: None, // required field
-      scalars: None, // required field
-      input_objects: None, // required field
-      enums: None, // required field
-      objects: None, // required field
-      interfaces: None, // required field
-      unions: None, // required field
-      fields: None, // required field
+    #[inline]
+    fn default() -> Self {
+        SchemaArgs {
+            query_type: 0,
+            has_mutation_type: false,
+            mutation_type: 0,
+            has_subscription_type: false,
+            subscription_type: 0,
+            types: None,         // required field
+            directives: None,    // required field
+            scalars: None,       // required field
+            input_objects: None, // required field
+            enums: None,         // required field
+            objects: None,       // required field
+            interfaces: None,    // required field
+            unions: None,        // required field
+            fields: None,        // required field
+        }
     }
-  }
 }
 
 pub struct SchemaBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> SchemaBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_query_type(&mut self, query_type: u32) {
-    self.fbb_.push_slot::<u32>(Schema::VT_QUERY_TYPE, query_type, 0);
-  }
-  #[inline]
-  pub fn add_has_mutation_type(&mut self, has_mutation_type: bool) {
-    self.fbb_.push_slot::<bool>(Schema::VT_HAS_MUTATION_TYPE, has_mutation_type, false);
-  }
-  #[inline]
-  pub fn add_mutation_type(&mut self, mutation_type: u32) {
-    self.fbb_.push_slot::<u32>(Schema::VT_MUTATION_TYPE, mutation_type, 0);
-  }
-  #[inline]
-  pub fn add_has_subscription_type(&mut self, has_subscription_type: bool) {
-    self.fbb_.push_slot::<bool>(Schema::VT_HAS_SUBSCRIPTION_TYPE, has_subscription_type, false);
-  }
-  #[inline]
-  pub fn add_subscription_type(&mut self, subscription_type: u32) {
-    self.fbb_.push_slot::<u32>(Schema::VT_SUBSCRIPTION_TYPE, subscription_type, 0);
-  }
-  #[inline]
-  pub fn add_types(&mut self, types: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<TypeMapEntry<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_TYPES, types);
-  }
-  #[inline]
-  pub fn add_directives(&mut self, directives: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<DirectiveMapEntry<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_DIRECTIVES, directives);
-  }
-  #[inline]
-  pub fn add_scalars(&mut self, scalars: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Scalar<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_SCALARS, scalars);
-  }
-  #[inline]
-  pub fn add_input_objects(&mut self, input_objects: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<InputObject<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_INPUT_OBJECTS, input_objects);
-  }
-  #[inline]
-  pub fn add_enums(&mut self, enums: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Enum<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_ENUMS, enums);
-  }
-  #[inline]
-  pub fn add_objects(&mut self, objects: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Object<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_OBJECTS, objects);
-  }
-  #[inline]
-  pub fn add_interfaces(&mut self, interfaces: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Interface<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_INTERFACES, interfaces);
-  }
-  #[inline]
-  pub fn add_unions(&mut self, unions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Union<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_UNIONS, unions);
-  }
-  #[inline]
-  pub fn add_fields(&mut self, fields: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Field<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_FIELDS, fields);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> SchemaBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    SchemaBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_query_type(&mut self, query_type: u32) {
+        self.fbb_
+            .push_slot::<u32>(Schema::VT_QUERY_TYPE, query_type, 0);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Schema<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    self.fbb_.required(o, Schema::VT_TYPES,"types");
-    self.fbb_.required(o, Schema::VT_DIRECTIVES,"directives");
-    self.fbb_.required(o, Schema::VT_SCALARS,"scalars");
-    self.fbb_.required(o, Schema::VT_INPUT_OBJECTS,"input_objects");
-    self.fbb_.required(o, Schema::VT_ENUMS,"enums");
-    self.fbb_.required(o, Schema::VT_OBJECTS,"objects");
-    self.fbb_.required(o, Schema::VT_INTERFACES,"interfaces");
-    self.fbb_.required(o, Schema::VT_UNIONS,"unions");
-    self.fbb_.required(o, Schema::VT_FIELDS,"fields");
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_has_mutation_type(&mut self, has_mutation_type: bool) {
+        self.fbb_
+            .push_slot::<bool>(Schema::VT_HAS_MUTATION_TYPE, has_mutation_type, false);
+    }
+    #[inline]
+    pub fn add_mutation_type(&mut self, mutation_type: u32) {
+        self.fbb_
+            .push_slot::<u32>(Schema::VT_MUTATION_TYPE, mutation_type, 0);
+    }
+    #[inline]
+    pub fn add_has_subscription_type(&mut self, has_subscription_type: bool) {
+        self.fbb_.push_slot::<bool>(
+            Schema::VT_HAS_SUBSCRIPTION_TYPE,
+            has_subscription_type,
+            false,
+        );
+    }
+    #[inline]
+    pub fn add_subscription_type(&mut self, subscription_type: u32) {
+        self.fbb_
+            .push_slot::<u32>(Schema::VT_SUBSCRIPTION_TYPE, subscription_type, 0);
+    }
+    #[inline]
+    pub fn add_types(
+        &mut self,
+        types: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<TypeMapEntry<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_TYPES, types);
+    }
+    #[inline]
+    pub fn add_directives(
+        &mut self,
+        directives: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<DirectiveMapEntry<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_DIRECTIVES, directives);
+    }
+    #[inline]
+    pub fn add_scalars(
+        &mut self,
+        scalars: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Scalar<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_SCALARS, scalars);
+    }
+    #[inline]
+    pub fn add_input_objects(
+        &mut self,
+        input_objects: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<InputObject<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_INPUT_OBJECTS, input_objects);
+    }
+    #[inline]
+    pub fn add_enums(
+        &mut self,
+        enums: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Enum<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_ENUMS, enums);
+    }
+    #[inline]
+    pub fn add_objects(
+        &mut self,
+        objects: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Object<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_OBJECTS, objects);
+    }
+    #[inline]
+    pub fn add_interfaces(
+        &mut self,
+        interfaces: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Interface<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_INTERFACES, interfaces);
+    }
+    #[inline]
+    pub fn add_unions(
+        &mut self,
+        unions: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Union<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_UNIONS, unions);
+    }
+    #[inline]
+    pub fn add_fields(
+        &mut self,
+        fields: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Field<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Schema::VT_FIELDS, fields);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> SchemaBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        SchemaBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Schema<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        self.fbb_.required(o, Schema::VT_TYPES, "types");
+        self.fbb_.required(o, Schema::VT_DIRECTIVES, "directives");
+        self.fbb_.required(o, Schema::VT_SCALARS, "scalars");
+        self.fbb_
+            .required(o, Schema::VT_INPUT_OBJECTS, "input_objects");
+        self.fbb_.required(o, Schema::VT_ENUMS, "enums");
+        self.fbb_.required(o, Schema::VT_OBJECTS, "objects");
+        self.fbb_.required(o, Schema::VT_INTERFACES, "interfaces");
+        self.fbb_.required(o, Schema::VT_UNIONS, "unions");
+        self.fbb_.required(o, Schema::VT_FIELDS, "fields");
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 impl core::fmt::Debug for Schema<'_> {
-  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Schema");
-      ds.field("query_type", &self.query_type());
-      ds.field("has_mutation_type", &self.has_mutation_type());
-      ds.field("mutation_type", &self.mutation_type());
-      ds.field("has_subscription_type", &self.has_subscription_type());
-      ds.field("subscription_type", &self.subscription_type());
-      ds.field("types", &self.types());
-      ds.field("directives", &self.directives());
-      ds.field("scalars", &self.scalars());
-      ds.field("input_objects", &self.input_objects());
-      ds.field("enums", &self.enums());
-      ds.field("objects", &self.objects());
-      ds.field("interfaces", &self.interfaces());
-      ds.field("unions", &self.unions());
-      ds.field("fields", &self.fields());
-      ds.finish()
-  }
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Schema");
+        ds.field("query_type", &self.query_type());
+        ds.field("has_mutation_type", &self.has_mutation_type());
+        ds.field("mutation_type", &self.mutation_type());
+        ds.field("has_subscription_type", &self.has_subscription_type());
+        ds.field("subscription_type", &self.subscription_type());
+        ds.field("types", &self.types());
+        ds.field("directives", &self.directives());
+        ds.field("scalars", &self.scalars());
+        ds.field("input_objects", &self.input_objects());
+        ds.field("enums", &self.enums());
+        ds.field("objects", &self.objects());
+        ds.field("interfaces", &self.interfaces());
+        ds.field("unions", &self.unions());
+        ds.field("fields", &self.fields());
+        ds.finish()
+    }
 }
 #[inline]
-#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+#[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
 pub fn get_root_as_schema<'a>(buf: &'a [u8]) -> Schema<'a> {
-  unsafe { flatbuffers::root_unchecked::<Schema<'a>>(buf) }
+    unsafe { flatbuffers::root_unchecked::<Schema<'a>>(buf) }
 }
 
 #[inline]
-#[deprecated(since="2.0.0", note="Deprecated in favor of `root_as...` methods.")]
+#[deprecated(since = "2.0.0", note = "Deprecated in favor of `root_as...` methods.")]
 pub fn get_size_prefixed_root_as_schema<'a>(buf: &'a [u8]) -> Schema<'a> {
-  unsafe { flatbuffers::size_prefixed_root_unchecked::<Schema<'a>>(buf) }
+    unsafe { flatbuffers::size_prefixed_root_unchecked::<Schema<'a>>(buf) }
 }
 
 #[inline]
@@ -3416,7 +4307,7 @@ pub fn get_size_prefixed_root_as_schema<'a>(buf: &'a [u8]) -> Schema<'a> {
 /// previous, unchecked, behavior use
 /// `root_as_schema_unchecked`.
 pub fn root_as_schema(buf: &[u8]) -> Result<Schema, flatbuffers::InvalidFlatbuffer> {
-  flatbuffers::root::<Schema>(buf)
+    flatbuffers::root::<Schema>(buf)
 }
 #[inline]
 /// Verifies that a buffer of bytes contains a size prefixed
@@ -3426,7 +4317,7 @@ pub fn root_as_schema(buf: &[u8]) -> Result<Schema, flatbuffers::InvalidFlatbuff
 /// previous, unchecked, behavior use
 /// `size_prefixed_root_as_schema_unchecked`.
 pub fn size_prefixed_root_as_schema(buf: &[u8]) -> Result<Schema, flatbuffers::InvalidFlatbuffer> {
-  flatbuffers::size_prefixed_root::<Schema>(buf)
+    flatbuffers::size_prefixed_root::<Schema>(buf)
 }
 #[inline]
 /// Verifies, with the given options, that a buffer of bytes
@@ -3436,10 +4327,10 @@ pub fn size_prefixed_root_as_schema(buf: &[u8]) -> Result<Schema, flatbuffers::I
 /// previous, unchecked, behavior use
 /// `root_as_schema_unchecked`.
 pub fn root_as_schema_with_opts<'b, 'o>(
-  opts: &'o flatbuffers::VerifierOptions,
-  buf: &'b [u8],
+    opts: &'o flatbuffers::VerifierOptions,
+    buf: &'b [u8],
 ) -> Result<Schema<'b>, flatbuffers::InvalidFlatbuffer> {
-  flatbuffers::root_with_opts::<Schema<'b>>(opts, buf)
+    flatbuffers::root_with_opts::<Schema<'b>>(opts, buf)
 }
 #[inline]
 /// Verifies, with the given verifier options, that a buffer of
@@ -3449,33 +4340,37 @@ pub fn root_as_schema_with_opts<'b, 'o>(
 /// previous, unchecked, behavior use
 /// `root_as_schema_unchecked`.
 pub fn size_prefixed_root_as_schema_with_opts<'b, 'o>(
-  opts: &'o flatbuffers::VerifierOptions,
-  buf: &'b [u8],
+    opts: &'o flatbuffers::VerifierOptions,
+    buf: &'b [u8],
 ) -> Result<Schema<'b>, flatbuffers::InvalidFlatbuffer> {
-  flatbuffers::size_prefixed_root_with_opts::<Schema<'b>>(opts, buf)
+    flatbuffers::size_prefixed_root_with_opts::<Schema<'b>>(opts, buf)
 }
 #[inline]
 /// Assumes, without verification, that a buffer of bytes contains a Schema and returns it.
 /// # Safety
 /// Callers must trust the given bytes do indeed contain a valid `Schema`.
 pub unsafe fn root_as_schema_unchecked(buf: &[u8]) -> Schema {
-  flatbuffers::root_unchecked::<Schema>(buf)
+    flatbuffers::root_unchecked::<Schema>(buf)
 }
 #[inline]
 /// Assumes, without verification, that a buffer of bytes contains a size prefixed Schema and returns it.
 /// # Safety
 /// Callers must trust the given bytes do indeed contain a valid size prefixed `Schema`.
 pub unsafe fn size_prefixed_root_as_schema_unchecked(buf: &[u8]) -> Schema {
-  flatbuffers::size_prefixed_root_unchecked::<Schema>(buf)
+    flatbuffers::size_prefixed_root_unchecked::<Schema>(buf)
 }
 #[inline]
 pub fn finish_schema_buffer<'a, 'b>(
     fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    root: flatbuffers::WIPOffset<Schema<'a>>) {
-  fbb.finish(root, None);
+    root: flatbuffers::WIPOffset<Schema<'a>>,
+) {
+    fbb.finish(root, None);
 }
 
 #[inline]
-pub fn finish_size_prefixed_schema_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<Schema<'a>>) {
-  fbb.finish_size_prefixed(root, None);
+pub fn finish_size_prefixed_schema_buffer<'a, 'b>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    root: flatbuffers::WIPOffset<Schema<'a>>,
+) {
+    fbb.finish_size_prefixed(root, None);
 }

--- a/compiler/crates/schema-print/tests/print_schema_consistency_test.rs
+++ b/compiler/crates/schema-print/tests/print_schema_consistency_test.rs
@@ -9,19 +9,35 @@
 
 mod print_schema_consistency;
 
-use print_schema_consistency::transform_fixture;
 use fixture_tests::test_fixture;
+use print_schema_consistency::transform_fixture;
 
 #[tokio::test]
 async fn kitchen_sink() {
     let input = include_str!("print_schema_consistency/fixtures/kitchen-sink.graphql");
     let expected = include_str!("print_schema_consistency/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, file!(), "kitchen-sink.graphql", "print_schema_consistency/fixtures/kitchen-sink.expected", input, expected).await;
+    test_fixture(
+        transform_fixture,
+        file!(),
+        "kitchen-sink.graphql",
+        "print_schema_consistency/fixtures/kitchen-sink.expected",
+        input,
+        expected,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn no_schema() {
     let input = include_str!("print_schema_consistency/fixtures/no-schema.graphql");
     let expected = include_str!("print_schema_consistency/fixtures/no-schema.expected");
-    test_fixture(transform_fixture, file!(), "no-schema.graphql", "print_schema_consistency/fixtures/no-schema.expected", input, expected).await;
+    test_fixture(
+        transform_fixture,
+        file!(),
+        "no-schema.graphql",
+        "print_schema_consistency/fixtures/no-schema.expected",
+        input,
+        expected,
+    )
+    .await;
 }

--- a/compiler/crates/schema-print/tests/print_schema_in_parallel_test.rs
+++ b/compiler/crates/schema-print/tests/print_schema_in_parallel_test.rs
@@ -9,19 +9,35 @@
 
 mod print_schema_in_parallel;
 
-use print_schema_in_parallel::transform_fixture;
 use fixture_tests::test_fixture;
+use print_schema_in_parallel::transform_fixture;
 
 #[tokio::test]
 async fn kitchen_sink() {
     let input = include_str!("print_schema_in_parallel/fixtures/kitchen-sink.graphql");
     let expected = include_str!("print_schema_in_parallel/fixtures/kitchen-sink.expected");
-    test_fixture(transform_fixture, file!(), "kitchen-sink.graphql", "print_schema_in_parallel/fixtures/kitchen-sink.expected", input, expected).await;
+    test_fixture(
+        transform_fixture,
+        file!(),
+        "kitchen-sink.graphql",
+        "print_schema_in_parallel/fixtures/kitchen-sink.expected",
+        input,
+        expected,
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn no_schema() {
     let input = include_str!("print_schema_in_parallel/fixtures/no-schema.graphql");
     let expected = include_str!("print_schema_in_parallel/fixtures/no-schema.expected");
-    test_fixture(transform_fixture, file!(), "no-schema.graphql", "print_schema_in_parallel/fixtures/no-schema.expected", input, expected).await;
+    test_fixture(
+        transform_fixture,
+        file!(),
+        "no-schema.graphql",
+        "print_schema_in_parallel/fixtures/no-schema.expected",
+        input,
+        expected,
+    )
+    .await;
 }


### PR DESCRIPTION
Right now, when the CLI is run in valdiate mode with persisted queries enabled, the compiler fails with connection refused errors (when the persisting server is not available).

Example error message:
```
➜  accounts (main) relay-compiler --validate                                                                                                                                                                                                                      ✭
[INFO] Querying files to compile...
[INFO] [default] compiling...
[ERROR] Error: Network error: error trying to connect: tcp connect error: Connection refused (os error 111)
[ERROR] Compilation failed.
[ERROR] Unable to run relay compiler. Error details: 
Failed to build:
 - Persisting operation(s) failed:
 - Network error: error trying to connect: tcp connect error: Connection refused (os error 111)
 ```
 
 But the expected behaviour is that the query persister must be disabled in validate mode.

This PR attempts to fix that.

Issue(s) closed: #5007 