### PR TITLE
Make schema def rendering more robust

### DIFF
--- a/website/docs/getting-started/compiler-config.md
+++ b/website/docs/getting-started/compiler-config.md
@@ -22,4 +22,4 @@ If you need more advanced options of the Relay Compiler Config, the exhaustive f
 Install the [Relay VSCode extension](../editor-support.md) to get autocomplete, hover tips, and type checking for the options in your Relay config.
 :::
 
-<CompilerConfig schema={schema} />
+<CompilerConfig schema={schema} definitions={schema.$defs} />

--- a/website/versioned_docs/version-v20.0.0/getting-started/compiler-config.md
+++ b/website/versioned_docs/version-v20.0.0/getting-started/compiler-config.md
@@ -10,7 +10,7 @@ keywords:
 hide_table_of_contents: false
 ---
 import CompilerConfig from '@site/src/compiler-config/CompilerConfig';
-import schema from '@compilerConfigJsonSchema';
+import schema from './relay-compiler-config-schema.json';
 
 ## Compiler Config Options
 
@@ -22,4 +22,4 @@ If you need more advanced options of the Relay Compiler Config, the exhaustive f
 Install the [Relay VSCode extension](../editor-support.md) to get autocomplete, hover tips, and type checking for the options in your Relay config.
 :::
 
-<CompilerConfig schema={schema} />
+<CompilerConfig schema={schema} definitions={schema.definitions} />

