### PR TITLE
Handle json schema consts in compiler config doc generation

### DIFF
--- a/website/src/compiler-config/CompilerConfig.js
+++ b/website/src/compiler-config/CompilerConfig.js
@@ -357,6 +357,9 @@ function T({prop, indirections}) {
     case 'number':
     case 'boolean':
     case 'null':
+      if (prop.const != null) {
+        return JSON.stringify(prop.const);
+      }
       return prop.type;
     case 'integer':
       // TODO: Clarify if this needs to be a unint8


### PR DESCRIPTION
Fixes #5045.

In https://github.com/facebook/relay/commit/b208fedd1c1e86cc63f69e9dfbe2accf6b240283 we upgraded schemars which changed how the json schema for the compiler config is represented. It looks like the previous representation used enums of a single string literal to represent string literals. The new version uses the [const keyword](https://json-schema.org/understanding-json-schema/reference/const) for string literals.

## Before

<img width="800" height="354" alt="Screenshot 2025-08-01 at 9 39 51 AM" src="https://github.com/user-attachments/assets/66c6ca23-7707-47cf-ad4f-f4bb554b8bec" />

## After

<img width="789" height="351" alt="Screenshot 2025-08-01 at 9 39 35 AM" src="https://github.com/user-attachments/assets/36ff9995-09bf-42e9-8cdd-30c5c3633172" />


Related: https://github.com/facebook/relay/pull/5036