### PR TITLE
Fix compiler playground build

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -24,7 +24,13 @@ jobs:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # ci.yml
-          toolchain: nightly-2025-03-29
+          # toolchain: nightly-2025-03-29
+
+          # Bug in rust causes wasm-pack to fail. Bug is fixed in
+          # https://github.com/rust-lang/rust/pull/139498 so we're temporarily
+          # ahead here while we wait for that fix to land in the common
+          # toolchain version used at Meta.
+          toolchain: nightly-2025-05-12
           override: true
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
## Test Plan

```
➜  relay-compiler-playground git:(9facd47af415) ✗ rustup default nightly-2025-05-12
info: syncing channel updates for 'nightly-2025-05-12-aarch64-apple-darwin'
info: latest update on 2025-05-12, rust version 1.89.0-nightly (ce7e97f73 2025-05-11)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-docs'
 20.1 MiB /  20.1 MiB (100 %)  12.4 MiB/s in  1s
info: downloading component 'rust-std'
info: downloading component 'rustc'
 60.4 MiB /  60.4 MiB (100 %)  32.8 MiB/s in  1s
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-docs'
 20.1 MiB /  20.1 MiB (100 %)   3.3 MiB/s in  3s
info: installing component 'rust-std'
 25.0 MiB /  25.0 MiB (100 %)  19.7 MiB/s in  1s
info: installing component 'rustc'
 60.4 MiB /  60.4 MiB (100 %)  20.9 MiB/s in  2s
info: installing component 'rustfmt'
info: default toolchain set to 'nightly-2025-05-12-aarch64-apple-darwin'

  nightly-2025-05-12-aarch64-apple-darwin installed - rustc 1.89.0-nightly (ce7e97f73 2025-05-11)

➜  relay-compiler-playground git:(9facd47af415) ✗ wasm-pack build --target web
[INFO]: 🎯  Checking for the Wasm target...
info: downloading component 'rust-std' for 'wasm32-unknown-unknown'
info: installing component 'rust-std' for 'wasm32-unknown-unknown'
 19.7 MiB /  19.7 MiB (100 %)  19.1 MiB/s in  1s
[INFO]: 🌀  Compiling to Wasm...
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/captbaritone/projects/relay/compiler/crates/relay-compiler-playground/Cargo.toml
workspace: /Users/captbaritone/projects/relay/compiler/Cargo.toml
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2024 which implies `resolver = "3"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2024 resolver, specify `workspace.resolver = "3"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
   Compiling proc-macro2 v1.0.93
   Compiling unicode-ident v1.0.14
   Compiling serde v1.0.217
   Compiling version_check v0.9.5
   Compiling stable_deref_trait v1.2.0
   Compiling crossbeam-utils v0.8.21
   Compiling writeable v0.5.5
   Compiling cfg-if v1.0.0
   Compiling litemap v0.7.4
   Compiling memchr v2.7.4
   Compiling rustversion v1.0.19
   Compiling rayon-core v1.12.1
   Compiling typenum v1.17.0
   Compiling icu_locid_transform_data v1.5.0
   Compiling once_cell v1.20.2
   Compiling generic-array v0.14.7
   Compiling either v1.13.0
   Compiling icu_properties_data v1.5.0
   Compiling autocfg v1.4.0
   Compiling ahash v0.8.11
   Compiling utf8_iter v1.0.4
   Compiling serde_json v1.0.140
   Compiling lock_api v0.4.12
   Compiling parking_lot_core v0.9.10
   Compiling icu_normalizer_data v1.5.0
   Compiling write16 v1.0.0
   Compiling utf16_iter v1.0.5
   Compiling ryu v1.0.18
   Compiling zerocopy v0.7.35
   Compiling typeid v1.0.2
   Compiling crossbeam-epoch v0.9.18
   Compiling quote v1.0.38
   Compiling itoa v1.0.14
   Compiling syn v2.0.96
   Compiling crossbeam-deque v0.8.6
   Compiling scopeguard v1.2.0
   Compiling allocator-api2 v0.2.21
   Compiling hashbrown v0.15.2
   Compiling percent-encoding v2.3.1
   Compiling schemars v0.8.21
   Compiling bitflags v1.3.2
   Compiling rayon v1.10.0
   Compiling arbitrary v1.4.1
   Compiling equivalent v1.0.1
   Compiling crypto-common v0.1.6
   Compiling block-buffer v0.10.4
   Compiling form_urlencoded v1.2.1
   Compiling dyn-clone v1.0.17
   Compiling spin v0.9.8
   Compiling value-bag v1.10.0
   Compiling digest v0.10.7
   Compiling lazy_static v1.5.0
   Compiling inventory v0.3.17
   Compiling fnv v1.0.7
   Compiling colored v2.2.0
   Compiling syn v1.0.109
   Compiling md-5 v0.10.6
   Compiling proc-macro2-diagnostics v0.10.1
   Compiling log v0.4.25
   Compiling thiserror v1.0.69
   Compiling beef v0.5.2
   Compiling yansi v1.0.1
   Compiling regex-syntax v0.6.29
   Compiling thiserror v2.0.12
   Compiling heck v0.4.1
   Compiling static_assertions v1.1.0
   Compiling heck v0.5.0
   Compiling aliasable v0.1.3
   Compiling aho-corasick v1.1.3
   Compiling strsim v0.10.0
   Compiling regex-syntax v0.8.5
   Compiling wasm-bindgen-shared v0.2.100
   Compiling bstr v1.11.3
   Compiling bumpalo v3.16.0
   Compiling pathdiff v0.2.3
   Compiling synstructure v0.13.1
   Compiling serde_derive_internals v0.29.1
   Compiling hex v0.4.3
   Compiling wasm-bindgen-backend v0.2.100
   Compiling itertools v0.14.0
   Compiling rustc-hash v2.1.1
   Compiling wasm-bindgen v0.2.100
   Compiling regex-automata v0.4.9
   Compiling serde_derive v1.0.217
   Compiling zerofrom-derive v0.1.5
   Compiling yoke-derive v0.7.5
   Compiling zerovec-derive v0.10.3
   Compiling displaydoc v0.2.5
   Compiling icu_provider_macros v1.5.0
   Compiling schemars_derive v0.8.21
   Compiling serde_repr v0.1.19
   Compiling typetag-impl v0.2.19
   Compiling thiserror-impl v1.0.69
   Compiling logos-derive v0.12.1
   Compiling thiserror-impl v2.0.12
   Compiling zerofrom v0.1.5
   Compiling ouroboros_macro v0.18.5
   Compiling strum_macros v0.27.1
   Compiling regex v1.11.1
   Compiling yoke v0.7.5
   Compiling zerovec v0.10.4
   Compiling wasm-bindgen-macro-support v0.2.100
   Compiling logos v0.12.1
   Compiling ouroboros v0.18.5
   Compiling tinystr v0.7.6
   Compiling icu_collections v1.5.0
   Compiling strum v0.27.1
   Compiling wasm-bindgen-macro v0.2.100
   Compiling icu_locid v1.5.0
   Compiling icu_provider v1.5.0
   Compiling smallvec v1.15.0
   Compiling icu_locid_transform v1.5.0
   Compiling hashbrown v0.14.5
   Compiling indexmap v2.9.0
   Compiling serde_bytes v0.11.15
   Compiling erased-serde v0.4.5
   Compiling flatbuffers v2.1.2
   Compiling globset v0.4.15
   Compiling parking_lot v0.12.3
   Compiling typetag v0.2.19
   Compiling console_error_panic_hook v0.1.7
   Compiling icu_properties v1.5.1
   Compiling dashmap v5.5.3
   Compiling schema-flatbuffer v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/schema-flatbuffer)
   Compiling icu_normalizer v1.5.0
   Compiling intern v0.1.0 (/Users/captbaritone/projects/relay/compiler/crates/intern)
   Compiling idna_adapter v1.2.0
   Compiling idna v1.0.3
   Compiling url v2.5.4
   Compiling lsp-types v0.94.1
   Compiling common v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/common)
   Compiling graphql-syntax v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/graphql-syntax)
   Compiling errors v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/errors)
   Compiling relay-config v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/relay-config)
   Compiling docblock-shared v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/docblock-shared)
   Compiling schema v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/schema)
   Compiling graphql-ir v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/graphql-ir)
   Compiling relay-schema v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/relay-schema)
   Compiling graphql-text-printer v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/graphql-text-printer)
   Compiling graphql-ir-validations v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/graphql-ir-validations)
   Compiling relay-transforms v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/relay-transforms)
   Compiling relay-typegen v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/relay-typegen)
   Compiling relay-codegen v0.0.0 (/Users/captbaritone/projects/relay/compiler/crates/relay-codegen)
   Compiling relay-compiler-playground v0.0.3 (/Users/captbaritone/projects/relay/compiler/crates/relay-compiler-playground)
    Finished `release` profile [optimized] target(s) in 34.59s
[INFO]: ⬇️  Installing wasm-bindgen...
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[INFO]: Optional fields missing from Cargo.toml: 'description', 'repository'. These are not necessary, but recommended
[INFO]: License key is set in Cargo.toml but no LICENSE file(s) were found; Please add the LICENSE file(s) to your project directory
[INFO]: ✨   Done in 1m 03s
[INFO]: 📦   Your wasm pkg is ready to publish at /Users/captbaritone/projects/relay/compiler/crates/relay-compiler-playground/pkg.
```