### PR TITLE
Add missing optional chaning to handle undefined fragmentNode

### DIFF
--- a/packages/react-relay/relay-hooks/useFragmentInternal_CURRENT.js
+++ b/packages/react-relay/relay-hooks/useFragmentInternal_CURRENT.js
@@ -462,7 +462,7 @@ hook useFragmentInternal(
   // Handle the queries for any missing client edges; this may suspend.
   // FIXME handle client edges in parallel.
   if (
-    fragmentNode.metadata?.hasClientEdges === true ||
+    fragmentNode?.metadata?.hasClientEdges === true ||
     RelayFeatureFlags.CHECK_ALL_FRAGMENTS_FOR_MISSING_CLIENT_EDGES
   ) {
     // The fragment is validated to be static (in useFragment) and hasClientEdges is
@@ -654,7 +654,7 @@ hook useFragmentInternal(
           "Make sure that that `%s`'s parent isn't " +
           'holding on to and/or passing a fragment reference for data that ' +
           'has been deleted.',
-        fragmentNode.name,
+        fragmentNode?.name,
         hookDisplayName,
         hookDisplayName,
       );
@@ -665,7 +665,7 @@ hook useFragmentInternal(
     // eslint-disable-next-line react-hooks/rules-of-hooks
     // $FlowFixMe[react-rule-hook]
     // $FlowFixMe[react-rule-hook-conditional]
-    useDebugValue({fragment: fragmentNode.name, data});
+    useDebugValue({fragment: fragmentNode?.name, data});
   }
 
   return data;

--- a/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
+++ b/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
@@ -486,7 +486,7 @@ hook useFragmentInternal_EXPERIMENTAL(
   // Handle the queries for any missing client edges; this may suspend.
   // FIXME handle client edges in parallel.
   if (
-    fragmentNode.metadata?.hasClientEdges === true ||
+    fragmentNode?.metadata?.hasClientEdges === true ||
     RelayFeatureFlags.CHECK_ALL_FRAGMENTS_FOR_MISSING_CLIENT_EDGES
   ) {
     // The fragment is validated to be static (in useFragment) and hasClientEdges is
@@ -735,7 +735,7 @@ hook useFragmentInternal_EXPERIMENTAL(
           "Make sure that that `%s`'s parent isn't " +
           'holding on to and/or passing a fragment reference for data that ' +
           'has been deleted.',
-        fragmentNode.name,
+        fragmentNode?.name,
         hookDisplayName,
         hookDisplayName,
       );
@@ -746,7 +746,7 @@ hook useFragmentInternal_EXPERIMENTAL(
     // eslint-disable-next-line react-hooks/rules-of-hooks
     // $FlowFixMe[react-rule-hook]
     // $FlowFixMe[react-rule-hook-conditional]
-    useDebugValue({fragment: fragmentNode.name, data});
+    useDebugValue({fragment: fragmentNode?.name, data});
   }
 
   return data;

--- a/packages/relay-runtime/util/getPendingOperationsForFragment.js
+++ b/packages/relay-runtime/util/getPendingOperationsForFragment.js
@@ -47,7 +47,7 @@ function getPendingOperationsForFragment(
   if (pendingOperationName == null || pendingOperationName.length === 0) {
     pendingOperationName = 'Unknown pending operation';
   }
-  const fragmentName = fragmentNode.name;
+  const fragmentName = fragmentNode?.name;
   const promiseDisplayName =
     pendingOperationName === fragmentName
       ? `Relay(${pendingOperationName})`


### PR DESCRIPTION
There's a case where the relay request lives for a long time time causing a timeout exception and getting an undefined fragmentNode for useFragmentInternal hook that throws an error like 'Cannot access property of undefined (reading "metadata")'.

