### PR TITLE
schemars 0.8.21 -> 1.0.4

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -1729,6 +1729,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,12 +2251,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "indexmap",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -2244,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/compiler/crates/common/Cargo.toml
+++ b/compiler/crates/common/Cargo.toml
@@ -16,7 +16,7 @@ log = { version = "0.4.22", features = ["kv_unstable", "kv_unstable_std"] }
 lsp-types = "0.94.1"
 md-5 = "0.10"
 rayon = "1.9.0"
-schemars = { version = "0.8.21", features = ["indexmap2"] }
+schemars = { version = "1.0.4", features = ["indexmap2"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }
 typetag = "0.2.15"

--- a/compiler/crates/common/src/named_item.rs
+++ b/compiler/crates/common/src/named_item.rs
@@ -96,7 +96,8 @@ impl fmt::Display for ArgumentName {
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize
+    Deserialize,
+    JsonSchema
 )]
 pub struct ScalarName(pub StringKey);
 

--- a/compiler/crates/intern/Cargo.toml
+++ b/compiler/crates/intern/Cargo.toml
@@ -15,7 +15,7 @@ hashbrown = { version = "0.14.5", features = ["raw", "serde"] }
 indexmap = { version = "2.9.0", features = ["arbitrary", "rayon", "serde"] }
 once_cell = "1.12"
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
-schemars = { version = "0.8.21", features = ["indexmap2"] }
+schemars = { version = "1.0.4", features = ["indexmap2"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde_derive = "1.0.185"

--- a/compiler/crates/intern/src/string_key.rs
+++ b/compiler/crates/intern/src/string_key.rs
@@ -13,11 +13,9 @@ use std::str::FromStr;
 
 use indexmap::IndexMap;
 use schemars::JsonSchema;
-use schemars::r#gen::SchemaGenerator;
-use schemars::schema::InstanceType;
-use schemars::schema::Schema;
-use schemars::schema::SchemaObject;
-use schemars::schema::SingleOrVec;
+use schemars::Schema;
+use schemars::SchemaGenerator;
+use schemars::json_schema;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -36,17 +34,16 @@ use crate::string::StringId;
 pub struct StringKey(StringId);
 
 impl JsonSchema for StringKey {
-    fn schema_name() -> std::string::String {
-        String::from("StringKey")
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        String::from("StringKey").into()
     }
 
     fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
-        SchemaObject {
-            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
-            format: None,
-            ..Default::default()
-        }
-        .into()
+        json_schema!({
+                "type": "string",
+                "format": null,
+                }
+        )
     }
 }
 

--- a/compiler/crates/relay-compiler/Cargo.toml
+++ b/compiler/crates/relay-compiler/Cargo.toml
@@ -67,7 +67,7 @@ rustc-hash = "2.1.1"
 schema = { path = "../schema" }
 schema-diff = { path = "../schema-diff" }
 schema-validate-lib = { path = "../schema-validate" }
-schemars = { version = "0.8.21", features = ["indexmap2"] }
+schemars = { version = "1.0.4", features = ["indexmap2"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_bser = "0.4"
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }

--- a/compiler/crates/relay-compiler/relay-compiler-config-schema.json
+++ b/compiler/crates/relay-compiler/relay-compiler-config-schema.json
@@ -1,60 +1,49 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ConfigFile",
-  "description": "Relay's configuration file. Supports a single project config for simple use cases and a multi-project config for cases where multiple projects live in the same repository.\n\nIn general, start with the SingleProjectConfigFile.",
+  "description": "Relay's configuration file. Supports a single project config for simple use\ncases and a multi-project config for cases where multiple projects live in\nthe same repository.\n\nIn general, start with the SingleProjectConfigFile.",
   "anyOf": [
     {
-      "description": "Base case configuration (mostly of OSS) where the project have single schema, and single source directory",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SingleProjectConfigFile"
-        }
-      ]
+      "description": "Base case configuration (mostly of OSS) where the project\nhave single schema, and single source directory",
+      "$ref": "#/$defs/SingleProjectConfigFile"
     },
     {
-      "description": "Relay can support multiple projects with multiple schemas and different options (output, typegen, etc...). This MultiProjectConfigFile is responsible for configuring these type of projects (complex)",
-      "allOf": [
-        {
-          "$ref": "#/definitions/MultiProjectConfigFile"
-        }
-      ]
+      "description": "Relay can support multiple projects with multiple schemas\nand different options (output, typegen, etc...).\nThis MultiProjectConfigFile is responsible for configuring\nthese type of projects (complex)",
+      "$ref": "#/$defs/MultiProjectConfigFile"
     }
   ],