--- a/website/versioned_docs/version-v20.0.0/getting-started/relay-compiler-config-schema.json
+++ b/website/versioned_docs/version-v20.0.0/getting-started/relay-compiler-config-schema.json
@@ -1,0 +1,1788 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ConfigFile",
+  "description": "Relay's configuration file. Supports a single project config for simple use cases and a multi-project config for cases where multiple projects live in the same repository.\n\nIn general, start with the SingleProjectConfigFile.",
+  "anyOf": [
+    {
+      "description": "Base case configuration (mostly of OSS) where the project have single schema, and single source directory",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SingleProjectConfigFile"
+        }
+      ]
+    },
+    {
+      "description": "Relay can support multiple projects with multiple schemas and different options (output, typegen, etc...). This MultiProjectConfigFile is responsible for configuring these type of projects (complex)",
+      "allOf": [
+        {
+          "$ref": "#/definitions/MultiProjectConfigFile"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "ArgumentName": {
+      "$ref": "#/definitions/StringKey"
+    },
+    "ConfigFileProject": {
+      "type": "object",
+      "required": [
+        "language"
+      ],
+      "properties": {
+        "base": {
+          "description": "If a base project is set, the documents of that project can be referenced, but won't produce output artifacts. Extensions from the base project will be added as well and the schema of the base project should be a subset of the schema of this project.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ProjectName"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "codegenCommand": {
+          "description": "Name of the command that runs the relay compiler. This will be added at the top of generated code to let readers know how to regenerate the file.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "customErrorType": {
+          "description": "A map from GraphQL error name to import path, example: {\"name:: \"MyErrorName\", \"path\": \"../src/MyError\"}",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CustomTypeImport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "customScalarTypes": {
+          "description": "A map from GraphQL scalar types to a custom JS type, example: { \"Url\": \"String\" } { \"Url\": {\"name:: \"MyURL\", \"path\": \"../src/MyUrlTypes\"} }",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/CustomType"
+          }
+        },
+        "diagnosticReportConfig": {
+          "description": "Threshold for diagnostics to be critical to the compiler's execution. All diagnostic with severities at and below this level will cause the compiler to fatally exit.",
+          "default": {
+            "criticalLevel": "error"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/DiagnosticReportConfig"
+            }
+          ]
+        },
+        "eagerEsModules": {
+          "description": "This option enables opting out of emitting es modules artifacts. When set to false, Relay will emit CommonJS modules.",
+          "default": true,
+          "type": "boolean"
+        },
+        "enumModuleSuffix": {
+          "title": "For Flow type generation",
+          "description": "When set, enum values are imported from a module with this suffix. For example, an enum Foo and this property set to \".test\" would be imported from \"Foo.test\". Note: an empty string is allowed and different from not setting the value, in the example above it would just import from \"Foo\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "excludesExtensions": {
+          "description": "Some projects may need to exclude files with certain extensions.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra": {
+          "description": "A placeholder for allowing extra information in the config file",
+          "default": null
+        },
+        "extraArtifactsOutput": {
+          "description": "Some projects may need to generate extra artifacts. For those, we may need to provide an additional directory to put them. By default the will use `output` *if available",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "featureFlags": {
+          "description": "Enable and disable experimental or legacy behaviors. WARNING! These are not stable and may change at any time.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FeatureFlags"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "jsModuleFormat": {
+          "description": "Import/export style to use in generated JavaScript modules.",
+          "default": "commonjs",
+          "allOf": [
+            {
+              "$ref": "#/definitions/JsModuleFormat"
+            }
+          ]
+        },
+        "language": {
+          "description": "The desired output language, \"flow\" or \"typescript\".",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TypegenLanguage"
+            }
+          ]
+        },
+        "moduleImportConfig": {
+          "description": "Configuration for the @module GraphQL directive.",
+          "default": {
+            "dynamicModuleProvider": null,
+            "operationModuleProvider": null,
+            "surface": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModuleImportConfig"
+            }
+          ]
+        },
+        "noFutureProofEnums": {
+          "description": "This option controls whether or not a catch-all entry is added to enum type definitions for values that may be added in the future. Enabling this means you will have to update your application whenever the GraphQL server schema adds new enum values to prevent it from breaking.",
+          "default": false,
+          "type": "boolean"
+        },
+        "optionalInputFields": {
+          "title": "For Flow type generation",
+          "description": "When set, generated input types will have the listed fields optional even if the schema defines them as required.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StringKey"
+          }
+        },
+        "output": {
+          "description": "A project without an output directory will put the generated files in a __generated__ directory next to the input file. All files in these directories should be generated by the Relay compiler, so that the compiler can cleanup extra files.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "persist": {
+          "description": "If this option is set, the compiler will persist queries using this config.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PersistConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "relativizeJsModulePaths": {
+          "description": "Whether to treat all JS module names as relative to './' (true) or not. default: true",
+          "default": true,
+          "type": "boolean"
+        },
+        "requireCustomScalarTypes": {
+          "description": "Require all GraphQL scalar types mapping to be defined, will throw if a GraphQL scalar type doesn't have a JS type",
+          "default": false,
+          "type": "boolean"
+        },
+        "resolverContextType": {
+          "description": "Indicates the type to import and use as the context for Relay Resolvers.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResolverContextTypeInput"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resolversSchemaModule": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResolversSchemaModuleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rollout": {
+          "description": "A generic rollout state for larger codegen changes. The default is to pass, otherwise it should be a number between 0 and 100 as a percentage.",
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/Rollout"
+            }
+          ]
+        },
+        "schema": {
+          "description": "Path to the schema.graphql or a directory containing a schema broken up in multiple *.graphql files. Exactly 1 of these options needs to be defined.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schemaConfig": {
+          "description": "Extra configuration for the GraphQL schema itself.",
+          "default": {
+            "connectionInterface": {
+              "cursor": "cursor",
+              "edges": "edges",
+              "endCursor": "endCursor",
+              "hasNextPage": "hasNextPage",
+              "hasPreviousPage": "hasPreviousPage",
+              "node": "node",
+              "pageInfo": "pageInfo",
+              "startCursor": "startCursor"
+            },
+            "deferStreamInterface": {
+              "deferName": "defer",
+              "ifArg": "if",
+              "initialCountArg": "initialCount",
+              "labelArg": "label",
+              "streamName": "stream",
+              "useCustomizedBatchArg": "useCustomizedBatch"
+            },
+            "enableTokenField": false,
+            "nodeInterfaceIdField": "id",
+            "nodeInterfaceIdVariableName": "id",
+            "nonNodeIdFields": null,
+            "unselectableDirectiveName": "unselectable"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SchemaConfig"
+            }
+          ]
+        },
+        "schemaDir": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schemaExtensions": {
+          "description": "Directory containing *.graphql files with schema extensions.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "schemaName": {
+          "description": "Schema name, if differs from project name. If schema name is unset, the project name will be used as schema name.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringKey"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "shardOutput": {
+          "description": "If `output` is provided and `shard_output` is `true`, shard the files by putting them under `{output_dir}/{source_relative_path}`",
+          "default": false,
+          "type": "boolean"
+        },
+        "shardStripRegex": {
+          "description": "Regex to match and strip parts of the `source_relative_path`",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "testPathRegex": {
+          "description": "Optional regex to restrict @relay_test_operation to directories matching this regex. Defaults to no limitations.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "typescriptExcludeUndefinedFromNullableUnion": {
+          "description": "Keep the previous compiler behavior by outputting an union of the raw type and null, and not the **correct** behavior of an union with the raw type, null and undefined.",
+          "default": false,
+          "type": "boolean"
+        },
+        "useImportTypeSyntax": {
+          "title": "For Typescript type generation",
+          "description": "Whether to use the `import type` syntax introduced in Typescript version 3.8. This will prevent warnings from `importsNotUsedAsValues`.",
+          "default": false,
+          "type": "boolean"
+        },
+        "variableNamesComment": {
+          "description": "Generates a `// @relayVariables name1 name2` header in generated operation files",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConnectionInterface": {
+      "description": "Configuration where Relay should expect some fields in the schema.",
+      "type": "object",
+      "required": [
+        "cursor",
+        "edges",
+        "endCursor",
+        "hasNextPage",
+        "hasPreviousPage",
+        "node",
+        "pageInfo",
+        "startCursor"
+      ],
+      "properties": {
+        "cursor": {
+          "$ref": "#/definitions/StringKey"
+        },
+        "edges": {
+          "$ref": "#/definitions/StringKey"
+        },
+        "endCursor": {
+          "$ref": "#/definitions/StringKey"
+        },
+        "hasNextPage": {
+          "$ref": "#/definitions/StringKey"
+        },
+        "hasPreviousPage": {
+          "$ref": "#/definitions/StringKey"
+        },
+        "node": {
+          "$ref": "#/definitions/StringKey"
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/StringKey"
+        },
+        "startCursor": {
+          "$ref": "#/definitions/StringKey"
+        }
+      },
+      "additionalProperties": false
+    },
+    "CustomType": {
+      "description": "Defines a custom GraphQL descrbing a custom scalar.",
+      "anyOf": [
+        {
+          "description": "A string representing the name of a custom type. e.g. \"string\" or \"number\"",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StringKey"
+            }
+          ]
+        },
+        {
+          "description": "A module which defines the custom type. e.g. { \"name\": \"MyCustomType\", \"path\": \"./Types.ts\" }",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CustomTypeImport"
+            }
+          ]
+        }
+      ]
+    },
+    "CustomTypeImport": {
+      "description": "Defines a module path and export name of the Flow or TypeScript type descrbing a GraphQL custom scalar.",
+      "type": "object",
+      "required": [
+        "name",
+        "path"
+      ],
+      "properties": {
+        "name": {
+          "description": "The name under which the type is exported from the module",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StringKey"
+            }
+          ]
+        },
+        "path": {
+          "description": "The path to the module relative to the project root",
+          "type": "string"
+        }
+      }
+    },
+    "DeferStreamInterface": {
+      "description": "Configuration where Relay should expect some fields in the schema.",
+      "type": "object",
+      "required": [
+        "deferName",
+        "ifArg",
+        "initialCountArg",
+        "labelArg",
+        "streamName",
+        "useCustomizedBatchArg"
+      ],
+      "properties": {
+        "deferName": {
+          "$ref": "#/definitions/DirectiveName"
+        },
+        "ifArg": {
+          "$ref": "#/definitions/ArgumentName"
+        },
+        "initialCountArg": {
+          "$ref": "#/definitions/ArgumentName"
+        },
+        "labelArg": {
+          "$ref": "#/definitions/ArgumentName"
+        },
+        "streamName": {
+          "$ref": "#/definitions/DirectiveName"
+        },
+        "useCustomizedBatchArg": {
+          "$ref": "#/definitions/ArgumentName"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DeserializableProjectSet": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ProjectName"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ProjectName"
+          }
+        }
+      ]
+    },
+    "DiagnosticLevel": {
+      "description": "Levels for reporting errors in the compiler.",
+      "oneOf": [
+        {
+          "description": "Report only errors",
+          "type": "string",
+          "enum": [
+            "error"
+          ]
+        },
+        {
+          "description": "Report diagnostics up to warnings",
+          "type": "string",
+          "enum": [
+            "warning"
+          ]
+        },
+        {
+          "description": "Report diagnostics up to informational diagnostics",
+          "type": "string",
+          "enum": [
+            "info"
+          ]
+        },
+        {
+          "description": "Report diagnostics up to hints",
+          "type": "string",
+          "enum": [
+            "hint"
+          ]
+        }
+      ]
+    },
+    "DiagnosticReportConfig": {
+      "description": "Configuration for all diagnostic reporting in the compiler",
+      "type": "object",
+      "required": [
+        "criticalLevel"
+      ],
+      "properties": {
+        "criticalLevel": {
+          "description": "Threshold for diagnostics to be critical to the compiler's execution. All diagnostic with severities at and below this level will cause the compiler to fatally exit.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DiagnosticLevel"
+            }
+          ]
+        }
+      }
+    },
+    "DirectiveName": {
+      "description": "Wrapper struct for clarity rather than having StringKey everywhere.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/StringKey"
+        }
+      ]
+    },
+    "FeatureFlag": {
+      "oneOf": [
+        {
+          "description": "Fully disabled: developers may not use this feature",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "disabled"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Fully enabled: developers may use this feature",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "enabled"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Partially enabled: developers may only use this feature on the listed items (fragments, fields, types).",
+          "type": "object",
+          "required": [
+            "allowlist",
+            "kind"
+          ],
+          "properties": {
+            "allowlist": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/StringKey"
+              },
+              "uniqueItems": true
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "limited"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Partially enabled: used for gradual rollout of the feature",
+          "type": "object",
+          "required": [
+            "kind",
+            "rollout"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "rollout"
+              ]
+            },
+            "rollout": {
+              "$ref": "#/definitions/Rollout"
+            }
+          }
+        },
+        {
+          "description": "Partially enabled: used for gradual rollout of the feature",
+          "type": "object",
+          "required": [
+            "kind",
+            "rollout"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "rolloutrange"
+              ]
+            },
+            "rollout": {
+              "$ref": "#/definitions/RolloutRange"
+            }
+          }
+        }
+      ]
+    },
+    "FeatureFlags": {
+      "type": "object",
+      "properties": {
+        "actor_change_support": {
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "allow_output_type_resolvers": {
+          "description": "@outputType resolvers are a discontinued experimental feature. This flag allows users to allowlist old uses of this feature while they work to remove them. Weak types (types without an `id` field) returned by a Relay Resolver should be limited to types defined using `@RelayResolver` with `@weak`.\n\nIf using the \"limited\" feature flag variant, users can allowlist a specific list of field names.\n\nhttps://relay.dev/docs/next/guides/relay-resolvers/defining-types/#defining-a-weak-type",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "allow_required_in_mutation_response": {
+          "description": "@required with an action of THROW is read-time feature that is not compatible with our mutation APIs. We are in the process of removing any existing examples, but this flag is part of a process of removing any existing examples.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "allow_resolver_non_nullable_return_type": {
+          "description": "Allow non-nullable return types from resolvers.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "allow_resolvers_in_mutation_response": {
+          "description": "Relay Resolvers are a read-time feature that are not actually handled in our mutation APIs. We are in the process of removing any existing examples, but this flag is part of a process of removing any existing examples.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "compact_query_text": {
+          "description": "Print queries in compact form",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "disable_deduping_common_structures_in_artifacts": {
+          "description": "Skip the optimization which extracts common JavaScript structures in generated artifacts into numbered variables and uses them by reference in each position in which they occur.\n\nThis optimization can make it hard to follow changes to generated code, so being able to disable it can be helpful for debugging.\n\nTo disable deduping for just one fragment or operation's generated artifacts:\n\n```json \"disable_deduping_common_structures_in_artifacts\": { { \"kind\": \"limited\", \"allowList\": [\"<operation_or_fragment_name>\"] } } ```",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "disable_edge_type_name_validation_on_declerative_connection_directives": {
+          "description": "Disable validation of the `edgeTypeName` argument on `@prependNode` and `@appendNode`.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "disable_full_argument_type_validation": {
+          "description": "Disable full GraphQL argument type validation. Historically, we only applied argument type validation to the query that was actually going to be persisted and sent to the server. This meant that we didn't typecheck arguments passed to Relay Resolvers or Client Schema Extensions.\n\nWe also permitted an escape hatch of `uncheckedArguments_DEPRECATED` for defining fragment arguments which were not typechecked.\n\nWe no-longer support `uncheckedArguments_DEPRECATED`, and we typecheck both client and server arguments. This flag allows you to opt out of this new behavior to enable gradual adoption of the new validations.\n\nThis flag will be removed in a future version of Relay.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "disable_resolver_reader_ast": {
+          "description": "Mirror of `enable_resolver_normalization_ast` excludes resolver metadata from reader ast",
+          "default": false,
+          "type": "boolean"
+        },
+        "disable_schema_validation": {
+          "description": "Disable validating the composite schema (server, client schema extensions, Relay Resolvers) after its built.",
+          "default": false,
+          "type": "boolean"
+        },
+        "enable_3d_branch_arg_generation": {
+          "default": false,
+          "type": "boolean"
+        },
+        "enable_exec_time_resolvers_directive": {
+          "description": "Allow per-query opt in to normalization AST for Resolvers with exec_time_resolvers directive. In contrast to enable_resolver_normalization_ast, if this is true, a normalization AST can be generated for a query using the @exec_time_resolvers directive",
+          "default": false,
+          "type": "boolean"
+        },
+        "enable_fragment_argument_transform": {
+          "description": "Add support for parsing and transforming variable definitions on fragment definitions and arguments on fragment spreads.",
+          "default": false,
+          "type": "boolean"
+        },
+        "enable_relay_resolver_mutations": {
+          "description": "Allow relay resolvers to extend the Mutation type",
+          "default": false,
+          "type": "boolean"
+        },
+        "enable_resolver_normalization_ast": {
+          "description": "Fully build the normalization AST for Resolvers",
+          "default": false,
+          "type": "boolean"
+        },
+        "enable_strict_custom_scalars": {
+          "description": "Perform strict validations when custom scalar types are used",
+          "default": false,
+          "type": "boolean"
+        },
+        "enforce_fragment_alias_where_ambiguous": {
+          "description": "Enforce that you must add `@alias` to a fragment if it may not match, due to type mismatch or `@skip`/`@include`",
+          "default": {
+            "kind": "enabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "legacy_include_path_in_required_reader_nodes": {
+          "description": "The `path` field in `@required` Reader AST nodes is no longer used. But removing them in one diff is too large of a change to ship at once.\n\nThis flag will allow us to use the rollout FeatureFlag to remove them across a number of diffs.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "no_inline": {
+          "description": "For now, this also disallows fragments with variable definitions This also makes @module to opt in using @no_inline internally NOTE that the presence of a fragment in this list only controls whether a fragment is *allowed* to use @no_inline: whether the fragment is inlined or not depends on whether it actually uses that directive.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "omit_resolver_type_assertions_for_confirmed_types": {
+          "description": "Skip generating resolver type assertions for resolvers which have been derived from TS/Flow types.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "prefer_fetchable_in_refetch_queries": {
+          "description": "Feature flag to prefer `fetch_MyType()` generatior over `node()` query generator in @refetchable transform",
+          "default": false,
+          "type": "boolean"
+        },
+        "relay_resolver_enable_interface_output_type": {
+          "description": "Enable returning interfaces from Relay Resolvers without @outputType",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "skip_printing_nulls": {
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "text_artifacts": {
+          "description": "Enable generation of text artifacts used to generate full query strings later.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        },
+        "use_reader_module_imports": {
+          "description": "Generate the `moduleImports` field in the Reader AST.",
+          "default": {
+            "kind": "disabled"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlag"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "JsModuleFormat": {
+      "description": "Formatting style for generated files.",
+      "oneOf": [
+        {
+          "description": "Common JS style, e.g. `require('../path/MyModule')`",
+          "type": "string",
+          "enum": [
+            "commonjs"
+          ]
+        },
+        {
+          "description": "Facebook style, e.g. `require('MyModule')`",
+          "type": "string",
+          "enum": [
+            "haste"
+          ]
+        }
+      ]
+    },
+    "LocalPersistAlgorithm": {
+      "type": "string",
+      "enum": [
+        "MD5",
+        "SHA1",
+        "SHA256"
+      ]
+    },
+    "LocalPersistConfig": {
+      "description": "Configuration for local persistence of GraphQL documents.\n\nThis struct contains settings that control how GraphQL documents are persisted locally.",
+      "type": "object",
+      "required": [
+        "file"
+      ],
+      "properties": {
+        "algorithm": {
+          "description": "The algorithm to use for hashing the operation text.",
+          "default": "MD5",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LocalPersistAlgorithm"
+            }
+          ]
+        },
+        "file": {
+          "description": "The file path where the persisted documents will be written.",
+          "type": "string"
+        },
+        "include_query_text": {
+          "description": "Whether to include the query text in the persisted document.",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ModuleImportConfig": {
+      "description": "Configuration for @module.",
+      "type": "object",
+      "properties": {
+        "dynamicModuleProvider": {
+          "description": "Defines the custom import statement to be generated on the `ModuleImport` node in ASTs, used for dynamically loading components at runtime.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModuleProvider"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "operationModuleProvider": {
+          "description": "Defines the custom import statement to be generated for the `operationModuleProvider` function on the `NormalizationModuleImport` node in ASTs. Used in exec time client 3D.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModuleProvider"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "surface": {
+          "description": "Defines the surface upon which @module is enabled.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Surface"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ModuleProvider": {
+      "oneOf": [
+        {
+          "description": "Generates a module provider using JSResource",
+          "type": "object",
+          "required": [
+            "mode"
+          ],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "JSResource"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Generates a custom JS import, Use `<$module>` as the placeholder for the actual module. e.g. `\"() => import('<$module>')\"`",
+          "type": "object",
+          "required": [
+            "mode",
+            "statement"
+          ],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "Custom"
+              ]
+            },
+            "statement": {
+              "$ref": "#/definitions/StringKey"
+            }
+          }
+        }
+      ]
+    },
+    "MultiProjectConfigFile": {
+      "description": "Schema of the compiler configuration JSON file.",
+      "type": "object",
+      "required": [
+        "projects",
+        "sources"
+      ],
+      "properties": {
+        "$schema": {
+          "description": "The user may hard-code the JSON Schema for their version of the config.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "codegenCommand": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "excludes": {
+          "description": "Glob patterns that should not be part of the sources even if they are in the source set directories.",
+          "default": [
+            "**/node_modules/**",
+            "**/__mocks__/**",
+            "**/__generated__/**"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "featureFlags": {
+          "description": "Enable and disable experimental or legacy behaviors. WARNING! These are not stable and may change at any time.",
+          "default": {
+            "actor_change_support": {
+              "kind": "disabled"
+            },
+            "allow_output_type_resolvers": {
+              "kind": "disabled"
+            },
+            "allow_required_in_mutation_response": {
+              "kind": "disabled"
+            },
+            "allow_resolver_non_nullable_return_type": {
+              "kind": "disabled"
+            },
+            "allow_resolvers_in_mutation_response": {
+              "kind": "disabled"
+            },
+            "compact_query_text": {
+              "kind": "disabled"
+            },
+            "disable_deduping_common_structures_in_artifacts": {
+              "kind": "disabled"
+            },
+            "disable_edge_type_name_validation_on_declerative_connection_directives": {
+              "kind": "disabled"
+            },
+            "disable_full_argument_type_validation": {
+              "kind": "disabled"
+            },
+            "disable_resolver_reader_ast": false,
+            "disable_schema_validation": false,
+            "enable_3d_branch_arg_generation": false,
+            "enable_exec_time_resolvers_directive": false,
+            "enable_fragment_argument_transform": false,
+            "enable_relay_resolver_mutations": false,
+            "enable_resolver_normalization_ast": false,
+            "enable_strict_custom_scalars": false,
+            "enforce_fragment_alias_where_ambiguous": {
+              "kind": "disabled"
+            },
+            "legacy_include_path_in_required_reader_nodes": {
+              "kind": "disabled"
+            },
+            "no_inline": {
+              "kind": "disabled"
+            },
+            "omit_resolver_type_assertions_for_confirmed_types": {
+              "kind": "disabled"
+            },
+            "prefer_fetchable_in_refetch_queries": false,
+            "relay_resolver_enable_interface_output_type": {
+              "kind": "disabled"
+            },
+            "skip_printing_nulls": {
+              "kind": "disabled"
+            },
+            "text_artifacts": {
+              "kind": "disabled"
+            },
+            "use_reader_module_imports": {
+              "kind": "disabled"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/FeatureFlags"
+            }
+          ]
+        },
+        "generatedSources": {
+          "description": "Similar to sources but not affected by excludes.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ProjectSet"
+          }
+        },
+        "header": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "isDevVariableName": {
+          "description": "Then name of the global __DEV__ variable to use in generated artifacts",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "Optional name for this config, might be used for logging or custom extra artifact generator code.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "noSourceControl": {
+          "description": "Opt out of source control checks/integration.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "projects": {
+          "description": "Configuration of projects to compile.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ConfigFileProject"
+          }
+        },
+        "root": {
+          "description": "Root directory relative to the config file. Defaults to the directory where the config is located.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "savedStateConfig": {
+          "description": "Watchman saved state config.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScmAwareClockData"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sources": {
+          "description": "A mapping from directory paths (relative to the root) to a source set. If a path is a subdirectory of another path, the more specific path wins.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DeserializableProjectSet"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "NonNodeIdFieldsConfig": {
+      "description": "Configuration of Relay's validation for `id` fields outside of the `Node` interface.",
+      "type": "object",
+      "properties": {
+        "allowedIdTypes": {
+          "description": "A map of parent type names to allowed type names for fields named `id`",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/StringKey"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "PersistConfig": {
+      "description": "Configuration for how the Relay Compiler should persist GraphQL queries.",
+      "anyOf": [
+        {
+          "description": "This variant represents a remote persistence configuration, where GraphQL queries are sent to a remote endpoint for persistence.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RemotePersistConfig"
+            }
+          ]
+        },
+        {
+          "description": "This variant represents a local persistence configuration, where GraphQL queries are persisted to a local JSON file.\n\nWhen this variant is used, the compiler will attempt to read the local file as a hash map, add new queries to the map, and then serialize and write the resulting map to the configured path.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LocalPersistConfig"
+            }
+          ]
+        }
+      ]
+    },
+    "ProjectName": {
+      "description": "Represents the name of a project in the Relay configuration.",
+      "anyOf": [
+        {
+          "description": "No project name is specified.",
+          "type": "null"
+        },
+        {
+          "description": "A project name.\n\nThis should match one the keys in the `projects` map in the Relay compiler config.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StringKey"
+            }
+          ]
+        }
+      ]
+    },
+    "ProjectSet": {
+      "description": "Set of project names.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ProjectName"
+      }
+    },
+    "RemotePersistConfig": {
+      "description": "Configuration for remote persistence of GraphQL documents.",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "concurrency": {
+          "description": "Number of concurrent requests that can be made to the server.",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "headers": {
+          "description": "Additional headers to include in the POST request.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "includeQueryText": {
+          "description": "Whether to include the query text in the persisted document.",
+          "default": false,
+          "type": "boolean"
+        },
+        "params": {
+          "description": "Additional parameters to include in the POST request.\n\nThe main document will be in a POST parameter `text`. This map can contain additional parameters to send.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "url": {
+          "description": "URL that the document should be persisted to via a POST request.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ResolverContextTypeInput": {
+      "description": "Describes the type to import and use as the context for Relay Resolvers.",
+      "anyOf": [
+        {
+          "description": "The type imported using a relative path",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ResolverContextTypeInputPath"
+            }
+          ]
+        },
+        {
+          "description": "The type imported using a named package",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ResolverContextTypeInputPackage"
+            }
+          ]
+        }
+      ]
+    },
+    "ResolverContextTypeInputPackage": {
+      "description": "Specifies how Relay can import the Resolver context type from a named package",
+      "type": "object",
+      "required": [
+        "name",
+        "package"
+      ],
+      "properties": {
+        "name": {
+          "description": "The name under which the type is exported from the package",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StringKey"
+            }
+          ]
+        },
+        "package": {
+          "description": "The name of the package",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StringKey"
+            }
+          ]
+        }
+      }
+    },
+    "ResolverContextTypeInputPath": {
+      "description": "Specifies how Relay can import the Resolver context type from a path",
+      "type": "object",
+      "required": [
+        "name",
+        "path"
+      ],
+      "properties": {
+        "name": {
+          "description": "The name under which the type is exported from the module",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StringKey"
+            }
+          ]
+        },
+        "path": {
+          "description": "The path to the module relative to the project root",
+          "type": "string"
+        }
+      }
+    },
+    "ResolversSchemaModuleConfig": {
+      "description": "Configuration for resolvers_schema_module generation",
+      "type": "object",
+      "properties": {
+        "applyToNormalizationAst": {
+          "default": false,
+          "type": "boolean"
+        },
+        "path": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Rollout": {
+      "description": "A utility to enable gradual rollout of large codegen changes. Can be constructed as the Default which passes or a percentage between 0 and 100.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "RolloutRange": {
+      "description": "A utility to enable gradual rollout of large codegen changes. Allows you to specify a range of percentages to rollout.",
+      "type": "object",
+      "required": [
+        "end",
+        "start"
+      ],
+      "properties": {
+        "end": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "start": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        }
+      }
+    },
+    "SavedStateClockData": {
+      "description": "Holds extended clock data that includes source control aware query metadata. <https://facebook.github.io/watchman/docs/scm-query.html>",
+      "type": "object",
+      "properties": {
+        "commit-id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "config": true,
+        "storage": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "SchemaConfig": {
+      "type": "object",
+      "properties": {
+        "connectionInterface": {
+          "default": {
+            "cursor": "cursor",
+            "edges": "edges",
+            "endCursor": "endCursor",
+            "hasNextPage": "hasNextPage",
+            "hasPreviousPage": "hasPreviousPage",
+            "node": "node",
+            "pageInfo": "pageInfo",
+            "startCursor": "startCursor"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectionInterface"
+            }
+          ]
+        },
+        "deferStreamInterface": {
+          "default": {
+            "deferName": "defer",
+            "ifArg": "if",
+            "initialCountArg": "initialCount",
+            "labelArg": "label",
+            "streamName": "stream",
+            "useCustomizedBatchArg": "useCustomizedBatch"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/DeferStreamInterface"
+            }
+          ]
+        },
+        "enableTokenField": {
+          "description": "If we should select __token field on fetchable types",
+          "default": false,
+          "type": "boolean"
+        },
+        "nodeInterfaceIdField": {
+          "description": "The name of the `id` field that exists on the `Node` interface.",
+          "default": "id",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StringKey"
+            }
+          ]
+        },
+        "nodeInterfaceIdVariableName": {
+          "description": "The name of the variable expected by the `node` query.",
+          "default": "id",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StringKey"
+            }
+          ]
+        },
+        "nonNodeIdFields": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NonNodeIdFieldsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "unselectableDirectiveName": {
+          "description": "The name of the directive indicating fields that cannot be selected",
+          "default": "unselectable",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DirectiveName"
+            }
+          ]
+        }
+      }
+    },
+    "ScmAwareClockData": {
+      "description": "Holds extended clock data that includes source control aware query metadata. <https://facebook.github.io/watchman/docs/scm-query.html>",
+      "type": "object",
+      "properties": {
+        "mergebase": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mergebase-with": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "saved-state": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SavedStateClockData"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "SingleProjectConfigFile": {
+      "type": "object",
+      "required": [
+        "language"
+      ],
+      "properties": {
+        "$schema": {
+          "description": "The user may hard-code the JSON Schema for their version of the config.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "artifactDirectory": {
+          "description": "A specific directory to output all artifacts to. When enabling this the babel plugin needs `artifactDirectory` set as well.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "codegenCommand": {
+          "description": "Name of the command that runs the relay compiler. This will be added at the top of generated code to let readers know how to regenerate the file.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "customErrorType": {
+          "description": "A map from GraphQL error name to import path, example: {\"name:: \"MyErrorName\", \"path\": \"../src/MyError\"}",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CustomTypeImport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "customScalarTypes": {
+          "description": "A map from GraphQL scalar types to a custom JS type, example: { \"Url\": \"String\" } { \"Url\": {\"name:: \"MyURL\", \"path\": \"../src/MyUrlTypes\"} }",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/CustomType"
+          }
+        },
+        "eagerEsModules": {
+          "description": "This option enables opting out of emitting es modules artifacts. When set to false, Relay will emit CommonJS modules.",
+          "default": true,
+          "type": "boolean"
+        },
+        "enumModuleSuffix": {
+          "title": "For Flow type generation",
+          "description": "When set, enum values are imported from a module with this suffix. For example, an enum Foo and this property set to \".test\" would be imported from \"Foo.test\". Note: an empty string is allowed and different from not setting the value, in the example above it would just import from \"Foo\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "excludes": {
+          "description": "Directories to ignore under src default: ['**/node_modules/**', '**/__mocks__/**', '**/__generated__/**'],",
+          "default": [
+            "**/node_modules/**",
+            "**/__mocks__/**",
+            "**/__generated__/**"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "featureFlags": {
+          "description": "Enable and disable experimental or legacy behaviors. WARNING! These are not stable and may change at any time.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FeatureFlags"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "isDevVariableName": {
+          "description": "We may generate some content in the artifacts that's stripped in production if __DEV__ variable is set This config option is here to define the name of that special variable",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "jsModuleFormat": {
+          "description": "Import/export style to use in generated JavaScript modules.",
+          "default": "commonjs",
+          "allOf": [
+            {
+              "$ref": "#/definitions/JsModuleFormat"
+            }
+          ]
+        },
+        "language": {
+          "description": "The desired output language, \"flow\" or \"typescript\".",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TypegenLanguage"
+            }
+          ]
+        },
+        "moduleImportConfig": {
+          "description": "Configuration for @module",
+          "default": {
+            "dynamicModuleProvider": null,
+            "operationModuleProvider": null,
+            "surface": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModuleImportConfig"
+            }
+          ]
+        },
+        "noFutureProofEnums": {
+          "description": "This option controls whether or not a catch-all entry is added to enum type definitions for values that may be added in the future. Enabling this means you will have to update your application whenever the GraphQL server schema adds new enum values to prevent it from breaking.",
+          "default": false,
+          "type": "boolean"
+        },
+        "noSourceControl": {
+          "description": "Opt out of source control checks/integration.",
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "optionalInputFields": {
+          "title": "For Flow type generation",
+          "description": "When set, generated input types will have the listed fields optional even if the schema defines them as required.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StringKey"
+          }
+        },
+        "persistConfig": {
+          "description": "Query Persist Configuration It contains URL and addition parameters that will be included with the request (think API_KEY, APP_ID, etc...)",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PersistConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "relativizeJsModulePaths": {
+          "description": "Whether to treat all JS module names as relative to './' (true) or not. default: true",
+          "default": true,
+          "type": "boolean"
+        },
+        "requireCustomScalarTypes": {
+          "description": "Require all GraphQL scalar types mapping to be defined, will throw if a GraphQL scalar type doesn't have a JS type",
+          "default": false,
+          "type": "boolean"
+        },
+        "resolverContextType": {
+          "description": "Indicates the type to import and use as the context for Relay Resolvers.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResolverContextTypeInput"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resolversSchemaModule": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResolversSchemaModuleConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema": {
+          "description": "Path to schema.graphql",
+          "default": "",
+          "type": "string"
+        },
+        "schemaConfig": {
+          "description": "Extra configuration for the GraphQL schema itself.",
+          "default": {
+            "connectionInterface": {
+              "cursor": "cursor",
+              "edges": "edges",
+              "endCursor": "endCursor",
+              "hasNextPage": "hasNextPage",
+              "hasPreviousPage": "hasPreviousPage",
+              "node": "node",
+              "pageInfo": "pageInfo",
+              "startCursor": "startCursor"
+            },
+            "deferStreamInterface": {
+              "deferName": "defer",
+              "ifArg": "if",
+              "initialCountArg": "initialCount",
+              "labelArg": "label",
+              "streamName": "stream",
+              "useCustomizedBatchArg": "useCustomizedBatch"
+            },
+            "enableTokenField": false,
+            "nodeInterfaceIdField": "id",
+            "nodeInterfaceIdVariableName": "id",
+            "nonNodeIdFields": null,
+            "unselectableDirectiveName": "unselectable"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SchemaConfig"
+            }
+          ]
+        },
+        "schemaExtensions": {
+          "description": "List of directories with schema extensions.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "src": {
+          "description": "Root directory of application code",
+          "default": "",
+          "type": "string"
+        },
+        "typescriptExcludeUndefinedFromNullableUnion": {
+          "description": "Keep the previous compiler behavior by outputting an union of the raw type and null, and not the **correct** behavior of an union with the raw type, null and undefined.",
+          "default": false,
+          "type": "boolean"
+        },
+        "useImportTypeSyntax": {
+          "title": "For Typescript type generation",
+          "description": "Whether to use the `import type` syntax introduced in Typescript version 3.8. This will prevent warnings from `importsNotUsedAsValues`.",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "StringKey": {
+      "type": "string"
+    },
+    "Surface": {
+      "type": "string",
+      "enum": [
+        "resolvers",
+        "all"
+      ]
+    },
+    "TypegenLanguage": {
+      "type": "string",
+      "enum": [
+        "javascript",
+        "typescript",
+        "flow"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
In https://github.com/facebook/relay/commit/b208fedd1c1e86cc63f69e9dfbe2accf6b240283 we upgraded schemars which changed how the json schema for the compiler config is represented. This uncovered gaps in our documentation renderer. Specifically, we had hard coded the assumption that the definitions would live on the `.defintitions` property of the schema. The new version of schemars puts them under `$defs` which aligns better with json schema spec.

This diff makes `$defs` the default assumed location for definitions, but lets the parent pass in definitions from another location. This diff also starts the process of using versioned schemas for our versioned docs. As part of this I pulled in the version of the config schema from the commit that added the v20 docs. So, now as our current config schema changes, the v20 docs will still reflect the config as it was at the v20 release.

This allows us to pressure test the docs rendering, ensuring they can render both the old and new representations.