### PR TITLE
doc(useSubscription): config argument should be memoized

### DIFF
--- a/website/docs/api-reference/hooks/use-subscription.md
+++ b/website/docs/api-reference/hooks/use-subscription.md
@@ -41,7 +41,7 @@ function UserComponent({ id }) {
 
 ### Arguments
 
-* `config`: a config of type [`GraphQLSubscriptionConfig`](#type-graphqlsubscriptionconfigtsubscriptionpayload) passed to [`requestSubscription`](../request-subscription/)
+* `config`: a memoized config of type [`GraphQLSubscriptionConfig`](#type-graphqlsubscriptionconfigtsubscriptionpayload) passed to [`requestSubscription`](../request-subscription/)
 * `requestSubscriptionFn`: `?<TSubscriptionPayload>(IEnvironment, GraphQLSubscriptionConfig<TSubscriptionPayload>) => Disposable`. An optional function with the same signature as [`requestSubscription`](../request-subscription/), which will be called in its stead. Defaults to `requestSubscription`.
 
 <GraphQLSubscriptionConfig />


### PR DESCRIPTION
Do not rely solely on the example. The documentation should explicitly state that the config argument must be memorized.