-  "definitions": {
+  "$defs": {
     "ArgumentName": {
-      "$ref": "#/definitions/StringKey"
+      "$ref": "#/$defs/StringKey"
     },
     "ConfigFileProject": {
       "type": "object",
-      "required": [
-        "language"
-      ],
       "properties": {
         "base": {
-          "description": "If a base project is set, the documents of that project can be referenced, but won't produce output artifacts. Extensions from the base project will be added as well and the schema of the base project should be a subset of the schema of this project.",
-          "default": null,
+          "description": "If a base project is set, the documents of that project can be\nreferenced, but won't produce output artifacts.\nExtensions from the base project will be added as well and the schema\nof the base project should be a subset of the schema of this project.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ProjectName"
+              "$ref": "#/$defs/ProjectName"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "codegenCommand": {
-          "description": "Name of the command that runs the relay compiler. This will be added at the top of generated code to let readers know how to regenerate the file.",
-          "default": null,
+          "description": "Name of the command that runs the relay compiler. This will be added at\nthe top of generated code to let readers know how to regenerate the file.",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "customErrorType": {
-          "description": "A map from GraphQL error name to import path, example: {\"name:: \"MyErrorName\", \"path\": \"../src/MyError\"}",
+          "description": "A map from GraphQL error name to import path, example:\n{\"name:: \"MyErrorName\", \"path\": \"../src/MyError\"}",
           "anyOf": [
             {
-              "$ref": "#/definitions/CustomTypeImport"
+              "$ref": "#/$defs/CustomTypeImport"
             },
             {
               "type": "null"
@@ -62,32 +51,28 @@
           ]
         },
         "customScalarTypes": {
-          "description": "A map from GraphQL scalar types to a custom JS type, example: { \"Url\": \"String\" } { \"Url\": {\"name:: \"MyURL\", \"path\": \"../src/MyUrlTypes\"} }",
-          "default": {},
+          "description": "A map from GraphQL scalar types to a custom JS type, example:\n{ \"Url\": \"String\" }\n{ \"Url\": {\"name:: \"MyURL\", \"path\": \"../src/MyUrlTypes\"} }",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/CustomType"
-          }
+            "$ref": "#/$defs/CustomType"
+          },
+          "default": {}
         },
         "diagnosticReportConfig": {
-          "description": "Threshold for diagnostics to be critical to the compiler's execution. All diagnostic with severities at and below this level will cause the compiler to fatally exit.",
+          "description": "Threshold for diagnostics to be critical to the compiler's execution.\nAll diagnostic with severities at and below this level will cause the\ncompiler to fatally exit.",
+          "$ref": "#/$defs/DiagnosticReportConfig",
           "default": {
             "criticalLevel": "error"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/DiagnosticReportConfig"
-            }
-          ]
+          }
         },
         "eagerEsModules": {
-          "description": "This option enables opting out of emitting es modules artifacts. When set to false, Relay will emit CommonJS modules.",
-          "default": true,
-          "type": "boolean"
+          "description": "This option enables opting out of emitting es modules artifacts. When\nset to false, Relay will emit CommonJS modules.",
+          "type": "boolean",
+          "default": true
         },
         "enumModuleSuffix": {
           "title": "For Flow type generation",
-          "description": "When set, enum values are imported from a module with this suffix. For example, an enum Foo and this property set to \".test\" would be imported from \"Foo.test\". Note: an empty string is allowed and different from not setting the value, in the example above it would just import from \"Foo\".",
+          "description": "When set, enum values are imported from a module with this suffix.\nFor example, an enum Foo and this property set to \".test\" would be\nimported from \"Foo.test\".\nNote: an empty string is allowed and different from not setting the\nvalue, in the example above it would just import from \"Foo\".",
           "type": [
             "string",
             "null"
@@ -108,81 +93,69 @@
           "default": null
         },
         "extraArtifactsOutput": {
-          "description": "Some projects may need to generate extra artifacts. For those, we may need to provide an additional directory to put them. By default the will use `output` *if available",
+          "description": "Some projects may need to generate extra artifacts. For those, we may\nneed to provide an additional directory to put them.\nBy default the will use `output` *if available",
           "type": [
             "string",
             "null"
           ]
         },
         "featureFlags": {
-          "description": "Enable and disable experimental or legacy behaviors. WARNING! These are not stable and may change at any time.",
-          "default": null,
+          "description": "Enable and disable experimental or legacy behaviors.\nWARNING! These are not stable and may change at any time.",
           "anyOf": [
             {
-              "$ref": "#/definitions/FeatureFlags"
+              "$ref": "#/$defs/FeatureFlags"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "jsModuleFormat": {
           "description": "Import/export style to use in generated JavaScript modules.",
-          "default": "commonjs",
-          "allOf": [
-            {
-              "$ref": "#/definitions/JsModuleFormat"
-            }
-          ]
+          "$ref": "#/$defs/JsModuleFormat",
+          "default": "commonjs"
         },
         "language": {
           "description": "The desired output language, \"flow\" or \"typescript\".",
-          "allOf": [
-            {
-              "$ref": "#/definitions/TypegenLanguage"
-            }
-          ]
+          "$ref": "#/$defs/TypegenLanguage"
         },
         "moduleImportConfig": {
           "description": "Configuration for the @module GraphQL directive.",
+          "$ref": "#/$defs/ModuleImportConfig",
           "default": {
             "dynamicModuleProvider": null,
             "operationModuleProvider": null,
             "surface": null
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/ModuleImportConfig"
-            }
-          ]
+          }
         },
         "noFutureProofEnums": {
-          "description": "This option controls whether or not a catch-all entry is added to enum type definitions for values that may be added in the future. Enabling this means you will have to update your application whenever the GraphQL server schema adds new enum values to prevent it from breaking.",
-          "default": false,
-          "type": "boolean"
+          "description": "This option controls whether or not a catch-all entry is added to enum type definitions\nfor values that may be added in the future. Enabling this means you will have to update\nyour application whenever the GraphQL server schema adds new enum values to prevent it\nfrom breaking.",
+          "type": "boolean",
+          "default": false
         },
         "optionalInputFields": {
           "title": "For Flow type generation",
-          "description": "When set, generated input types will have the listed fields optional even if the schema defines them as required.",
-          "default": [],
+          "description": "When set, generated input types will have the listed fields optional\neven if the schema defines them as required.",
           "type": "array",
+          "default": [],
           "items": {
-            "$ref": "#/definitions/StringKey"
+            "$ref": "#/$defs/StringKey"
           }
         },
         "output": {
-          "description": "A project without an output directory will put the generated files in a __generated__ directory next to the input file. All files in these directories should be generated by the Relay compiler, so that the compiler can cleanup extra files.",
-          "default": null,
+          "description": "A project without an output directory will put the generated files in\na __generated__ directory next to the input file.\nAll files in these directories should be generated by the Relay\ncompiler, so that the compiler can cleanup extra files.",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "persist": {
-          "description": "If this option is set, the compiler will persist queries using this config.",
+          "description": "If this option is set, the compiler will persist queries using this\nconfig.",
           "anyOf": [
             {
-              "$ref": "#/definitions/PersistConfig"
+              "$ref": "#/$defs/PersistConfig"
             },
             {
               "type": "null"
@@ -190,49 +163,45 @@
           ]
         },
         "relativizeJsModulePaths": {
-          "description": "Whether to treat all JS module names as relative to './' (true) or not. default: true",
-          "default": true,
-          "type": "boolean"
+          "description": "Whether to treat all JS module names as relative to './' (true) or not.\ndefault: true",
+          "type": "boolean",
+          "default": true
         },
         "requireCustomScalarTypes": {
-          "description": "Require all GraphQL scalar types mapping to be defined, will throw if a GraphQL scalar type doesn't have a JS type",
-          "default": false,
-          "type": "boolean"
+          "description": "Require all GraphQL scalar types mapping to be defined, will throw\nif a GraphQL scalar type doesn't have a JS type",
+          "type": "boolean",
+          "default": false
         },
         "resolverContextType": {
           "description": "Indicates the type to import and use as the context for Relay Resolvers.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/ResolverContextTypeInput"
+              "$ref": "#/$defs/ResolverContextTypeInput"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "resolversSchemaModule": {
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/ResolversSchemaModuleConfig"
+              "$ref": "#/$defs/ResolversSchemaModuleConfig"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "rollout": {
-          "description": "A generic rollout state for larger codegen changes. The default is to pass, otherwise it should be a number between 0 and 100 as a percentage.",
-          "default": null,
-          "allOf": [
-            {
-              "$ref": "#/definitions/Rollout"
-            }
-          ]
+          "description": "A generic rollout state for larger codegen changes. The default is to\npass, otherwise it should be a number between 0 and 100 as a percentage.",
+          "$ref": "#/$defs/Rollout",
+          "default": null
         },
         "schema": {
-          "description": "Path to the schema.graphql or a directory containing a schema broken up in multiple *.graphql files. Exactly 1 of these options needs to be defined.",
+          "description": "Path to the schema.graphql or a directory containing a schema broken up\nin multiple *.graphql files.\nExactly 1 of these options needs to be defined.",
           "type": [
             "string",
             "null"
@@ -240,6 +209,7 @@
         },
         "schemaConfig": {
           "description": "Extra configuration for the GraphQL schema itself.",
+          "$ref": "#/$defs/SchemaConfig",
           "default": {
             "connectionInterface": {
               "cursor": "cursor",
@@ -264,12 +234,7 @@
             "nodeInterfaceIdVariableName": "id",
             "nonNodeIdFields": null,
             "unselectableDirectiveName": "unselectable"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/SchemaConfig"
-            }
-          ]
+          }
         },
         "schemaDir": {
           "type": [
@@ -279,67 +244,97 @@
         },
         "schemaExtensions": {
           "description": "Directory containing *.graphql files with schema extensions.",
-          "default": [],
           "type": "array",
+          "default": [],
           "items": {
             "type": "string"
           }
         },
         "schemaName": {
-          "description": "Schema name, if differs from project name. If schema name is unset, the project name will be used as schema name.",
-          "default": null,
+          "description": "Schema name, if differs from project name.\nIf schema name is unset, the project name will be used as schema name.",
           "anyOf": [
             {
-              "$ref": "#/definitions/StringKey"
+              "$ref": "#/$defs/StringKey"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "shardOutput": {
-          "description": "If `output` is provided and `shard_output` is `true`, shard the files by putting them under `{output_dir}/{source_relative_path}`",
-          "default": false,
-          "type": "boolean"
+          "description": "If `output` is provided and `shard_output` is `true`, shard the files\nby putting them under `{output_dir}/{source_relative_path}`",
+          "type": "boolean",
+          "default": false
         },
         "shardStripRegex": {
           "description": "Regex to match and strip parts of the `source_relative_path`",
-          "default": null,
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "testPathRegex": {
-          "description": "Optional regex to restrict @relay_test_operation to directories matching this regex. Defaults to no limitations.",
-          "default": null,
+          "description": "Optional regex to restrict @relay_test_operation to directories matching\nthis regex. Defaults to no limitations.",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "typescriptExcludeUndefinedFromNullableUnion": {
-          "description": "Keep the previous compiler behavior by outputting an union of the raw type and null, and not the **correct** behavior of an union with the raw type, null and undefined.",
-          "default": false,
-          "type": "boolean"
+          "description": "Keep the previous compiler behavior by outputting an union\nof the raw type and null, and not the **correct** behavior\nof an union with the raw type, null and undefined.",
+          "type": "boolean",
+          "default": false
         },
         "useImportTypeSyntax": {
           "title": "For Typescript type generation",
-          "description": "Whether to use the `import type` syntax introduced in Typescript version 3.8. This will prevent warnings from `importsNotUsedAsValues`.",
-          "default": false,
-          "type": "boolean"
+          "description": "Whether to use the `import type` syntax introduced in Typescript\nversion 3.8. This will prevent warnings from `importsNotUsedAsValues`.",
+          "type": "boolean",
+          "default": false
         },
         "variableNamesComment": {
           "description": "Generates a `// @relayVariables name1 name2` header in generated operation files",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "language"
+      ]
     },
     "ConnectionInterface": {
       "description": "Configuration where Relay should expect some fields in the schema.",
       "type": "object",
+      "properties": {
+        "cursor": {
+          "$ref": "#/$defs/StringKey"
+        },
+        "edges": {
+          "$ref": "#/$defs/StringKey"
+        },
+        "endCursor": {
+          "$ref": "#/$defs/StringKey"
+        },
+        "hasNextPage": {
+          "$ref": "#/$defs/StringKey"
+        },
+        "hasPreviousPage": {
+          "$ref": "#/$defs/StringKey"
+        },
+        "node": {
+          "$ref": "#/$defs/StringKey"
+        },
+        "pageInfo": {
+          "$ref": "#/$defs/StringKey"
+        },
+        "startCursor": {
+          "$ref": "#/$defs/StringKey"
+        }
+      },
+      "additionalProperties": false,
       "required": [
         "cursor",
         "edges",
@@ -349,120 +344,81 @@
         "node",
         "pageInfo",
         "startCursor"
-      ],
-      "properties": {
-        "cursor": {
-          "$ref": "#/definitions/StringKey"
-        },
-        "edges": {
-          "$ref": "#/definitions/StringKey"
-        },
-        "endCursor": {
-          "$ref": "#/definitions/StringKey"
-        },
-        "hasNextPage": {
-          "$ref": "#/definitions/StringKey"
-        },
-        "hasPreviousPage": {
-          "$ref": "#/definitions/StringKey"
-        },
-        "node": {
-          "$ref": "#/definitions/StringKey"
-        },
-        "pageInfo": {
-          "$ref": "#/definitions/StringKey"
-        },
-        "startCursor": {
-          "$ref": "#/definitions/StringKey"
-        }
-      },
-      "additionalProperties": false
+      ]
     },
     "CustomType": {
-      "description": "Defines a custom GraphQL descrbing a custom scalar.",
+      "description": "Defines a custom GraphQL\ndescrbing a custom scalar.",
       "anyOf": [
         {
           "description": "A string representing the name of a custom type. e.g. \"string\" or \"number\"",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringKey"
-            }
-          ]
+          "$ref": "#/$defs/StringKey"
         },
         {
           "description": "A module which defines the custom type. e.g. { \"name\": \"MyCustomType\", \"path\": \"./Types.ts\" }",
-          "allOf": [
-            {
-              "$ref": "#/definitions/CustomTypeImport"
-            }
-          ]
+          "$ref": "#/$defs/CustomTypeImport"
         }
       ]
     },
     "CustomTypeImport": {
-      "description": "Defines a module path and export name of the Flow or TypeScript type descrbing a GraphQL custom scalar.",
+      "description": "Defines a module path and export name of the Flow or TypeScript type\ndescrbing a GraphQL custom scalar.",
       "type": "object",
-      "required": [
-        "name",
-        "path"
-      ],
       "properties": {
         "name": {
           "description": "The name under which the type is exported from the module",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringKey"
-            }
-          ]
+          "$ref": "#/$defs/StringKey"
         },
         "path": {
           "description": "The path to the module relative to the project root",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "name",
+        "path"
+      ]
     },
     "DeferStreamInterface": {
       "description": "Configuration where Relay should expect some fields in the schema.",
       "type": "object",
-      "required": [
-        "deferName",
-        "ifArg",
-        "initialCountArg",
-        "labelArg",
-        "streamName",
-        "useCustomizedBatchArg"
-      ],
       "properties": {
         "deferName": {
-          "$ref": "#/definitions/DirectiveName"
+          "$ref": "#/$defs/DirectiveName"
         },
         "ifArg": {
-          "$ref": "#/definitions/ArgumentName"
+          "$ref": "#/$defs/ArgumentName"
         },
         "initialCountArg": {
-          "$ref": "#/definitions/ArgumentName"
+          "$ref": "#/$defs/ArgumentName"
         },
         "labelArg": {
-          "$ref": "#/definitions/ArgumentName"
+          "$ref": "#/$defs/ArgumentName"
         },
         "streamName": {
-          "$ref": "#/definitions/DirectiveName"
+          "$ref": "#/$defs/DirectiveName"
         },
         "useCustomizedBatchArg": {
-          "$ref": "#/definitions/ArgumentName"
+          "$ref": "#/$defs/ArgumentName"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "deferName",
+        "streamName",
+        "ifArg",
+        "labelArg",
+        "initialCountArg",
+        "useCustomizedBatchArg"
+      ]
     },
     "DeserializableProjectSet": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ProjectName"
+          "$ref": "#/$defs/ProjectName"
         },
         {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ProjectName"
+            "$ref": "#/$defs/ProjectName"
           }
         }
       ]
@@ -473,150 +429,124 @@
         {
           "description": "Report only errors",
           "type": "string",
-          "enum": [
-            "error"
-          ]
+          "const": "error"
         },
         {
           "description": "Report diagnostics up to warnings",
           "type": "string",
-          "enum": [
-            "warning"
-          ]
+          "const": "warning"
         },
         {
           "description": "Report diagnostics up to informational diagnostics",
           "type": "string",
-          "enum": [
-            "info"
-          ]
+          "const": "info"
         },
         {
           "description": "Report diagnostics up to hints",
           "type": "string",
-          "enum": [
-            "hint"
-          ]
+          "const": "hint"
         }
       ]
     },
     "DiagnosticReportConfig": {
       "description": "Configuration for all diagnostic reporting in the compiler",
       "type": "object",
-      "required": [
-        "criticalLevel"
-      ],
       "properties": {
         "criticalLevel": {
-          "description": "Threshold for diagnostics to be critical to the compiler's execution. All diagnostic with severities at and below this level will cause the compiler to fatally exit.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/DiagnosticLevel"
-            }
-          ]
+          "description": "Threshold for diagnostics to be critical to the compiler's execution.\nAll diagnostic with severities at and below this level will cause the\ncompiler to fatally exit.",
+          "$ref": "#/$defs/DiagnosticLevel"
         }
-      }
+      },
+      "required": [
+        "criticalLevel"
+      ]
     },
     "DirectiveName": {
       "description": "Wrapper struct for clarity rather than having StringKey everywhere.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/StringKey"
-        }
-      ]
+      "$ref": "#/$defs/StringKey"
     },
     "FeatureFlag": {
       "oneOf": [
         {
           "description": "Fully disabled: developers may not use this feature",
           "type": "object",
-          "required": [
-            "kind"
-          ],
           "properties": {
             "kind": {
               "type": "string",
-              "enum": [
-                "disabled"
-              ]
+              "const": "disabled"
             }
-          }
+          },
+          "required": [
+            "kind"
+          ]
         },
         {
           "description": "Fully enabled: developers may use this feature",
           "type": "object",
-          "required": [
-            "kind"
-          ],
           "properties": {
             "kind": {
               "type": "string",
-              "enum": [
-                "enabled"
-              ]
+              "const": "enabled"
             }
-          }
+          },
+          "required": [
+            "kind"
+          ]
         },
         {
           "description": "Partially enabled: developers may only use this feature on the listed items (fragments, fields, types).",
           "type": "object",
-          "required": [
-            "allowlist",
-            "kind"
-          ],
           "properties": {
             "allowlist": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/StringKey"
+                "$ref": "#/$defs/StringKey"
               },
               "uniqueItems": true
             },
             "kind": {
               "type": "string",
-              "enum": [
-                "limited"
-              ]
+              "const": "limited"
             }
-          }
+          },
+          "required": [
+            "kind",
+            "allowlist"
+          ]
         },
         {
           "description": "Partially enabled: used for gradual rollout of the feature",
           "type": "object",
-          "required": [
-            "kind",
-            "rollout"
-          ],
           "properties": {
             "kind": {
               "type": "string",
-              "enum": [
-                "rollout"
-              ]
+              "const": "rollout"
             },
             "rollout": {
-              "$ref": "#/definitions/Rollout"
+              "$ref": "#/$defs/Rollout"
             }
-          }
+          },
+          "required": [
+            "kind",
+            "rollout"
+          ]
         },
         {
           "description": "Partially enabled: used for gradual rollout of the feature",
           "type": "object",
-          "required": [
-            "kind",
-            "rollout"
-          ],
           "properties": {
             "kind": {
               "type": "string",
-              "enum": [
-                "rolloutrange"
-              ]
+              "const": "rolloutrange"
             },
             "rollout": {
-              "$ref": "#/definitions/RolloutRange"
+              "$ref": "#/$defs/RolloutRange"
             }
-          }
+          },
+          "required": [
+            "kind",
+            "rollout"
+          ]
         }
       ]
     },
