### PR TITLE
Check FORCE_NO_WATCHMAN env var before invoking watchman

### DIFF
--- a/compiler/crates/relay-bin/src/main.rs
+++ b/compiler/crates/relay-bin/src/main.rs
@@ -455,9 +455,11 @@ async fn handle_lsp_command(command: LspCommand) -> Result<(), Error> {
 /// environment variable. If this `FORCE_NO_WATCHMAN` is set, this method will return `false`
 /// and compiler will use non-watchman file finder.
 fn should_use_watchman() -> bool {
-    let check_watchman = Command::new("watchman")
+    if !env::var("FORCE_NO_WATCHMAN").is_err() {
+        return false;
+    }
+    Command::new("watchman")
         .args(["list-capabilities"])
-        .output();
-
-    check_watchman.is_ok() && env::var("FORCE_NO_WATCHMAN").is_err()
+        .output()
+        .is_ok()
 }


### PR DESCRIPTION
I had a bug where `watchman list-capabilities` was hanging and this env variable was not letting me work around that bug. By moving this check earlier it should help more fully skip watchman.

# Test Plan

Run `./scripts/compile-tests.sh` hard coding it to `--output=debug` both with and without `FORCE_NO_WATCHMAN=1` and see that it runs with Watchman by default and does not use Watchman when `FORCE_NO_WATCHMAN=1`.