### PR TITLE
fix(relay-runtime): prototype less payloads

### DIFF
--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -250,7 +250,11 @@ class RelayResponseNormalizer {
               this._traverseSelections(selection, record, data);
             }
           } else {
-            const implementsInterface = data.hasOwnProperty(abstractKey);
+            // $FlowFixMe[method-unbinding] - data could be prototype less
+            const implementsInterface = Object.prototype.hasOwnProperty.call(
+              data,
+              abstractKey,
+            );
             const typeName = RelayModernRecord.getType(record);
             const typeID = generateTypeID(typeName);
             let typeRecord = this._recordSource.get(typeID);
@@ -271,7 +275,11 @@ class RelayResponseNormalizer {
         }
         case 'TypeDiscriminator': {
           const {abstractKey} = selection;
-          const implementsInterface = data.hasOwnProperty(abstractKey);
+          // $FlowFixMe[method-unbinding] - data could be prototype less
+          const implementsInterface = Object.prototype.hasOwnProperty.call(
+            data,
+            abstractKey,
+          );
           const typeName = RelayModernRecord.getType(record);
           const typeID = generateTypeID(typeName);
           let typeRecord = this._recordSource.get(typeID);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest42Fragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest42Fragment.graphql.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<75b5cc0be88d4b06a0383561c063320c>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RelayResponseNormalizerTest42Fragment$fragmentType: FragmentType;
+export type RelayResponseNormalizerTest42Fragment$data = {|
+  +id: string,
+  +name?: ?string,
+  +$fragmentType: RelayResponseNormalizerTest42Fragment$fragmentType,
+|};
+export type RelayResponseNormalizerTest42Fragment$key = {
+  +$data?: RelayResponseNormalizerTest42Fragment$data,
+  +$fragmentSpreads: RelayResponseNormalizerTest42Fragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayResponseNormalizerTest42Fragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "type": "User",
+      "abstractKey": null
+    }
+  ],
+  "type": "Node",
+  "abstractKey": "__isNode"
+};
+
+if (__DEV__) {
+  (node/*: any*/).hash = "591f4f73e73d3aa4fa8dbc86ca5c9690";
+}
+
+module.exports = ((node/*: any*/)/*: Fragment<
+  RelayResponseNormalizerTest42Fragment$fragmentType,
+  RelayResponseNormalizerTest42Fragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest42Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest42Query.graphql.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<f9c459980094343d4c20243b3bb9ed87>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { RelayResponseNormalizerTest42Fragment$fragmentType } from "./RelayResponseNormalizerTest42Fragment.graphql";
+export type RelayResponseNormalizerTest42Query$variables = {|
+  id: string,
+|};
+export type RelayResponseNormalizerTest42Query$data = {|
+  +node: ?{|
+    +$fragmentSpreads: RelayResponseNormalizerTest42Fragment$fragmentType,
+  |},
+|};
+export type RelayResponseNormalizerTest42Query = {|
+  response: RelayResponseNormalizerTest42Query$data,
+  variables: RelayResponseNormalizerTest42Query$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayResponseNormalizerTest42Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "RelayResponseNormalizerTest42Fragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RelayResponseNormalizerTest42Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "TypeDiscriminator",
+            "abstractKey": "__isNode"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "88937bb7d3f011243792258ece6f7218",
+    "id": null,
+    "metadata": {},
+    "name": "RelayResponseNormalizerTest42Query",
+    "operationKind": "query",
+    "text": "query RelayResponseNormalizerTest42Query(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RelayResponseNormalizerTest42Fragment\n    id\n  }\n}\n\nfragment RelayResponseNormalizerTest42Fragment on Node {\n  __isNode: __typename\n  id\n  ... on User {\n    name\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "df5d2a14838f0b7c2322699b0f2aaf26";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  RelayResponseNormalizerTest42Query$variables,
+  RelayResponseNormalizerTest42Query$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest43Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest43Query.graphql.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<f0fa6944a28207e9c7f4f5d77a60c274>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type RelayResponseNormalizerTest43Query$variables = {|
+  id: string,
+|};
+export type RelayResponseNormalizerTest43Query$data = {|
+  +userOrPage: ?{|
+    +id?: string,
+  |},
+|};
+export type RelayResponseNormalizerTest43Query = {|
+  response: RelayResponseNormalizerTest43Query$data,
+  variables: RelayResponseNormalizerTest43Query$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "id",
+    "storageKey": null
+  }
+],
+v3 = {
+  "kind": "InlineFragment",
+  "selections": (v2/*: any*/),
+  "type": "User",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayResponseNormalizerTest43Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "userOrPage",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RelayResponseNormalizerTest43Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "userOrPage",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": (v2/*: any*/),
+            "type": "Node",
+            "abstractKey": "__isNode"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1ce76a46dba4f92ff0d73f009a2e5d30",
+    "id": null,
+    "metadata": {},
+    "name": "RelayResponseNormalizerTest43Query",
+    "operationKind": "query",
+    "text": "query RelayResponseNormalizerTest43Query(\n  $id: ID!\n) {\n  userOrPage(id: $id) {\n    __typename\n    ... on User {\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*: any*/).hash = "1f32c7b33101aed4f9650bfc68e12aad";
+}
+
+module.exports = ((node/*: any*/)/*: Query<
+  RelayResponseNormalizerTest43Query$variables,
+  RelayResponseNormalizerTest43Query$data,
+>*/);


### PR DESCRIPTION
Relay throws an error when execution and consumption occur in the same thread without a serialization boundary (no JSON.parse()). This occurs because popular execution library have prototype less object (to allow keys like constructor etc.). Relay should not assume payload has any method available. 

graphql-js: https://github.com/graphql/graphql-js/blob/16.x.x/src/execution/execute.ts#L298
supermassive: https://github.com/microsoft/graphitation/blob/main/packages/supermassive/src/executeWithoutSchema.ts#L201