@@ -624,233 +554,165 @@
       "type": "object",
       "properties": {
         "actor_change_support": {
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "allow_output_type_resolvers": {
-          "description": "@outputType resolvers are a discontinued experimental feature. This flag allows users to allowlist old uses of this feature while they work to remove them. Weak types (types without an `id` field) returned by a Relay Resolver should be limited to types defined using `@RelayResolver` with `@weak`.\n\nIf using the \"limited\" feature flag variant, users can allowlist a specific list of field names.\n\nhttps://relay.dev/docs/next/guides/relay-resolvers/defining-types/#defining-a-weak-type",
+          "description": "@outputType resolvers are a discontinued experimental feature. This flag\nallows users to allowlist old uses of this feature while they work to\nremove them. Weak types (types without an `id` field) returned by a Relay\nResolver should be limited to types defined using `@RelayResolver` with `@weak`.\n\nIf using the \"limited\" feature flag variant, users can allowlist a\nspecific list of field names.\n\nhttps://relay.dev/docs/next/guides/relay-resolvers/defining-types/#defining-a-weak-type",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "allow_required_in_mutation_response": {
-          "description": "@required with an action of THROW is read-time feature that is not compatible with our mutation APIs. We are in the process of removing any existing examples, but this flag is part of a process of removing any existing examples.",
+          "description": "@required with an action of THROW is read-time feature that is not\ncompatible with our mutation APIs. We are in the process of removing\nany existing examples, but this flag is part of a process of removing\nany existing examples.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "allow_resolver_non_nullable_return_type": {
           "description": "Allow non-nullable return types from resolvers.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "allow_resolvers_in_mutation_response": {
-          "description": "Relay Resolvers are a read-time feature that are not actually handled in our mutation APIs. We are in the process of removing any existing examples, but this flag is part of a process of removing any existing examples.",
+          "description": "Relay Resolvers are a read-time feature that are not actually handled in\nour mutation APIs. We are in the process of removing any existing\nexamples, but this flag is part of a process of removing any existing\nexamples.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "compact_query_text": {
           "description": "Print queries in compact form",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "disable_deduping_common_structures_in_artifacts": {
-          "description": "Skip the optimization which extracts common JavaScript structures in generated artifacts into numbered variables and uses them by reference in each position in which they occur.\n\nThis optimization can make it hard to follow changes to generated code, so being able to disable it can be helpful for debugging.\n\nTo disable deduping for just one fragment or operation's generated artifacts:\n\n```json \"disable_deduping_common_structures_in_artifacts\": { { \"kind\": \"limited\", \"allowList\": [\"<operation_or_fragment_name>\"] } } ```",
+          "description": "Skip the optimization which extracts common JavaScript structures in\ngenerated artifacts into numbered variables and uses them by reference\nin each position in which they occur.\n\nThis optimization can make it hard to follow changes to generated\ncode, so being able to disable it can be helpful for debugging.\n\nTo disable deduping for just one fragment or operation's generated\nartifacts:\n\n```json\n\"disable_deduping_common_structures_in_artifacts\": {\n  { \"kind\": \"limited\", \"allowList\": [\"<operation_or_fragment_name>\"] }\n}\n```",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "disable_edge_type_name_validation_on_declerative_connection_directives": {
           "description": "Disable validation of the `edgeTypeName` argument on `@prependNode` and `@appendNode`.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "disable_full_argument_type_validation": {
-          "description": "Disable full GraphQL argument type validation. Historically, we only applied argument type validation to the query that was actually going to be persisted and sent to the server. This meant that we didn't typecheck arguments passed to Relay Resolvers or Client Schema Extensions.\n\nWe also permitted an escape hatch of `uncheckedArguments_DEPRECATED` for defining fragment arguments which were not typechecked.\n\nWe no-longer support `uncheckedArguments_DEPRECATED`, and we typecheck both client and server arguments. This flag allows you to opt out of this new behavior to enable gradual adoption of the new validations.\n\nThis flag will be removed in a future version of Relay.",
+          "description": "Disable full GraphQL argument type validation. Historically, we only applied argument type\nvalidation to the query that was actually going to be persisted and sent\nto the server. This meant that we didn't typecheck arguments passed to\nRelay Resolvers or Client Schema Extensions.\n\nWe also permitted an escape hatch of `uncheckedArguments_DEPRECATED` for\ndefining fragment arguments which were not typechecked.\n\nWe no-longer support `uncheckedArguments_DEPRECATED`, and we typecheck\nboth client and server arguments. This flag allows you to opt out of\nthis new behavior to enable gradual adoption of the new validations.\n\nThis flag will be removed in a future version of Relay.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "disable_resolver_reader_ast": {
-          "description": "Mirror of `enable_resolver_normalization_ast` excludes resolver metadata from reader ast",
-          "default": false,
-          "type": "boolean"
+          "description": "Mirror of `enable_resolver_normalization_ast`\nexcludes resolver metadata from reader ast",
+          "type": "boolean",
+          "default": false
         },
         "disable_schema_validation": {
-          "description": "Disable validating the composite schema (server, client schema extensions, Relay Resolvers) after its built.",
-          "default": false,
-          "type": "boolean"
+          "description": "Disable validating the composite schema (server, client schema\nextensions, Relay Resolvers) after its built.",
+          "type": "boolean",
+          "default": false
         },
         "enable_3d_branch_arg_generation": {
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "enable_exec_time_resolvers_directive": {
-          "description": "Allow per-query opt in to normalization AST for Resolvers with exec_time_resolvers directive. In contrast to enable_resolver_normalization_ast, if this is true, a normalization AST can be generated for a query using the @exec_time_resolvers directive",
-          "default": false,
-          "type": "boolean"
+          "description": "Allow per-query opt in to normalization AST for Resolvers with exec_time_resolvers\ndirective. In contrast to enable_resolver_normalization_ast, if this is true, a\nnormalization AST can be generated for a query using the @exec_time_resolvers directive",
+          "type": "boolean",
+          "default": false
         },
         "enable_fragment_argument_transform": {
-          "description": "Add support for parsing and transforming variable definitions on fragment definitions and arguments on fragment spreads.",
-          "default": false,
-          "type": "boolean"
+          "description": "Add support for parsing and transforming variable definitions on fragment\ndefinitions and arguments on fragment spreads.",
+          "type": "boolean",
+          "default": false
         },
         "enable_relay_resolver_mutations": {
           "description": "Allow relay resolvers to extend the Mutation type",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "enable_resolver_normalization_ast": {
           "description": "Fully build the normalization AST for Resolvers",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "enable_strict_custom_scalars": {
           "description": "Perform strict validations when custom scalar types are used",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "enforce_fragment_alias_where_ambiguous": {
-          "description": "Enforce that you must add `@alias` to a fragment if it may not match, due to type mismatch or `@skip`/`@include`",
+          "description": "Enforce that you must add `@alias` to a fragment if it may not match,\ndue to type mismatch or `@skip`/`@include`",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "enabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "legacy_include_path_in_required_reader_nodes": {
-          "description": "The `path` field in `@required` Reader AST nodes is no longer used. But removing them in one diff is too large of a change to ship at once.\n\nThis flag will allow us to use the rollout FeatureFlag to remove them across a number of diffs.",
+          "description": "The `path` field in `@required` Reader AST nodes is no longer used. But\nremoving them in one diff is too large of a change to ship at once.\n\nThis flag will allow us to use the rollout FeatureFlag to remove them\nacross a number of diffs.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "no_inline": {
-          "description": "For now, this also disallows fragments with variable definitions This also makes @module to opt in using @no_inline internally NOTE that the presence of a fragment in this list only controls whether a fragment is *allowed* to use @no_inline: whether the fragment is inlined or not depends on whether it actually uses that directive.",
+          "description": "For now, this also disallows fragments with variable definitions\nThis also makes @module to opt in using @no_inline internally\nNOTE that the presence of a fragment in this list only controls whether a fragment is *allowed* to\nuse @no_inline: whether the fragment is inlined or not depends on whether it actually uses that\ndirective.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "omit_resolver_type_assertions_for_confirmed_types": {
-          "description": "Skip generating resolver type assertions for resolvers which have been derived from TS/Flow types.",
+          "description": "Skip generating resolver type assertions for resolvers which have\nbeen derived from TS/Flow types.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "prefer_fetchable_in_refetch_queries": {
-          "description": "Feature flag to prefer `fetch_MyType()` generatior over `node()` query generator in @refetchable transform",
-          "default": false,
-          "type": "boolean"
+          "description": "Feature flag to prefer `fetch_MyType()` generatior over `node()` query generator\nin @refetchable transform",
+          "type": "boolean",
+          "default": false
         },
         "relay_resolver_enable_interface_output_type": {
           "description": "Enable returning interfaces from Relay Resolvers without @outputType",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "skip_printing_nulls": {
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "text_artifacts": {
-          "description": "Enable generation of text artifacts used to generate full query strings later.",
+          "description": "Enable generation of text artifacts used to generate full query strings\nlater.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         },
         "use_reader_module_imports": {
           "description": "Generate the `moduleImports` field in the Reader AST.",
+          "$ref": "#/$defs/FeatureFlag",
           "default": {
             "kind": "disabled"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlag"
-            }
-          ]
+          }
         }
       },
       "additionalProperties": false
@@ -861,16 +723,12 @@
         {
           "description": "Common JS style, e.g. `require('../path/MyModule')`",
           "type": "string",
-          "enum": [
-            "commonjs"
-          ]
+          "const": "commonjs"
         },
         {
           "description": "Facebook style, e.g. `require('MyModule')`",
           "type": "string",
-          "enum": [
-            "haste"
-          ]
+          "const": "haste"
         }
       ]
     },
@@ -885,18 +743,11 @@
     "LocalPersistConfig": {
       "description": "Configuration for local persistence of GraphQL documents.\n\nThis struct contains settings that control how GraphQL documents are persisted locally.",
       "type": "object",
-      "required": [
-        "file"
-      ],
       "properties": {
         "algorithm": {
           "description": "The algorithm to use for hashing the operation text.",
-          "default": "MD5",
-          "allOf": [
-            {
-              "$ref": "#/definitions/LocalPersistAlgorithm"
-            }
-          ]
+          "$ref": "#/$defs/LocalPersistAlgorithm",
+          "default": "MD5"
         },
         "file": {
           "description": "The file path where the persisted documents will be written.",
@@ -904,21 +755,24 @@
         },
         "include_query_text": {
           "description": "Whether to include the query text in the persisted document.",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "file"
+      ]
     },
     "ModuleImportConfig": {
       "description": "Configuration for @module.",
       "type": "object",
       "properties": {
         "dynamicModuleProvider": {
-          "description": "Defines the custom import statement to be generated on the `ModuleImport` node in ASTs, used for dynamically loading components at runtime.",
+          "description": "Defines the custom import statement to be generated on the\n`ModuleImport` node in ASTs, used for dynamically loading\ncomponents at runtime.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ModuleProvider"
+              "$ref": "#/$defs/ModuleProvider"
             },
             {
               "type": "null"
@@ -926,10 +780,10 @@
           ]
         },
         "operationModuleProvider": {
-          "description": "Defines the custom import statement to be generated for the `operationModuleProvider` function on the `NormalizationModuleImport` node in ASTs. Used in exec time client 3D.",
+          "description": "Defines the custom import statement to be generated for the\n`operationModuleProvider` function on the `NormalizationModuleImport`\nnode in ASTs. Used in exec time client 3D.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ModuleProvider"
+              "$ref": "#/$defs/ModuleProvider"
             },
             {
               "type": "null"
@@ -940,7 +794,7 @@
           "description": "Defines the surface upon which @module is enabled.",
           "anyOf": [
             {
-              "$ref": "#/definitions/Surface"
+              "$ref": "#/$defs/Surface"
             },
             {
               "type": "null"
@@ -955,46 +809,38 @@
         {
           "description": "Generates a module provider using JSResource",
           "type": "object",
-          "required": [
-            "mode"
-          ],
           "properties": {
             "mode": {
               "type": "string",
-              "enum": [
-                "JSResource"
-              ]
+              "const": "JSResource"
             }
-          }
+          },
+          "required": [
+            "mode"
+          ]
         },
         {
-          "description": "Generates a custom JS import, Use `<$module>` as the placeholder for the actual module. e.g. `\"() => import('<$module>')\"`",
+          "description": "Generates a custom JS import, Use `<$module>` as the placeholder\nfor the actual module. e.g. `\"() => import('<$module>')\"`",
           "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "const": "Custom"
+            },
+            "statement": {
+              "$ref": "#/$defs/StringKey"
+            }
+          },
           "required": [
             "mode",
             "statement"
-          ],
-          "properties": {
-            "mode": {
-              "type": "string",
-              "enum": [
-                "Custom"
-              ]
-            },
-            "statement": {
-              "$ref": "#/definitions/StringKey"
-            }
-          }
+          ]
         }
       ]
     },
     "MultiProjectConfigFile": {
       "description": "Schema of the compiler configuration JSON file.",
       "type": "object",
-      "required": [
-        "projects",
-        "sources"
-      ],
       "properties": {
         "$schema": {
           "description": "The user may hard-code the JSON Schema for their version of the config.",
@@ -1004,26 +850,27 @@
           ]
         },
         "codegenCommand": {
-          "default": null,
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "excludes": {
-          "description": "Glob patterns that should not be part of the sources even if they are in the source set directories.",
+          "description": "Glob patterns that should not be part of the sources even if they are\nin the source set directories.",
+          "type": "array",
           "default": [
             "**/node_modules/**",
             "**/__mocks__/**",
             "**/__generated__/**"
           ],
-          "type": "array",
           "items": {
             "type": "string"
           }
         },
         "featureFlags": {
-          "description": "Enable and disable experimental or legacy behaviors. WARNING! These are not stable and may change at any time.",
+          "description": "Enable and disable experimental or legacy behaviors.\nWARNING! These are not stable and may change at any time.",
+          "$ref": "#/$defs/FeatureFlags",
           "default": {
             "actor_change_support": {
               "kind": "disabled"
@@ -1085,24 +932,19 @@
             "use_reader_module_imports": {
               "kind": "disabled"
             }
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/FeatureFlags"
-            }
-          ]
+          }
         },
         "generatedSources": {
           "description": "Similar to sources but not affected by excludes.",
-          "default": {},
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/ProjectSet"
-          }
+            "$ref": "#/$defs/ProjectSet"
+          },
+          "default": {}
         },
         "header": {
-          "default": [],
           "type": "array",
+          "default": [],
           "items": {
             "type": "string"
           }
@@ -1115,12 +957,12 @@
           ]
         },
         "name": {
-          "description": "Optional name for this config, might be used for logging or custom extra artifact generator code.",
-          "default": null,
+          "description": "Optional name for this config, might be used for logging or custom extra\nartifact generator code.",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "noSourceControl": {
           "description": "Opt out of source control checks/integration.",
@@ -1133,22 +975,22 @@
           "description": "Configuration of projects to compile.",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/ConfigFileProject"
+            "$ref": "#/$defs/ConfigFileProject"
           }
         },
         "root": {
-          "description": "Root directory relative to the config file. Defaults to the directory where the config is located.",
-          "default": null,
+          "description": "Root directory relative to the config file. Defaults to the directory\nwhere the config is located.",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "savedStateConfig": {
           "description": "Watchman saved state config.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ScmAwareClockData"
+              "$ref": "#/$defs/ScmAwareClockData"
             },
             {
               "type": "null"
@@ -1156,14 +998,18 @@
           ]
         },
         "sources": {
-          "description": "A mapping from directory paths (relative to the root) to a source set. If a path is a subdirectory of another path, the more specific path wins.",
+          "description": "A mapping from directory paths (relative to the root) to a source set.\nIf a path is a subdirectory of another path, the more specific path\nwins.",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/DeserializableProjectSet"
+            "$ref": "#/$defs/DeserializableProjectSet"
           }
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "sources",
+        "projects"
+      ]
     },
     "NonNodeIdFieldsConfig": {
       "description": "Configuration of Relay's validation for `id` fields outside of the `Node` interface.",
@@ -1171,11 +1017,11 @@
       "properties": {
         "allowedIdTypes": {
           "description": "A map of parent type names to allowed type names for fields named `id`",
-          "default": {},
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/StringKey"
-          }
+            "$ref": "#/$defs/StringKey"
+          },
+          "default": {}
         }
       },
       "additionalProperties": false
@@ -1185,19 +1031,11 @@
       "anyOf": [
         {
           "description": "This variant represents a remote persistence configuration, where GraphQL queries are sent to a remote endpoint for persistence.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/RemotePersistConfig"
-            }
-          ]
+          "$ref": "#/$defs/RemotePersistConfig"
         },
         {
-          "description": "This variant represents a local persistence configuration, where GraphQL queries are persisted to a local JSON file.\n\nWhen this variant is used, the compiler will attempt to read the local file as a hash map, add new queries to the map, and then serialize and write the resulting map to the configured path.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/LocalPersistConfig"
-            }
-          ]
+          "description": "This variant represents a local persistence configuration, where GraphQL queries are persisted to a local JSON file.\n\nWhen this variant is used, the compiler will attempt to read the local file as a hash map,\nadd new queries to the map, and then serialize and write the resulting map to the configured path.",
+          "$ref": "#/$defs/LocalPersistConfig"
         }
       ]
     },
@@ -1210,181 +1048,167 @@
         },
         {
           "description": "A project name.\n\nThis should match one the keys in the `projects` map in the Relay compiler config.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringKey"
-            }
-          ]
+          "$ref": "#/$defs/StringKey"
         }
       ]
     },
     "ProjectSet": {
       "description": "Set of project names.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/ProjectName"
-      }
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ProjectName"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ProjectName"
+          }
+        }
+      ]
     },
     "RemotePersistConfig": {
       "description": "Configuration for remote persistence of GraphQL documents.",
       "type": "object",
-      "required": [
-        "url"
-      ],
       "properties": {
         "concurrency": {
           "description": "Number of concurrent requests that can be made to the server.",
-          "default": null,
           "type": [
             "integer",
             "null"
           ],
           "format": "uint",
-          "minimum": 0.0
+          "default": null,
+          "minimum": 0
         },
         "headers": {
           "description": "Additional headers to include in the POST request.",
-          "default": {},
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "default": {}
         },
         "includeQueryText": {
           "description": "Whether to include the query text in the persisted document.",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "params": {
-          "description": "Additional parameters to include in the POST request.\n\nThe main document will be in a POST parameter `text`. This map can contain additional parameters to send.",
-          "default": {},
+          "description": "Additional parameters to include in the POST request.\n\nThe main document will be in a POST parameter `text`. This map can contain\nadditional parameters to send.",
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "default": {}
         },
         "url": {
           "description": "URL that the document should be persisted to via a POST request.",
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ]
     },
     "ResolverContextTypeInput": {
       "description": "Describes the type to import and use as the context for Relay Resolvers.",
       "anyOf": [
         {
           "description": "The type imported using a relative path",
-          "allOf": [
-            {
-              "$ref": "#/definitions/ResolverContextTypeInputPath"
-            }
-          ]
+          "$ref": "#/$defs/ResolverContextTypeInputPath"
         },
         {
           "description": "The type imported using a named package",
-          "allOf": [
-            {
-              "$ref": "#/definitions/ResolverContextTypeInputPackage"
-            }
-          ]
+          "$ref": "#/$defs/ResolverContextTypeInputPackage"
         }
       ]
     },
     "ResolverContextTypeInputPackage": {
       "description": "Specifies how Relay can import the Resolver context type from a named package",
       "type": "object",
-      "required": [
-        "name",
-        "package"
-      ],
       "properties": {
         "name": {
           "description": "The name under which the type is exported from the package",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringKey"
-            }
-          ]
+          "$ref": "#/$defs/StringKey"
         },
         "package": {
           "description": "The name of the package",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringKey"
-            }
-          ]
+          "$ref": "#/$defs/StringKey"
         }
-      }
+      },
+      "required": [
+        "name",
+        "package"
+      ]
     },
     "ResolverContextTypeInputPath": {
       "description": "Specifies how Relay can import the Resolver context type from a path",
       "type": "object",
-      "required": [
-        "name",
-        "path"
-      ],
       "properties": {
         "name": {
           "description": "The name under which the type is exported from the module",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringKey"
-            }
-          ]
+          "$ref": "#/$defs/StringKey"
         },
         "path": {
           "description": "The path to the module relative to the project root",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "name",
+        "path"
+      ]
     },
     "ResolversSchemaModuleConfig": {
       "description": "Configuration for resolvers_schema_module generation",
       "type": "object",
       "properties": {
         "applyToNormalizationAst": {
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "path": {
-          "default": "",
-          "type": "string"
+          "type": "string",
+          "default": ""
         }
       },
       "additionalProperties": false
     },
     "Rollout": {
-      "description": "A utility to enable gradual rollout of large codegen changes. Can be constructed as the Default which passes or a percentage between 0 and 100.",
+      "description": "A utility to enable gradual rollout of large codegen changes.\nCan be constructed as the Default which passes or a percentage between 0 and\n100.",
       "type": [
         "integer",
         "null"
       ],
       "format": "uint8",
-      "minimum": 0.0
+      "maximum": 255,
+      "minimum": 0
     },
     "RolloutRange": {
-      "description": "A utility to enable gradual rollout of large codegen changes. Allows you to specify a range of percentages to rollout.",
+      "description": "A utility to enable gradual rollout of large codegen changes. Allows you to\nspecify a range of percentages to rollout.",
       "type": "object",
-      "required": [
-        "end",
-        "start"
-      ],
       "properties": {
         "end": {
           "type": "integer",
           "format": "uint8",
-          "minimum": 0.0
+          "maximum": 255,
+          "minimum": 0
         },
         "start": {
           "type": "integer",
           "format": "uint8",
-          "minimum": 0.0
+          "maximum": 255,
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "start",
+        "end"
+      ]
     },
     "SavedStateClockData": {
-      "description": "Holds extended clock data that includes source control aware query metadata. <https://facebook.github.io/watchman/docs/scm-query.html>",
+      "description": "Holds extended clock data that includes source control aware\nquery metadata.\n<https://facebook.github.io/watchman/docs/scm-query.html>",
       "type": "object",
       "properties": {
         "commit-id": {
@@ -1406,6 +1230,7 @@
       "type": "object",
       "properties": {
         "connectionInterface": {
+          "$ref": "#/$defs/ConnectionInterface",
           "default": {
             "cursor": "cursor",
             "edges": "edges",
@@ -1415,14 +1240,10 @@
             "node": "node",
             "pageInfo": "pageInfo",
             "startCursor": "startCursor"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/ConnectionInterface"
-            }
-          ]
+          }
         },
         "deferStreamInterface": {
+          "$ref": "#/$defs/DeferStreamInterface",
           "default": {
             "deferName": "defer",
             "ifArg": "if",
@@ -1430,60 +1251,43 @@
             "labelArg": "label",
             "streamName": "stream",
             "useCustomizedBatchArg": "useCustomizedBatch"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/DeferStreamInterface"
-            }
-          ]
+          }
         },
         "enableTokenField": {
           "description": "If we should select __token field on fetchable types",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "nodeInterfaceIdField": {
           "description": "The name of the `id` field that exists on the `Node` interface.",
-          "default": "id",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringKey"
-            }
-          ]
+          "$ref": "#/$defs/StringKey",
+          "default": "id"
         },
         "nodeInterfaceIdVariableName": {
           "description": "The name of the variable expected by the `node` query.",
-          "default": "id",
-          "allOf": [
-            {
-              "$ref": "#/definitions/StringKey"
-            }
-          ]
+          "$ref": "#/$defs/StringKey",
+          "default": "id"
         },
         "nonNodeIdFields": {
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/NonNodeIdFieldsConfig"
+              "$ref": "#/$defs/NonNodeIdFieldsConfig"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "unselectableDirectiveName": {
           "description": "The name of the directive indicating fields that cannot be selected",
-          "default": "unselectable",
-          "allOf": [
-            {
-              "$ref": "#/definitions/DirectiveName"
-            }
-          ]
+          "$ref": "#/$defs/DirectiveName",
+          "default": "unselectable"
         }
       }
     },
     "ScmAwareClockData": {
-      "description": "Holds extended clock data that includes source control aware query metadata. <https://facebook.github.io/watchman/docs/scm-query.html>",
+      "description": "Holds extended clock data that includes source control aware\nquery metadata.\n<https://facebook.github.io/watchman/docs/scm-query.html>",
       "type": "object",
       "properties": {
         "mergebase": {
@@ -1501,7 +1305,7 @@
         "saved-state": {
           "anyOf": [
             {
-              "$ref": "#/definitions/SavedStateClockData"
+              "$ref": "#/$defs/SavedStateClockData"
             },
             {
               "type": "null"
@@ -1512,39 +1316,36 @@
     },
     "SingleProjectConfigFile": {
       "type": "object",
-      "required": [
-        "language"
-      ],
       "properties": {
         "$schema": {
           "description": "The user may hard-code the JSON Schema for their version of the config.",
-          "default": null,
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "artifactDirectory": {
-          "description": "A specific directory to output all artifacts to. When enabling this the babel plugin needs `artifactDirectory` set as well.",
-          "default": null,
+          "description": "A specific directory to output all artifacts to. When enabling this\nthe babel plugin needs `artifactDirectory` set as well.",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "codegenCommand": {
-          "description": "Name of the command that runs the relay compiler. This will be added at the top of generated code to let readers know how to regenerate the file.",
-          "default": null,
+          "description": "Name of the command that runs the relay compiler. This will be added at\nthe top of generated code to let readers know how to regenerate the file.",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "customErrorType": {
-          "description": "A map from GraphQL error name to import path, example: {\"name:: \"MyErrorName\", \"path\": \"../src/MyError\"}",
+          "description": "A map from GraphQL error name to import path, example:\n{\"name:: \"MyErrorName\", \"path\": \"../src/MyError\"}",
           "anyOf": [
             {
-              "$ref": "#/definitions/CustomTypeImport"
+              "$ref": "#/$defs/CustomTypeImport"
             },
             {
               "type": "null"
@@ -1552,162 +1353,151 @@
           ]
         },
         "customScalarTypes": {
-          "description": "A map from GraphQL scalar types to a custom JS type, example: { \"Url\": \"String\" } { \"Url\": {\"name:: \"MyURL\", \"path\": \"../src/MyUrlTypes\"} }",
-          "default": {},
+          "description": "A map from GraphQL scalar types to a custom JS type, example:\n{ \"Url\": \"String\" }\n{ \"Url\": {\"name:: \"MyURL\", \"path\": \"../src/MyUrlTypes\"} }",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/CustomType"
-          }
+            "$ref": "#/$defs/CustomType"
+          },
+          "default": {}
         },
         "eagerEsModules": {
-          "description": "This option enables opting out of emitting es modules artifacts. When set to false, Relay will emit CommonJS modules.",
-          "default": true,
-          "type": "boolean"
+          "description": "This option enables opting out of emitting es modules artifacts. When\nset to false, Relay will emit CommonJS modules.",
+          "type": "boolean",
+          "default": true
         },
         "enumModuleSuffix": {
           "title": "For Flow type generation",
-          "description": "When set, enum values are imported from a module with this suffix. For example, an enum Foo and this property set to \".test\" would be imported from \"Foo.test\". Note: an empty string is allowed and different from not setting the value, in the example above it would just import from \"Foo\".",
+          "description": "When set, enum values are imported from a module with this suffix.\nFor example, an enum Foo and this property set to \".test\" would be\nimported from \"Foo.test\".\nNote: an empty string is allowed and different from not setting the\nvalue, in the example above it would just import from \"Foo\".",
           "type": [
             "string",
             "null"
           ]
         },
         "excludes": {
-          "description": "Directories to ignore under src default: ['**/node_modules/**', '**/__mocks__/**', '**/__generated__/**'],",
+          "description": "Directories to ignore under src\ndefault: ['**/node_modules/**', '**/__mocks__/**', '**/__generated__/**'],",
+          "type": "array",
           "default": [
             "**/node_modules/**",
             "**/__mocks__/**",
             "**/__generated__/**"
           ],
-          "type": "array",
           "items": {
             "type": "string"
           }
         },
         "featureFlags": {
-          "description": "Enable and disable experimental or legacy behaviors. WARNING! These are not stable and may change at any time.",
-          "default": null,
+          "description": "Enable and disable experimental or legacy behaviors.\nWARNING! These are not stable and may change at any time.",
           "anyOf": [
             {
-              "$ref": "#/definitions/FeatureFlags"
+              "$ref": "#/$defs/FeatureFlags"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "isDevVariableName": {
-          "description": "We may generate some content in the artifacts that's stripped in production if __DEV__ variable is set This config option is here to define the name of that special variable",
-          "default": null,
+          "description": "We may generate some content in the artifacts that's stripped in production if __DEV__ variable is set\nThis config option is here to define the name of that special variable",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "jsModuleFormat": {
           "description": "Import/export style to use in generated JavaScript modules.",
-          "default": "commonjs",
-          "allOf": [
-            {
-              "$ref": "#/definitions/JsModuleFormat"
-            }
-          ]
+          "$ref": "#/$defs/JsModuleFormat",
+          "default": "commonjs"
         },
         "language": {
           "description": "The desired output language, \"flow\" or \"typescript\".",
-          "allOf": [
-            {
-              "$ref": "#/definitions/TypegenLanguage"
-            }
-          ]
+          "$ref": "#/$defs/TypegenLanguage"
         },
         "moduleImportConfig": {
           "description": "Configuration for @module",
+          "$ref": "#/$defs/ModuleImportConfig",
           "default": {
             "dynamicModuleProvider": null,
             "operationModuleProvider": null,
             "surface": null
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/ModuleImportConfig"
-            }
-          ]
+          }
         },
         "noFutureProofEnums": {
-          "description": "This option controls whether or not a catch-all entry is added to enum type definitions for values that may be added in the future. Enabling this means you will have to update your application whenever the GraphQL server schema adds new enum values to prevent it from breaking.",
-          "default": false,
-          "type": "boolean"
+          "description": "This option controls whether or not a catch-all entry is added to enum type definitions\nfor values that may be added in the future. Enabling this means you will have to update\nyour application whenever the GraphQL server schema adds new enum values to prevent it\nfrom breaking.",
+          "type": "boolean",
+          "default": false
         },
         "noSourceControl": {
           "description": "Opt out of source control checks/integration.",
-          "default": null,
           "type": [
             "boolean",
             "null"
-          ]
+          ],
+          "default": null
         },
         "optionalInputFields": {
           "title": "For Flow type generation",
-          "description": "When set, generated input types will have the listed fields optional even if the schema defines them as required.",
-          "default": [],
+          "description": "When set, generated input types will have the listed fields optional\neven if the schema defines them as required.",
           "type": "array",
+          "default": [],
           "items": {
-            "$ref": "#/definitions/StringKey"
+            "$ref": "#/$defs/StringKey"
           }
         },
         "persistConfig": {
-          "description": "Query Persist Configuration It contains URL and addition parameters that will be included with the request (think API_KEY, APP_ID, etc...)",
-          "default": null,
+          "description": "Query Persist Configuration\nIt contains URL and addition parameters that will be included\nwith the request (think API_KEY, APP_ID, etc...)",
           "anyOf": [
             {
-              "$ref": "#/definitions/PersistConfig"
+              "$ref": "#/$defs/PersistConfig"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "relativizeJsModulePaths": {
-          "description": "Whether to treat all JS module names as relative to './' (true) or not. default: true",
-          "default": true,
-          "type": "boolean"
+          "description": "Whether to treat all JS module names as relative to './' (true) or not.\ndefault: true",
+          "type": "boolean",
+          "default": true
         },
         "requireCustomScalarTypes": {
-          "description": "Require all GraphQL scalar types mapping to be defined, will throw if a GraphQL scalar type doesn't have a JS type",
-          "default": false,
-          "type": "boolean"
+          "description": "Require all GraphQL scalar types mapping to be defined, will throw\nif a GraphQL scalar type doesn't have a JS type",
+          "type": "boolean",
+          "default": false
         },
         "resolverContextType": {
           "description": "Indicates the type to import and use as the context for Relay Resolvers.",
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/ResolverContextTypeInput"
+              "$ref": "#/$defs/ResolverContextTypeInput"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "resolversSchemaModule": {
-          "default": null,
           "anyOf": [
             {
-              "$ref": "#/definitions/ResolversSchemaModuleConfig"
+              "$ref": "#/$defs/ResolversSchemaModuleConfig"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "schema": {
           "description": "Path to schema.graphql",
-          "default": "",
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "schemaConfig": {
           "description": "Extra configuration for the GraphQL schema itself.",
+          "$ref": "#/$defs/SchemaConfig",
           "default": {
             "connectionInterface": {
               "cursor": "cursor",
@@ -1732,42 +1522,41 @@
             "nodeInterfaceIdVariableName": "id",
             "nonNodeIdFields": null,
             "unselectableDirectiveName": "unselectable"
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/SchemaConfig"
-            }
-          ]
+          }
         },
         "schemaExtensions": {
           "description": "List of directories with schema extensions.",
-          "default": [],
           "type": "array",
+          "default": [],
           "items": {
             "type": "string"
           }
         },
         "src": {
           "description": "Root directory of application code",
-          "default": "",
-          "type": "string"
+          "type": "string",
+          "default": ""
         },
         "typescriptExcludeUndefinedFromNullableUnion": {
-          "description": "Keep the previous compiler behavior by outputting an union of the raw type and null, and not the **correct** behavior of an union with the raw type, null and undefined.",
-          "default": false,
-          "type": "boolean"
+          "description": "Keep the previous compiler behavior by outputting an union\nof the raw type and null, and not the **correct** behavior\nof an union with the raw type, null and undefined.",
+          "type": "boolean",
+          "default": false
         },
         "useImportTypeSyntax": {
           "title": "For Typescript type generation",
-          "description": "Whether to use the `import type` syntax introduced in Typescript version 3.8. This will prevent warnings from `importsNotUsedAsValues`.",
-          "default": false,
-          "type": "boolean"
+          "description": "Whether to use the `import type` syntax introduced in Typescript\nversion 3.8. This will prevent warnings from `importsNotUsedAsValues`.",
+          "type": "boolean",
+          "default": false
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "language"
+      ]
     },
     "StringKey": {
-      "type": "string"
+      "type": "string",
+      "format": null
     },
     "Surface": {
       "type": "string",

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -52,8 +52,9 @@ use relay_docblock::DocblockIr;
 use relay_saved_state_loader::SavedStateLoader;
 use relay_transforms::CustomTransformsConfig;
 use schemars::JsonSchema;
-use schemars::r#gen::SchemaSettings;
-use schemars::r#gen::{self};
+use schemars::SchemaGenerator;
+use schemars::generate::SchemaSettings;
+use schemars::{self};
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -307,7 +308,7 @@ impl Config {
                 ),
             }),
             Err(error) => Err(Error::ConfigError {
-                details: format!("Error searching config: {}", error),
+                details: format!("Error searching config: {error}"),
             }),
         }
     }
@@ -1100,7 +1101,7 @@ pub enum ConfigFile {
 impl ConfigFile {
     pub fn json_schema() -> String {
         let settings: SchemaSettings = Default::default();
-        let generator = r#gen::SchemaGenerator::from(settings);
+        let generator = SchemaGenerator::from(settings);
         let schema = generator.into_root_schema_for::<Self>();
         serde_json::to_string_pretty(&schema).unwrap()
     }
@@ -1116,11 +1117,10 @@ impl<'de> Deserialize<'de> for ConfigFile {
                 Err(single_project_error) => {
                     let error_message = format!(
                         r#"The config file cannot be parsed as a single-project config file due to:
- - {:?}.
+ - {single_project_error:?}.
 
  It also cannot be a multi-project config file due to:
- - {:?}."#,
-                        single_project_error, multi_project_error,
+ - {multi_project_error:?}."#
                     );
 
                     Err(DeError::custom(error_message))

--- a/compiler/crates/relay-config/Cargo.toml
+++ b/compiler/crates/relay-config/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = { version = "2.9.0", features = ["arbitrary", "rayon", "serde"] }
 intern = { path = "../intern" }
 pathdiff = "0.2"
 regex = "1.11.1"
-schemars = { version = "0.8.21", features = ["indexmap2"] }
+schemars = { version = "1.0.4", features = ["indexmap2"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }
 strum = { version = "0.27.1", features = ["derive"] }


### PR DESCRIPTION
Schemars: Followed the migration guide the best I could: https://graham.cool/schemars/migrating/

But fingers crossed for tests being good.

Warning: As a result of the change in schemars **the output has changed and I've "fixed" the tests to match the new output!**.

Some changes are expected (I think), for example:

```
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
```

Seems reasonable.

Other changes such as new line breaks like this:
```
-  "description": "Relay's configuration file. Supports a single project config for simple use cases and a multi-project config for cases where multiple p
rojects live in the same repository.\n\nIn general, start with the SingleProjectConfigFile.",
+  "description": "Relay's configuration file. Supports a single project config for simple use\ncases and a multi-project config for cases where multiple
projects live in\nthe same repository.\n\nIn general, start with the SingleProjectConfigFile.",
```
might cause problems?

And this one:
```
-      "allOf": [
-        {
-          "$ref": "#/definitions/SingleProjectConfigFile"
-        }
-      ]
+      "$ref": "#/$defs/SingleProjectConfigFile"
```

I have no idea if it's correct.

 Update schemars crate from 0.8 to 1.0.4

Differential Revision: D78455871
